### PR TITLE
chore: add coverage artifacts to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,8 @@ tmp/
 # mdBook build output
 docs/book/
 support-package-*.tar.gz
+coverage_analysis.md
+coverage_output.txt
+lcov.info
+*.profraw
+target/tarpaulin/


### PR DESCRIPTION
## Summary

Adds coverage-related files to .gitignore to prevent committing test artifacts.

## Changes

- `coverage_analysis.md` - local coverage analysis
- `coverage_output.txt` - tarpaulin output
- `lcov.info` - coverage report
- `*.profraw` - LLVM profile data
- `target/tarpaulin/` - tarpaulin build artifacts

## Context

Related to #462 - Test coverage tracking for v1.0 transfer readiness.