### PR TITLE
feat(cloud): add missing user commands (update and delete)

### DIFF
--- a/crates/redisctl/src/cli.rs
+++ b/crates/redisctl/src/cli.rs
@@ -607,6 +607,33 @@ pub enum CloudUserCommands {
         /// User ID
         id: u32,
     },
+
+    /// Update user information
+    Update {
+        /// User ID
+        id: u32,
+        /// New name for the user
+        #[arg(long)]
+        name: Option<String>,
+        /// New role for the user (owner, manager, viewer, billing_admin)
+        #[arg(long)]
+        role: Option<String>,
+        /// Enable/disable email alerts
+        #[arg(long)]
+        alerts_email: Option<bool>,
+        /// Enable/disable SMS alerts
+        #[arg(long)]
+        alerts_sms: Option<bool>,
+    },
+
+    /// Delete a user
+    Delete {
+        /// User ID
+        id: u32,
+        /// Skip confirmation prompt
+        #[arg(long)]
+        force: bool,
+    },
 }
 
 #[derive(Subcommand, Debug)]


### PR DESCRIPTION
## Summary
Implements the remaining user management operations, closing #117.

## Features Added
- ✅ **Update user** - Modify user information with partial updates
- ✅ **Delete user** - Remove users with safety confirmation

## Implementation Details

### Update Command
- Supports partial updates (only specified fields are modified)
- Role validation with allowed values: owner, manager, viewer, billing_admin
- Smart name parsing (automatically splits into firstName/lastName)
- Alert settings management for email and SMS notifications
- Clear error messages for invalid roles

### Delete Command  
- Confirmation prompt by default for safety
- `--force` flag to skip confirmation in scripts
- Clear success/cancellation messages

## Testing
- ✅ cargo build (no errors)
- ✅ cargo clippy (no warnings)
- ✅ cargo test (all pass)

## Usage Examples
```bash
# Update user name
redisctl cloud user update 12345 --name "John Doe"

# Update user role
redisctl cloud user update 12345 --role manager

# Update alert settings
redisctl cloud user update 12345 --alerts-email true --alerts-sms false

# Combined update
redisctl cloud user update 12345 --name "Jane Smith" --role viewer --alerts-email true

# Delete user with confirmation
redisctl cloud user delete 12345

# Delete user without confirmation
redisctl cloud user delete 12345 --force
```

Closes #117