### PR TITLE
docs: add profile storage location to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ redisctl profile set cloud-prod \
 redisctl --profile cloud-prod cloud database list
 ```
 
+Profiles are stored in:
+- **Linux/macOS**: `~/.config/redisctl/config.toml`
+- **Windows**: `%APPDATA%\redis\redisctl\config.toml`
+
 ### 2. Basic Commands
 
 ```bash


### PR DESCRIPTION
## Summary
Quick documentation improvement to make profile configuration more discoverable.

Part of #251

## Changes
- Added profile storage locations to README after the profile creation example
- Shows platform-specific paths:
  - Linux/macOS: `~/.config/redisctl/config.toml`
  - Windows: `%APPDATA%\redis\redisctl\config.toml`

## Impact
- Users can now easily find where their profiles are stored
- Helpful for manual editing or troubleshooting
- Makes configuration more transparent

## Next Steps
As noted in #251, we should also:
- Add `profile path` command to show config location
- Show path in `profile list` output
- Add path info to `profile set` success message