### PR TITLE
feat(redis-cloud): add AWS PrivateLink connectivity support

### DIFF
--- a/crates/redis-cloud/src/client.rs
+++ b/crates/redis-cloud/src/client.rs
@@ -301,6 +301,26 @@ impl CloudClient {
         }
     }
 
+    /// Execute DELETE request with JSON body (used by some endpoints like PrivateLink principals)
+    pub async fn delete_with_body<T: serde::de::DeserializeOwned>(
+        &self,
+        path: &str,
+        body: serde_json::Value,
+    ) -> Result<T> {
+        let url = self.normalize_url(path);
+
+        let response = self
+            .client
+            .delete(&url)
+            .header("x-api-key", &self.api_key)
+            .header("x-api-secret-key", &self.api_secret)
+            .json(&body)
+            .send()
+            .await?;
+
+        self.handle_response(response).await
+    }
+
     /// Handle HTTP response
     async fn handle_response<T: serde::de::DeserializeOwned>(
         &self,

--- a/crates/redis-cloud/src/connectivity/mod.rs
+++ b/crates/redis-cloud/src/connectivity/mod.rs
@@ -2,26 +2,30 @@
 //!
 //! This module manages advanced networking features for Redis Cloud Pro subscriptions,
 //! including VPC peering, AWS Transit Gateway attachments, GCP Private Service Connect,
-//! and other cloud-native networking integrations.
+//! AWS PrivateLink, and other cloud-native networking integrations.
 //!
 //! # Supported Connectivity Types
 //!
 //! - **VPC Peering**: Direct peering between Redis Cloud VPC and your VPC
 //! - **Transit Gateway**: AWS Transit Gateway attachments for hub-and-spoke topologies
 //! - **Private Service Connect**: GCP Private Service Connect for private endpoints
+//! - **PrivateLink**: AWS PrivateLink for secure private connectivity
 //!
 //! # Module Organization
 //!
-//! The connectivity features are split into three specialized modules:
+//! The connectivity features are split into four specialized modules:
 //! - `vpc_peering` - VPC peering operations for AWS, GCP, and Azure
 //! - `psc` - Google Cloud Private Service Connect endpoints
 //! - `transit_gateway` - AWS Transit Gateway attachments
+//! - `private_link` - AWS PrivateLink connectivity
 
+pub mod private_link;
 pub mod psc;
 pub mod transit_gateway;
 pub mod vpc_peering;
 
 // Re-export handlers for convenience
+pub use private_link::PrivateLinkHandler;
 pub use psc::PscHandler;
 pub use transit_gateway::TransitGatewayHandler;
 pub use vpc_peering::VpcPeeringHandler;

--- a/crates/redis-cloud/src/connectivity/private_link.rs
+++ b/crates/redis-cloud/src/connectivity/private_link.rs
@@ -1,0 +1,319 @@
+//! AWS PrivateLink connectivity operations
+//!
+//! This module provides AWS PrivateLink connectivity functionality for Redis Cloud,
+//! enabling secure, private connections from AWS VPCs to Redis Cloud databases.
+//!
+//! # Overview
+//!
+//! AWS PrivateLink allows you to connect to Redis Cloud from your AWS VPC without
+//! traversing the public internet. This provides enhanced security and potentially
+//! lower latency.
+//!
+//! # Features
+//!
+//! - **PrivateLink Management**: Create and retrieve PrivateLink configurations
+//! - **Principal Management**: Control which AWS principals can access the service
+//! - **Endpoint Scripts**: Get scripts to create endpoints in your AWS account
+//! - **Active-Active Support**: PrivateLink for CRDB (Active-Active) databases
+//!
+//! # Example Usage
+//!
+//! ```no_run
+//! use redis_cloud::{CloudClient, PrivateLinkHandler};
+//! use serde_json::json;
+//!
+//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! let client = CloudClient::builder()
+//!     .api_key("your-api-key")
+//!     .api_secret("your-api-secret")
+//!     .build()?;
+//!
+//! let handler = PrivateLinkHandler::new(client);
+//!
+//! // Create a PrivateLink
+//! let request = json!({
+//!     "shareName": "my-redis-share",
+//!     "principal": "123456789012",
+//!     "type": "aws_account",
+//!     "alias": "Production Account"
+//! });
+//! let result = handler.create(123, request).await?;
+//!
+//! // Get PrivateLink configuration
+//! let config = handler.get(123).await?;
+//! # Ok(())
+//! # }
+//! ```
+
+use crate::{CloudClient, Result};
+use serde_json::Value;
+
+/// AWS PrivateLink handler
+///
+/// Manages AWS PrivateLink connectivity for Redis Cloud subscriptions.
+pub struct PrivateLinkHandler {
+    client: CloudClient,
+}
+
+impl PrivateLinkHandler {
+    /// Create a new PrivateLink handler
+    pub fn new(client: CloudClient) -> Self {
+        Self { client }
+    }
+
+    /// Get PrivateLink configuration
+    ///
+    /// Gets the AWS PrivateLink configuration for a subscription.
+    ///
+    /// GET /subscriptions/{subscriptionId}/private-link
+    ///
+    /// # Arguments
+    ///
+    /// * `subscription_id` - The subscription ID
+    ///
+    /// # Returns
+    ///
+    /// Returns the PrivateLink configuration as JSON
+    pub async fn get(&self, subscription_id: i32) -> Result<Value> {
+        self.client
+            .get(&format!("/subscriptions/{}/private-link", subscription_id))
+            .await
+    }
+
+    /// Create a PrivateLink
+    ///
+    /// Creates a new AWS PrivateLink configuration for a subscription.
+    ///
+    /// POST /subscriptions/{subscriptionId}/private-link
+    ///
+    /// # Arguments
+    ///
+    /// * `subscription_id` - The subscription ID
+    /// * `request` - PrivateLink creation request (shareName, principal, type required)
+    ///
+    /// # Returns
+    ///
+    /// Returns a task response that can be tracked for completion
+    pub async fn create(&self, subscription_id: i32, request: Value) -> Result<Value> {
+        self.client
+            .post(
+                &format!("/subscriptions/{}/private-link", subscription_id),
+                &request,
+            )
+            .await
+    }
+
+    /// Add principals to PrivateLink
+    ///
+    /// Adds AWS principals (accounts, IAM roles, etc.) that can access the PrivateLink.
+    ///
+    /// POST /subscriptions/{subscriptionId}/private-link/principals
+    ///
+    /// # Arguments
+    ///
+    /// * `subscription_id` - The subscription ID
+    /// * `request` - Principal to add (principal required, type/alias optional)
+    ///
+    /// # Returns
+    ///
+    /// Returns the updated principal configuration
+    pub async fn add_principals(&self, subscription_id: i32, request: Value) -> Result<Value> {
+        self.client
+            .post(
+                &format!("/subscriptions/{}/private-link/principals", subscription_id),
+                &request,
+            )
+            .await
+    }
+
+    /// Remove principals from PrivateLink
+    ///
+    /// Removes AWS principals from the PrivateLink access list.
+    ///
+    /// DELETE /subscriptions/{subscriptionId}/private-link/principals
+    ///
+    /// # Arguments
+    ///
+    /// * `subscription_id` - The subscription ID
+    /// * `request` - Principal to remove (principal, type, alias)
+    ///
+    /// # Returns
+    ///
+    /// Returns confirmation of deletion
+    pub async fn remove_principals(&self, subscription_id: i32, request: Value) -> Result<Value> {
+        self.client
+            .delete_with_body(
+                &format!("/subscriptions/{}/private-link/principals", subscription_id),
+                request,
+            )
+            .await
+    }
+
+    /// Get endpoint creation script
+    ///
+    /// Gets a script to create the VPC endpoint in your AWS account.
+    ///
+    /// GET /subscriptions/{subscriptionId}/private-link/endpoint-script
+    ///
+    /// # Arguments
+    ///
+    /// * `subscription_id` - The subscription ID
+    ///
+    /// # Returns
+    ///
+    /// Returns the endpoint creation script
+    pub async fn get_endpoint_script(&self, subscription_id: i32) -> Result<Value> {
+        self.client
+            .get(&format!(
+                "/subscriptions/{}/private-link/endpoint-script",
+                subscription_id
+            ))
+            .await
+    }
+
+    /// Get Active-Active PrivateLink configuration
+    ///
+    /// Gets the AWS PrivateLink configuration for an Active-Active (CRDB) subscription region.
+    ///
+    /// GET /subscriptions/{subscriptionId}/regions/{regionId}/private-link
+    ///
+    /// # Arguments
+    ///
+    /// * `subscription_id` - The subscription ID
+    /// * `region_id` - The region ID
+    ///
+    /// # Returns
+    ///
+    /// Returns the PrivateLink configuration for the region
+    pub async fn get_active_active(&self, subscription_id: i32, region_id: i32) -> Result<Value> {
+        self.client
+            .get(&format!(
+                "/subscriptions/{}/regions/{}/private-link",
+                subscription_id, region_id
+            ))
+            .await
+    }
+
+    /// Create Active-Active PrivateLink
+    ///
+    /// Creates a new AWS PrivateLink for an Active-Active (CRDB) subscription region.
+    ///
+    /// POST /subscriptions/{subscriptionId}/regions/{regionId}/private-link
+    ///
+    /// # Arguments
+    ///
+    /// * `subscription_id` - The subscription ID
+    /// * `region_id` - The region ID
+    /// * `request` - PrivateLink creation request
+    ///
+    /// # Returns
+    ///
+    /// Returns a task response
+    pub async fn create_active_active(
+        &self,
+        subscription_id: i32,
+        region_id: i32,
+        request: Value,
+    ) -> Result<Value> {
+        self.client
+            .post(
+                &format!(
+                    "/subscriptions/{}/regions/{}/private-link",
+                    subscription_id, region_id
+                ),
+                &request,
+            )
+            .await
+    }
+
+    /// Add principals to Active-Active PrivateLink
+    ///
+    /// Adds AWS principals to an Active-Active PrivateLink.
+    ///
+    /// POST /subscriptions/{subscriptionId}/regions/{regionId}/private-link/principals
+    ///
+    /// # Arguments
+    ///
+    /// * `subscription_id` - The subscription ID
+    /// * `region_id` - The region ID
+    /// * `request` - Principal to add
+    ///
+    /// # Returns
+    ///
+    /// Returns the updated configuration
+    pub async fn add_principals_active_active(
+        &self,
+        subscription_id: i32,
+        region_id: i32,
+        request: Value,
+    ) -> Result<Value> {
+        self.client
+            .post(
+                &format!(
+                    "/subscriptions/{}/regions/{}/private-link/principals",
+                    subscription_id, region_id
+                ),
+                &request,
+            )
+            .await
+    }
+
+    /// Remove principals from Active-Active PrivateLink
+    ///
+    /// Removes AWS principals from an Active-Active PrivateLink.
+    ///
+    /// DELETE /subscriptions/{subscriptionId}/regions/{regionId}/private-link/principals
+    ///
+    /// # Arguments
+    ///
+    /// * `subscription_id` - The subscription ID
+    /// * `region_id` - The region ID
+    /// * `request` - Principal to remove
+    ///
+    /// # Returns
+    ///
+    /// Returns confirmation of deletion
+    pub async fn remove_principals_active_active(
+        &self,
+        subscription_id: i32,
+        region_id: i32,
+        request: Value,
+    ) -> Result<Value> {
+        self.client
+            .delete_with_body(
+                &format!(
+                    "/subscriptions/{}/regions/{}/private-link/principals",
+                    subscription_id, region_id
+                ),
+                request,
+            )
+            .await
+    }
+
+    /// Get Active-Active endpoint creation script
+    ///
+    /// Gets a script to create the VPC endpoint for an Active-Active region.
+    ///
+    /// GET /subscriptions/{subscriptionId}/regions/{regionId}/private-link/endpoint-script
+    ///
+    /// # Arguments
+    ///
+    /// * `subscription_id` - The subscription ID
+    /// * `region_id` - The region ID
+    ///
+    /// # Returns
+    ///
+    /// Returns the endpoint creation script
+    pub async fn get_endpoint_script_active_active(
+        &self,
+        subscription_id: i32,
+        region_id: i32,
+    ) -> Result<Value> {
+        self.client
+            .get(&format!(
+                "/subscriptions/{}/regions/{}/private-link/endpoint-script",
+                subscription_id, region_id
+            ))
+            .await
+    }
+}

--- a/crates/redis-cloud/src/lib.rs
+++ b/crates/redis-cloud/src/lib.rs
@@ -309,6 +309,7 @@ pub use acl::AclHandler;
 pub use cloud_accounts::CloudAccountsHandler as CloudAccountHandler;
 
 // Connectivity handlers
+pub use connectivity::private_link::PrivateLinkHandler;
 pub use connectivity::psc::PscHandler;
 pub use connectivity::transit_gateway::TransitGatewayHandler;
 pub use connectivity::vpc_peering::VpcPeeringHandler;

--- a/crates/redis-cloud/tests/private_link_tests.rs
+++ b/crates/redis-cloud/tests/private_link_tests.rs
@@ -1,0 +1,468 @@
+use redis_cloud::{CloudClient, PrivateLinkHandler};
+use serde_json::json;
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test]
+async fn test_get_private_link() {
+    let mock_server = MockServer::start().await;
+
+    let response_body = json!({
+        "resourceId": 123456,
+        "status": "active",
+        "shareName": "my-redis-share",
+        "principals": [
+            {
+                "principal": "123456789012",
+                "type": "aws_account",
+                "alias": "Production Account"
+            }
+        ]
+    });
+
+    Mock::given(method("GET"))
+        .and(path("/subscriptions/123/private-link"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&response_body))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key")
+        .api_secret("test-secret")
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = PrivateLinkHandler::new(client);
+    let result = handler.get(123).await.unwrap();
+
+    assert_eq!(result["resourceId"], 123456);
+    assert_eq!(result["status"], "active");
+    assert_eq!(result["shareName"], "my-redis-share");
+}
+
+#[tokio::test]
+async fn test_create_private_link() {
+    let mock_server = MockServer::start().await;
+
+    let response_body = json!({
+        "resourceId": 123456,
+        "status": "pending",
+        "taskId": "task-789"
+    });
+
+    Mock::given(method("POST"))
+        .and(path("/subscriptions/123/private-link"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&response_body))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key")
+        .api_secret("test-secret")
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = PrivateLinkHandler::new(client);
+
+    let request = json!({
+        "shareName": "my-redis-share",
+        "principal": "123456789012",
+        "type": "aws_account",
+        "alias": "Production Account"
+    });
+
+    let result = handler.create(123, request).await.unwrap();
+
+    assert_eq!(result["resourceId"], 123456);
+    assert_eq!(result["status"], "pending");
+    assert_eq!(result["taskId"], "task-789");
+}
+
+#[tokio::test]
+async fn test_add_principals() {
+    let mock_server = MockServer::start().await;
+
+    let response_body = json!({
+        "resourceId": 123456,
+        "principals": [
+            {
+                "principal": "987654321098",
+                "type": "iam_role",
+                "alias": "Dev Role"
+            }
+        ]
+    });
+
+    Mock::given(method("POST"))
+        .and(path("/subscriptions/123/private-link/principals"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&response_body))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key")
+        .api_secret("test-secret")
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = PrivateLinkHandler::new(client);
+
+    let request = json!({
+        "principal": "987654321098",
+        "type": "iam_role",
+        "alias": "Dev Role"
+    });
+
+    let result = handler.add_principals(123, request).await.unwrap();
+
+    assert_eq!(result["resourceId"], 123456);
+    assert!(result["principals"].is_array());
+}
+
+#[tokio::test]
+async fn test_remove_principals() {
+    let mock_server = MockServer::start().await;
+
+    let response_body = json!({
+        "status": "deleted"
+    });
+
+    Mock::given(method("DELETE"))
+        .and(path("/subscriptions/123/private-link/principals"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&response_body))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key")
+        .api_secret("test-secret")
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = PrivateLinkHandler::new(client);
+
+    let request = json!({
+        "principal": "987654321098",
+        "type": "iam_role",
+        "alias": "Dev Role"
+    });
+
+    let result = handler.remove_principals(123, request).await.unwrap();
+
+    assert_eq!(result["status"], "deleted");
+}
+
+#[tokio::test]
+async fn test_get_endpoint_script() {
+    let mock_server = MockServer::start().await;
+
+    let response_body = json!({
+        "script": "aws ec2 create-vpc-endpoint --vpc-id vpc-123 --service-name com.amazonaws.vpce.us-east-1.vpce-svc-abc123"
+    });
+
+    Mock::given(method("GET"))
+        .and(method("GET"))
+        .and(path("/subscriptions/123/private-link/endpoint-script"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&response_body))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key")
+        .api_secret("test-secret")
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = PrivateLinkHandler::new(client);
+    let result = handler.get_endpoint_script(123).await.unwrap();
+
+    assert!(result["script"].is_string());
+    assert!(result["script"].as_str().unwrap().contains("aws ec2"));
+}
+
+#[tokio::test]
+async fn test_get_active_active_private_link() {
+    let mock_server = MockServer::start().await;
+
+    let response_body = json!({
+        "resourceId": 123456,
+        "regionId": 1,
+        "status": "active",
+        "shareName": "my-crdb-share"
+    });
+
+    Mock::given(method("GET"))
+        .and(method("GET"))
+        .and(path("/subscriptions/123/regions/1/private-link"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&response_body))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key")
+        .api_secret("test-secret")
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = PrivateLinkHandler::new(client);
+    let result = handler.get_active_active(123, 1).await.unwrap();
+
+    assert_eq!(result["resourceId"], 123456);
+    assert_eq!(result["regionId"], 1);
+    assert_eq!(result["shareName"], "my-crdb-share");
+}
+
+#[tokio::test]
+async fn test_create_active_active_private_link() {
+    let mock_server = MockServer::start().await;
+
+    let response_body = json!({
+        "resourceId": 123456,
+        "regionId": 1,
+        "status": "pending",
+        "taskId": "task-999"
+    });
+
+    Mock::given(method("POST"))
+        .and(path("/subscriptions/123/regions/1/private-link"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&response_body))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key")
+        .api_secret("test-secret")
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = PrivateLinkHandler::new(client);
+
+    let request = json!({
+        "shareName": "my-crdb-share",
+        "principal": "111222333444",
+        "type": "aws_account"
+    });
+
+    let result = handler.create_active_active(123, 1, request).await.unwrap();
+
+    assert_eq!(result["resourceId"], 123456);
+    assert_eq!(result["regionId"], 1);
+    assert_eq!(result["taskId"], "task-999");
+}
+
+#[tokio::test]
+async fn test_add_principals_active_active() {
+    let mock_server = MockServer::start().await;
+
+    let response_body = json!({
+        "resourceId": 123456,
+        "regionId": 1,
+        "principals": [
+            {
+                "principal": "555666777888",
+                "type": "aws_account"
+            }
+        ]
+    });
+
+    Mock::given(method("POST"))
+        .and(path("/subscriptions/123/regions/1/private-link/principals"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&response_body))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key")
+        .api_secret("test-secret")
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = PrivateLinkHandler::new(client);
+
+    let request = json!({
+        "principal": "555666777888",
+        "type": "aws_account"
+    });
+
+    let result = handler
+        .add_principals_active_active(123, 1, request)
+        .await
+        .unwrap();
+
+    assert_eq!(result["resourceId"], 123456);
+    assert_eq!(result["regionId"], 1);
+}
+
+#[tokio::test]
+async fn test_remove_principals_active_active() {
+    let mock_server = MockServer::start().await;
+
+    let response_body = json!({
+        "status": "deleted"
+    });
+
+    Mock::given(method("DELETE"))
+        .and(path("/subscriptions/123/regions/1/private-link/principals"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&response_body))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key")
+        .api_secret("test-secret")
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = PrivateLinkHandler::new(client);
+
+    let request = json!({
+        "principal": "555666777888",
+        "type": "aws_account"
+    });
+
+    let result = handler
+        .remove_principals_active_active(123, 1, request)
+        .await
+        .unwrap();
+
+    assert_eq!(result["status"], "deleted");
+}
+
+#[tokio::test]
+async fn test_get_endpoint_script_active_active() {
+    let mock_server = MockServer::start().await;
+
+    let response_body = json!({
+        "script": "aws ec2 create-vpc-endpoint --vpc-id vpc-456 --service-name com.amazonaws.vpce.us-west-2.vpce-svc-xyz789"
+    });
+
+    Mock::given(method("GET"))
+        .and(method("GET"))
+        .and(path(
+            "/subscriptions/123/regions/1/private-link/endpoint-script",
+        ))
+        .and(header("x-api-key", "test-key"))
+        .and(header("x-api-secret-key", "test-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&response_body))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key")
+        .api_secret("test-secret")
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = PrivateLinkHandler::new(client);
+    let result = handler
+        .get_endpoint_script_active_active(123, 1)
+        .await
+        .unwrap();
+
+    assert!(result["script"].is_string());
+    assert!(result["script"].as_str().unwrap().contains("aws ec2"));
+}
+
+#[tokio::test]
+async fn test_error_handling_401() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(method("GET"))
+        .and(path("/subscriptions/123/private-link"))
+        .respond_with(ResponseTemplate::new(401).set_body_string("Unauthorized"))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("invalid-key")
+        .api_secret("invalid-secret")
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = PrivateLinkHandler::new(client);
+    let result = handler.get(123).await;
+
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_error_handling_404() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(method("GET"))
+        .and(path("/subscriptions/999/private-link"))
+        .respond_with(ResponseTemplate::new(404).set_body_string("Not Found"))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key")
+        .api_secret("test-secret")
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = PrivateLinkHandler::new(client);
+    let result = handler.get(999).await;
+
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_error_handling_500() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/subscriptions/123/private-link"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("Internal Server Error"))
+        .mount(&mock_server)
+        .await;
+
+    let client = CloudClient::builder()
+        .api_key("test-key")
+        .api_secret("test-secret")
+        .base_url(mock_server.uri())
+        .build()
+        .unwrap();
+
+    let handler = PrivateLinkHandler::new(client);
+    let request = json!({
+        "shareName": "test",
+        "principal": "123",
+        "type": "aws_account"
+    });
+    let result = handler.create(123, request).await;
+
+    assert!(result.is_err());
+}


### PR DESCRIPTION
## Summary

Adds complete AWS PrivateLink support to the Redis Cloud API client library, achieving 100% coverage of all documented Cloud API endpoints.

## Changes

### New Handler
- **PrivateLinkHandler** with 10 methods supporting both standard and Active-Active (CRDB) configurations
  - Get/create PrivateLink configurations
  - Manage AWS principals (accounts, IAM roles, etc.)
  - Get VPC endpoint creation scripts
  - Full Active-Active region support

### Client Enhancement
- Added `delete_with_body()` method to CloudClient for DELETE requests with JSON payloads

### Test Coverage
- 13 new comprehensive tests using wiremock
- Tests for all PrivateLink operations (standard and Active-Active)
- Error handling tests (401, 404, 500)
- **All 177 redis-cloud tests passing**

### Updated Spec
- Updated OpenAPI spec to latest version from redis.io
- Identified and implemented 6 new endpoints

## API Endpoints Implemented

- `GET/POST /subscriptions/{id}/private-link`
- `POST/DELETE /subscriptions/{id}/private-link/principals`
- `GET /subscriptions/{id}/private-link/endpoint-script`
- `GET/POST /subscriptions/{id}/regions/{id}/private-link`
- `POST/DELETE /subscriptions/{id}/regions/{id}/private-link/principals`
- `GET /subscriptions/{id}/regions/{id}/private-link/endpoint-script`

## CLI Access

All PrivateLink operations are immediately available via raw API access:

```bash
# Get PrivateLink configuration
redisctl api cloud get /subscriptions/123/private-link

# Create PrivateLink
redisctl api cloud post /subscriptions/123/private-link -d '{"shareName":"my-share","principal":"123456789012","type":"aws_account"}'

# Add principals
redisctl api cloud post /subscriptions/123/private-link/principals -d '{"principal":"987654321098","type":"iam_role"}'
```

## Quality Checks

- ✅ All tests passing (177 total)
- ✅ Clippy clean (no warnings)
- ✅ Formatted with cargo fmt
- ✅ 100% API coverage

## Issue Resolution

Resolves #12 - Investigation revealed that the library already had comprehensive test coverage for all existing handlers. The only missing functionality was AWS PrivateLink, which is now implemented. The endpoints mentioned in the issue (api_keys, billing, sso) don't exist in the official Redis Cloud API specification.