### PR TITLE
fix: handler naming inconsistencies and user request types

### DIFF
--- a/crates/redis-enterprise/src/alerts.rs
+++ b/crates/redis-enterprise/src/alerts.rs
@@ -192,6 +192,9 @@ pub struct AlertHandler {
     client: RestClient,
 }
 
+/// Alias for backwards compatibility and intuitive plural naming
+pub type AlertsHandler = AlertHandler;
+
 impl AlertHandler {
     pub fn new(client: RestClient) -> Self {
         AlertHandler { client }

--- a/crates/redis-enterprise/src/lib.rs
+++ b/crates/redis-enterprise/src/lib.rs
@@ -149,13 +149,13 @@
 //! }
 //!
 //! // Create a new user
-//! let request = CreateUserRequest {
-//!     username: "newuser".to_string(),
-//!     password: "secure_password".to_string(),
-//!     role: "db_member".to_string(),
-//!     email: Some("newuser@example.com".to_string()),
-//!     email_alerts: Some(true),
-//! };
+//! let request = CreateUserRequest::builder()
+//!     .email("newuser@example.com")
+//!     .password("secure_password")
+//!     .role("db_member")
+//!     .name("New User")
+//!     .email_alerts(true)
+//!     .build();
 //!
 //! let new_user = handler.create(request).await?;
 //! println!("Created user: {}", new_user.uid);

--- a/crates/redis-enterprise/src/modules.rs
+++ b/crates/redis-enterprise/src/modules.rs
@@ -36,6 +36,9 @@ pub struct ModuleHandler {
     client: RestClient,
 }
 
+/// Alias for backwards compatibility and intuitive plural naming
+pub type ModulesHandler = ModuleHandler;
+
 impl ModuleHandler {
     pub fn new(client: RestClient) -> Self {
         ModuleHandler { client }

--- a/crates/redis-enterprise/src/nodes.rs
+++ b/crates/redis-enterprise/src/nodes.rs
@@ -113,6 +113,9 @@ pub struct NodeHandler {
     client: RestClient,
 }
 
+/// Alias for backwards compatibility and intuitive plural naming
+pub type NodesHandler = NodeHandler;
+
 impl NodeHandler {
     pub fn new(client: RestClient) -> Self {
         NodeHandler { client }

--- a/crates/redis-enterprise/src/redis_acls.rs
+++ b/crates/redis-enterprise/src/redis_acls.rs
@@ -36,6 +36,9 @@ pub struct RedisAclHandler {
     client: RestClient,
 }
 
+/// Alias for backwards compatibility and intuitive plural naming
+pub type RedisAclsHandler = RedisAclHandler;
+
 impl RedisAclHandler {
     pub fn new(client: RestClient) -> Self {
         RedisAclHandler { client }

--- a/crates/redis-enterprise/src/users.rs
+++ b/crates/redis-enterprise/src/users.rs
@@ -30,27 +30,44 @@ pub struct User {
 /// use redis_enterprise::CreateUserRequest;
 ///
 /// let request = CreateUserRequest::builder()
-///     .username("john.doe")
+///     .email("john.doe@example.com")
 ///     .password("secure-password-123")
 ///     .role("db_admin")
-///     .email("john.doe@example.com")
+///     .name("John Doe")
 ///     .email_alerts(true)
 ///     .build();
 /// ```
 #[derive(Debug, Serialize, TypedBuilder)]
 pub struct CreateUserRequest {
+    /// User's email address (required, used as login)
     #[builder(setter(into))]
-    pub username: String,
+    pub email: String,
+    /// User's password (required)
     #[builder(setter(into))]
     pub password: String,
+    /// User's role (required) - for RBAC-enabled clusters, use role_uids instead
     #[builder(setter(into))]
     pub role: String,
+    /// User's full name
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into, strip_option))]
-    pub email: Option<String>,
+    pub name: Option<String>,
+    /// Whether user should receive email alerts
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
     pub email_alerts: Option<bool>,
+    /// Database IDs for which the user should receive email alerts
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(strip_option))]
+    pub bdbs_email_alerts: Option<Vec<String>>,
+    /// Role IDs for RBAC-enabled clusters
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(strip_option))]
+    pub role_uids: Option<Vec<u32>>,
+    /// Authentication method (e.g., "regular")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(into, strip_option))]
+    pub auth_method: Option<String>,
 }
 
 /// Update user request
@@ -67,18 +84,38 @@ pub struct CreateUserRequest {
 /// ```
 #[derive(Debug, Serialize, TypedBuilder)]
 pub struct UpdateUserRequest {
+    /// New password for the user
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into, strip_option))]
     pub password: Option<String>,
+    /// Update user's role
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into, strip_option))]
     pub role: Option<String>,
+    /// Update user's email address
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into, strip_option))]
     pub email: Option<String>,
+    /// Update user's full name
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(into, strip_option))]
+    pub name: Option<String>,
+    /// Update email alerts preference
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
     pub email_alerts: Option<bool>,
+    /// Update database IDs for email alerts
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(strip_option))]
+    pub bdbs_email_alerts: Option<Vec<String>>,
+    /// Update role IDs for RBAC-enabled clusters
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(strip_option))]
+    pub role_uids: Option<Vec<u32>>,
+    /// Update authentication method
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(into, strip_option))]
+    pub auth_method: Option<String>,
 }
 
 /// Role information
@@ -97,6 +134,9 @@ pub struct Role {
 pub struct UserHandler {
     client: RestClient,
 }
+
+/// Alias for backwards compatibility and intuitive plural naming
+pub type UsersHandler = UserHandler;
 
 impl UserHandler {
     pub fn new(client: RestClient) -> Self {

--- a/crates/redis-enterprise/tests/user_tests.rs
+++ b/crates/redis-enterprise/tests/user_tests.rs
@@ -109,13 +109,11 @@ async fn test_user_create() {
         .unwrap();
 
     let handler = UserHandler::new(client);
-    let user_data = CreateUserRequest {
-        username: "test-user".to_string(),
-        email: Some("test@example.com".to_string()),
-        password: "secret123".to_string(),
-        role: "admin".to_string(),
-        email_alerts: None,
-    };
+    let user_data = CreateUserRequest::builder()
+        .email("test@example.com")
+        .password("secret123")
+        .role("admin")
+        .build();
     let result = handler.create(user_data).await;
 
     assert!(result.is_ok());
@@ -143,12 +141,9 @@ async fn test_user_update() {
         .unwrap();
 
     let handler = UserHandler::new(client);
-    let user_data = UpdateUserRequest {
-        password: None,
-        role: None,
-        email: Some("updated@example.com".to_string()),
-        email_alerts: None,
-    };
+    let user_data = UpdateUserRequest::builder()
+        .email("updated@example.com")
+        .build();
     let result = handler.update(1, user_data).await;
 
     assert!(result.is_ok());

--- a/crates/redisctl/src/commands/enterprise.rs
+++ b/crates/redisctl/src/commands/enterprise.rs
@@ -339,13 +339,12 @@ pub async fn handle_user_command(
             roles,
         } => {
             let handler = redis_enterprise::UserHandler::new(client.clone());
-            let request = redis_enterprise::CreateUserRequest {
-                username: name.clone(),
-                password: password.unwrap_or_else(|| "default_password".to_string()),
-                role: roles.first().unwrap_or(&"db_viewer".to_string()).clone(),
-                email,
-                email_alerts: None,
-            };
+            let request = redis_enterprise::CreateUserRequest::builder()
+                .email(email.unwrap_or_else(|| format!("{}@redis.local", name)))
+                .password(password.unwrap_or_else(|| "default_password".to_string()))
+                .role(roles.first().unwrap_or(&"db_viewer".to_string()).clone())
+                .name(name.clone())
+                .build();
             let user = handler.create(request).await?;
             let value = serde_json::to_value(user)?;
             print_output(value, output_format, query)?;
@@ -359,8 +358,12 @@ pub async fn handle_user_command(
             let request = redis_enterprise::UpdateUserRequest {
                 email,
                 password,
+                name: None,
                 role: None,
                 email_alerts: None,
+                bdbs_email_alerts: None,
+                role_uids: None,
+                auth_method: None,
             };
             let user = handler.update(id.parse()?, request).await?;
             let value = serde_json::to_value(user)?;


### PR DESCRIPTION
## Summary
- Add type aliases for backwards compatibility with plural handler names
- Fix CreateUserRequest and UpdateUserRequest to match actual API requirements
- Update CLI command handlers to use new struct fields

## Changes
- Added type aliases: `AlertsHandler`, `NodesHandler`, `ModulesHandler`, `RedisAclsHandler`, `UsersHandler`
- Updated `CreateUserRequest`:
  - Changed `username` to `email` (required field per API spec)
  - Added fields: `name`, `bdbs_email_alerts`, `role_uids`, `auth_method`
- Updated `UpdateUserRequest` with all supported fields
- Fixed CLI command handlers to use builder pattern
- Updated tests to use builder pattern

## Test Plan
- [x] All existing tests pass
- [x] cargo fmt passes
- [x] cargo clippy passes
- [x] Documentation tests pass

## Related Issues
Addresses remaining items from #64
Closes #61 (redis-enterprise improvements)

## Progress on Issue #61
This PR, combined with #63 and #65, completes the core improvements for #61:
- ✅ Comprehensive documentation with examples
- ✅ Error handling improvements with specific variants
- ✅ Builder patterns for all request types
- ✅ Example programs (basic and cluster setup)
- ✅ Environment variable support via `from_env()`
- ✅ Helper methods and convenience functions
- ✅ Full API coverage with 29 endpoint categories
- ✅ Strong typing and comprehensive tests

Advanced features like connection pooling, retry logic, and metrics will be tracked in a separate issue for future enhancement.