### PR TITLE
fix(cli): make HTTP methods case-insensitive

### DIFF
--- a/crates/redisctl/src/cli.rs
+++ b/crates/redisctl/src/cli.rs
@@ -57,7 +57,7 @@ pub enum Commands {
         deployment: DeploymentType,
 
         /// HTTP method
-        #[arg(value_enum)]
+        #[arg(value_parser = parse_http_method)]
         method: HttpMethod,
 
         /// API endpoint path (e.g., /subscriptions)
@@ -89,13 +89,28 @@ pub enum Commands {
 }
 
 /// HTTP methods for raw API access
-#[derive(Debug, Clone, clap::ValueEnum)]
+#[derive(Debug, Clone)]
 pub enum HttpMethod {
     Get,
     Post,
     Put,
     Patch,
     Delete,
+}
+
+/// Parse HTTP method case-insensitively
+fn parse_http_method(s: &str) -> Result<HttpMethod, String> {
+    match s.to_lowercase().as_str() {
+        "get" => Ok(HttpMethod::Get),
+        "post" => Ok(HttpMethod::Post),
+        "put" => Ok(HttpMethod::Put),
+        "patch" => Ok(HttpMethod::Patch),
+        "delete" => Ok(HttpMethod::Delete),
+        _ => Err(format!(
+            "invalid HTTP method: {} (valid: get, post, put, patch, delete)",
+            s
+        )),
+    }
 }
 
 /// Profile management commands


### PR DESCRIPTION
Closes #96

## Summary
Makes HTTP method arguments case-insensitive for better user experience.

## Changes
- Replace `ValueEnum` with custom parser for `HttpMethod`
- Convert input to lowercase before matching
- Now accepts any case variation: `GET`, `get`, `GeT`, `PosT`, etc.

## Testing
```bash
# All of these now work:
redisctl api cloud GET /
redisctl api cloud get /
redisctl api cloud GeT /
redisctl api cloud pOsT /test
```

## Impact
Improves user experience - no more "invalid value 'GET'" errors when typing commands naturally.