### PR TITLE
feat(cloud): add available-versions command for Essentials databases

### DIFF
--- a/crates/redisctl/src/cli/cloud.rs
+++ b/crates/redisctl/src/cli/cloud.rs
@@ -650,6 +650,12 @@ pub enum CloudFixedDatabaseCommands {
         #[arg(long)]
         key: String,
     },
+    /// Get available Redis versions for upgrade
+    #[command(name = "available-versions")]
+    AvailableVersions {
+        /// Database ID (format: subscription_id:database_id)
+        id: String,
+    },
 }
 
 /// Cloud Fixed Subscription Commands

--- a/crates/redisctl/src/commands/cloud/fixed_database.rs
+++ b/crates/redisctl/src/commands/cloud/fixed_database.rs
@@ -400,5 +400,17 @@ pub async fn handle_fixed_database_command(
             eprintln!("Tag '{}' deleted successfully", key);
             Ok(())
         }
+        CloudFixedDatabaseCommands::AvailableVersions { id } => {
+            let (subscription_id, database_id) = parse_fixed_database_id(id)?;
+
+            let json_response = handler
+                .get_available_target_versions(subscription_id, database_id)
+                .await
+                .context("Failed to get available versions")?;
+
+            let data = handle_output(json_response, output_format, query)?;
+            print_formatted_output(data, output_format)?;
+            Ok(())
+        }
     }
 }


### PR DESCRIPTION
Adds the `cloud fixed-database available-versions` command to get available Redis upgrade versions for Essentials (fixed) databases.

The library method already existed, this adds the CLI command.

## Usage

```bash
redisctl cloud fixed-database available-versions <subscription_id:database_id>
```

Closes #466