### PR TITLE
refactor: remove smart command placeholders

### DIFF
--- a/crates/redisctl/src/cli.rs
+++ b/crates/redisctl/src/cli.rs
@@ -80,10 +80,6 @@ pub enum Commands {
     #[command(subcommand, visible_alias = "ent", visible_alias = "en")]
     Enterprise(EnterpriseCommands),
 
-    /// Smart commands that work with both deployments
-    #[command(subcommand, visible_alias = "db", visible_alias = "dat")]
-    Database(DatabaseCommands),
-
     /// Version information
     #[command(visible_alias = "ver", visible_alias = "v")]
     Version,
@@ -228,29 +224,6 @@ pub enum EnterpriseCommands {
     /// User operations
     #[command(subcommand)]
     User(EnterpriseUserCommands),
-}
-
-/// Smart database commands that work with both deployments
-#[derive(Subcommand, Debug)]
-pub enum DatabaseCommands {
-    /// List databases
-    List,
-
-    /// Get database details
-    Get {
-        /// Database identifier
-        id: String,
-    },
-
-    /// Create a new database
-    Create {
-        /// Database name
-        name: String,
-
-        /// Additional parameters as JSON
-        #[arg(long)]
-        params: Option<String>,
-    },
 }
 
 // Placeholder command structures - will be expanded in later PRs

--- a/crates/redisctl/src/main.rs
+++ b/crates/redisctl/src/main.rs
@@ -108,12 +108,6 @@ async fn execute_command(cli: &Cli, conn_mgr: &ConnectionManager) -> Result<(), 
             println!("Enterprise commands are not yet implemented in this version");
             Ok(())
         }
-
-        Commands::Database(_) => {
-            warn!("Smart database commands not yet implemented");
-            println!("Smart database commands are not yet implemented in this version");
-            Ok(())
-        }
     };
 
     let duration = start.elapsed();
@@ -149,7 +143,6 @@ fn format_command(command: &Commands) -> String {
         }
         Commands::Cloud(cmd) => format!("cloud {:?}", cmd),
         Commands::Enterprise(cmd) => format!("enterprise {:?}", cmd),
-        Commands::Database(cmd) => format!("database {:?}", cmd),
     }
 }
 


### PR DESCRIPTION
## Description

Removes the non-functional "smart command" placeholders that were just printing "not yet implemented". This simplifies the CLI and removes confusion.

## Changes

- ❌ Remove  enum 
- ❌ Remove  variant from main  enum
- ❌ Remove placeholder handler code in main.rs
- ❌ Remove associated comments

## Rationale

The smart commands that would auto-detect deployment type (Cloud vs Enterprise) based on profile:
- Added no current value (just printed "not implemented")
- Would add complexity and potential confusion 
- Explicit `cloud database` and `enterprise database` commands are clearer
- Profile system already provides deployment context

## Related

- See #139 for discussion on potentially adding smart commands as a future feature if there's user demand
- The explicit approach keeps the CLI simpler and more predictable

## Testing

Confirmed that:
- Build succeeds without warnings
- `redisctl database` command no longer appears in help
- `redisctl cloud database` commands still work as expected