### PR TITLE
docs: add SECURITY.md and CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,75 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official project email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainers responsible for enforcement via GitHub. All complaints will be reviewed and investigated promptly and fairly.
+
+All project maintainers are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Project maintainers will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from project maintainers, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.0, available at https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,55 @@
+# Security Policy
+
+## Supported Versions
+
+We release patches for security vulnerabilities for the following versions:
+
+| Version | Supported          |
+| ------- | ------------------ |
+| Latest  | :white_check_mark: |
+| < Latest| :x:                |
+
+We recommend always using the latest version to ensure you have the most recent security updates.
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in redisctl, please report it privately to help us address it before public disclosure.
+
+**Please do NOT report security vulnerabilities through public GitHub issues.**
+
+### How to Report
+
+1. **Email**: Send details to the project maintainers via GitHub
+2. **Include**:
+   - Description of the vulnerability
+   - Steps to reproduce the issue
+   - Potential impact
+   - Any suggested fixes (if available)
+
+### What to Expect
+
+- **Acknowledgment**: We will acknowledge receipt of your report within 48 hours
+- **Updates**: We will provide regular updates on our progress
+- **Timeline**: We aim to release a fix within 90 days of the initial report
+- **Credit**: We will credit you in the security advisory (unless you prefer to remain anonymous)
+
+### Security Best Practices
+
+When using redisctl:
+
+1. **Credentials**: Use the `--use-keyring` flag with `secure-storage` feature to store credentials securely
+2. **Permissions**: Store configuration files with restrictive permissions (e.g., `chmod 600 ~/.config/redisctl/config.toml`)
+3. **TLS**: Always use HTTPS endpoints; only use `REDIS_ENTERPRISE_INSECURE=true` for testing
+4. **Environment Variables**: Be cautious when using environment variables for credentials in shared environments
+5. **Updates**: Keep redisctl updated to the latest version
+
+## Known Security Considerations
+
+- Credentials stored in plain text configuration files are readable by any process with access to the file
+- The `--insecure` flag disables TLS certificate verification and should only be used in development
+- API keys and secrets in command-line arguments may be visible in process listings
+
+For enhanced security, we recommend:
+- Using the `secure-storage` feature for credential management
+- Configuring proper file system permissions
+- Using environment variables or profiles instead of command-line flags for sensitive data


### PR DESCRIPTION
## Summary

Adds standard security policy and code of conduct files for project governance.

## Changes

- **SECURITY.md**: Standard vulnerability reporting process and security best practices
  - Private vulnerability reporting instructions
  - Security best practices for credential storage and TLS
  - Known security considerations
  
- **CODE_OF_CONDUCT.md**: Contributor Covenant 2.0
  - Community standards and behavior expectations
  - Enforcement guidelines
  - Standard language for official open source projects

## Context

These files are essential for the redisctl transfer to redis-field-engineering as an official Redis project. Both use widely-adopted standards:
- SECURITY.md follows common OSS security disclosure practices
- CODE_OF_CONDUCT.md uses Contributor Covenant 2.0

Part of v1.0 transfer readiness initiative.