### PR TITLE
feat(redis-enterprise): add stats streaming with --follow flag

### DIFF
--- a/crates/redisctl/src/cli/enterprise.rs
+++ b/crates/redisctl/src/cli/enterprise.rs
@@ -1332,6 +1332,12 @@ pub enum EnterpriseStatsCommands {
     Database {
         /// Database ID
         id: u32,
+        /// Stream stats continuously
+        #[arg(long, short = 'f')]
+        follow: bool,
+        /// Poll interval in seconds (for --follow)
+        #[arg(long, default_value = "5")]
+        poll_interval: u64,
     },
 
     /// Get database shard statistics
@@ -1353,6 +1359,12 @@ pub enum EnterpriseStatsCommands {
     Node {
         /// Node ID
         id: u32,
+        /// Stream stats continuously
+        #[arg(long, short = 'f')]
+        follow: bool,
+        /// Poll interval in seconds (for --follow)
+        #[arg(long, default_value = "5")]
+        poll_interval: u64,
     },
 
     /// Get node metrics over time
@@ -1365,7 +1377,14 @@ pub enum EnterpriseStatsCommands {
     },
 
     /// Get cluster-wide statistics
-    Cluster,
+    Cluster {
+        /// Stream stats continuously
+        #[arg(long, short = 'f')]
+        follow: bool,
+        /// Poll interval in seconds (for --follow)
+        #[arg(long, default_value = "5")]
+        poll_interval: u64,
+    },
 
     /// Get cluster metrics over time
     ClusterMetrics {


### PR DESCRIPTION
Closes #453

Adds streaming support for stats commands following the existing log streaming pattern.

## Changes
- Add `stream_cluster`, `stream_node`, `stream_database` methods to StatsHandler
- Add `--follow` and `--poll-interval` flags to `enterprise stats database/node/cluster` commands
- Implement continuous streaming output with configurable polling interval

## Usage
```bash
# Stream cluster stats every 5 seconds (default)
redisctl enterprise stats cluster --follow

# Stream database stats every 2 seconds
redisctl enterprise stats database 1 --follow --poll-interval 2

# Stream node stats
redisctl enterprise stats node 1 --follow
```

Press Ctrl+C to stop streaming.