### PR TITLE
fix: enable multi-platform Docker builds for main branch

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -58,7 +61,7 @@ jobs:
           else
             echo "VERSION=dev" >> $GITHUB_OUTPUT
             echo "DOCKERFILE=./Dockerfile.dev" >> $GITHUB_OUTPUT
-            echo "PLATFORMS=linux/amd64" >> $GITHUB_OUTPUT
+            echo "PLATFORMS=linux/amd64,linux/arm64" >> $GITHUB_OUTPUT
           fi
 
       - name: Build and push Docker image


### PR DESCRIPTION
## Summary
- Add QEMU setup action for cross-platform Docker builds
- Enable linux/arm64 builds for main branch pushes (not just releases)
- Fixes Docker pull issues on Apple Silicon Macs

## Problem
Currently when trying to pull the Docker image on Apple Silicon Macs (ARM64), users get:
```
docker: Error response from daemon: no matching manifest for linux/arm64/v8 in the manifest list entries
```

This is because the workflow only builds multi-platform images for releases, but main branch builds (which create the `latest` tag) only build for AMD64.

## Solution
- Added `docker/setup-qemu-action@v3` to enable cross-platform compilation
- Changed the main branch platform list from `linux/amd64` to `linux/amd64,linux/arm64`

## Test plan
After merging:
1. Wait for Docker workflow to complete
2. Run on Apple Silicon Mac: `docker run --rm joshrotenberg/redisctl:latest --help`
3. Verify it pulls and runs successfully