### PR TITLE
fix: add default-members to workspace configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,11 @@ members = [
     "crates/redis-enterprise",
     "crates/redisctl",
 ]
+default-members = [
+    "crates/redis-cloud",
+    "crates/redis-enterprise",
+    "crates/redisctl",
+]
 
 [workspace.package]
 version = "0.3.1"


### PR DESCRIPTION
## Summary

Final fix for the 'no packages selected' error - adding `default-members` to workspace configuration.

## Problem

cargo-release reports 'no packages selected' even with `--workspace` flag.

## Root Cause

In a Cargo workspace without `default-members`, cargo-release doesn't know which packages to operate on when running from the workspace root. The `--workspace` flag alone isn't enough in some configurations.

## Solution

Add `default-members` to the workspace configuration:
```toml
[workspace]
members = [
    "crates/redis-cloud",
    "crates/redis-enterprise",
    "crates/redisctl",
]
default-members = [
    "crates/redis-cloud",
    "crates/redis-enterprise",
    "crates/redisctl",
]
```

This explicitly tells cargo-release which packages to operate on.

## Why This Works

- `members` defines what's in the workspace
- `default-members` defines what to operate on by default
- With this configuration, cargo-release knows to release all three packages
- This works with or without the `--workspace` flag

This is the final piece of the puzzle for getting releases working!