### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2219,7 +2219,7 @@ dependencies = [
 
 [[package]]
 name = "redis-cloud"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2241,7 +2241,7 @@ dependencies = [
 
 [[package]]
 name = "redis-enterprise"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2268,7 +2268,7 @@ dependencies = [
 
 [[package]]
 name = "redisctl"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2311,7 +2311,7 @@ dependencies = [
 
 [[package]]
 name = "redisctl-config"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "directories",

--- a/crates/redis-cloud/CHANGELOG.md
+++ b/crates/redis-cloud/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1](https://github.com/joshrotenberg/redisctl/compare/redis-cloud-v0.7.0...redis-cloud-v0.7.1) - 2025-10-29
+
+### Added
+
+- *(redis-cloud)* add AWS PrivateLink connectivity support ([#406](https://github.com/joshrotenberg/redisctl/pull/406))
+
+### Other
+
+- rewrite README for presentation readiness ([#408](https://github.com/joshrotenberg/redisctl/pull/408))
+- implement fixture-based validation for Enterprise API ([#352](https://github.com/joshrotenberg/redisctl/pull/352)) ([#398](https://github.com/joshrotenberg/redisctl/pull/398))
+
 ## [0.7.0](https://github.com/joshrotenberg/redisctl/compare/redis-cloud-v0.6.2...redis-cloud-v0.7.0) - 2025-10-07
 
 ### Added

--- a/crates/redis-cloud/Cargo.toml
+++ b/crates/redis-cloud/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-cloud"
-version = "0.7.0"
+version = "0.7.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/redis-enterprise/CHANGELOG.md
+++ b/crates/redis-enterprise/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.4](https://github.com/joshrotenberg/redisctl/compare/redis-enterprise-v0.6.3...redis-enterprise-v0.6.4) - 2025-10-29
+
+### Added
+
+- Add streaming logs support with --follow flag (Issue #70) ([#404](https://github.com/joshrotenberg/redisctl/pull/404))
+
+### Other
+
+- add comprehensive presentation outline and rladmin comparison ([#415](https://github.com/joshrotenberg/redisctl/pull/415))
+- rewrite README for presentation readiness ([#408](https://github.com/joshrotenberg/redisctl/pull/408))
+- implement fixture-based validation for Enterprise API ([#352](https://github.com/joshrotenberg/redisctl/pull/352)) ([#398](https://github.com/joshrotenberg/redisctl/pull/398))
+
 ## [0.6.3](https://github.com/joshrotenberg/redisctl/compare/redis-enterprise-v0.6.2...redis-enterprise-v0.6.3) - 2025-10-07
 
 ### Other

--- a/crates/redis-enterprise/Cargo.toml
+++ b/crates/redis-enterprise/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-enterprise"
-version = "0.6.3"
+version = "0.6.4"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/redisctl-config/CHANGELOG.md
+++ b/crates/redisctl-config/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/joshrotenberg/redisctl/compare/redisctl-config-v0.1.0...redisctl-config-v0.1.1) - 2025-10-29
+
+### Added
+
+- add --config-file flag for alternate configuration file ([#430](https://github.com/joshrotenberg/redisctl/pull/430))

--- a/crates/redisctl-config/Cargo.toml
+++ b/crates/redisctl-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redisctl-config"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 authors = ["Josh Rotenberg <josh@redislabs.com>"]
 license = "MIT OR Apache-2.0"

--- a/crates/redisctl/CHANGELOG.md
+++ b/crates/redisctl/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.6](https://github.com/joshrotenberg/redisctl/compare/redisctl-v0.6.5...redisctl-v0.6.6) - 2025-10-29
+
+### Added
+
+- add --config-file flag for alternate configuration file ([#430](https://github.com/joshrotenberg/redisctl/pull/430))
+- *(cli)* add AWS PrivateLink human-friendly commands ([#407](https://github.com/joshrotenberg/redisctl/pull/407))
+- Add streaming logs support with --follow flag (Issue #70) ([#404](https://github.com/joshrotenberg/redisctl/pull/404))
+- Add improved error messages with actionable suggestions (Issue #259) ([#401](https://github.com/joshrotenberg/redisctl/pull/401))
+
+### Fixed
+
+- handle processing-error state in async operations ([#431](https://github.com/joshrotenberg/redisctl/pull/431))
+
+### Other
+
+- add comprehensive presentation outline and rladmin comparison ([#415](https://github.com/joshrotenberg/redisctl/pull/415))
+- Extract config/profile management to library crate ([#410](https://github.com/joshrotenberg/redisctl/pull/410))
+- rewrite README for presentation readiness ([#408](https://github.com/joshrotenberg/redisctl/pull/408))
+- extract profile commands from main.rs to dedicated module ([#403](https://github.com/joshrotenberg/redisctl/pull/403))
+
 ## [0.6.5](https://github.com/joshrotenberg/redisctl/compare/redisctl-v0.6.4...redisctl-v0.6.5) - 2025-10-07
 
 ### Added

--- a/crates/redisctl/Cargo.toml
+++ b/crates/redisctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redisctl"
-version = "0.6.5"
+version = "0.6.6"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
@@ -18,9 +18,9 @@ path = "src/main.rs"
 
 
 [dependencies]
-redisctl-config = { version = "0.1.0", path = "../redisctl-config" }
-redis-cloud = { version = "0.7.0", path = "../redis-cloud" }
-redis-enterprise = { version = "0.6.3", path = "../redis-enterprise" }
+redisctl-config = { version = "0.1.1", path = "../redisctl-config" }
+redis-cloud = { version = "0.7.1", path = "../redis-cloud" }
+redis-enterprise = { version = "0.6.4", path = "../redis-enterprise" }
 files-sdk = { workspace = true, optional = true }
 
 # CLI dependencies


### PR DESCRIPTION



## 🤖 New release

* `redisctl-config`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `redis-cloud`: 0.7.0 -> 0.7.1 (✓ API compatible changes)
* `redis-enterprise`: 0.6.3 -> 0.6.4 (✓ API compatible changes)
* `redisctl`: 0.6.5 -> 0.6.6 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `redisctl-config`

<blockquote>

## [0.1.1](https://github.com/joshrotenberg/redisctl/compare/redisctl-config-v0.1.0...redisctl-config-v0.1.1) - 2025-10-29

### Added

- add --config-file flag for alternate configuration file ([#430](https://github.com/joshrotenberg/redisctl/pull/430))
</blockquote>

## `redis-cloud`

<blockquote>

## [0.7.1](https://github.com/joshrotenberg/redisctl/compare/redis-cloud-v0.7.0...redis-cloud-v0.7.1) - 2025-10-29

### Added

- *(redis-cloud)* add AWS PrivateLink connectivity support ([#406](https://github.com/joshrotenberg/redisctl/pull/406))

### Other

- rewrite README for presentation readiness ([#408](https://github.com/joshrotenberg/redisctl/pull/408))
- implement fixture-based validation for Enterprise API ([#352](https://github.com/joshrotenberg/redisctl/pull/352)) ([#398](https://github.com/joshrotenberg/redisctl/pull/398))
</blockquote>

## `redis-enterprise`

<blockquote>

## [0.6.4](https://github.com/joshrotenberg/redisctl/compare/redis-enterprise-v0.6.3...redis-enterprise-v0.6.4) - 2025-10-29

### Added

- Add streaming logs support with --follow flag (Issue #70) ([#404](https://github.com/joshrotenberg/redisctl/pull/404))

### Other

- add comprehensive presentation outline and rladmin comparison ([#415](https://github.com/joshrotenberg/redisctl/pull/415))
- rewrite README for presentation readiness ([#408](https://github.com/joshrotenberg/redisctl/pull/408))
- implement fixture-based validation for Enterprise API ([#352](https://github.com/joshrotenberg/redisctl/pull/352)) ([#398](https://github.com/joshrotenberg/redisctl/pull/398))
</blockquote>

## `redisctl`

<blockquote>

## [0.6.6](https://github.com/joshrotenberg/redisctl/compare/redisctl-v0.6.5...redisctl-v0.6.6) - 2025-10-29

### Added

- add --config-file flag for alternate configuration file ([#430](https://github.com/joshrotenberg/redisctl/pull/430))
- *(cli)* add AWS PrivateLink human-friendly commands ([#407](https://github.com/joshrotenberg/redisctl/pull/407))
- Add streaming logs support with --follow flag (Issue #70) ([#404](https://github.com/joshrotenberg/redisctl/pull/404))
- Add improved error messages with actionable suggestions (Issue #259) ([#401](https://github.com/joshrotenberg/redisctl/pull/401))

### Fixed

- handle processing-error state in async operations ([#431](https://github.com/joshrotenberg/redisctl/pull/431))

### Other

- add comprehensive presentation outline and rladmin comparison ([#415](https://github.com/joshrotenberg/redisctl/pull/415))
- Extract config/profile management to library crate ([#410](https://github.com/joshrotenberg/redisctl/pull/410))
- rewrite README for presentation readiness ([#408](https://github.com/joshrotenberg/redisctl/pull/408))
- extract profile commands from main.rs to dedicated module ([#403](https://github.com/joshrotenberg/redisctl/pull/403))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).