### PR TITLE
chore: add Swatinem/rust-cache to remaining workflows

### DIFF
--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -2,20 +2,20 @@ name: Cargo Deny
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     paths:
-      - '**/Cargo.toml'
-      - '**/Cargo.lock'
-      - 'deny.toml'
-      - '.github/workflows/cargo-deny.yml'
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - "deny.toml"
+      - ".github/workflows/cargo-deny.yml"
   pull_request:
     paths:
-      - '**/Cargo.toml'
-      - '**/Cargo.lock'
-      - 'deny.toml'
-      - '.github/workflows/cargo-deny.yml'
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - "deny.toml"
+      - ".github/workflows/cargo-deny.yml"
   schedule:
-    - cron: '0 0 * * MON'  # Weekly on Monday
+    - cron: "0 0 * * MON" # Weekly on Monday
 
 jobs:
   cargo-deny:
@@ -34,12 +34,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@7b1c307e0dcbda6122208f10795a713336a9b35a  # stable
+        uses: dtolnay/rust-toolchain@7b1c307e0dcbda6122208f10795a713336a9b35a # stable
         with:
           toolchain: stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
 
       - name: Install cargo-deny
         uses: taiki-e/install-action@v2

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       dry-run:
-        description: 'Dry run (do not actually publish)'
+        description: "Dry run (do not actually publish)"
         required: false
         default: false
         type: boolean
@@ -42,6 +42,9 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
 
       - name: Install cargo-workspaces
         run: cargo install cargo-workspaces


### PR DESCRIPTION
This PR adds the Swatinem/rust-cache action to the remaining workflows that were missing it.

## Changes

- Added caching to  workflow to speed up crate publishing
- Added caching to  workflow to speed up license/security checks

## Why Swatinem/rust-cache?

As discussed, Swatinem/rust-cache is better than manual caching because it:
- Knows exactly what Rust artifacts to cache
- Automatically excludes problematic build outputs
- Cleans up unused dependencies automatically
- Uses more intelligent cache keys (includes rustc version, target triple, etc.)
- Is workspace-aware and handles shared dependencies correctly

## Impact

This should speed up:
- Publishing crates to crates.io after releases
- License and security checks in cargo-deny workflow

The CI workflow already uses Swatinem/rust-cache, so this brings consistency across all workflows.