### PR TITLE
feat: implement profile management commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1966,7 +1966,7 @@ dependencies = [
 
 [[package]]
 name = "redis-cloud"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1987,7 +1987,7 @@ dependencies = [
 
 [[package]]
 name = "redis-enterprise"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2010,7 +2010,7 @@ dependencies = [
 
 [[package]]
 name = "redisctl"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "assert_cmd",


### PR DESCRIPTION
## Summary

Implements the missing profile management commands: `set`, `remove`, and `default`.

## Features

### Profile Set
- Create new profiles or update existing ones
- Overwrite protection with confirmation prompt
- Password prompting for Enterprise profiles when not provided via CLI
- Automatic suggestion to set as default for first/only profile

### Profile Remove  
- Delete profiles with confirmation prompt
- Warning when removing the default profile
- Clears default profile if the removed profile was default

### Profile Default
- Set the default profile
- Validates that the profile exists

## Safety Features
- ✅ Confirmation prompts before overwriting existing profiles
- ✅ Confirmation prompts before removing profiles  
- ✅ Warning when removing the default profile
- ✅ Secure password entry for Enterprise profiles
- ✅ Profile existence validation

## Testing
```bash
# List profiles
redisctl profile list

# Set default profile
redisctl profile default cloud

# Create new profile (with overwrite protection)
redisctl profile set test-cloud --deployment cloud --api-key KEY --api-secret SECRET

# Remove profile (with confirmation)
redisctl profile remove test-cloud
```

Fixes #181

## Release Note
This is a feature addition that will trigger a minor version bump (v0.3.0 → v0.4.0) when merged.