### PR TITLE
fix: update cargo-dist to 0.30.1 for macOS runner compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ on:
   pull_request:
   push:
     tags:
-      - "redisctl-v[0-9]+.[0-9]+.[0-9]+*"
+      - '**[0-9]+.[0-9]+.[0-9]+*'
 
 jobs:
   # Run 'dist plan' (or host) to determine what tasks we need to do
@@ -64,7 +64,7 @@ jobs:
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.29.0/cargo-dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.30.1/cargo-dist-installer.sh | sh"
       - name: Cache dist
         uses: actions/upload-artifact@v4
         with:
@@ -217,8 +217,8 @@ jobs:
       - plan
       - build-local-artifacts
       - build-global-artifacts
-    # Only run if we're "publishing", and only if local and global didn't fail (skipped is fine)
-    if: ${{ always() && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
+    # Only run if we're "publishing", and only if plan, local and global didn't fail (skipped is fine)
+    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     runs-on: "ubuntu-22.04"
@@ -277,32 +277,6 @@ jobs:
           echo "$ANNOUNCEMENT_BODY" > $RUNNER_TEMP/notes.txt
 
           gh release create "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
-
-  update_brew_formula:
-    name: Update Brew Formula
-    runs-on: ubuntu-latest
-    needs: [plan, host]
-    if: ${{ needs.plan.outputs.publishing == 'true' }}
-    steps:
-      - name: Extract version from tag
-        id: extract_version
-        run: |
-          TAG="${{ github.ref_name }}"
-          # Strip 'redisctl-v' prefix to get version number (e.g., redisctl-v0.6.6 -> 0.6.6)
-          VERSION="${TAG#redisctl-v}"
-          # Add 'v' prefix for Homebrew (e.g., 0.6.6 -> v0.6.6)
-          echo "version=v${VERSION}" >> $GITHUB_OUTPUT
-          echo "Extracted version: v${VERSION}"
-
-      - uses: mislav/bump-homebrew-formula-action@v3.1
-        with:
-          formula-name: redisctl
-          formula-path: Formula/redisctl.rb
-          base-branch: main
-          tag-name: ${{ steps.extract_version.outputs.version }}
-          homebrew-tap: joshrotenberg/homebrew-brew
-        env:
-          COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
 
   announce:
     needs:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,13 +30,12 @@ documentation = "https://docs.rs/redisctl"
 # Config for 'dist'
 [workspace.metadata.dist]
 # The preferred dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "0.29.0"
+cargo-dist-version = "0.30.1"
 # CI backends to support
 ci = "github"
 # The installers to generate for each app
 installers = ["shell", "powershell"]
 # Target platforms to build apps for (Rust target-triple syntax)
-# Note: x86_64-unknown-linux-musl removed due to keyring incompatibility with musl
 targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
 # Which actions to run on pull requests
 pr-run-mode = "plan"
@@ -46,7 +45,7 @@ create-release = true
 install-path = "CARGO_HOME"
 # Whether to install an updater program
 install-updater = false
-# Allow custom modifications to generated CI files
+# Skip checking whether the specified configuration files are up to date
 allow-dirty = ["ci"]
 
 [workspace.dependencies]


### PR DESCRIPTION
The macOS-13 runner is now retired by GitHub. This updates cargo-dist to 0.30.1 which uses:

- `macos-14` for aarch64-apple-darwin (ARM)
- `macos-15-intel` for x86_64-apple-darwin (Intel)

This fixes the release build failures seen in the v0.7.0 release.

Sources:
- [GitHub Actions: macOS 13 runner image is closing down](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/)
- [cargo-dist releases](https://github.com/axodotdev/cargo-dist/releases)