### PR TITLE
docs: expand JMESPath documentation and add presentation slides

### DIFF
--- a/docs/src/common-features/jmespath-queries.md
+++ b/docs/src/common-features/jmespath-queries.md
@@ -1,6 +1,6 @@
 # JMESPath Queries
 
-Filter and transform output using JMESPath expressions with the `-q` or `--query` flag.
+Filter and transform output using JMESPath expressions with the `-q` or `--query` flag. redisctl includes 300+ extended functions beyond standard JMESPath.
 
 ## Basic Usage
 
@@ -12,7 +12,7 @@ redisctl enterprise cluster get -q 'name'
 redisctl cloud database get 123:456 -q 'security.ssl_client_authentication'
 
 # Get multiple fields
-redisctl enterprise database get 1:-q '{name: name, memory: memory_size, port: port}'
+redisctl enterprise database get 1 -q '{name: name, memory: memory_size, port: port}'
 ```
 
 ## Array Operations
@@ -54,6 +54,20 @@ redisctl cloud subscription list -q "reverse(sort_by(@, &id))"
 redisctl enterprise database list -q '[:5]'
 ```
 
+## Pipelines
+
+Chain operations together with `|` for complex transformations:
+
+```bash
+# Filter -> Sort -> Take top 3 -> Reshape
+redisctl enterprise database list -q '
+  [?status==`active`]
+  | sort_by(@, &memory_size)
+  | reverse(@)
+  | [:3]
+  | [*].{name: name, memory_gb: to_string(memory_size / `1073741824`)}'
+```
+
 ## Common Patterns
 
 ### Extract Single Value
@@ -88,17 +102,112 @@ redisctl cloud subscription list -q 'length(@) == `0`'
 
 ## Extended Functions
 
-redisctl includes 150+ extended JMESPath functions beyond the standard built-ins.
+redisctl includes 300+ extended JMESPath functions. Here are the most useful categories:
 
 ### String Functions
 
 ```bash
-# Uppercase/lowercase
-redisctl enterprise database list -q '[].{name: name, status: upper(status)}'
+# Case conversion
+redisctl enterprise database list -q '[].{name: upper(name)}'
 
 # String manipulation
 redisctl enterprise cluster get -q 'split(name, `-`)'
 redisctl enterprise database list -q '[].{name: trim(name)}'
+
+# Case transformations
+redisctl api cloud get /subscriptions -q '[].{id: id, name: snake_case(name)}'
+```
+
+### Formatting Functions
+
+```bash
+# Format bytes (human readable)
+redisctl enterprise database list -q '[].{name: name, memory: format_bytes(memory_size)}'
+# Output: [{"name": "cache", "memory": "1.00 GB"}]
+
+# Format duration
+redisctl enterprise database list -q '[].{name: name, uptime: format_duration(uptime_seconds)}'
+# Output: [{"name": "cache", "uptime": "2d 5h 30m"}]
+
+# Parse bytes
+redisctl api cloud get /subscriptions -q '[].{name: name, bytes: parse_bytes(memory_limit)}'
+```
+
+### Date/Time Functions
+
+```bash
+# Human-readable relative time
+redisctl cloud task list -q '[].{id: id, created: time_ago(created_time)}'
+# Output: [{"id": "task-123", "created": "2 hours ago"}]
+
+# Format timestamps
+redisctl cloud subscription list -q '[].{name: name, created: format_date(createdAt, `"%Y-%m-%d"`)}'
+
+# Current timestamp
+redisctl enterprise cluster get -q '{name: name, checked_at: now()}'
+
+# Check if weekend/weekday
+redisctl cloud task list -q '[?is_weekday(created_timestamp)]'
+
+# Time calculations
+redisctl enterprise database list -q '[].{name: name, age_days: date_diff(now(), created_at, `"days"`)}'
+```
+
+### Duration Functions
+
+```bash
+# Convert seconds to human format
+redisctl enterprise database list -q '[].{name: name, uptime: format_duration(uptime_seconds)}'
+
+# Parse duration strings
+redisctl api enterprise get /v1/cluster -q '{timeout: parse_duration(`"1h30m"`)}'
+# Output: {"timeout": 5400}
+```
+
+### Network Functions
+
+```bash
+# Check if IP is private
+redisctl enterprise node list -q '[?is_private_ip(addr)].addr'
+
+# Check CIDR containment
+redisctl enterprise node list -q '[?cidr_contains(`"10.0.0.0/8"`, addr)]'
+
+# Get network info
+redisctl api enterprise get /v1/cluster -q '{
+  network: cidr_network(deployment_cidr),
+  broadcast: cidr_broadcast(deployment_cidr)
+}'
+```
+
+### Math Functions
+
+```bash
+# Rounding
+redisctl enterprise database list -q '[].{name: name, memory_gb: round(memory_size / `1073741824`, `2`)}'
+
+# Min/max
+redisctl enterprise database list -q 'max_by(@, &memory_size).name'
+
+# Statistics
+redisctl enterprise database list -q '{
+  total: sum([].memory_size),
+  avg: avg([].memory_size),
+  count: length(@)
+}'
+```
+
+### Semver Functions
+
+```bash
+# Compare versions
+redisctl enterprise cluster get -q '{
+  version: version,
+  needs_upgrade: semver_compare(version, `"7.4.0"`) < `0`
+}'
+
+# Check version constraints
+redisctl enterprise node list -q '[?semver_satisfies(redis_version, `">=7.0.0"`)]'
 ```
 
 ### Type Functions
@@ -114,16 +223,6 @@ redisctl cloud database get 123:456 -q '{name: name, region: default(region, `"u
 redisctl enterprise database get 1 -q '{name: name, has_endpoints: not(is_empty(endpoints))}'
 ```
 
-### Math Functions
-
-```bash
-# Rounding
-redisctl enterprise database list -q '[].{name: name, memory_gb: round(memory_size / `1073741824`, `2`)}'
-
-# Min/max
-redisctl enterprise database list -q 'max_by(@, &memory_size).name'
-```
-
 ### Utility Functions
 
 ```bash
@@ -137,45 +236,98 @@ redisctl cloud database get 123:456 -q '{region: coalesce(region, cloud_region, 
 redisctl enterprise database list -q 'unique([].status)'
 ```
 
-### Date/Time Functions
-
-```bash
-# Current timestamp
-redisctl enterprise cluster get -q '{name: name, checked_at: now()}'
-
-# Format dates
-redisctl cloud subscription list -q '[].{name: name, created: format_date(createdAt, `"%Y-%m-%d"`)}'
-```
-
 ### Validation Functions
 
 ```bash
-# Validate IPs
-redisctl enterprise database list -q '[].{name: name, valid_endpoint: is_ipv4(endpoints[0].addr)}'
+# Validate formats
+redisctl enterprise database list -q '[].{
+  name: name,
+  valid_endpoint: is_ipv4(endpoints[0].addr),
+  valid_uuid: is_uuid(database_id)
+}'
+
+# Email validation
+redisctl api cloud get /users -q '[?is_email(email)].email'
 ```
 
 ### Encoding Functions
 
 ```bash
-# Base64 decode
-redisctl enterprise cluster get -q '{decoded: base64_decode(encoded_field)}'
+# Base64 encode/decode
+redisctl enterprise cluster get -q '{encoded: base64_encode(name)}'
+redisctl api enterprise get /v1/cluster -q '{decoded: base64_decode(encoded_field)}'
+
+# URL encode/decode
+redisctl api cloud get /subscriptions -q '[].{safe_name: url_encode(name)}'
 ```
 
-For a complete list of extended functions, see the
-[jmespath-extensions documentation](https://github.com/joshrotenberg/jmespath-extensions).
+### Hash Functions
 
-## JMESPath Reference
+```bash
+# Generate hashes
+redisctl enterprise database list -q '[].{name: name, hash: sha256(name)}'
+redisctl api cloud get /subscriptions -q '[].{id: id, checksum: md5(to_string(@))}'
+```
 
-- Strings: `'value'` (single quotes)
-- Numbers: `` `123` `` (backticks)
-- Booleans: `` `true` ``, `` `false` ``
-- Current element: `@`
-- Child: `.field`
-- Index: `[0]`
-- Slice: `[0:5]`
-- Filter: `[?condition]`
-- Multi-select: `{key1: field1, key2: field2}`
-- Pipe: `expression | another`
+### JSON Patch Functions
+
+```bash
+# Compare two configs
+redisctl enterprise database get 1 -q 'json_diff(current_config, desired_config)'
+
+# Apply patches
+redisctl api enterprise get /v1/bdbs/1 -q 'json_patch(@, `[{"op": "add", "path": "/tags", "value": ["prod"]}]`)'
+```
+
+### Fuzzy Matching
+
+```bash
+# Levenshtein distance
+redisctl enterprise database list -q '[?levenshtein(name, `"cache"`) < `3`]'
+
+# Phonetic matching
+redisctl api cloud get /users -q '[?sounds_like(name, `"Smith"`)]'
+```
+
+## Function Categories Reference
+
+| Category | Example Functions |
+|----------|-------------------|
+| String | `upper`, `lower`, `trim`, `split`, `snake_case`, `camel_case` |
+| Array | `unique`, `flatten`, `chunk`, `zip`, `intersection` |
+| Object | `keys`, `values`, `pick`, `omit`, `deep_merge` |
+| Math | `round`, `floor`, `ceil`, `sum`, `avg`, `stddev` |
+| Type | `type_of`, `is_array`, `is_string`, `to_boolean` |
+| Utility | `if`, `coalesce`, `default`, `now` |
+| DateTime | `format_date`, `time_ago`, `relative_time`, `is_weekend` |
+| Duration | `format_duration`, `parse_duration` |
+| Network | `is_private_ip`, `cidr_contains`, `ip_to_int` |
+| Computing | `format_bytes`, `parse_bytes`, `bit_and`, `bit_or` |
+| Validation | `is_email`, `is_uuid`, `is_ipv4`, `is_url` |
+| Encoding | `base64_encode`, `base64_decode`, `url_encode` |
+| Hash | `md5`, `sha256`, `hmac_sha256` |
+| Regex | `regex_match`, `regex_replace`, `regex_extract` |
+| Semver | `semver_compare`, `semver_satisfies`, `semver_parse` |
+| Fuzzy | `levenshtein`, `soundex`, `jaro_winkler` |
+| JSON Patch | `json_diff`, `json_patch`, `json_merge_patch` |
+
+For the complete list, see the [jmespath-extensions documentation](https://docs.rs/jmespath_extensions).
+
+## JMESPath Syntax Reference
+
+| Syntax | Description | Example |
+|--------|-------------|---------|
+| `'value'` | String literal | `[?name=='cache']` |
+| `` `123` `` | Number literal | `[?size > `1024`]` |
+| `` `true` `` | Boolean literal | `[?active == `true`]` |
+| `@` | Current element | `sort_by(@, &name)` |
+| `.field` | Child access | `cluster.name` |
+| `[0]` | Index access | `nodes[0]` |
+| `[0:5]` | Slice | `databases[:5]` |
+| `[?expr]` | Filter | `[?status=='active']` |
+| `{k: v}` | Multi-select | `{id: uid, n: name}` |
+| `\|` | Pipe | `[].name \| sort(@)` |
+| `&field` | Expression reference | `sort_by(@, &name)` |
 
 For full syntax, see [jmespath.org](https://jmespath.org/).
 

--- a/docs/src/presentation/slides.html
+++ b/docs/src/presentation/slides.html
@@ -333,18 +333,48 @@ redisctl enterprise database update 1 --memory-size 2147483648</code></pre>
 
                 <!-- Layer 3: Human Commands - JMESPath -->
                 <section>
-                    <h2>
-                        <span class="green">Human Commands:</span> JMESPath
-                        Queries
-                    </h2>
-                    <pre><code class="language-bash">$ redisctl cloud subscription list -q '[*].{name: name, cost: price}'</code></pre>
+                    <h2><span class="green">Human Commands:</span> JMESPath Queries</h2>
+                    <p>Filter, reshape, and transform any JSON output</p>
+                    <pre><code class="language-bash">$ redisctl enterprise database list -o json</code></pre>
+                    <pre><code class="language-json">[{"uid":1,"name":"session-cache","memory_size":1073741824,"status":"active"},
+ {"uid":2,"name":"user-data","memory_size":2147483648,"status":"active"},
+ {"uid":3,"name":"analytics","memory_size":4294967296,"status":"pending"}]</code></pre>
+                    <pre><code class="language-bash">$ redisctl enterprise database list -q '[?status==`active`].name'</code></pre>
+                    <pre><code class="language-json">["session-cache", "user-data"]</code></pre>
+                </section>
+
+                <!-- JMESPath Pipelines -->
+                <section>
+                    <h2><span class="green">JMESPath:</span> Pipelines</h2>
+                    <p>Chain operations with <code>|</code></p>
+                    <pre><code class="language-bash"># Filter -> Sort -> Take first 3 -> Reshape
+$ redisctl enterprise database list -q '
+  [?status==`active`]
+  | sort_by(@, &memory_size)
+  | reverse(@)
+  | [:3]
+  | [*].{name: name, gb: to_string(memory_size / `1073741824`)}'</code></pre>
                     <pre><code class="language-json">[
-  {"name": "production", "cost": 250.00},
-  {"name": "staging", "cost": 50.00},
-  {"name": "dev", "cost": 25.00}
+  {"name": "analytics", "gb": "4"},
+  {"name": "user-data", "gb": "2"},
+  {"name": "session-cache", "gb": "1"}
 ]</code></pre>
-                    <pre><code class="language-bash">$ redisctl enterprise node list -q '[?status==`active`].addr'</code></pre>
-                    <pre><code class="language-json">["10.0.0.1", "10.0.0.2", "10.0.0.3"]</code></pre>
+                </section>
+
+                <!-- JMESPath Extended Functions -->
+                <section>
+                    <h2><span class="green">JMESPath:</span> 300+ Functions</h2>
+                    <p>Beyond standard JMESPath</p>
+                    <pre><code class="language-bash"># Format bytes, dates, durations
+$ redisctl enterprise database list -q '[*].{
+  name: name,
+  memory: format_bytes(memory_size),
+  uptime: format_duration(uptime_seconds)
+}'</code></pre>
+                    <pre><code class="language-json">[{"name": "session-cache", "memory": "1.00 GB", "uptime": "45d 12h 30m"}]</code></pre>
+                    <pre><code class="language-bash"># Network validation
+$ redisctl enterprise node list -q '[?is_private_ip(addr)].addr'</code></pre>
+                    <pre><code class="language-json">["10.0.0.1", "10.0.0.2", "192.168.1.10"]</code></pre>
                 </section>
 
                 <!-- Layer 4: Workflows - Cloud -->


### PR DESCRIPTION
## Summary

Expands JMESPath documentation and adds JMESPath slides to the presentation.

> **Note**: This PR includes the presentation slides from #495. Merge #495 first, or merge this one to get both changes.

## Changes

### Presentation (3 new slides)

1. **JMESPath Queries** - Basic filtering with real command/output example
2. **JMESPath Pipelines** - Chaining operations with `|`
3. **JMESPath 300+ Functions** - Extended functions like `format_bytes`, `is_private_ip`

### Documentation

Completely rewrote `docs/src/common-features/jmespath-queries.md` to cover:

- **Pipelines** - Chaining operations together
- **New function categories** (from jmespath_extensions 0.6):
  - `format_bytes`, `parse_bytes` - Human-readable memory sizes
  - `format_duration`, `parse_duration` - Duration formatting  
  - `time_ago`, `relative_time` - Human-readable timestamps
  - `is_private_ip`, `cidr_contains` - Network validation
  - `semver_compare`, `semver_satisfies` - Version checking
  - `json_diff`, `json_patch` - Config comparison
  - `levenshtein`, `soundex` - Fuzzy matching
- **Function categories reference table**
- **Syntax reference table**

## Related PRs

- #495 - Initial reveal.js presentation
- #496 - jmespath_extensions 0.6 upgrade (adds these functions)