### PR TITLE
fix: normalize URL path concatenation to prevent double slashes

### DIFF
--- a/crates/redis-cloud/src/client.rs
+++ b/crates/redis-cloud/src/client.rs
@@ -126,9 +126,16 @@ impl CloudClient {
         CloudClientBuilder::new()
     }
 
+    /// Normalize URL path concatenation to avoid double slashes
+    fn normalize_url(&self, path: &str) -> String {
+        let base = self.base_url.trim_end_matches('/');
+        let path = path.trim_start_matches('/');
+        format!("{}/{}", base, path)
+    }
+
     /// Make a GET request with API key authentication
     pub async fn get<T: serde::de::DeserializeOwned>(&self, path: &str) -> Result<T> {
-        let url = format!("{}{}", self.base_url, path);
+        let url = self.normalize_url(path);
 
         // Redis Cloud API uses these headers for authentication
         let response = self
@@ -148,7 +155,7 @@ impl CloudClient {
         path: &str,
         body: &B,
     ) -> Result<T> {
-        let url = format!("{}{}", self.base_url, path);
+        let url = self.normalize_url(path);
 
         // Same backwards header naming as GET
         let response = self
@@ -169,7 +176,7 @@ impl CloudClient {
         path: &str,
         body: &B,
     ) -> Result<T> {
-        let url = format!("{}{}", self.base_url, path);
+        let url = self.normalize_url(path);
 
         // Same backwards header naming as GET
         let response = self
@@ -186,7 +193,7 @@ impl CloudClient {
 
     /// Make a DELETE request
     pub async fn delete(&self, path: &str) -> Result<()> {
-        let url = format!("{}{}", self.base_url, path);
+        let url = self.normalize_url(path);
 
         // Same backwards header naming as GET
         let response = self
@@ -240,7 +247,7 @@ impl CloudClient {
         path: &str,
         body: serde_json::Value,
     ) -> Result<serde_json::Value> {
-        let url = format!("{}{}", self.base_url, path);
+        let url = self.normalize_url(path);
 
         // Use backwards header names for compatibility
         let response = self
@@ -257,7 +264,7 @@ impl CloudClient {
 
     /// Execute raw DELETE request returning any response body
     pub async fn delete_raw(&self, path: &str) -> Result<serde_json::Value> {
-        let url = format!("{}{}", self.base_url, path);
+        let url = self.normalize_url(path);
 
         // Use backwards header names for compatibility
         let response = self


### PR DESCRIPTION
## Problem
When constructing URLs, the libraries were concatenating the base URL and path directly, which could result in double slashes (`//`) if the base URL ended with `/` or paths started with `/`. This was visible in requests like `https://localhost:9443//v1/cluster`.

## Solution
Added a `normalize_url()` method to both `CloudClient` and `EnterpriseClient` that:
- Trims trailing slashes from the base URL
- Trims leading slashes from the path
- Ensures exactly one slash between base URL and path

## Changes
- Added `normalize_url() private method to `redis-cloud/src/client.rs`
- Updated all URL construction in both clients to use the new method
- Added comprehensive tests for URL normalization

## Test Coverage
Added tests that verify all combinations work correctly:
- Base URL: `https://localhost:9443`, Path: `/v1/cluster` → `https://localhost:9443/v1/cluster`
- Base URL: `https://localhost:9443/`, Path: `/v1/cluster` → `https://localhost:9443/v1/cluster`
- Base URL: `https://localhost:9443`, Path: `v1/cluster` → `https://localhost:9443/v1/cluster`
- Base URL: `https://localhost:9443/`, Path: `v1/cluster` → `https://localhost:9443/v1/cluster`

All tests pass and the libraries now handle URL construction robustly.

## Impact
This fix makes both libraries more robust and user-friendly by:
- Preventing potential issues with servers/proxies that don't handle double slashes well
- Making the libraries more forgiving of different URL/path formats
- Ensuring consistent URL construction across all API calls

Reported by a user of the redis-enterprise library.