### PR TITLE
feat(enterprise): add database watch command for real-time status monitoring

### DIFF
--- a/crates/redisctl/src/cli/enterprise.rs
+++ b/crates/redisctl/src/cli/enterprise.rs
@@ -451,6 +451,15 @@ NOTE: Memory size is in bytes. Common values:
         force: bool,
     },
 
+    /// Watch database status changes in real-time
+    Watch {
+        /// Database ID
+        id: u32,
+        /// Poll interval in seconds
+        #[arg(long, default_value = "5")]
+        poll_interval: u64,
+    },
+
     /// Export database
     Export {
         /// Database ID

--- a/crates/redisctl/src/commands/enterprise/database.rs
+++ b/crates/redisctl/src/commands/enterprise/database.rs
@@ -74,6 +74,9 @@ pub async fn handle_database_command(
             )
             .await
         }
+        EnterpriseDatabaseCommands::Watch { id, poll_interval } => {
+            database_impl::watch_database(conn_mgr, profile_name, *id, *poll_interval, query).await
+        }
         EnterpriseDatabaseCommands::Export { id, data } => {
             database_impl::export_database(conn_mgr, profile_name, *id, data, output_format, query)
                 .await


### PR DESCRIPTION
## Summary

Implements Phase 2 of issue #405 - Database Lifecycle Event Monitoring

Adds a  subcommand for monitoring Redis Enterprise database status changes in real-time.

## Changes

### Library ()
- Added  method to  that streams database status updates
- Returns an async stream that polls database info at configurable intervals
- Detects status transitions and includes previous status for comparison
- Uses type alias  to reduce complexity

### CLI ()
- Added  command
- Supports  flag (default: 5 seconds)
- Ctrl+C handling for graceful shutdown
- Timestamped output with status transitions highlighted
- Shows key metrics (memory, ops/sec, connections)
- Supports JMESPath filtering via  flag

## Example Usage

```bash
# Watch database with default 5-second interval
redisctl enterprise database watch 1

# Custom poll interval
redisctl enterprise database watch 1 --poll-interval 10

# Filter with JMESPath
redisctl enterprise database watch 1 --query 'status'
```

## Output Format

```
Watching database 1 (Ctrl+C to stop)...

[10:30:15] Database 1: active | Memory: 5.2MB / 10.0MB | Ops: 120/sec | Conns: 5
[10:30:20] Database 1: active -> pending (TRANSITION)
[10:30:25] Database 1: pending | Memory: 5.2MB / 10.0MB
```

## Testing

- Tested against Docker Redis Enterprise cluster
- All unit tests pass
- Verified Ctrl+C handling works correctly
- Confirmed status transition detection

Closes #405