### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2367,7 +2367,7 @@ dependencies = [
 
 [[package]]
 name = "redis-cloud"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2419,7 +2419,7 @@ dependencies = [
 
 [[package]]
 name = "redisctl"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/crates/redis-cloud/CHANGELOG.md
+++ b/crates/redis-cloud/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.4](https://github.com/joshrotenberg/redisctl/compare/redis-cloud-v0.7.3...redis-cloud-v0.7.4) - 2025-12-13
+
+### Other
+
+- remove outdated implementation tracking file ([#492](https://github.com/joshrotenberg/redisctl/pull/492))
+
 ## [0.7.3](https://github.com/joshrotenberg/redisctl/compare/redis-cloud-v0.7.2...redis-cloud-v0.7.3) - 2025-12-09
 
 ### Added

--- a/crates/redis-cloud/Cargo.toml
+++ b/crates/redis-cloud/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-cloud"
-version = "0.7.3"
+version = "0.7.4"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/redisctl/CHANGELOG.md
+++ b/crates/redisctl/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.2](https://github.com/joshrotenberg/redisctl/compare/redisctl-v0.7.1...redisctl-v0.7.2) - 2025-12-13
+
+### Added
+
+- upgrade jmespath_extensions to 0.6 with full feature set ([#496](https://github.com/joshrotenberg/redisctl/pull/496))
+
 ## [0.7.1](https://github.com/joshrotenberg/redisctl/compare/redisctl-v0.7.0...redisctl-v0.7.1) - 2025-12-09
 
 ### Added

--- a/crates/redisctl/Cargo.toml
+++ b/crates/redisctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redisctl"
-version = "0.7.1"
+version = "0.7.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
@@ -19,7 +19,7 @@ path = "src/main.rs"
 
 [dependencies]
 redisctl-config = { version = "0.2.0", path = "../redisctl-config" }
-redis-cloud = { version = "0.7.3", path = "../redis-cloud", features = ["tower-integration"] }
+redis-cloud = { version = "0.7.4", path = "../redis-cloud", features = ["tower-integration"] }
 redis-enterprise = { version = "0.7.0", path = "../redis-enterprise", features = ["tower-integration"] }
 files-sdk = { workspace = true, optional = true }
 


### PR DESCRIPTION



## 🤖 New release

* `redis-cloud`: 0.7.3 -> 0.7.4 (✓ API compatible changes)
* `redisctl`: 0.7.1 -> 0.7.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `redis-cloud`

<blockquote>

## [0.7.4](https://github.com/joshrotenberg/redisctl/compare/redis-cloud-v0.7.3...redis-cloud-v0.7.4) - 2025-12-13

### Other

- remove outdated implementation tracking file ([#492](https://github.com/joshrotenberg/redisctl/pull/492))
</blockquote>

## `redisctl`

<blockquote>

## [0.7.2](https://github.com/joshrotenberg/redisctl/compare/redisctl-v0.7.1...redisctl-v0.7.2) - 2025-12-13

### Added

- upgrade jmespath_extensions to 0.6 with full feature set ([#496](https://github.com/joshrotenberg/redisctl/pull/496))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).