### PR TITLE
feat: add caching for cargo-release installation

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -42,8 +42,26 @@ jobs:
           git config --global init.defaultBranch main
           git config --global push.autoSetupRemote true
 
+      - name: Cache cargo registry and tools
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-tools-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-tools-
+
       - name: Install cargo-release
-        run: cargo install cargo-release
+        run: |
+          if ! command -v cargo-release &> /dev/null; then
+            echo "Installing cargo-release..."
+            cargo install cargo-release
+          else
+            echo "cargo-release already installed"
+          fi
 
       - name: Dry Run Release
         if: inputs.dry_run


### PR DESCRIPTION
## Summary

Adds caching for cargo-release to speed up the release workflow significantly.

## Problem

Every release workflow run takes 3+ minutes just to install cargo-release from source.

## Solution

- Cache the cargo registry and tools directory
- Check if cargo-release is already installed before attempting installation
- Use cache key based on Cargo.lock hash for proper invalidation

## Benefits

- ⚡ Release workflow starts ~3 minutes faster
- 💾 Saves bandwidth and CPU cycles
- 🚀 Faster iteration when troubleshooting releases

## Cache Details

Caches:
- `~/.cargo/bin/` - Installed tools including cargo-release
- `~/.cargo/registry/` - Downloaded crates
- `~/.cargo/git/db/` - Git dependencies

Cache key: `${{ runner.os }}-cargo-tools-${{ hashFiles('**/Cargo.lock') }}`

This will make the release workflow much faster!