### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2176,7 +2176,7 @@ dependencies = [
 
 [[package]]
 name = "redis-cloud"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2200,7 +2200,7 @@ dependencies = [
 
 [[package]]
 name = "redis-enterprise"
-version = "0.6.4"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2228,7 +2228,7 @@ dependencies = [
 
 [[package]]
 name = "redisctl"
-version = "0.6.6"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/crates/redis-cloud/CHANGELOG.md
+++ b/crates/redis-cloud/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.2](https://github.com/joshrotenberg/redisctl/compare/redis-cloud-v0.7.1...redis-cloud-v0.7.2) - 2025-12-01
+
+### Added
+
+- add user agent header to HTTP requests ([#473](https://github.com/joshrotenberg/redisctl/pull/473))
+- *(redis-cloud)* add tracing instrumentation to API client ([#452](https://github.com/joshrotenberg/redisctl/pull/452))
+- Add optional Tower service integration to API clients ([#447](https://github.com/joshrotenberg/redisctl/pull/447))
+
+### Fixed
+
+- *(release)* improve Homebrew formula auto-update ([#433](https://github.com/joshrotenberg/redisctl/pull/433))
+
 ## [0.7.1](https://github.com/joshrotenberg/redisctl/compare/redis-cloud-v0.7.0...redis-cloud-v0.7.1) - 2025-10-29
 
 ### Added

--- a/crates/redis-cloud/Cargo.toml
+++ b/crates/redis-cloud/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-cloud"
-version = "0.7.1"
+version = "0.7.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/redis-enterprise/CHANGELOG.md
+++ b/crates/redis-enterprise/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/joshrotenberg/redisctl/compare/redis-enterprise-v0.6.4...redis-enterprise-v0.7.0) - 2025-12-01
+
+### Added
+
+- add user agent header to HTTP requests ([#473](https://github.com/joshrotenberg/redisctl/pull/473))
+- *(enterprise)* add database watch command for real-time status monitoring ([#458](https://github.com/joshrotenberg/redisctl/pull/458))
+- *(redis-enterprise)* add stats streaming with --follow flag ([#455](https://github.com/joshrotenberg/redisctl/pull/455))
+- Add optional Tower service integration to API clients ([#447](https://github.com/joshrotenberg/redisctl/pull/447))
+- add database upgrade command for Redis version upgrades ([#442](https://github.com/joshrotenberg/redisctl/pull/442))
+
+### Fixed
+
+- *(redis-enterprise)* remove non-existent database action methods ([#443](https://github.com/joshrotenberg/redisctl/pull/443))
+- *(release)* improve Homebrew formula auto-update ([#433](https://github.com/joshrotenberg/redisctl/pull/433))
+
 ## [0.6.4](https://github.com/joshrotenberg/redisctl/compare/redis-enterprise-v0.6.3...redis-enterprise-v0.6.4) - 2025-10-29
 
 ### Added

--- a/crates/redis-enterprise/Cargo.toml
+++ b/crates/redis-enterprise/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-enterprise"
-version = "0.6.4"
+version = "0.7.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/redisctl/CHANGELOG.md
+++ b/crates/redisctl/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/joshrotenberg/redisctl/compare/redisctl-v0.6.6...redisctl-v0.7.0) - 2025-12-01
+
+### Added
+
+- add user agent header to HTTP requests ([#473](https://github.com/joshrotenberg/redisctl/pull/473))
+- *(enterprise)* add database watch command for real-time status monitoring ([#458](https://github.com/joshrotenberg/redisctl/pull/458))
+- *(enterprise)* improve stats streaming UX with Ctrl+C handling ([#457](https://github.com/joshrotenberg/redisctl/pull/457))
+- *(redis-enterprise)* add stats streaming with --follow flag ([#455](https://github.com/joshrotenberg/redisctl/pull/455))
+- add first-class parameters to major create commands ([#449](https://github.com/joshrotenberg/redisctl/pull/449))
+- add database upgrade command for Redis version upgrades ([#442](https://github.com/joshrotenberg/redisctl/pull/442))
+- [**breaking**] improve CLI help text accuracy and add comprehensive test coverage ([#444](https://github.com/joshrotenberg/redisctl/pull/444))
+- add payment-method commands to CLI ([#439](https://github.com/joshrotenberg/redisctl/pull/439))
+- make --config-file take precedence over environment variables ([#438](https://github.com/joshrotenberg/redisctl/pull/438))
+
+### Fixed
+
+- upgrade indicatif to 0.18 to resolve RUSTSEC-2025-0119 ([#474](https://github.com/joshrotenberg/redisctl/pull/474))
+- *(release)* improve Homebrew formula auto-update ([#433](https://github.com/joshrotenberg/redisctl/pull/433))
+
+### Other
+
+- *(redisctl)* add async_utils unit tests ([#472](https://github.com/joshrotenberg/redisctl/pull/472))
+- split cli.rs into cloud.rs and enterprise.rs modules ([#454](https://github.com/joshrotenberg/redisctl/pull/454))
+- update presentation materials with first-class parameters feature ([#450](https://github.com/joshrotenberg/redisctl/pull/450))
+- add comprehensive CLI test coverage  ([#448](https://github.com/joshrotenberg/redisctl/pull/448))
+- add comprehensive CLI tests with assert_cmd ([#435](https://github.com/joshrotenberg/redisctl/pull/435))
+
 ## [0.6.6](https://github.com/joshrotenberg/redisctl/compare/redisctl-v0.6.5...redisctl-v0.6.6) - 2025-10-29
 
 ### Added

--- a/crates/redisctl/Cargo.toml
+++ b/crates/redisctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redisctl"
-version = "0.6.6"
+version = "0.7.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
@@ -19,8 +19,8 @@ path = "src/main.rs"
 
 [dependencies]
 redisctl-config = { version = "0.1.1", path = "../redisctl-config" }
-redis-cloud = { version = "0.7.1", path = "../redis-cloud" }
-redis-enterprise = { version = "0.6.4", path = "../redis-enterprise" }
+redis-cloud = { version = "0.7.2", path = "../redis-cloud" }
+redis-enterprise = { version = "0.7.0", path = "../redis-enterprise" }
 files-sdk = { workspace = true, optional = true }
 
 # CLI dependencies


### PR DESCRIPTION



## 🤖 New release

* `redis-cloud`: 0.7.1 -> 0.7.2 (✓ API compatible changes)
* `redis-enterprise`: 0.6.4 -> 0.7.0 (⚠ API breaking changes)
* `redisctl`: 0.6.6 -> 0.7.0 (✓ API compatible changes)

### ⚠ `redis-enterprise` breaking changes

```text
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/inherent_method_missing.ron

Failed in:
  DatabaseHandler::start, previously in file /tmp/.tmplmd5qo/redis-enterprise/src/bdb.rs:526
  DatabaseHandler::stop, previously in file /tmp/.tmplmd5qo/redis-enterprise/src/bdb.rs:536
  DatabaseHandler::restart, previously in file /tmp/.tmplmd5qo/redis-enterprise/src/bdb.rs:546
  DatabaseHandler::start, previously in file /tmp/.tmplmd5qo/redis-enterprise/src/bdb.rs:526
  DatabaseHandler::stop, previously in file /tmp/.tmplmd5qo/redis-enterprise/src/bdb.rs:536
  DatabaseHandler::restart, previously in file /tmp/.tmplmd5qo/redis-enterprise/src/bdb.rs:546
  DatabaseHandler::start, previously in file /tmp/.tmplmd5qo/redis-enterprise/src/bdb.rs:526
  DatabaseHandler::stop, previously in file /tmp/.tmplmd5qo/redis-enterprise/src/bdb.rs:536
  DatabaseHandler::restart, previously in file /tmp/.tmplmd5qo/redis-enterprise/src/bdb.rs:546
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `redis-cloud`

<blockquote>

## [0.7.2](https://github.com/joshrotenberg/redisctl/compare/redis-cloud-v0.7.1...redis-cloud-v0.7.2) - 2025-12-01

### Added

- add user agent header to HTTP requests ([#473](https://github.com/joshrotenberg/redisctl/pull/473))
- *(redis-cloud)* add tracing instrumentation to API client ([#452](https://github.com/joshrotenberg/redisctl/pull/452))
- Add optional Tower service integration to API clients ([#447](https://github.com/joshrotenberg/redisctl/pull/447))

### Fixed

- *(release)* improve Homebrew formula auto-update ([#433](https://github.com/joshrotenberg/redisctl/pull/433))
</blockquote>

## `redis-enterprise`

<blockquote>

## [0.7.0](https://github.com/joshrotenberg/redisctl/compare/redis-enterprise-v0.6.4...redis-enterprise-v0.7.0) - 2025-12-01

### Added

- add user agent header to HTTP requests ([#473](https://github.com/joshrotenberg/redisctl/pull/473))
- *(enterprise)* add database watch command for real-time status monitoring ([#458](https://github.com/joshrotenberg/redisctl/pull/458))
- *(redis-enterprise)* add stats streaming with --follow flag ([#455](https://github.com/joshrotenberg/redisctl/pull/455))
- Add optional Tower service integration to API clients ([#447](https://github.com/joshrotenberg/redisctl/pull/447))
- add database upgrade command for Redis version upgrades ([#442](https://github.com/joshrotenberg/redisctl/pull/442))

### Fixed

- *(redis-enterprise)* remove non-existent database action methods ([#443](https://github.com/joshrotenberg/redisctl/pull/443))
- *(release)* improve Homebrew formula auto-update ([#433](https://github.com/joshrotenberg/redisctl/pull/433))
</blockquote>

## `redisctl`

<blockquote>

## [0.7.0](https://github.com/joshrotenberg/redisctl/compare/redisctl-v0.6.6...redisctl-v0.7.0) - 2025-12-01

### Added

- add user agent header to HTTP requests ([#473](https://github.com/joshrotenberg/redisctl/pull/473))
- *(enterprise)* add database watch command for real-time status monitoring ([#458](https://github.com/joshrotenberg/redisctl/pull/458))
- *(enterprise)* improve stats streaming UX with Ctrl+C handling ([#457](https://github.com/joshrotenberg/redisctl/pull/457))
- *(redis-enterprise)* add stats streaming with --follow flag ([#455](https://github.com/joshrotenberg/redisctl/pull/455))
- add first-class parameters to major create commands ([#449](https://github.com/joshrotenberg/redisctl/pull/449))
- add database upgrade command for Redis version upgrades ([#442](https://github.com/joshrotenberg/redisctl/pull/442))
- [**breaking**] improve CLI help text accuracy and add comprehensive test coverage ([#444](https://github.com/joshrotenberg/redisctl/pull/444))
- add payment-method commands to CLI ([#439](https://github.com/joshrotenberg/redisctl/pull/439))
- make --config-file take precedence over environment variables ([#438](https://github.com/joshrotenberg/redisctl/pull/438))

### Fixed

- upgrade indicatif to 0.18 to resolve RUSTSEC-2025-0119 ([#474](https://github.com/joshrotenberg/redisctl/pull/474))
- *(release)* improve Homebrew formula auto-update ([#433](https://github.com/joshrotenberg/redisctl/pull/433))

### Other

- *(redisctl)* add async_utils unit tests ([#472](https://github.com/joshrotenberg/redisctl/pull/472))
- split cli.rs into cloud.rs and enterprise.rs modules ([#454](https://github.com/joshrotenberg/redisctl/pull/454))
- update presentation materials with first-class parameters feature ([#450](https://github.com/joshrotenberg/redisctl/pull/450))
- add comprehensive CLI test coverage  ([#448](https://github.com/joshrotenberg/redisctl/pull/448))
- add comprehensive CLI tests with assert_cmd ([#435](https://github.com/joshrotenberg/redisctl/pull/435))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).