### PR TITLE
feat: upgrade jmespath_extensions to 0.6 with full feature set

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,6 +298,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -676,6 +686,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1167,6 +1178,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "http"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1456,12 +1476,9 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "ipnetwork"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf466541e9d546596ee94f9f69590f89473455f88372423e0008fc1a7daf100e"
-dependencies = [
- "serde",
-]
+checksum = "cf370abdafd54d13e54a620e8c3e1145f28e46cc9d704bc6d94414559df41763"
 
 [[package]]
 name = "iri-string"
@@ -1542,15 +1559,18 @@ dependencies = [
 
 [[package]]
 name = "jmespath_extensions"
-version = "0.3.5"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac33f051002bc3cde2054fc37a38abd5b321be6781d96f1b3bf5c2f619e5204c"
+checksum = "d95ee2950a69b6aea207537220d40a00a7ddb5a259faefdc32cd01d7402d8e41"
 dependencies = [
+ "aho-corasick",
  "base64 0.22.1",
  "chrono",
+ "chrono-tz",
  "crc32fast",
  "geoutils",
  "hex",
+ "hmac",
  "ipnetwork",
  "jmespath",
  "json-patch",
@@ -1560,10 +1580,12 @@ dependencies = [
  "regex",
  "rphonetic",
  "semver",
+ "serde",
  "serde_json",
  "sha1",
  "sha2",
  "strsim",
+ "toml 0.8.23",
  "ulid",
  "url",
  "urlencoding",
@@ -2024,6 +2046,24 @@ checksum = "72f27a2cfee9f9039c4d86faa5af122a0ac3851441a34865b8a043b46be0065a"
 dependencies = [
  "pest",
  "sha2",
+]
+
+[[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -2953,6 +2993,12 @@ name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"

--- a/crates/redisctl/Cargo.toml
+++ b/crates/redisctl/Cargo.toml
@@ -51,7 +51,7 @@ thiserror = { workspace = true }
 serde_yaml = { workspace = true }
 comfy-table = { workspace = true }
 jmespath = { workspace = true }
-jmespath_extensions = { version = "0.3", features = ["string", "array", "object", "math", "type", "utility", "datetime", "encoding", "validation"] }
+jmespath_extensions = { version = "0.6", features = ["full"] }
 config = { workspace = true }
 
 # Keyring for Files.com API key storage (separate from profile credentials)

--- a/crates/redisctl/src/output.rs
+++ b/crates/redisctl/src/output.rs
@@ -52,7 +52,7 @@ pub fn print_output<T: Serialize>(
 ) -> Result<()> {
     let mut json_value = serde_json::to_value(data)?;
 
-    // Apply JMESPath query if provided (using extended runtime with 150+ functions)
+    // Apply JMESPath query if provided (using extended runtime with 300+ functions)
     if let Some(query_str) = query {
         let runtime = get_jmespath_runtime();
         let expr = runtime


### PR DESCRIPTION
## Summary

Upgrades jmespath_extensions from 0.3.5 to 0.6.2, enabling all 297 extension functions (up from ~100).

## New Function Categories

| Category | Functions | Use Cases |
|----------|-----------|-----------|
| **DURATION** | `format_duration`, `parse_duration` | Display uptimes, format intervals |
| **NETWORK** | `cidr_contains`, `is_private_ip` | Validate cluster networking |
| **COMPUTING** | `format_bytes`, `parse_bytes` | Memory/storage display |
| **DATETIME** | `relative_time`, `time_ago`, `timezone_convert` | Human-readable timestamps |
| **SEMVER** | `semver_compare`, `semver_satisfies` | Version checking |
| **REGEX** | `regex_match`, `regex_replace` | Pattern matching |
| **HASH** | `sha256`, `md5` | Checksums |
| **FUZZY** | `levenshtein`, `soundex` | Fuzzy name matching |
| **JSONPATCH** | `json_diff`, `json_patch` | Config comparison |

## Example Use Cases

```bash
# Format memory sizes
redisctl enterprise database list -q '[*].{name: name, memory: format_bytes(memory_size)}'

# Human-readable timestamps  
redisctl cloud task list -q '[*].{id: id, created: time_ago(created_time)}'

# Check CIDR ranges
redisctl enterprise node list -q '[?cidr_contains(`"10.0.0.0/8"`, addr)]'

# Compare versions
redisctl enterprise cluster get -q '{version: version, needs_upgrade: semver_compare(version, `"7.4.0"`) < `0`}'
```

## Testing

- All existing tests pass
- No breaking changes to API