### PR TITLE
feat(cloud): add update single tag endpoint for Pro databases

### DIFF
--- a/crates/redisctl/src/cli/cloud.rs
+++ b/crates/redisctl/src/cli/cloud.rs
@@ -1329,6 +1329,18 @@ pub enum CloudDatabaseCommands {
         data: String,
     },
 
+    /// Update a single tag value
+    UpdateTag {
+        /// Database ID (format: subscription_id:database_id)
+        id: String,
+        /// Tag key
+        #[arg(long)]
+        key: String,
+        /// Tag value
+        #[arg(long)]
+        value: String,
+    },
+
     /// Delete a tag from database
     DeleteTag {
         /// Database ID (format: subscription_id:database_id)

--- a/crates/redisctl/src/commands/cloud/database.rs
+++ b/crates/redisctl/src/commands/cloud/database.rs
@@ -205,6 +205,18 @@ pub async fn handle_database_command(
             )
             .await
         }
+        CloudDatabaseCommands::UpdateTag { id, key, value } => {
+            super::database_impl::update_tag(
+                conn_mgr,
+                profile_name,
+                id,
+                key,
+                value,
+                output_format,
+                query,
+            )
+            .await
+        }
         CloudDatabaseCommands::DeleteTag { id, key } => {
             super::database_impl::delete_tag(conn_mgr, profile_name, id, key, output_format, query)
                 .await

--- a/crates/redisctl/tests/cli_basic_tests.rs
+++ b/crates/redisctl/tests/cli_basic_tests.rs
@@ -2768,3 +2768,17 @@ fn test_enterprise_cluster_maintenance_mode_disable_help() {
         .success()
         .stdout(predicate::str::contains("maintenance"));
 }
+
+#[test]
+fn test_cloud_database_update_tag_help() {
+    redisctl()
+        .arg("cloud")
+        .arg("database")
+        .arg("update-tag")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Update a single tag value"))
+        .stdout(predicate::str::contains("--key"))
+        .stdout(predicate::str::contains("--value"));
+}


### PR DESCRIPTION
Adds the ability to update a single tag value without replacing all tags.

## Changes
- Add `UpdateTag` CLI command to `CloudDatabaseCommands`
- Add `update_tag` handler function in database_impl
- Add CLI test for update-tag help

## Usage
```bash
# Update a single tag value for a Pro database
redisctl cloud database update-tag 123:456 --key environment --value production

# With JSON output
redisctl cloud database update-tag 123:456 --key environment --value production -o json
```

## Notes
This provides parity with Essentials databases which already have `fixed-database update-tag`.

Closes #471