### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2327,7 +2327,7 @@ dependencies = [
 
 [[package]]
 name = "redis-cloud"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2379,7 +2379,7 @@ dependencies = [
 
 [[package]]
 name = "redisctl"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/crates/redis-cloud/CHANGELOG.md
+++ b/crates/redis-cloud/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.3](https://github.com/joshrotenberg/redisctl/compare/redis-cloud-v0.7.2...redis-cloud-v0.7.3) - 2025-12-09
+
+### Added
+
+- *(cloud)* add delete endpoint for PrivateLink ([#487](https://github.com/joshrotenberg/redisctl/pull/487))
+- *(cloud)* add upgrade endpoints for Essentials databases ([#488](https://github.com/joshrotenberg/redisctl/pull/488))
+
 ## [0.7.2](https://github.com/joshrotenberg/redisctl/compare/redis-cloud-v0.7.1...redis-cloud-v0.7.2) - 2025-12-09
 
 ### Added

--- a/crates/redis-cloud/Cargo.toml
+++ b/crates/redis-cloud/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-cloud"
-version = "0.7.2"
+version = "0.7.3"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/redisctl/CHANGELOG.md
+++ b/crates/redisctl/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1](https://github.com/joshrotenberg/redisctl/compare/redisctl-v0.7.0...redisctl-v0.7.1) - 2025-12-09
+
+### Added
+
+- add cross-platform pager support for Windows ([#491](https://github.com/joshrotenberg/redisctl/pull/491))
+- *(cloud)* add delete endpoint for PrivateLink ([#487](https://github.com/joshrotenberg/redisctl/pull/487))
+- *(cloud)* add upgrade endpoints for Essentials databases ([#488](https://github.com/joshrotenberg/redisctl/pull/488))
+- *(cloud)* add available-versions command for Essentials databases ([#485](https://github.com/joshrotenberg/redisctl/pull/485))
+- *(cloud)* add update-aa-regions command for Active-Active databases ([#486](https://github.com/joshrotenberg/redisctl/pull/486))
+- *(cloud)* add update single tag endpoint for Pro databases ([#489](https://github.com/joshrotenberg/redisctl/pull/489))
+
 ## [0.7.0](https://github.com/joshrotenberg/redisctl/compare/redisctl-v0.6.6...redisctl-v0.7.0) - 2025-12-09
 
 ### Added

--- a/crates/redisctl/Cargo.toml
+++ b/crates/redisctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redisctl"
-version = "0.7.0"
+version = "0.7.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
@@ -19,7 +19,7 @@ path = "src/main.rs"
 
 [dependencies]
 redisctl-config = { version = "0.2.0", path = "../redisctl-config" }
-redis-cloud = { version = "0.7.2", path = "../redis-cloud", features = ["tower-integration"] }
+redis-cloud = { version = "0.7.3", path = "../redis-cloud", features = ["tower-integration"] }
 redis-enterprise = { version = "0.7.0", path = "../redis-enterprise", features = ["tower-integration"] }
 files-sdk = { workspace = true, optional = true }
 


### PR DESCRIPTION



## 🤖 New release

* `redis-cloud`: 0.7.2 -> 0.7.3 (✓ API compatible changes)
* `redisctl`: 0.7.0 -> 0.7.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `redis-cloud`

<blockquote>

## [0.7.3](https://github.com/joshrotenberg/redisctl/compare/redis-cloud-v0.7.2...redis-cloud-v0.7.3) - 2025-12-09

### Added

- *(cloud)* add delete endpoint for PrivateLink ([#487](https://github.com/joshrotenberg/redisctl/pull/487))
- *(cloud)* add upgrade endpoints for Essentials databases ([#488](https://github.com/joshrotenberg/redisctl/pull/488))
</blockquote>

## `redisctl`

<blockquote>

## [0.7.1](https://github.com/joshrotenberg/redisctl/compare/redisctl-v0.7.0...redisctl-v0.7.1) - 2025-12-09

### Added

- add cross-platform pager support for Windows ([#491](https://github.com/joshrotenberg/redisctl/pull/491))
- *(cloud)* add delete endpoint for PrivateLink ([#487](https://github.com/joshrotenberg/redisctl/pull/487))
- *(cloud)* add upgrade endpoints for Essentials databases ([#488](https://github.com/joshrotenberg/redisctl/pull/488))
- *(cloud)* add available-versions command for Essentials databases ([#485](https://github.com/joshrotenberg/redisctl/pull/485))
- *(cloud)* add update-aa-regions command for Active-Active databases ([#486](https://github.com/joshrotenberg/redisctl/pull/486))
- *(cloud)* add update single tag endpoint for Pro databases ([#489](https://github.com/joshrotenberg/redisctl/pull/489))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).