### PR TITLE
chore: release v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2012,7 +2012,7 @@ dependencies = [
 
 [[package]]
 name = "redis-enterprise"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2035,7 +2035,7 @@ dependencies = [
 
 [[package]]
 name = "redisctl"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.3.3"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.89"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]

--- a/crates/redis-enterprise/Cargo.toml
+++ b/crates/redis-enterprise/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-enterprise"
-version = "0.3.3"
+version = "0.4.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/redisctl/Cargo.toml
+++ b/crates/redisctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redisctl"
-version = "0.3.3"
+version = "0.4.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
@@ -19,7 +19,7 @@ path = "src/main.rs"
 
 [dependencies]
 redis-cloud = { version = "0.3.3", path = "../redis-cloud" }
-redis-enterprise = { version = "0.3.3", path = "../redis-enterprise" }
+redis-enterprise = { version = "0.4.0", path = "../redis-enterprise" }
 
 # CLI dependencies
 clap = { workspace = true }


### PR DESCRIPTION
## Release v0.4.0

This release brings **100% Redis Enterprise API field coverage** - a major milestone! 

### 🎯 Key Achievements

- **100% API Coverage**: Added 120 missing fields to achieve complete API coverage
- **Comprehensive Documentation**: Added field-level documentation for 350+ fields across 19 modules
- **Field Coverage Improvement**: Increased from 61% to 100% across all structs

### 📊 Coverage Improvements

| Struct | Before | After |
|--------|--------|-------|
| ClusterInfo | 8% | 100% ✅ |
| Proxy | 8% | 100% ✅ |
| Node | 96% | 100% ✅ |
| Module | 59% | 100% ✅ |
| Alert | 83% | 100% ✅ |
| BdbGroup | 90% | 100% ✅ |
| Bootstrap | 67% | 100% ✅ |
| License | 73% | 100% ✅ |
| CRDB Instances | - | 100% ✅ |

### ✨ Notable Features

#### Complete Redis Enterprise API Support (#270, #272)
- Added all missing fields from the official REST API
- Proper type annotations and serde attributes
- Full support for advanced cluster configurations

#### Comprehensive Field Documentation (#273)
- Documented 350+ fields across 19 modules
- Clear descriptions for every API response field
- Improved developer experience with inline documentation

#### New Workflow System (#261, #269)
- Enterprise cluster initialization workflow
- Redis Cloud subscription setup workflow
- Automated environment configuration

#### Enhanced Module Management (#242)
- Module listing and retrieval
- Module upload with multipart support
- Database module configuration

#### Logging and Metrics (#240, #241)
- Cluster event log retrieval
- Comprehensive stats and metrics commands
- Node, database, and shard statistics

### 📚 Documentation Improvements
- Complete command reference documentation (#250, #255)
- Real-world usage tutorials (#254)
- Simplified getting started guide (#249)
- Profile storage documentation (#252, #253)

### 🔧 Other Improvements
- Manual release script for streamlined releases (#238)
- Improved CI/CD workflows (#236, #237, #239)
- Enhanced error handling and debugging

### Breaking Changes
None - all changes are backward compatible

### Note on Version Bump
The redis-cloud crate remains at v0.3.3 as it had no changes in this release.