### PR TITLE
chore: release v0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1991,7 +1991,7 @@ dependencies = [
 
 [[package]]
 name = "redis-cloud"
-version = "0.3.3"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2012,7 +2012,7 @@ dependencies = [
 
 [[package]]
 name = "redis-enterprise"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2035,7 +2035,7 @@ dependencies = [
 
 [[package]]
 name = "redisctl"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/crates/redis-cloud/Cargo.toml
+++ b/crates/redis-cloud/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-cloud"
-version = "0.3.3"
+version = "0.4.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/redis-enterprise/Cargo.toml
+++ b/crates/redis-enterprise/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-enterprise"
-version = "0.4.0"
+version = "0.4.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/redisctl/Cargo.toml
+++ b/crates/redisctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redisctl"
-version = "0.4.0"
+version = "0.4.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
@@ -18,8 +18,8 @@ path = "src/main.rs"
 
 
 [dependencies]
-redis-cloud = { version = "0.3.3", path = "../redis-cloud" }
-redis-enterprise = { version = "0.4.0", path = "../redis-enterprise" }
+redis-cloud = { version = "0.4.1", path = "../redis-cloud" }
+redis-enterprise = { version = "0.4.1", path = "../redis-enterprise" }
 
 # CLI dependencies
 clap = { workspace = true }


### PR DESCRIPTION
## Release v0.4.1

This release includes important bug fixes and improvements.

### 🐛 Bug Fixes
- **URL Path Concatenation**: Fixed an issue where URLs could have double slashes (e.g., `https://localhost:9443//v1/cluster`) when the base URL ended with `/` or paths started with `/`. Both `redis-cloud` and `redis-enterprise` libraries now properly normalize URLs.

### 📚 Documentation
- Fixed all JMESPath examples to use correct Cloud API field names (`planMemoryLimit` instead of `memoryLimitInGb`, `databaseId` instead of `id`)
- Removed remaining references to deprecated smart routing feature
- Updated all command examples to use explicit `cloud` or `enterprise` prefixes

### 🔧 CI/CD Improvements
- Added Swatinem/rust-cache to `publish-crates.yml` and `cargo-deny.yml` workflows for better performance
- Fixed npm cache configuration error in documentation workflow

### Version Bumps
- `redis-cloud`: 0.3.3 → 0.4.1
- `redis-enterprise`: 0.4.0 → 0.4.1
- `redisctl`: 0.4.0 → 0.4.1

All tests pass ✅