### PR TITLE
feat(cloud): add upgrade endpoints for Essentials databases

### DIFF
--- a/crates/redis-cloud/src/fixed/databases.rs
+++ b/crates/redis-cloud/src/fixed/databases.rs
@@ -1218,4 +1218,45 @@ impl FixedDatabaseHandler {
             ))
             .await
     }
+
+    /// Get Essentials database version upgrade status
+    /// Gets information on the latest upgrade attempt for this Essentials database.
+    ///
+    /// GET /fixed/subscriptions/{subscriptionId}/databases/{databaseId}/upgrade
+    pub async fn get_upgrade_status(
+        &self,
+        subscription_id: i32,
+        database_id: i32,
+    ) -> Result<Value> {
+        self.client
+            .get_raw(&format!(
+                "/fixed/subscriptions/{}/databases/{}/upgrade",
+                subscription_id, database_id
+            ))
+            .await
+    }
+
+    /// Upgrade Essentials database Redis version
+    /// Upgrades the specified Essentials database to a later Redis version.
+    ///
+    /// POST /fixed/subscriptions/{subscriptionId}/databases/{databaseId}/upgrade
+    pub async fn upgrade_redis_version(
+        &self,
+        subscription_id: i32,
+        database_id: i32,
+        target_version: &str,
+    ) -> Result<Value> {
+        let request = serde_json::json!({
+            "targetVersion": target_version
+        });
+        self.client
+            .post_raw(
+                &format!(
+                    "/fixed/subscriptions/{}/databases/{}/upgrade",
+                    subscription_id, database_id
+                ),
+                request,
+            )
+            .await
+    }
 }

--- a/crates/redisctl/src/cli/cloud.rs
+++ b/crates/redisctl/src/cli/cloud.rs
@@ -656,6 +656,24 @@ pub enum CloudFixedDatabaseCommands {
         /// Database ID (format: subscription_id:database_id)
         id: String,
     },
+    /// Get Redis version upgrade status
+    #[command(name = "upgrade-status")]
+    UpgradeStatus {
+        /// Database ID (format: subscription_id:database_id)
+        id: String,
+    },
+    /// Upgrade Redis version
+    #[command(name = "upgrade-redis")]
+    UpgradeRedis {
+        /// Database ID (format: subscription_id:database_id)
+        id: String,
+        /// Target Redis version
+        #[arg(long)]
+        version: String,
+        /// Async operation options
+        #[command(flatten)]
+        async_ops: crate::commands::cloud::async_utils::AsyncOperationArgs,
+    },
 }
 
 /// Cloud Fixed Subscription Commands

--- a/crates/redisctl/tests/cli_basic_tests.rs
+++ b/crates/redisctl/tests/cli_basic_tests.rs
@@ -2782,3 +2782,29 @@ fn test_cloud_database_update_tag_help() {
         .stdout(predicate::str::contains("--key"))
         .stdout(predicate::str::contains("--value"));
 }
+
+#[test]
+fn test_cloud_fixed_database_upgrade_status_help() {
+    redisctl()
+        .arg("cloud")
+        .arg("fixed-database")
+        .arg("upgrade-status")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("upgrade status"))
+        .stdout(predicate::str::contains("subscription_id:database_id"));
+}
+
+#[test]
+fn test_cloud_fixed_database_upgrade_redis_help() {
+    redisctl()
+        .arg("cloud")
+        .arg("fixed-database")
+        .arg("upgrade-redis")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Upgrade Redis version"))
+        .stdout(predicate::str::contains("--version"));
+}


### PR DESCRIPTION
Adds Redis version upgrade operations for Essentials (fixed) databases.

## Changes
- Add `get_upgrade_status` method to `FixedDatabaseHandler` in redis-cloud library
- Add `upgrade_redis_version` method to `FixedDatabaseHandler`
- Add `UpgradeStatus` CLI command for fixed-database
- Add `UpgradeRedis` CLI command for fixed-database with async operation support
- Add CLI tests for new commands

## Usage
```bash
# Get upgrade status for an Essentials database
redisctl cloud fixed-database upgrade-status 123:456

# Upgrade Redis version
redisctl cloud fixed-database upgrade-redis 123:456 --version 7.2

# Upgrade with async wait
redisctl cloud fixed-database upgrade-redis 123:456 --version 7.2 --wait
```

Closes #470