### PR TITLE
fix(redis-enterprise): correct master_persistence type from String to bool

### DIFF
--- a/crates/redis-enterprise/src/bdb.rs
+++ b/crates/redis-enterprise/src/bdb.rs
@@ -227,7 +227,7 @@ pub struct DatabaseInfo {
     pub crdt_repl_backlog_size: Option<String>,
 
     // Replication settings
-    pub master_persistence: Option<String>,
+    pub master_persistence: Option<bool>,
     pub slave_ha: Option<bool>,
     pub slave_ha_priority: Option<u32>,
     pub replica_read_only: Option<bool>,

--- a/crates/redis-enterprise/tests/database_tests.rs
+++ b/crates/redis-enterprise/tests/database_tests.rs
@@ -26,7 +26,9 @@ fn test_database() -> serde_json::Value {
         "type": "redis",
         "memory_size": 1073741824,
         "port": 12000,
-        "status": "active"
+        "status": "active",
+        "master_persistence": false,
+        "data_persistence": "disabled"
     })
 }
 


### PR DESCRIPTION
## Summary

Fixes #347 - Type mismatch in Redis Enterprise database response for `master_persistence` field.

## Problem

The `master_persistence` field in the `DatabaseInfo` struct was defined as `Option<String>`, but the Redis Enterprise API actually returns this field as a boolean value (e.g., `false`). This caused deserialization errors when fetching database information.

## Solution

Changed the type from `Option<String>` to `Option<bool>` to match the actual API response format.

## Changes

- Updated `master_persistence` field type in `crates/redis-enterprise/src/bdb.rs`
- Added test data with correct type in `crates/redis-enterprise/tests/database_tests.rs`

## Testing

- All existing tests pass
- cargo fmt and clippy checks pass
- Verified against actual API responses showing boolean values