### PR TITLE
feat(cloud): add cost-report API support (Beta)

### DIFF
--- a/crates/redis-cloud/src/cost_report.rs
+++ b/crates/redis-cloud/src/cost_report.rs
@@ -1,0 +1,449 @@
+//! Cost Report Generation and Retrieval
+//!
+//! This module provides functionality for generating and downloading cost reports
+//! in FOCUS format from Redis Cloud. FOCUS (FinOps Cost and Usage Specification)
+//! is an open standard for cloud cost data.
+//!
+//! # Overview
+//!
+//! Cost reports provide detailed billing information for your Redis Cloud resources,
+//! allowing you to analyze costs by subscription, database, region, and custom tags.
+//!
+//! # Report Generation Flow
+//!
+//! 1. **Generate Request**: Submit a cost report request with date range and filters
+//! 2. **Track Task**: Monitor the async task until completion
+//! 3. **Download Report**: Retrieve the generated report using the costReportId
+//!
+//! # Key Features
+//!
+//! - **Date Range Filtering**: Specify start and end dates (max 40 days)
+//! - **Output Formats**: CSV or JSON
+//! - **Subscription Filtering**: Filter by specific subscription IDs
+//! - **Database Filtering**: Filter by specific database IDs
+//! - **Plan Type Filtering**: Filter by "pro" or "essentials"
+//! - **Region Filtering**: Filter by cloud regions
+//! - **Tag Filtering**: Filter by custom key-value tags
+//!
+//! # Example Usage
+//!
+//! ```no_run
+//! use redis_cloud::{CloudClient, CostReportHandler, CostReportCreateRequest, CostReportFormat};
+//!
+//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! let client = CloudClient::builder()
+//!     .api_key("your-api-key")
+//!     .api_secret("your-api-secret")
+//!     .build()?;
+//!
+//! let handler = CostReportHandler::new(client);
+//!
+//! // Generate a cost report for the last month
+//! let request = CostReportCreateRequest::builder()
+//!     .start_date("2025-01-01")
+//!     .end_date("2025-01-31")
+//!     .format(CostReportFormat::Csv)
+//!     .build();
+//!
+//! let task = handler.generate_cost_report(request).await?;
+//! println!("Task ID: {:?}", task.task_id);
+//!
+//! // Once the task completes, download the report
+//! // The costReportId is returned in the task response
+//! let report_bytes = handler.download_cost_report("cost-report-12345").await?;
+//! std::fs::write("cost-report.csv", report_bytes)?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # FOCUS Format
+//!
+//! The cost report follows the [FOCUS specification](https://focus.finops.org/),
+//! providing standardized columns including:
+//! - BilledCost, EffectiveCost, ListCost, ContractedCost
+//! - Resource identifiers (subscription, database)
+//! - Service categories and SKU details
+//! - Billing period and usage information
+
+use crate::{CloudClient, Result, tasks::TaskStateUpdate};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+// ============================================================================
+// Models
+// ============================================================================
+
+/// Output format for cost reports
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum CostReportFormat {
+    /// CSV format (default)
+    #[default]
+    Csv,
+    /// JSON format
+    Json,
+}
+
+impl std::fmt::Display for CostReportFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CostReportFormat::Csv => write!(f, "csv"),
+            CostReportFormat::Json => write!(f, "json"),
+        }
+    }
+}
+
+/// Subscription type filter for cost reports
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum SubscriptionType {
+    /// Pro subscriptions (pay-as-you-go)
+    Pro,
+    /// Essentials subscriptions (fixed plans)
+    Essentials,
+}
+
+impl std::fmt::Display for SubscriptionType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SubscriptionType::Pro => write!(f, "pro"),
+            SubscriptionType::Essentials => write!(f, "essentials"),
+        }
+    }
+}
+
+/// Tag filter for cost reports
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Tag {
+    /// Tag key
+    pub key: String,
+    /// Tag value
+    pub value: String,
+}
+
+impl Tag {
+    /// Create a new tag filter
+    pub fn new(key: impl Into<String>, value: impl Into<String>) -> Self {
+        Self {
+            key: key.into(),
+            value: value.into(),
+        }
+    }
+}
+
+/// Request to generate a cost report
+///
+/// Cost reports are generated asynchronously. After submitting a request,
+/// you'll receive a task ID that can be used to track the generation progress.
+/// Once complete, use the costReportId from the task response to download the report.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct CostReportCreateRequest {
+    /// Start date for the report (YYYY-MM-DD format, required)
+    pub start_date: String,
+
+    /// End date for the report (YYYY-MM-DD format, required)
+    /// Must be after start_date and within 40 days of start_date
+    pub end_date: String,
+
+    /// Output format (csv or json, defaults to csv)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub format: Option<CostReportFormat>,
+
+    /// Filter by subscription IDs
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subscription_ids: Option<Vec<i32>>,
+
+    /// Filter by database IDs
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub database_ids: Option<Vec<i32>>,
+
+    /// Filter by subscription type (pro or essentials)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subscription_type: Option<SubscriptionType>,
+
+    /// Filter by regions
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub regions: Option<Vec<String>>,
+
+    /// Filter by tags (key-value pairs)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tags: Option<Vec<Tag>>,
+
+    /// Additional fields for forward compatibility
+    #[serde(flatten)]
+    pub extra: Value,
+}
+
+impl CostReportCreateRequest {
+    /// Create a new cost report request builder
+    pub fn builder() -> CostReportCreateRequestBuilder {
+        CostReportCreateRequestBuilder::default()
+    }
+
+    /// Create a simple request with just date range
+    pub fn new(start_date: impl Into<String>, end_date: impl Into<String>) -> Self {
+        Self {
+            start_date: start_date.into(),
+            end_date: end_date.into(),
+            ..Default::default()
+        }
+    }
+}
+
+/// Builder for CostReportCreateRequest
+#[derive(Debug, Clone, Default)]
+pub struct CostReportCreateRequestBuilder {
+    start_date: Option<String>,
+    end_date: Option<String>,
+    format: Option<CostReportFormat>,
+    subscription_ids: Option<Vec<i32>>,
+    database_ids: Option<Vec<i32>>,
+    subscription_type: Option<SubscriptionType>,
+    regions: Option<Vec<String>>,
+    tags: Option<Vec<Tag>>,
+}
+
+impl CostReportCreateRequestBuilder {
+    /// Set the start date (required, YYYY-MM-DD format)
+    pub fn start_date(mut self, date: impl Into<String>) -> Self {
+        self.start_date = Some(date.into());
+        self
+    }
+
+    /// Set the end date (required, YYYY-MM-DD format)
+    pub fn end_date(mut self, date: impl Into<String>) -> Self {
+        self.end_date = Some(date.into());
+        self
+    }
+
+    /// Set the output format
+    pub fn format(mut self, format: CostReportFormat) -> Self {
+        self.format = Some(format);
+        self
+    }
+
+    /// Filter by subscription IDs
+    pub fn subscription_ids(mut self, ids: Vec<i32>) -> Self {
+        self.subscription_ids = Some(ids);
+        self
+    }
+
+    /// Filter by database IDs
+    pub fn database_ids(mut self, ids: Vec<i32>) -> Self {
+        self.database_ids = Some(ids);
+        self
+    }
+
+    /// Filter by subscription type
+    pub fn subscription_type(mut self, sub_type: SubscriptionType) -> Self {
+        self.subscription_type = Some(sub_type);
+        self
+    }
+
+    /// Filter by regions
+    pub fn regions(mut self, regions: Vec<String>) -> Self {
+        self.regions = Some(regions);
+        self
+    }
+
+    /// Filter by tags
+    pub fn tags(mut self, tags: Vec<Tag>) -> Self {
+        self.tags = Some(tags);
+        self
+    }
+
+    /// Add a single tag filter
+    pub fn tag(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        let tag = Tag::new(key, value);
+        match &mut self.tags {
+            Some(tags) => tags.push(tag),
+            None => self.tags = Some(vec![tag]),
+        }
+        self
+    }
+
+    /// Build the request
+    ///
+    /// # Panics
+    /// Panics if start_date or end_date is not set
+    pub fn build(self) -> CostReportCreateRequest {
+        CostReportCreateRequest {
+            start_date: self.start_date.expect("start_date is required"),
+            end_date: self.end_date.expect("end_date is required"),
+            format: self.format,
+            subscription_ids: self.subscription_ids,
+            database_ids: self.database_ids,
+            subscription_type: self.subscription_type,
+            regions: self.regions,
+            tags: self.tags,
+            extra: Value::Null,
+        }
+    }
+}
+
+// ============================================================================
+// Handler
+// ============================================================================
+
+/// Handler for cost report operations
+///
+/// Provides methods to generate and download cost reports in FOCUS format.
+pub struct CostReportHandler {
+    client: CloudClient,
+}
+
+impl CostReportHandler {
+    /// Create a new handler
+    pub fn new(client: CloudClient) -> Self {
+        Self { client }
+    }
+
+    /// Generate a cost report (Beta)
+    ///
+    /// Generates a cost report in FOCUS format for the specified time period
+    /// and filters. The maximum date range is 40 days.
+    ///
+    /// This is an asynchronous operation. The returned TaskStateUpdate contains
+    /// a task_id that can be used to track progress. Once complete, the task
+    /// response will contain the costReportId needed to download the report.
+    ///
+    /// POST /cost-report
+    ///
+    /// # Arguments
+    /// * `request` - The cost report generation request with date range and filters
+    ///
+    /// # Returns
+    /// A TaskStateUpdate with the task ID for tracking the generation
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use redis_cloud::{CloudClient, CostReportHandler, CostReportCreateRequest};
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let client = CloudClient::builder().api_key("k").api_secret("s").build()?;
+    /// let handler = CostReportHandler::new(client);
+    /// let request = CostReportCreateRequest::new("2025-01-01", "2025-01-31");
+    /// let task = handler.generate_cost_report(request).await?;
+    /// println!("Task ID: {:?}", task.task_id);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn generate_cost_report(
+        &self,
+        request: CostReportCreateRequest,
+    ) -> Result<TaskStateUpdate> {
+        self.client.post("/cost-report", &request).await
+    }
+
+    /// Generate a cost report and return raw JSON response
+    ///
+    /// POST /cost-report
+    pub async fn generate_cost_report_raw(
+        &self,
+        request: CostReportCreateRequest,
+    ) -> Result<Value> {
+        let body = serde_json::to_value(request).map_err(crate::CloudError::from)?;
+        self.client.post_raw("/cost-report", body).await
+    }
+
+    /// Download a generated cost report (Beta)
+    ///
+    /// Returns the generated cost report file in FOCUS format. The costReportId
+    /// is obtained from the task response after the generation task completes.
+    ///
+    /// GET /cost-report/{costReportId}
+    ///
+    /// # Arguments
+    /// * `cost_report_id` - The cost report ID from the completed generation task
+    ///
+    /// # Returns
+    /// The raw bytes of the cost report file (CSV or JSON depending on request)
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use redis_cloud::{CloudClient, CostReportHandler};
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let client = CloudClient::builder().api_key("k").api_secret("s").build()?;
+    /// let handler = CostReportHandler::new(client);
+    /// let report = handler.download_cost_report("cost-report-12345").await?;
+    /// std::fs::write("cost-report.csv", report)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn download_cost_report(&self, cost_report_id: &str) -> Result<Vec<u8>> {
+        self.client
+            .get_bytes(&format!("/cost-report/{}", cost_report_id))
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cost_report_request_builder() {
+        let request = CostReportCreateRequest::builder()
+            .start_date("2025-01-01")
+            .end_date("2025-01-31")
+            .format(CostReportFormat::Csv)
+            .subscription_ids(vec![123, 456])
+            .regions(vec!["us-east-1".to_string()])
+            .tag("env", "prod")
+            .build();
+
+        assert_eq!(request.start_date, "2025-01-01");
+        assert_eq!(request.end_date, "2025-01-31");
+        assert_eq!(request.format, Some(CostReportFormat::Csv));
+        assert_eq!(request.subscription_ids, Some(vec![123, 456]));
+        assert_eq!(request.regions, Some(vec!["us-east-1".to_string()]));
+        assert!(request.tags.is_some());
+        let tags = request.tags.unwrap();
+        assert_eq!(tags.len(), 1);
+        assert_eq!(tags[0].key, "env");
+        assert_eq!(tags[0].value, "prod");
+    }
+
+    #[test]
+    fn test_cost_report_request_simple() {
+        let request = CostReportCreateRequest::new("2025-01-01", "2025-01-31");
+        assert_eq!(request.start_date, "2025-01-01");
+        assert_eq!(request.end_date, "2025-01-31");
+        assert!(request.format.is_none());
+    }
+
+    #[test]
+    fn test_cost_report_format_display() {
+        assert_eq!(CostReportFormat::Csv.to_string(), "csv");
+        assert_eq!(CostReportFormat::Json.to_string(), "json");
+    }
+
+    #[test]
+    fn test_subscription_type_display() {
+        assert_eq!(SubscriptionType::Pro.to_string(), "pro");
+        assert_eq!(SubscriptionType::Essentials.to_string(), "essentials");
+    }
+
+    #[test]
+    fn test_tag_creation() {
+        let tag = Tag::new("environment", "production");
+        assert_eq!(tag.key, "environment");
+        assert_eq!(tag.value, "production");
+    }
+
+    #[test]
+    fn test_request_serialization() {
+        let request = CostReportCreateRequest::builder()
+            .start_date("2025-01-01")
+            .end_date("2025-01-31")
+            .format(CostReportFormat::Json)
+            .subscription_type(SubscriptionType::Pro)
+            .build();
+
+        let json = serde_json::to_value(&request).unwrap();
+        assert_eq!(json["startDate"], "2025-01-01");
+        assert_eq!(json["endDate"], "2025-01-31");
+        assert_eq!(json["format"], "json");
+        assert_eq!(json["subscriptionType"], "pro");
+    }
+}

--- a/crates/redis-cloud/src/lib.rs
+++ b/crates/redis-cloud/src/lib.rs
@@ -296,6 +296,7 @@ pub mod account;
 pub mod acl;
 pub mod cloud_accounts;
 pub mod connectivity;
+pub mod cost_report;
 pub mod fixed;
 pub mod flexible;
 pub mod tasks;
@@ -334,6 +335,8 @@ pub use flexible::subscriptions::SubscriptionHandler;
 pub use flexible::databases::DatabaseHandler as DatabasesHandler;
 pub use flexible::subscriptions::SubscriptionHandler as SubscriptionsHandler;
 
+pub use cost_report::CostReportHandler;
+pub use cost_report::{CostReportCreateRequest, CostReportFormat, SubscriptionType, Tag};
 pub use tasks::TasksHandler as TaskHandler;
 pub use users::UsersHandler as UserHandler;
 

--- a/crates/redisctl/src/commands/cloud/cost_report.rs
+++ b/crates/redisctl/src/commands/cloud/cost_report.rs
@@ -1,0 +1,227 @@
+//! Cost report command implementations
+//!
+//! Handles generating and downloading cost reports in FOCUS format.
+
+#![allow(dead_code)] // Functions used from main.rs binary
+
+use crate::cli::{CloudCostReportCommands, OutputFormat};
+use crate::commands::cloud::async_utils::{AsyncOperationArgs, handle_async_response};
+use crate::connection::ConnectionManager;
+use crate::error::Result as CliResult;
+use anyhow::Context;
+use redis_cloud::cost_report::{CostReportCreateRequest, CostReportFormat, SubscriptionType, Tag};
+use serde_json::json;
+use std::io::Write;
+
+/// Handle cost report commands
+pub async fn handle_cost_report_command(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    command: CloudCostReportCommands,
+    output_format: OutputFormat,
+) -> CliResult<()> {
+    match command {
+        CloudCostReportCommands::Generate {
+            start_date,
+            end_date,
+            format,
+            subscription_ids,
+            database_ids,
+            subscription_type,
+            regions,
+            tags,
+            async_ops,
+        } => {
+            generate_cost_report(
+                conn_mgr,
+                profile_name,
+                start_date,
+                end_date,
+                format,
+                subscription_ids,
+                database_ids,
+                subscription_type,
+                regions,
+                tags,
+                async_ops,
+                output_format,
+            )
+            .await
+        }
+        CloudCostReportCommands::Download {
+            cost_report_id,
+            output,
+        } => {
+            download_cost_report(
+                conn_mgr,
+                profile_name,
+                cost_report_id,
+                output,
+                output_format,
+            )
+            .await
+        }
+    }
+}
+
+/// Generate a cost report
+#[allow(clippy::too_many_arguments)]
+async fn generate_cost_report(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    start_date: String,
+    end_date: String,
+    format: String,
+    subscription_ids: Vec<i32>,
+    database_ids: Vec<i32>,
+    subscription_type: Option<String>,
+    regions: Vec<String>,
+    tags: Vec<String>,
+    async_ops: AsyncOperationArgs,
+    output_format: OutputFormat,
+) -> CliResult<()> {
+    let client = conn_mgr.create_cloud_client(profile_name).await?;
+
+    // Build the request
+    let mut request = CostReportCreateRequest::new(&start_date, &end_date);
+
+    // Set format
+    request.format = Some(match format.as_str() {
+        "json" => CostReportFormat::Json,
+        _ => CostReportFormat::Csv,
+    });
+
+    // Set subscription IDs if provided
+    if !subscription_ids.is_empty() {
+        request.subscription_ids = Some(subscription_ids);
+    }
+
+    // Set database IDs if provided
+    if !database_ids.is_empty() {
+        request.database_ids = Some(database_ids);
+    }
+
+    // Set subscription type if provided
+    if let Some(sub_type) = subscription_type {
+        request.subscription_type = Some(match sub_type.as_str() {
+            "essentials" => SubscriptionType::Essentials,
+            _ => SubscriptionType::Pro,
+        });
+    }
+
+    // Set regions if provided
+    if !regions.is_empty() {
+        request.regions = Some(regions);
+    }
+
+    // Parse and set tags if provided
+    if !tags.is_empty() {
+        let parsed_tags: Vec<Tag> = tags
+            .iter()
+            .filter_map(|t| {
+                let parts: Vec<&str> = t.splitn(2, ':').collect();
+                if parts.len() == 2 {
+                    Some(Tag::new(parts[0], parts[1]))
+                } else {
+                    eprintln!("Warning: Invalid tag format '{}', expected 'key:value'", t);
+                    None
+                }
+            })
+            .collect();
+        if !parsed_tags.is_empty() {
+            request.tags = Some(parsed_tags);
+        }
+    }
+
+    // Convert to JSON for the raw API call
+    let body = serde_json::to_value(&request).context("Failed to serialize request")?;
+
+    // Make the API call
+    let response = client
+        .post_raw("/cost-report", body)
+        .await
+        .context("Failed to generate cost report")?;
+
+    // Handle async response
+    handle_async_response(
+        conn_mgr,
+        profile_name,
+        response,
+        &async_ops,
+        output_format,
+        None,
+        "Cost report generation",
+    )
+    .await
+}
+
+/// Download a generated cost report
+async fn download_cost_report(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    cost_report_id: String,
+    output: Option<String>,
+    output_format: OutputFormat,
+) -> CliResult<()> {
+    let client = conn_mgr.create_cloud_client(profile_name).await?;
+
+    let bytes = client
+        .get_bytes(&format!("/cost-report/{}", cost_report_id))
+        .await?;
+
+    match output {
+        Some(path) => {
+            // Write to file
+            std::fs::write(&path, &bytes)
+                .with_context(|| format!("Failed to write cost report to '{}'", path))?;
+
+            match output_format {
+                OutputFormat::Json => {
+                    let result = json!({
+                        "success": true,
+                        "cost_report_id": cost_report_id,
+                        "output_file": path,
+                        "bytes_written": bytes.len(),
+                    });
+                    println!("{}", serde_json::to_string_pretty(&result)?);
+                }
+                _ => {
+                    println!(
+                        "Cost report downloaded successfully to '{}' ({} bytes)",
+                        path,
+                        bytes.len()
+                    );
+                }
+            }
+        }
+        None => {
+            // Write to stdout
+            match output_format {
+                OutputFormat::Json => {
+                    // For JSON output format, try to parse the content as JSON
+                    // If it's CSV, wrap it in a JSON structure
+                    if let Ok(json_content) = serde_json::from_slice::<serde_json::Value>(&bytes) {
+                        println!("{}", serde_json::to_string_pretty(&json_content)?);
+                    } else {
+                        // It's probably CSV, wrap in JSON
+                        let content = String::from_utf8_lossy(&bytes);
+                        let result = json!({
+                            "cost_report_id": cost_report_id,
+                            "format": "csv",
+                            "content": content,
+                        });
+                        println!("{}", serde_json::to_string_pretty(&result)?);
+                    }
+                }
+                _ => {
+                    // Write raw content to stdout
+                    std::io::stdout()
+                        .write_all(&bytes)
+                        .context("Failed to write cost report to stdout")?;
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/crates/redisctl/src/commands/cloud/mod.rs
+++ b/crates/redisctl/src/commands/cloud/mod.rs
@@ -5,6 +5,7 @@
 //! - `subscription`: Subscription management commands
 //! - `user`: User management commands
 //! - `database`: Database management commands
+//! - `cost_report`: Cost report generation and download
 //! - `utils`: Shared utilities and helper functions
 
 pub mod account;
@@ -14,6 +15,7 @@ pub mod async_utils;
 pub mod cloud_account;
 pub mod cloud_account_impl;
 pub mod connectivity;
+pub mod cost_report;
 pub mod database;
 pub mod database_impl;
 pub mod fixed_database;
@@ -30,6 +32,8 @@ pub mod utils;
 pub use account::handle_account_command;
 #[allow(unused_imports)]
 pub use connectivity::handle_connectivity_command;
+#[allow(unused_imports)]
+pub use cost_report::handle_cost_report_command;
 #[allow(unused_imports)]
 pub use database::handle_database_command;
 #[allow(unused_imports)]

--- a/crates/redisctl/src/main.rs
+++ b/crates/redisctl/src/main.rs
@@ -962,5 +962,14 @@ async fn execute_cloud_command(
             .await
         }
         Workflow(workflow_cmd) => handle_cloud_workflow_command(conn_mgr, cli, workflow_cmd).await,
+        CostReport(cost_report_cmd) => {
+            commands::cloud::cost_report::handle_cost_report_command(
+                conn_mgr,
+                cli.profile.as_deref(),
+                cost_report_cmd.clone(),
+                cli.output,
+            )
+            .await
+        }
     }
 }

--- a/crates/redisctl/tests/cli_basic_tests.rs
+++ b/crates/redisctl/tests/cli_basic_tests.rs
@@ -669,6 +669,50 @@ fn test_cloud_workflow_help() {
         .stdout(predicate::str::contains("Workflow operations"));
 }
 
+#[test]
+fn test_cloud_cost_report_help() {
+    redisctl()
+        .arg("cloud")
+        .arg("cost-report")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Cost report operations"))
+        .stdout(predicate::str::contains("generate"))
+        .stdout(predicate::str::contains("download"));
+}
+
+#[test]
+fn test_cloud_cost_report_generate_help() {
+    redisctl()
+        .arg("cloud")
+        .arg("cost-report")
+        .arg("generate")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Generate a cost report"))
+        .stdout(predicate::str::contains("--start-date"))
+        .stdout(predicate::str::contains("--end-date"))
+        .stdout(predicate::str::contains("--format"))
+        .stdout(predicate::str::contains("--subscription"))
+        .stdout(predicate::str::contains("--region"))
+        .stdout(predicate::str::contains("--tag"));
+}
+
+#[test]
+fn test_cloud_cost_report_download_help() {
+    redisctl()
+        .arg("cloud")
+        .arg("cost-report")
+        .arg("download")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Download a generated cost report"))
+        .stdout(predicate::str::contains("--output"));
+}
+
 // === ENTERPRISE SUBCOMMAND HELP TESTS ===
 
 #[test]


### PR DESCRIPTION
## Summary

Add support for the new Redis Cloud cost-report API endpoints announced at https://redis.io/docs/latest/operate/rc/api/examples/generate-cost-report/

## Changes

### Library (redis-cloud)
- Add `cost_report` module with `CostReportHandler`
- Add `CostReportCreateRequest` with builder pattern for ergonomic request construction
- Add `CostReportFormat` (csv/json), `SubscriptionType` (pro/essentials), and `Tag` types
- Add `get_bytes()` method to `CloudClient` for downloading binary content

### CLI (redisctl)
- Add `cloud cost-report generate` command with comprehensive filtering options:
  - `--start-date` / `--end-date` (YYYY-MM-DD format, max 40 days range)
  - `--format` (csv or json, defaults to csv)
  - `--subscription` (filter by subscription IDs, repeatable)
  - `--database` (filter by database IDs, repeatable)
  - `--subscription-type` (pro or essentials)
  - `--region` (filter by regions, repeatable)
  - `--tag` (filter by key:value tags, repeatable)
  - Async operation support (--wait, --wait-timeout)
- Add `cloud cost-report download` command with `--output` option

### Tests
- Add CLI help tests for cost-report commands

## API Endpoints

- `POST /cost-report` - Generate cost reports in FOCUS format
- `GET /cost-report/{costReportId}` - Download generated reports

## Usage Examples

```bash
# Generate a cost report for January 2025
redisctl cloud cost-report generate --start-date 2025-01-01 --end-date 2025-01-31

# Generate with filters and wait for completion
redisctl cloud cost-report generate --start-date 2025-01-01 --end-date 2025-01-31 \
  --subscription 123 --region us-east-1 --tag team:marketing --wait

# Download the report
redisctl cloud cost-report download cost-report-12345-abcdef --output report.csv
```

## Notes

- The cost report API is currently in Beta
- Reports are in FOCUS (FinOps Cost and Usage Specification) format
- Maximum date range is 40 days

Closes #478