### PR TITLE
fix: improve profile resolution for explicit cloud/enterprise commands

### DIFF
--- a/crates/redisctl/src/cli.rs
+++ b/crates/redisctl/src/cli.rs
@@ -210,10 +210,17 @@ pub enum ProfileCommands {
         name: String,
     },
 
-    /// Set the default profile
-    #[command(visible_alias = "def")]
-    Default {
-        /// Profile name to set as default
+    /// Set the default profile for enterprise commands
+    #[command(name = "default-enterprise", visible_alias = "def-ent")]
+    DefaultEnterprise {
+        /// Profile name to set as default for enterprise commands
+        name: String,
+    },
+
+    /// Set the default profile for cloud commands
+    #[command(name = "default-cloud", visible_alias = "def-cloud")]
+    DefaultCloud {
+        /// Profile name to set as default for cloud commands
         name: String,
     },
 }

--- a/crates/redisctl/src/commands/cloud/cloud_account.rs
+++ b/crates/redisctl/src/commands/cloud/cloud_account.rs
@@ -2,7 +2,6 @@
 
 use crate::cli::{CloudProviderAccountCommands, OutputFormat};
 use crate::commands::cloud::cloud_account_impl::{self, CloudAccountOperationParams};
-use crate::commands::cloud::utils::create_cloud_client_raw;
 use crate::connection::ConnectionManager;
 use crate::error::Result as CliResult;
 
@@ -13,8 +12,7 @@ pub async fn handle_cloud_account_command(
     output_format: OutputFormat,
     query: Option<&str>,
 ) -> CliResult<()> {
-    let profile = conn_mgr.get_profile(profile_name)?;
-    let client = create_cloud_client_raw(profile).await?;
+    let client = conn_mgr.create_cloud_client(profile_name).await?;
 
     match command {
         CloudProviderAccountCommands::List => {

--- a/crates/redisctl/src/commands/cloud/connectivity/vpc_peering.rs
+++ b/crates/redisctl/src/commands/cloud/connectivity/vpc_peering.rs
@@ -22,8 +22,7 @@ pub async fn handle_vpc_peering_command(
     output_format: OutputFormat,
     query: Option<&str>,
 ) -> CliResult<()> {
-    let profile = conn_mgr.get_profile(profile_name)?;
-    let client = crate::commands::cloud::utils::create_cloud_client_raw(profile).await?;
+    let client = conn_mgr.create_cloud_client(profile_name).await?;
 
     match command {
         VpcPeeringCommands::Get { subscription } => {

--- a/crates/redisctl/src/commands/cloud/utils.rs
+++ b/crates/redisctl/src/commands/cloud/utils.rs
@@ -3,7 +3,6 @@
 use anyhow::Context;
 use chrono::{DateTime, Utc};
 use colored::Colorize;
-use redis_cloud::CloudClient;
 use serde_json::Value;
 use std::fs;
 use std::io::{self, Write};
@@ -13,7 +12,7 @@ use tabled::Tabled;
 use std::io::IsTerminal;
 
 use crate::cli::OutputFormat;
-use crate::config::Profile;
+
 use crate::error::{RedisCtlError, Result as CliResult};
 use crate::output::print_output;
 
@@ -251,30 +250,6 @@ pub fn confirm_action(message: &str) -> CliResult<bool> {
     io::stdin().read_line(&mut input)?;
 
     Ok(input.trim().eq_ignore_ascii_case("y") || input.trim().eq_ignore_ascii_case("yes"))
-}
-
-/// Create a raw cloud client from profile
-pub async fn create_cloud_client_raw(profile: &Profile) -> CliResult<CloudClient> {
-    match &profile.credentials {
-        crate::config::ProfileCredentials::Cloud {
-            api_key,
-            api_secret,
-            api_url,
-        } => {
-            let client = redis_cloud::client::CloudClientBuilder::new()
-                .api_key(api_key.clone())
-                .api_secret(api_secret.clone())
-                .base_url(api_url.clone())
-                .build()
-                .map_err(|e| {
-                    RedisCtlError::Configuration(format!("Failed to create cloud client: {}", e))
-                })?;
-            Ok(client)
-        }
-        _ => Err(RedisCtlError::Configuration(
-            "Profile is not configured for Cloud deployment".to_string(),
-        )),
-    }
 }
 
 /// Read file input, supporting @filename notation


### PR DESCRIPTION
## Description
This PR fixes issue #350 by improving how profiles are resolved for explicit cloud and enterprise commands. Previously, if the default profile was incompatible with the command type, it would fail with an unhelpful error.

## Changes
- Replace generic `default_profile` with type-specific defaults (`default_enterprise`, `default_cloud`)
- Add `resolve_enterprise_profile()` and `resolve_cloud_profile()` helper methods in Config
- Update ConnectionManager to use type-specific resolution
- Replace single `Default` profile command with `DefaultEnterprise` and `DefaultCloud` commands
- Remove obsolete `get_profile()` and `get_active_profile()` methods

## Resolution Priority
1. Explicitly specified profile with `--profile` flag
2. Type-specific default (if configured)
3. First profile of matching type
4. Helpful error message listing available profiles of the other type

## Testing
- Added comprehensive unit tests for all profile resolution scenarios
- Tests cover explicit profiles, defaults, mixed deployments, and error cases
- All existing tests pass

Fixes #350