### PR TITLE
fix(redis-enterprise): remove non-existent database action methods

### DIFF
--- a/crates/redis-enterprise/src/bdb.rs
+++ b/crates/redis-enterprise/src/bdb.rs
@@ -522,36 +522,6 @@ impl DatabaseHandler {
         self.client.get(&format!("/v1/bdbs/{}/metrics", uid)).await
     }
 
-    /// Start database (BDB.START)
-    pub async fn start(&self, uid: u32) -> Result<Value> {
-        self.client
-            .post(
-                &format!("/v1/bdbs/{}/actions/start", uid),
-                &serde_json::json!({}),
-            )
-            .await
-    }
-
-    /// Stop database (BDB.STOP)
-    pub async fn stop(&self, uid: u32) -> Result<Value> {
-        self.client
-            .post(
-                &format!("/v1/bdbs/{}/actions/stop", uid),
-                &serde_json::json!({}),
-            )
-            .await
-    }
-
-    /// Restart database (BDB.RESTART)
-    pub async fn restart(&self, uid: u32) -> Result<DatabaseActionResponse> {
-        self.client
-            .post(
-                &format!("/v1/bdbs/{}/actions/restart", uid),
-                &serde_json::json!({}),
-            )
-            .await
-    }
-
     /// Export database (BDB.EXPORT)
     pub async fn export(&self, uid: u32, export_location: &str) -> Result<ExportResponse> {
         let body = serde_json::json!({

--- a/crates/redis-enterprise/src/lib_tests.rs
+++ b/crates/redis-enterprise/src/lib_tests.rs
@@ -191,60 +191,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_database_action_start() {
-        let mock_server = MockServer::start().await;
-
-        Mock::given(method("POST"))
-            .and(path("/v1/bdbs/1/actions/start"))
-            .and(basic_auth("admin", "password"))
-            .respond_with(
-                ResponseTemplate::new(200).set_body_json(serde_json::json!({"status": "started"})),
-            )
-            .mount(&mock_server)
-            .await;
-
-        let client = EnterpriseClient::builder()
-            .base_url(mock_server.uri())
-            .username("admin")
-            .password("password")
-            .build()
-            .unwrap();
-
-        let handler = crate::bdb::DatabaseHandler::new(client);
-        let result = handler.start(1).await;
-
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap()["status"], "started");
-    }
-
-    #[tokio::test]
-    async fn test_database_action_stop() {
-        let mock_server = MockServer::start().await;
-
-        Mock::given(method("POST"))
-            .and(path("/v1/bdbs/1/actions/stop"))
-            .and(basic_auth("admin", "password"))
-            .respond_with(
-                ResponseTemplate::new(200).set_body_json(serde_json::json!({"status": "stopped"})),
-            )
-            .mount(&mock_server)
-            .await;
-
-        let client = EnterpriseClient::builder()
-            .base_url(mock_server.uri())
-            .username("admin")
-            .password("password")
-            .build()
-            .unwrap();
-
-        let handler = crate::bdb::DatabaseHandler::new(client);
-        let result = handler.stop(1).await;
-
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap()["status"], "stopped");
-    }
-
-    #[tokio::test]
     async fn test_database_action_export() {
         let mock_server = MockServer::start().await;
 

--- a/crates/redis-enterprise/tests/database_tests.rs
+++ b/crates/redis-enterprise/tests/database_tests.rs
@@ -158,56 +158,6 @@ async fn test_database_delete() {
 // Database Action Tests
 
 #[tokio::test]
-async fn test_database_start() {
-    let mock_server = MockServer::start().await;
-
-    Mock::given(method("POST"))
-        .and(path("/v1/bdbs/1/actions/start"))
-        .and(basic_auth("admin", "password"))
-        .respond_with(success_response(json!({"status": "started"})))
-        .mount(&mock_server)
-        .await;
-
-    let client = EnterpriseClient::builder()
-        .base_url(mock_server.uri())
-        .username("admin")
-        .password("password")
-        .build()
-        .unwrap();
-
-    let handler = BdbHandler::new(client);
-    let result = handler.start(1).await;
-
-    assert!(result.is_ok());
-    assert_eq!(result.unwrap()["status"], "started");
-}
-
-#[tokio::test]
-async fn test_database_stop() {
-    let mock_server = MockServer::start().await;
-
-    Mock::given(method("POST"))
-        .and(path("/v1/bdbs/1/actions/stop"))
-        .and(basic_auth("admin", "password"))
-        .respond_with(success_response(json!({"status": "stopped"})))
-        .mount(&mock_server)
-        .await;
-
-    let client = EnterpriseClient::builder()
-        .base_url(mock_server.uri())
-        .username("admin")
-        .password("password")
-        .build()
-        .unwrap();
-
-    let handler = BdbHandler::new(client);
-    let result = handler.stop(1).await;
-
-    assert!(result.is_ok());
-    assert_eq!(result.unwrap()["status"], "stopped");
-}
-
-#[tokio::test]
 async fn test_database_export() {
     let mock_server = MockServer::start().await;
 

--- a/docs/src/enterprise/api-access.md
+++ b/docs/src/enterprise/api-access.md
@@ -98,7 +98,7 @@ redisctl api enterprise delete /v1/nodes/3
 ### Database Operations (BDB)
 - `/v1/bdbs` - Database list and creation
 - `/v1/bdbs/{id}` - Database details and management
-- `/v1/bdbs/{id}/actions` - Database actions (flush, restart)
+- `/v1/bdbs/{id}/actions` - Database actions (stop_traffic, resume_traffic, export, import, etc.)
 - `/v1/bdbs/{id}/stats` - Database statistics
 
 ### Node Management

--- a/docs/src/enterprise/examples.md
+++ b/docs/src/enterprise/examples.md
@@ -305,24 +305,30 @@ redisctl api enterprise post /v1/crdbs \
 
 ## Maintenance Operations
 
-### Rolling Restart
+### Rolling Traffic Management
 
 ```bash
 #!/bin/bash
-# Perform rolling restart of all databases
+# Stop and resume traffic for all databases (for maintenance)
 
 redisctl enterprise database list -q "[].uid" | while read db_id; do
-  echo "Restarting database $db_id..."
+  echo "Stopping traffic for database $db_id..."
   
-  # Restart database
-  redisctl api enterprise post /v1/bdbs/$db_id/actions/restart
+  # Stop database traffic
+  redisctl api enterprise post /v1/bdbs/$db_id/actions/stop_traffic
+  
+  # Perform maintenance operations here
+  sleep 5
+  
+  # Resume database traffic
+  redisctl api enterprise post /v1/bdbs/$db_id/actions/resume_traffic
   
   # Wait for database to be active
   while [ "$(redisctl enterprise database get $db_id -q status)" != "active" ]; do
     sleep 5
   done
   
-  echo "Database $db_id restarted successfully"
+  echo "Database $db_id traffic resumed successfully"
 done
 ```
 


### PR DESCRIPTION
## Summary

Removes three database action methods from  crate that call non-existent API endpoints.

## Problem

The library contained three methods that always fail with 404:
- `BdbHandler::start()` - calls `/v1/bdbs/{uid}/actions/start`
- `BdbHandler::stop()` - calls `/v1/bdbs/{uid}/actions/stop`
- `BdbHandler::restart()` - calls `/v1/bdbs/{uid}/actions/restart`

## Verification

**Docker Cluster Testing:**
```bash
# All return 404 Not Found
curl -k -u "admin@redis.local:Redis123!" -X POST https://localhost:9443/v1/bdbs/1/actions/restart
curl -k -u "admin@redis.local:Redis123!" -X POST https://localhost:9443/v1/bdbs/1/actions/start
curl -k -u "admin@redis.local:Redis123!" -X POST https://localhost:9443/v1/bdbs/1/actions/stop
```

**Documentation Search:**
Comprehensive search of redis.io REST API documentation confirms these endpoints do not exist. The complete list of documented database action endpoints is:

- `stop_traffic` / `resume_traffic` (NOT the same as stop/start)
- `export` / `import` / `recover`
- `optimize_shards_placement` / `rebalance`
- `backup_reset_status` / `import_reset_status` / `export_reset_status`

Search results: https://redis.io/docs/latest/operate/rs/references/rest-api/requests/bdbs/actions/

## Changes

**Removed Methods:**
- `crates/redis-enterprise/src/bdb.rs` - Removed `start()`, `stop()`, `restart()` methods

**Removed Tests:**
- `crates/redis-enterprise/tests/database_tests.rs` - Removed `test_database_start`, `test_database_stop`
- `crates/redis-enterprise/src/lib_tests.rs` - Removed `test_database_action_start`, `test_database_action_stop`

**Documentation Updates:**
- `docs/src/enterprise/examples.md` - Changed "Rolling Restart" example to use `stop_traffic`/`resume_traffic`
- `docs/src/enterprise/api-access.md` - Updated action list to show actual endpoints

## Testing

```bash
cargo test --package redis-enterprise  # ✅ All 335 tests pass
cargo clippy --all-targets --all-features -- -D warnings  # ✅ No warnings
cargo fmt --all -- --check  # ✅ Clean
```

## Related Issues

Closes #421 - Database restart command cannot be implemented as the API doesn't support it

## Notes

While `rladmin restart db` exists as a CLI command, it uses internal mechanisms not exposed via the REST API. Users needing to pause traffic should use `stop_traffic` + `resume_traffic` instead, though this doesn't achieve the same effect as restarting the database process.