### PR TITLE
docs: add good first issues section to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,22 @@ Please be respectful and constructive in all interactions.
 
 ## How to Contribute
 
+### Finding Good First Issues
+
+New to the project? Look for issues labeled [`good first issue`](https://github.com/joshrotenberg/redisctl/labels/good%20first%20issue).
+
+These issues are:
+- Well-defined with clear acceptance criteria
+- Include implementation hints and code pointers
+- Have existing patterns you can follow
+- Are great for learning the codebase
+
+**Current good first issues:**
+- **#138** - Add pager support for Windows (cross-platform development)
+- **#426** - Add payment-method commands (CLI wrapper for existing API)
+
+Each issue has detailed guidance in the comments. Don't hesitate to ask questions!
+
 ### Reporting Issues
 
 - Check existing issues first to avoid duplicates


### PR DESCRIPTION
## Summary

Enhances CONTRIBUTING.md with a dedicated section for newcomers to easily find good first issues.

## Changes

- Added "Finding Good First Issues" section with link to labeled issues
- Listed current good first issues (#138, #426) with brief descriptions
- Positioned prominently at the start of "How to Contribute" section

## Benefits

- Makes it easier for new contributors to get started
- Reduces friction for first-time contributors
- Improves visibility of beginner-friendly issues
- Encourages community contributions

## Related

- #138 - Windows pager support (labeled as good first issue)
- #426 - Payment-method commands (labeled as good first issue)