### PR TITLE
feat: make --config-file take precedence over environment variables

### DIFF
--- a/crates/redisctl/src/commands/api.rs
+++ b/crates/redisctl/src/commands/api.rs
@@ -12,6 +12,7 @@ use serde_json::Value;
 #[allow(dead_code)] // Used by binary target
 pub struct ApiCommandParams {
     pub config: Config,
+    pub config_path: Option<std::path::PathBuf>,
     pub profile_name: Option<String>,
     pub deployment: DeploymentType,
     pub method: HttpMethod,
@@ -24,7 +25,7 @@ pub struct ApiCommandParams {
 /// Handle raw API commands
 #[allow(dead_code)] // Used by binary target
 pub async fn handle_api_command(params: ApiCommandParams) -> CliResult<()> {
-    let connection_manager = ConnectionManager::new(params.config);
+    let connection_manager = ConnectionManager::with_config_path(params.config, params.config_path);
 
     match params.deployment {
         DeploymentType::Cloud => {

--- a/crates/redisctl/src/connection.rs
+++ b/crates/redisctl/src/connection.rs
@@ -46,6 +46,10 @@ impl ConnectionManager {
     }
 
     /// Create a Cloud client from profile credentials with environment variable override support
+    ///
+    /// When --config-file is explicitly specified, environment variables are ignored to provide
+    /// true configuration isolation. This allows testing with isolated configs and follows the
+    /// principle of "explicit wins" (CLI args > env vars > defaults).
     #[allow(dead_code)] // Used by binary target
     pub async fn create_cloud_client(
         &self,
@@ -54,10 +58,35 @@ impl ConnectionManager {
         debug!("Creating Redis Cloud client");
         trace!("Profile name: {:?}", profile_name);
 
-        // Check if all required environment variables are present
-        let env_api_key = std::env::var("REDIS_CLOUD_API_KEY").ok();
-        let env_api_secret = std::env::var("REDIS_CLOUD_SECRET_KEY").ok();
-        let env_api_url = std::env::var("REDIS_CLOUD_API_URL").ok();
+        // When --config-file is explicitly specified, ignore environment variables
+        // This provides true configuration isolation for testing and follows CLI best practices
+        let use_env_vars = self.config_path.is_none();
+
+        debug!(
+            "Config path: {:?}, use_env_vars: {}",
+            self.config_path, use_env_vars
+        );
+
+        if !use_env_vars {
+            info!("--config-file specified explicitly, ignoring environment variables");
+        }
+
+        // Check if all required environment variables are present (only if we're using them)
+        let env_api_key = if use_env_vars {
+            std::env::var("REDIS_CLOUD_API_KEY").ok()
+        } else {
+            None
+        };
+        let env_api_secret = if use_env_vars {
+            std::env::var("REDIS_CLOUD_SECRET_KEY").ok()
+        } else {
+            None
+        };
+        let env_api_url = if use_env_vars {
+            std::env::var("REDIS_CLOUD_API_URL").ok()
+        } else {
+            None
+        };
 
         if env_api_key.is_some() {
             debug!("Found REDIS_CLOUD_API_KEY environment variable");
@@ -140,6 +169,10 @@ impl ConnectionManager {
     }
 
     /// Create an Enterprise client from profile credentials with environment variable override support
+    ///
+    /// When --config-file is explicitly specified, environment variables are ignored to provide
+    /// true configuration isolation. This allows testing with isolated configs and follows the
+    /// principle of "explicit wins" (CLI args > env vars > defaults).
     #[allow(dead_code)] // Used by binary target
     pub async fn create_enterprise_client(
         &self,
@@ -148,11 +181,40 @@ impl ConnectionManager {
         debug!("Creating Redis Enterprise client");
         trace!("Profile name: {:?}", profile_name);
 
-        // Check if all required environment variables are present
-        let env_url = std::env::var("REDIS_ENTERPRISE_URL").ok();
-        let env_user = std::env::var("REDIS_ENTERPRISE_USER").ok();
-        let env_password = std::env::var("REDIS_ENTERPRISE_PASSWORD").ok();
-        let env_insecure = std::env::var("REDIS_ENTERPRISE_INSECURE").ok();
+        // When --config-file is explicitly specified, ignore environment variables
+        // This provides true configuration isolation for testing and follows CLI best practices
+        let use_env_vars = self.config_path.is_none();
+
+        debug!(
+            "Config path: {:?}, use_env_vars: {}",
+            self.config_path, use_env_vars
+        );
+
+        if !use_env_vars {
+            info!("--config-file specified explicitly, ignoring environment variables");
+        }
+
+        // Check if all required environment variables are present (only if we're using them)
+        let env_url = if use_env_vars {
+            std::env::var("REDIS_ENTERPRISE_URL").ok()
+        } else {
+            None
+        };
+        let env_user = if use_env_vars {
+            std::env::var("REDIS_ENTERPRISE_USER").ok()
+        } else {
+            None
+        };
+        let env_password = if use_env_vars {
+            std::env::var("REDIS_ENTERPRISE_PASSWORD").ok()
+        } else {
+            None
+        };
+        let env_insecure = if use_env_vars {
+            std::env::var("REDIS_ENTERPRISE_INSECURE").ok()
+        } else {
+            None
+        };
 
         if env_url.is_some() {
             debug!("Found REDIS_ENTERPRISE_URL environment variable");

--- a/crates/redisctl/src/main.rs
+++ b/crates/redisctl/src/main.rs
@@ -26,11 +26,17 @@ async fn main() -> Result<()> {
     // Load configuration from specified path or default location
     let (config, config_path) = if let Some(config_file) = &cli.config_file {
         let path = std::path::PathBuf::from(config_file);
+        debug!("Loading config from explicit path: {:?}", path);
         let config = Config::load_from_path(&path)?;
         (config, Some(path))
     } else {
+        debug!("Loading config from default location");
         (Config::load()?, None)
     };
+    debug!(
+        "Creating ConnectionManager with config_path: {:?}",
+        config_path
+    );
     let conn_mgr = ConnectionManager::with_config_path(config, config_path);
 
     // Execute command
@@ -821,6 +827,7 @@ async fn execute_api_command(
 ) -> Result<(), RedisCtlError> {
     commands::api::handle_api_command(commands::api::ApiCommandParams {
         config: conn_mgr.config.clone(),
+        config_path: conn_mgr.config_path.clone(),
         profile_name: cli.profile.clone(),
         deployment: *deployment,
         method: method.clone(),


### PR DESCRIPTION
## Summary

Fixes #436 - When `--config-file` is explicitly specified, environment variables are now ignored to provide true configuration isolation.

## Problem

Previously, environment variables always took precedence over config files, even when `--config-file` was explicitly specified. This made it impossible to achieve true configuration isolation for testing and violated the principle of "explicit wins" in CLI design.

**Old behavior (problematic):**
```
Priority: Env vars > --config-file > Default config
```

## Solution

**New behavior:**
```
Priority: --config-file (explicit) > Env vars > Default config
```

When `--config-file` is explicitly provided, environment variables are completely ignored for credential resolution.

## Changes

1. **ConnectionManager**: Tracks whether `config_path` was explicitly provided
2. **Credential Resolution**: 
   - `create_cloud_client()` and `create_enterprise_client()` skip env var checks when `config_path` is `Some()`
   - Added debug logging showing when env vars are ignored
3. **API Command**: Fixed bug where `ApiCommandParams` wasn't preserving `config_path`, causing it to be lost
4. **Tests**: Added 2 new integration tests to verify the behavior

## Testing

### New Tests
- `test_config_file_overrides_env_vars`: Verifies env vars are ignored when `--config-file` is specified
- `test_env_vars_work_without_config_file`: Verifies env vars still work without `--config-file`

### Test Results
```
redisctl tests: 132 passed (31 unit + 24 basic CLI + 29 mocked + 15 profile + 2 output + 31 other)
```

## Benefits

1. **Testing Isolation**: Tests can use `--config-file` without worrying about env vars
2. **Principle of Least Surprise**: Explicit flags override implicit environment
3. **CLI Best Practice**: Follows patterns from `kubectl --kubeconfig`, `git --config`, etc.
4. **Backward Compatible**: Only affects behavior when `--config-file` is explicitly used

## Example

**Before (env vars override config file):**
```bash
export REDIS_CLOUD_API_KEY=production-key
redisctl --config-file test.toml cloud subscription list
# Uses production-key (WRONG!)
```

**After (config file wins when explicit):**
```bash
export REDIS_CLOUD_API_KEY=production-key  
redisctl --config-file test.toml cloud subscription list
# Uses test.toml credentials (CORRECT!)
```

**Without --config-file (env vars still work):**
```bash
export REDIS_CLOUD_API_KEY=my-key
redisctl cloud subscription list
# Uses my-key from env (works as before)
```

Closes #436