### PR TITLE
fix: update cargo-dist tag pattern to match redisctl-v* format

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ on:
   pull_request:
   push:
     tags:
-      - "**[0-9]+.[0-9]+.[0-9]+*"
+      - "redisctl-v[0-9]+.[0-9]+.[0-9]+*"
 
 jobs:
   # Run 'dist plan' (or host) to determine what tasks we need to do


### PR DESCRIPTION
## Issue

The v0.6.3 release was published to crates.io successfully by release-plz, but cargo-dist did not trigger to build binaries.

## Root Cause

- release-plz creates tags: `redisctl-v0.6.3`
- cargo-dist expects: `**[0-9]+.[0-9]+.[0-9]+*` (doesn't match `redisctl-v` prefix)

## Fix

Update cargo-dist workflow tag pattern to: `redisctl-v[0-9]+.[0-9]+.[0-9]+*`

## Verification

After merge, we can manually trigger the release workflow or re-tag `redisctl-v0.6.3` to test.

## Related

- Part of release automation consolidation (#381, #332)