### PR TITLE
feat(cli): add AWS PrivateLink human-friendly commands

### DIFF
--- a/crates/redisctl/src/cli.rs
+++ b/crates/redisctl/src/cli.rs
@@ -405,6 +405,9 @@ pub enum CloudConnectivityCommands {
     /// Transit Gateway operations
     #[command(subcommand, name = "tgw")]
     Tgw(TgwCommands),
+    /// AWS PrivateLink operations
+    #[command(subcommand, name = "privatelink")]
+    PrivateLink(PrivateLinkCommands),
 }
 
 /// VPC Peering Commands
@@ -807,6 +810,67 @@ pub enum TgwCommands {
         region_id: i32,
         /// Invitation ID
         invitation_id: String,
+    },
+}
+
+/// AWS PrivateLink Commands
+#[derive(Subcommand, Debug)]
+pub enum PrivateLinkCommands {
+    /// Get PrivateLink configuration
+    Get {
+        /// Subscription ID
+        #[arg(long)]
+        subscription: i32,
+        /// Region ID (for Active-Active databases)
+        #[arg(long)]
+        region: Option<i32>,
+    },
+    /// Create PrivateLink
+    Create {
+        /// Subscription ID
+        #[arg(long)]
+        subscription: i32,
+        /// Region ID (for Active-Active databases)
+        #[arg(long)]
+        region: Option<i32>,
+        /// Configuration JSON file or string (use @filename for file)
+        data: String,
+        #[command(flatten)]
+        async_ops: crate::commands::cloud::async_utils::AsyncOperationArgs,
+    },
+    /// Add principals to PrivateLink
+    #[command(name = "add-principal")]
+    AddPrincipal {
+        /// Subscription ID
+        #[arg(long)]
+        subscription: i32,
+        /// Region ID (for Active-Active databases)
+        #[arg(long)]
+        region: Option<i32>,
+        /// Configuration JSON file or string (use @filename for file)
+        data: String,
+    },
+    /// Remove principals from PrivateLink
+    #[command(name = "remove-principal")]
+    RemovePrincipal {
+        /// Subscription ID
+        #[arg(long)]
+        subscription: i32,
+        /// Region ID (for Active-Active databases)
+        #[arg(long)]
+        region: Option<i32>,
+        /// Configuration JSON file or string (use @filename for file)
+        data: String,
+    },
+    /// Get VPC endpoint creation script
+    #[command(name = "get-script")]
+    GetScript {
+        /// Subscription ID
+        #[arg(long)]
+        subscription: i32,
+        /// Region ID (for Active-Active databases)
+        #[arg(long)]
+        region: Option<i32>,
     },
 }
 

--- a/crates/redisctl/src/commands/cloud/connectivity/mod.rs
+++ b/crates/redisctl/src/commands/cloud/connectivity/mod.rs
@@ -2,6 +2,7 @@
 
 #![allow(dead_code)]
 
+pub mod private_link;
 pub mod psc;
 pub mod tgw;
 pub mod vpc_peering;
@@ -47,6 +48,16 @@ pub async fn handle_connectivity_command(
         }
         CloudConnectivityCommands::Tgw(tgw_cmd) => {
             tgw::handle_tgw_command(conn_mgr, profile_name, tgw_cmd, output_format, query).await
+        }
+        CloudConnectivityCommands::PrivateLink(pl_cmd) => {
+            private_link::handle_private_link_command(
+                conn_mgr,
+                profile_name,
+                pl_cmd,
+                output_format,
+                query,
+            )
+            .await
         }
     }
 }

--- a/crates/redisctl/src/commands/cloud/connectivity/private_link.rs
+++ b/crates/redisctl/src/commands/cloud/connectivity/private_link.rs
@@ -1,0 +1,210 @@
+//! AWS PrivateLink command implementations
+
+#![allow(dead_code)]
+
+use super::ConnectivityOperationParams;
+use crate::cli::{OutputFormat, PrivateLinkCommands};
+use crate::commands::cloud::async_utils::handle_async_response;
+use crate::commands::cloud::utils::{handle_output, print_formatted_output, read_file_input};
+use crate::connection::ConnectionManager;
+use crate::error::Result as CliResult;
+use anyhow::Context;
+use redis_cloud::PrivateLinkHandler;
+use serde_json::Value;
+
+/// Handle PrivateLink commands
+pub async fn handle_private_link_command(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    command: &PrivateLinkCommands,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    let client = conn_mgr.create_cloud_client(profile_name).await?;
+    let handler = PrivateLinkHandler::new(client.clone());
+
+    match command {
+        PrivateLinkCommands::Get {
+            subscription,
+            region,
+        } => handle_get(&handler, *subscription, *region, output_format, query).await,
+        PrivateLinkCommands::Create {
+            subscription,
+            region,
+            data,
+            async_ops,
+        } => {
+            let params = ConnectivityOperationParams {
+                conn_mgr,
+                profile_name,
+                client: &client,
+                subscription_id: *subscription,
+                async_ops,
+                output_format,
+                query,
+            };
+            handle_create(&handler, &params, *region, data).await
+        }
+        PrivateLinkCommands::AddPrincipal {
+            subscription,
+            region,
+            data,
+        } => {
+            handle_add_principal(&handler, *subscription, *region, data, output_format, query).await
+        }
+        PrivateLinkCommands::RemovePrincipal {
+            subscription,
+            region,
+            data,
+        } => {
+            handle_remove_principal(&handler, *subscription, *region, data, output_format, query)
+                .await
+        }
+        PrivateLinkCommands::GetScript {
+            subscription,
+            region,
+        } => handle_get_script(&handler, *subscription, *region, output_format, query).await,
+    }
+}
+
+/// Get PrivateLink configuration
+async fn handle_get(
+    handler: &PrivateLinkHandler,
+    subscription_id: i32,
+    region_id: Option<i32>,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    let result = if let Some(region) = region_id {
+        handler
+            .get_active_active(subscription_id, region)
+            .await
+            .context("Failed to get Active-Active PrivateLink configuration")?
+    } else {
+        handler
+            .get(subscription_id)
+            .await
+            .context("Failed to get PrivateLink configuration")?
+    };
+
+    let data = handle_output(result, output_format, query)?;
+    print_formatted_output(data, output_format)?;
+    Ok(())
+}
+
+/// Create PrivateLink
+async fn handle_create(
+    handler: &PrivateLinkHandler,
+    params: &ConnectivityOperationParams<'_>,
+    region_id: Option<i32>,
+    data: &str,
+) -> CliResult<()> {
+    let content = read_file_input(data)?;
+    let request: Value = serde_json::from_str(&content).context("Failed to parse JSON input")?;
+
+    let result = if let Some(region) = region_id {
+        handler
+            .create_active_active(params.subscription_id, region, request)
+            .await
+            .context("Failed to create Active-Active PrivateLink")?
+    } else {
+        handler
+            .create(params.subscription_id, request)
+            .await
+            .context("Failed to create PrivateLink")?
+    };
+
+    handle_async_response(
+        params.conn_mgr,
+        params.profile_name,
+        result,
+        params.async_ops,
+        params.output_format,
+        params.query,
+        "Create PrivateLink",
+    )
+    .await
+}
+
+/// Add principals to PrivateLink
+async fn handle_add_principal(
+    handler: &PrivateLinkHandler,
+    subscription_id: i32,
+    region_id: Option<i32>,
+    data: &str,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    let content = read_file_input(data)?;
+    let request: Value = serde_json::from_str(&content).context("Failed to parse JSON input")?;
+
+    let result = if let Some(region) = region_id {
+        handler
+            .add_principals_active_active(subscription_id, region, request)
+            .await
+            .context("Failed to add principals to Active-Active PrivateLink")?
+    } else {
+        handler
+            .add_principals(subscription_id, request)
+            .await
+            .context("Failed to add principals to PrivateLink")?
+    };
+
+    let data = handle_output(result, output_format, query)?;
+    print_formatted_output(data, output_format)?;
+    Ok(())
+}
+
+/// Remove principals from PrivateLink
+async fn handle_remove_principal(
+    handler: &PrivateLinkHandler,
+    subscription_id: i32,
+    region_id: Option<i32>,
+    data: &str,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    let content = read_file_input(data)?;
+    let request: Value = serde_json::from_str(&content).context("Failed to parse JSON input")?;
+
+    let result = if let Some(region) = region_id {
+        handler
+            .remove_principals_active_active(subscription_id, region, request)
+            .await
+            .context("Failed to remove principals from Active-Active PrivateLink")?
+    } else {
+        handler
+            .remove_principals(subscription_id, request)
+            .await
+            .context("Failed to remove principals from PrivateLink")?
+    };
+
+    let data = handle_output(result, output_format, query)?;
+    print_formatted_output(data, output_format)?;
+    Ok(())
+}
+
+/// Get VPC endpoint creation script
+async fn handle_get_script(
+    handler: &PrivateLinkHandler,
+    subscription_id: i32,
+    region_id: Option<i32>,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    let result = if let Some(region) = region_id {
+        handler
+            .get_endpoint_script_active_active(subscription_id, region)
+            .await
+            .context("Failed to get Active-Active endpoint script")?
+    } else {
+        handler
+            .get_endpoint_script(subscription_id)
+            .await
+            .context("Failed to get endpoint script")?
+    };
+
+    let data = handle_output(result, output_format, query)?;
+    print_formatted_output(data, output_format)?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Adds typed CLI commands for AWS PrivateLink connectivity operations, completing **100% CLI coverage** for the Cloud API.

## Background

PR #406 added the  to the redis-cloud library with 10 methods. This PR adds the corresponding human-friendly CLI commands so users don't have to use raw API access.

## Commands Added

```bash
# Get PrivateLink configuration
redisctl cloud connectivity privatelink get --subscription <id>

# Create PrivateLink
redisctl cloud connectivity privatelink create --subscription <id> <json-data>

# Add principals (AWS accounts, IAM roles, etc.)
redisctl cloud connectivity privatelink add-principal --subscription <id> <json-data>

# Remove principals
redisctl cloud connectivity privatelink remove-principal --subscription <id> <json-data>

# Get VPC endpoint creation script
redisctl cloud connectivity privatelink get-script --subscription <id>
```

## Active-Active (CRDB) Support

All commands support Active-Active databases via optional `--region` flag:

```bash
redisctl cloud connectivity privatelink get --subscription 123 --region 1
```

## Examples

```bash
# Get PrivateLink configuration
redisctl cloud connectivity privatelink get --subscription 123 -o json

# Create PrivateLink with JSON data
redisctl cloud connectivity privatelink create --subscription 123 \
  '{"shareName":"my-share","principal":"123456789012","type":"aws_account"}' \
  --wait

# Add IAM role principal
redisctl cloud connectivity privatelink add-principal --subscription 123 \
  '{"principal":"arn:aws:iam::123456789012:role/MyRole","type":"iam_role"}'

# Get endpoint creation script
redisctl cloud connectivity privatelink get-script --subscription 123
```

## Architecture

Follows the established pattern from VPC Peering, PSC, and Transit Gateway:
- Commands defined in `cli.rs` as `PrivateLinkCommands` enum
- Handler implementation in `commands/cloud/connectivity/private_link.rs`
- Integrated into `CloudConnectivityCommands`
- Supports all standard features: `--wait`, `--output`, `--query`, etc.

## CLI Coverage Status

**Cloud API vs CLI: 100% complete**

All Cloud API handlers now have human-friendly CLI commands:
- ✅ Account (8/8)
- ✅ ACL (13/13)
- ✅ Provider Accounts (5/5)
- ✅ Subscriptions (13/13)
- ✅ Fixed Subscriptions (8/8)
- ✅ Databases (18/18)
- ✅ Fixed Databases (11/11)
- ✅ VPC Peering (4/4)
- ✅ Private Service Connect (6/6)
- ✅ Transit Gateway (6/6)
- ✅ **PrivateLink (5/5)** ← NEW
- ✅ Tasks (2/2)
- ✅ Users (4/4)

## Quality Checks

- ✅ Compiles cleanly
- ✅ Clippy passes with no warnings
- ✅ Formatted with cargo fmt
- ✅ Help output verified for all commands
- ✅ Follows established CLI patterns

## Related

- Depends on: #406 (AWS PrivateLink library implementation)
- Completes: 100% Cloud API CLI coverage