### PR TITLE
fix: upgrade indicatif to 0.18 to resolve RUSTSEC-2025-0119

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,6 +434,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b430743a6eb14e9764d4260d4c0d8123087d504eeb9c48f2b2a5e810dd369df4"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -636,7 +649,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
 dependencies = [
- "console",
+ "console 0.15.11",
  "shell-words",
  "tempfile",
  "thiserror 1.0.69",
@@ -1392,14 +1405,14 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.11"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+checksum = "9375e112e4b463ec1b1c6c011953545c65a30164fbab5b581df32b3abf0dcb88"
 dependencies = [
- "console",
- "number_prefix",
+ "console 0.16.1",
  "portable-atomic",
  "unicode-width",
+ "unit-prefix",
  "web-time",
 ]
 
@@ -1712,12 +1725,6 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
-
-[[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "once_cell"
@@ -3384,6 +3391,12 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/crates/redisctl/Cargo.toml
+++ b/crates/redisctl/Cargo.toml
@@ -41,7 +41,7 @@ dialoguer = "0.11"
 colored = "2.1"
 tabled = { version = "0.17", features = ["ansi"] }
 terminal_size = "0.4"
-indicatif = "0.17"
+indicatif = "0.18"
 unicode-segmentation = "1.12"
 tar = { workspace = true }
 flate2 = { workspace = true }


### PR DESCRIPTION
## Summary

Upgrade indicatif from 0.17 to 0.18 to resolve the security advisory RUSTSEC-2025-0119.

## Problem

The `number_prefix` crate (dependency of indicatif 0.17) has been marked as unmaintained, causing CI failures in the release PR #460.

## Solution

Upgrade to indicatif 0.18 which replaces `number_prefix` with `unit-prefix`.

## Testing

- All unit tests pass
- Clippy passes with no warnings
- Build succeeds on all platforms

## Related

- Fixes CI failure on #460
- Advisory: https://rustsec.org/advisories/RUSTSEC-2025-0119