### PR TITLE
feat: add comprehensive tracing support (Phase 1)

### DIFF
--- a/crates/redisctl/src/cli.rs
+++ b/crates/redisctl/src/cli.rs
@@ -114,6 +114,18 @@ fn parse_http_method(s: &str) -> Result<HttpMethod, String> {
     }
 }
 
+impl std::fmt::Display for HttpMethod {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            HttpMethod::Get => write!(f, "GET"),
+            HttpMethod::Post => write!(f, "POST"),
+            HttpMethod::Put => write!(f, "PUT"),
+            HttpMethod::Patch => write!(f, "PATCH"),
+            HttpMethod::Delete => write!(f, "DELETE"),
+        }
+    }
+}
+
 /// Profile management commands
 #[derive(Subcommand, Debug)]
 pub enum ProfileCommands {

--- a/crates/redisctl/src/connection.rs
+++ b/crates/redisctl/src/connection.rs
@@ -3,6 +3,7 @@
 use crate::config::{Config, Profile};
 use crate::error::Result as CliResult;
 use anyhow::Context;
+use tracing::{debug, info, trace};
 
 /// Connection manager for creating authenticated clients
 #[allow(dead_code)] // Used by binary target
@@ -41,29 +42,59 @@ impl ConnectionManager {
         &self,
         profile_name: Option<&str>,
     ) -> CliResult<redis_cloud::CloudClient> {
+        debug!("Creating Redis Cloud client");
+        trace!("Profile name: {:?}", profile_name);
+
         // Check if all required environment variables are present
         let env_api_key = std::env::var("REDIS_CLOUD_API_KEY").ok();
         let env_api_secret = std::env::var("REDIS_CLOUD_SECRET_KEY").ok();
         let env_api_url = std::env::var("REDIS_CLOUD_API_URL").ok();
 
+        if env_api_key.is_some() {
+            debug!("Found REDIS_CLOUD_API_KEY environment variable");
+        }
+        if env_api_secret.is_some() {
+            debug!("Found REDIS_CLOUD_SECRET_KEY environment variable");
+        }
+        if env_api_url.is_some() {
+            debug!("Found REDIS_CLOUD_API_URL environment variable");
+        }
+
         let (final_api_key, final_api_secret, final_api_url) =
             if let (Some(key), Some(secret)) = (&env_api_key, &env_api_secret) {
                 // Environment variables provide complete credentials
+                info!("Using Redis Cloud credentials from environment variables");
                 let url = env_api_url.unwrap_or_else(|| "https://api.redislabs.com/v1".to_string());
                 (key.clone(), secret.clone(), url)
             } else {
                 // Fall back to profile credentials
+                info!("Using Redis Cloud credentials from profile");
                 let profile = self.get_profile(profile_name)?;
                 let (api_key, api_secret, api_url) = profile
                     .cloud_credentials()
                     .context("Profile is not configured for Redis Cloud")?;
 
+                // Check for partial overrides before consuming the Options
+                let has_overrides =
+                    env_api_key.is_some() || env_api_secret.is_some() || env_api_url.is_some();
+
                 // Allow partial environment variable overrides
                 let key = env_api_key.unwrap_or_else(|| api_key.to_string());
                 let secret = env_api_secret.unwrap_or_else(|| api_secret.to_string());
                 let url = env_api_url.unwrap_or_else(|| api_url.to_string());
+
+                if has_overrides {
+                    debug!("Applied partial environment variable overrides");
+                }
+
                 (key, secret, url)
             };
+
+        info!("Connecting to Redis Cloud API: {}", final_api_url);
+        trace!(
+            "API key: {}...",
+            &final_api_key[..final_api_key.len().min(8)]
+        );
 
         // Create and configure the Cloud client
         let client = redis_cloud::CloudClient::builder()
@@ -73,6 +104,7 @@ impl ConnectionManager {
             .build()
             .context("Failed to create Redis Cloud client")?;
 
+        debug!("Redis Cloud client created successfully");
         Ok(client)
     }
 
@@ -82,15 +114,32 @@ impl ConnectionManager {
         &self,
         profile_name: Option<&str>,
     ) -> CliResult<redis_enterprise::EnterpriseClient> {
+        debug!("Creating Redis Enterprise client");
+        trace!("Profile name: {:?}", profile_name);
+
         // Check if all required environment variables are present
         let env_url = std::env::var("REDIS_ENTERPRISE_URL").ok();
         let env_user = std::env::var("REDIS_ENTERPRISE_USER").ok();
         let env_password = std::env::var("REDIS_ENTERPRISE_PASSWORD").ok();
         let env_insecure = std::env::var("REDIS_ENTERPRISE_INSECURE").ok();
 
+        if env_url.is_some() {
+            debug!("Found REDIS_ENTERPRISE_URL environment variable");
+        }
+        if env_user.is_some() {
+            debug!("Found REDIS_ENTERPRISE_USER environment variable");
+        }
+        if env_password.is_some() {
+            debug!("Found REDIS_ENTERPRISE_PASSWORD environment variable");
+        }
+        if env_insecure.is_some() {
+            debug!("Found REDIS_ENTERPRISE_INSECURE environment variable");
+        }
+
         let (final_url, final_username, final_password, final_insecure) =
             if let (Some(url), Some(user)) = (&env_url, &env_user) {
                 // Environment variables provide complete credentials
+                info!("Using Redis Enterprise credentials from environment variables");
                 let password = env_password.clone(); // Password can be None for interactive prompting
                 let insecure = env_insecure
                     .as_ref()
@@ -99,10 +148,17 @@ impl ConnectionManager {
                 (url.clone(), user.clone(), password, insecure)
             } else {
                 // Fall back to profile credentials
+                info!("Using Redis Enterprise credentials from profile");
                 let profile = self.get_profile(profile_name)?;
                 let (url, username, password, insecure) = profile
                     .enterprise_credentials()
                     .context("Profile is not configured for Redis Enterprise")?;
+
+                // Check for partial overrides before consuming the Options
+                let has_overrides = env_url.is_some()
+                    || env_user.is_some()
+                    || env_password.is_some()
+                    || env_insecure.is_some();
 
                 // Allow partial environment variable overrides
                 let final_url = env_url.unwrap_or_else(|| url.to_string());
@@ -112,8 +168,25 @@ impl ConnectionManager {
                     .as_ref()
                     .map(|s| s.to_lowercase() == "true" || s == "1")
                     .unwrap_or(insecure);
+
+                if has_overrides {
+                    debug!("Applied partial environment variable overrides");
+                }
+
                 (final_url, final_user, final_password, final_insecure)
             };
+
+        info!("Connecting to Redis Enterprise: {}", final_url);
+        debug!("Username: {}", final_username);
+        debug!(
+            "Password: {}",
+            if final_password.is_some() {
+                "configured"
+            } else {
+                "not set"
+            }
+        );
+        debug!("Insecure mode: {}", final_insecure);
 
         // Build the Enterprise client
         let mut builder = redis_enterprise::EnterpriseClient::builder()
@@ -123,17 +196,20 @@ impl ConnectionManager {
         // Add password if provided
         if let Some(ref password) = final_password {
             builder = builder.password(password);
+            trace!("Password added to client builder");
         }
 
         // Set insecure flag if needed
         if final_insecure {
             builder = builder.insecure(true);
+            debug!("SSL certificate verification disabled");
         }
 
         let client = builder
             .build()
             .context("Failed to create Redis Enterprise client")?;
 
+        debug!("Redis Enterprise client created successfully");
         Ok(client)
     }
 }


### PR DESCRIPTION
## Summary
Implements Phase 1 of comprehensive tracing support (#95) for better debugging and observability of redisctl operations.

## Changes

### CLI Command Dispatch Tracing
- Log command execution with sanitized parameters (no secrets exposed)
- Track command execution time with duration reporting
- Add human-readable command formatting for logs
- Support `RUST_LOG` environment variable override

### Configuration Resolution Tracing
- Log configuration file path discovery process
- Track profile resolution hierarchy (explicit → env var → default)
- Debug environment variable expansion in config files
- Trace config file loading and TOML parsing

### Authentication Flow Tracing
- Log credential source (profile vs environment variables)
- Track partial environment variable overrides
- Debug client creation with properly redacted secrets
- Add connection details logging (URLs, usernames, no passwords)

## Tracing Levels
```
ERROR: Critical failures only
WARN: Configuration issues, unimplemented features  
INFO: High-level operations (default)
DEBUG: Detailed execution flow
TRACE: Very detailed logging including API keys (truncated)
```

## Usage Examples

```bash
# Default (info level)
redisctl profile list

# Debug mode via environment
RUST_LOG=redisctl=debug redisctl api cloud get /account

# Full trace for all components
RUST_LOG=trace redisctl enterprise cluster info

# Or use CLI verbosity flags
redisctl -v profile list     # info
redisctl -vv profile list    # debug  
redisctl -vvv profile list   # trace
```

## Testing
- ✅ All existing tests pass
- ✅ No secrets exposed in logs (passwords redacted, API keys truncated)
- ✅ Compiles without warnings
- ✅ Clippy passes

## Next Steps (Future PRs)
- Phase 2: HTTP client instrumentation in libraries
- Phase 3: Request/response timing and retry logic
- Phase 4: Documentation and debugging workflows

Closes #95 (Phase 1 complete)