### PR TITLE
feat(cloud): add update-aa-regions command for Active-Active databases

### DIFF
--- a/crates/redisctl/src/cli/cloud.rs
+++ b/crates/redisctl/src/cli/cloud.rs
@@ -1356,6 +1356,18 @@ pub enum CloudDatabaseCommands {
         force: bool,
     },
 
+    /// Update Active-Active database regions
+    #[command(name = "update-aa-regions")]
+    UpdateAaRegions {
+        /// Database ID (format: subscription_id:database_id)
+        id: String,
+        /// JSON file with region configuration (use @filename or - for stdin)
+        file: String,
+        /// Async operation options
+        #[command(flatten)]
+        async_ops: crate::commands::cloud::async_utils::AsyncOperationArgs,
+    },
+
     /// Get available Redis versions for upgrade
     AvailableVersions {
         /// Database ID (format: subscription_id:database_id)

--- a/crates/redisctl/src/commands/cloud/database.rs
+++ b/crates/redisctl/src/commands/cloud/database.rs
@@ -231,6 +231,22 @@ pub async fn handle_database_command(
             )
             .await
         }
+        CloudDatabaseCommands::UpdateAaRegions {
+            id,
+            file,
+            async_ops,
+        } => {
+            super::database_impl::update_aa_regions(
+                conn_mgr,
+                profile_name,
+                id,
+                file,
+                async_ops,
+                output_format,
+                query,
+            )
+            .await
+        }
         CloudDatabaseCommands::AvailableVersions { id } => {
             super::database_impl::get_available_versions(
                 conn_mgr,


### PR DESCRIPTION
Adds the `cloud database update-aa-regions` command to update region configuration for Active-Active (CRDB) databases.

## Usage

```bash
redisctl cloud database update-aa-regions <subscription_id:database_id> @regions.json
```

Closes #468