### PR TITLE
fix: add version specifications to internal dependencies

### DIFF
--- a/crates/redisctl/Cargo.toml
+++ b/crates/redisctl/Cargo.toml
@@ -16,8 +16,8 @@ name = "redisctl"
 path = "src/main.rs"
 
 [dependencies]
-redis-cloud = { path = "../redis-cloud" }
-redis-enterprise = { path = "../redis-enterprise" }
+redis-cloud = { version = "0.2.1", path = "../redis-cloud" }
+redis-enterprise = { version = "0.2.1", path = "../redis-enterprise" }
 
 # CLI dependencies
 clap = { workspace = true }


### PR DESCRIPTION
## Summary

Fix cargo publish for redisctl by adding version specifications to internal dependencies.

## Problem
When trying to publish redisctl to crates.io, we got this error:
```
error: all dependencies must have a version specified when publishing.
dependency `redis-cloud` does not specify a version
dependency `redis-enterprise` does not specify a version
```

## Solution
Add version specifications alongside path specifications for internal dependencies:
```toml
redis-cloud = { version = "0.2.1", path = "../redis-cloud" }
redis-enterprise = { version = "0.2.1", path = "../redis-enterprise" }
```

This fix commit will trigger release-plz to create a release PR for version 0.2.2 (patch increment).