### PR TITLE
fix: correct Redis Cloud API endpoint documentation

### DIFF
--- a/docs/src/common-features/raw-api.md
+++ b/docs/src/common-features/raw-api.md
@@ -117,7 +117,7 @@ redisctl api cloud get /subscriptions | jq '.' > subscriptions.json
 ## Common Endpoints
 
 ### Account & Billing
-- `/account` - Account information
+- `/` - Account information (root endpoint)
 - `/payment-methods` - Payment methods
 - `/cloud-accounts` - Cloud provider accounts
 

--- a/docs/src/developer/libraries.md
+++ b/docs/src/developer/libraries.md
@@ -24,8 +24,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "your-api-secret",
     )?;
 
-    // Get account info
-    let account = client.get_raw("/account").await?;
+    // Get account info (root endpoint)
+    let account = client.get_raw("/").await?;
     println!("{}", account);
 
     Ok(())


### PR DESCRIPTION
## Description

Fixes incorrect Redis Cloud API endpoint references in documentation.

## Changes

- Fixed `/account` references to use `/` (root endpoint) in:
  - `docs/src/common-features/raw-api.md` 
  - `docs/src/developer/libraries.md`
- Added clarifying comments that account info is at root endpoint
- No code changes needed - no incorrect references found in source code

## Background

During testing of the Cloud API, we discovered:
1. The account endpoint is actually `/` not `/account` 
2. Database stats/metrics endpoints (`/stats`, `/stats/last`, `/metrics`) don't exist - metrics are included in database details response

## Testing

- Verified `/` returns account information correctly
- Confirmed `/account` doesn't exist 
- Checked that no code references these incorrect endpoints
- All tests pass

Fixes #367