### PR TITLE
chore: bump to v0.3.0 to fix version conflicts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.2"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.89"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]

--- a/crates/redisctl/Cargo.toml
+++ b/crates/redisctl/Cargo.toml
@@ -16,8 +16,8 @@ name = "redisctl"
 path = "src/main.rs"
 
 [dependencies]
-redis-cloud = { version = "0.2.2", path = "../redis-cloud" }
-redis-enterprise = { version = "0.2.2", path = "../redis-enterprise" }
+redis-cloud = { version = "0.3.0", path = "../redis-cloud" }
+redis-enterprise = { version = "0.3.0", path = "../redis-enterprise" }
 
 # CLI dependencies
 clap = { workspace = true }


### PR DESCRIPTION
## Summary

Bump all packages to v0.3.0 to resolve version conflicts from partial v0.2.2 release.

## Problem
- redis-cloud 0.2.2 and redis-enterprise 0.2.2 were published
- redisctl failed to publish due to tag conflict
- v0.2.2 tag exists, causing release-plz to fail

## Solution
Jump to v0.3.0 for a clean slate. This will:
- Skip over the conflicting v0.2.2 versions
- Allow release-plz to work properly going forward
- Ensure all three crates are synchronized

## After Merging
release-plz should:
1. Create a release PR for v0.3.0
2. Publish all three crates at v0.3.0
3. Create tag v0.3.0
4. Trigger cargo-dist and Docker builds