### PR TITLE
fix: remove exposed Redis credentials from demo file

### DIFF
--- a/examples/presentation/DEMO.md
+++ b/examples/presentation/DEMO.md
@@ -65,7 +65,9 @@ redisctl cloud database get 2969240:13684622 \
 
 ```bash
 # Connect using the endpoint and password from above
-redis-cli -u redis://default:cozsNl5jC2PsUZq7TWcPmoDSu0QDM41Y@redis-19206.c89.us-east-1-3.ec2.redns.redis-cloud.com:19206
+redis-cli -u redis://default:<YOUR_PASSWORD>@<YOUR_ENDPOINT>:<PORT>
+
+# Example: redis-cli -u redis://default:password123@redis-12345.c1.us-east-1-3.ec2.redns.redis-cloud.com:12345
 
 # Test some commands
 SET demo:key "Hello from redisctl demo"


### PR DESCRIPTION
## Problem
Exposed real Redis Cloud credentials (password and endpoint) in the presentation demo file.

## Solution
Replace real credentials with placeholders:
- `<YOUR_PASSWORD>`
- `<YOUR_ENDPOINT>`
- `<PORT>`

Added example showing format without real credentials.

## Security Note
This fixes the exposed credentials going forward. The commit history in main still contains the credentials. After merging this PR, we should consider using git-filter-repo or BFG Repo-Cleaner to rewrite history and remove the credentials completely from all commits.

Fixes exposed credentials in `examples/presentation/DEMO.md`