### PR TITLE
feat(cloud): add delete endpoint for PrivateLink

### DIFF
--- a/crates/redis-cloud/src/connectivity/private_link.rs
+++ b/crates/redis-cloud/src/connectivity/private_link.rs
@@ -171,6 +171,25 @@ impl PrivateLinkHandler {
             .await
     }
 
+    /// Delete PrivateLink
+    ///
+    /// Deletes the AWS PrivateLink configuration for a subscription.
+    ///
+    /// DELETE /subscriptions/{subscriptionId}/private-link
+    ///
+    /// # Arguments
+    ///
+    /// * `subscription_id` - The subscription ID
+    ///
+    /// # Returns
+    ///
+    /// Returns task information for tracking the deletion
+    pub async fn delete(&self, subscription_id: i32) -> Result<Value> {
+        self.client
+            .delete_raw(&format!("/subscriptions/{}/private-link", subscription_id))
+            .await
+    }
+
     /// Get Active-Active PrivateLink configuration
     ///
     /// Gets the AWS PrivateLink configuration for an Active-Active (CRDB) subscription region.

--- a/crates/redisctl/src/cli/cloud.rs
+++ b/crates/redisctl/src/cli/cloud.rs
@@ -480,6 +480,18 @@ pub enum PrivateLinkCommands {
         #[arg(long)]
         region: Option<i32>,
     },
+    /// Delete PrivateLink configuration
+    Delete {
+        /// Subscription ID
+        #[arg(long)]
+        subscription: i32,
+        /// Skip confirmation prompt
+        #[arg(long)]
+        force: bool,
+        /// Async operation options
+        #[command(flatten)]
+        async_ops: crate::commands::cloud::async_utils::AsyncOperationArgs,
+    },
 }
 
 /// Cloud Task Commands

--- a/crates/redisctl/tests/cli_basic_tests.rs
+++ b/crates/redisctl/tests/cli_basic_tests.rs
@@ -2808,3 +2808,18 @@ fn test_cloud_fixed_database_upgrade_redis_help() {
         .stdout(predicate::str::contains("Upgrade Redis version"))
         .stdout(predicate::str::contains("--version"));
 }
+
+#[test]
+fn test_cloud_connectivity_privatelink_delete_help() {
+    redisctl()
+        .arg("cloud")
+        .arg("connectivity")
+        .arg("privatelink")
+        .arg("delete")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Delete PrivateLink"))
+        .stdout(predicate::str::contains("--subscription"))
+        .stdout(predicate::str::contains("--force"));
+}


### PR DESCRIPTION
Adds the ability to delete PrivateLink configuration for a subscription.

## Changes
- Add `delete` method to `PrivateLinkHandler` in redis-cloud library
- Add `Delete` command to `PrivateLinkCommands` CLI enum
- Implement `handle_delete` with confirmation prompt (`--force` to skip)
- Support async operation handling for delete operations
- Add CLI test for privatelink delete help

## Usage
```bash
# Delete PrivateLink with confirmation prompt
redisctl cloud connectivity privatelink delete --subscription 123

# Delete PrivateLink without confirmation
redisctl cloud connectivity privatelink delete --subscription 123 --force

# With async operation handling
redisctl cloud connectivity privatelink delete --subscription 123 --force --wait
```

Closes #469