### PR TITLE
chore: switch to GHCR for Docker images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  REGISTRY: docker.io
+  REGISTRY: ghcr.io
   IMAGE_NAME: redis-developer/redisctl
 
 jobs:
@@ -67,12 +67,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
@@ -88,20 +82,9 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ${{ env.IMAGE_NAME }}:latest
-            ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
-            ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.minor }}
-            ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.major }}
             ghcr.io/${{ env.IMAGE_NAME }}:latest
             ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
+            ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.minor }}
+            ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.major }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-      - name: Update Docker Hub README
-        uses: peter-evans/dockerhub-description@v4
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-          repository: redis-developer/redisctl
-          readme-filepath: ./README.md
-          short-description: "Unified CLI for Redis Cloud and Redis Enterprise management"

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 [![Crates.io](https://img.shields.io/crates/v/redisctl.svg)](https://crates.io/crates/redisctl)
 [![Documentation](https://docs.rs/redisctl/badge.svg)](https://docs.rs/redisctl)
-[![CI](https://github.com/redis-developer/redisctl/actions/workflows/ci.yml/badge.svg)](https://github.com/redis-developer/redisctl/actions/workflows/ci.yml)
-[![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](https://github.com/redis-developer/redisctl#license)
+[![CI](https://github.com/ghcr.io/redis-developer/redisctl/actions/workflows/ci.yml/badge.svg)](https://github.com/ghcr.io/redis-developer/redisctl/actions/workflows/ci.yml)
+[![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](https://github.com/ghcr.io/redis-developer/redisctl#license)
 
 ```bash
 # Create a Redis Cloud subscription with one command
@@ -47,7 +47,7 @@ brew install joshrotenberg/brew/redisctl
 cargo install redisctl
 
 # Or download from releases
-# https://github.com/redis-developer/redisctl/releases
+# https://github.com/ghcr.io/redis-developer/redisctl/releases
 ```
 
 ### 2. Configure
@@ -277,7 +277,7 @@ cargo install redisctl --features secure-storage
 ```
 
 ### Binary Releases
-Download the latest release for your platform from [GitHub Releases](https://github.com/redis-developer/redisctl/releases).
+Download the latest release for your platform from [GitHub Releases](https://github.com/ghcr.io/redis-developer/redisctl/releases).
 
 Binaries are available for:
 - macOS (Intel and Apple Silicon)
@@ -290,13 +290,13 @@ Binaries are available for:
 docker run --rm \
   -e REDIS_CLOUD_API_KEY \
   -e REDIS_CLOUD_SECRET_KEY \
-  redis-developer/redisctl:latest \
+  ghcr.io/redis-developer/redisctl:latest \
   cloud subscription list
 
 # Mount config for persistent profiles
 docker run --rm \
   -v ~/.config/redisctl:/root/.config/redisctl:ro \
-  redis-developer/redisctl:latest \
+  ghcr.io/redis-developer/redisctl:latest \
   cloud database list
 
 # Development environment
@@ -437,7 +437,7 @@ Contributions welcome! See our [Contributing Guide](https://joshrotenberg.github
 
 ```bash
 # Clone and build
-git clone https://github.com/redis-developer/redisctl.git
+git clone https://github.com/ghcr.io/redis-developer/redisctl.git
 cd redisctl
 cargo build --release
 
@@ -464,5 +464,5 @@ at your option.
 ## Support
 
 - [Documentation](https://joshrotenberg.github.io/redisctl/)
-- [Issue Tracker](https://github.com/redis-developer/redisctl/issues)
-- [Discussions](https://github.com/redis-developer/redisctl/discussions)
+- [Issue Tracker](https://github.com/ghcr.io/redis-developer/redisctl/issues)
+- [Discussions](https://github.com/ghcr.io/redis-developer/redisctl/discussions)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -73,7 +73,7 @@ After workflows complete, verify:
 
 - [ ] GitHub Release: https://github.com/redis-developer/redisctl/releases
   - Should have binaries for all platforms
-- [ ] Docker Hub: https://hub.docker.com/r/redis-developer/redisctl/tags
+- [ ] Docker Hub: https://ghcr.io/redis-developer/redisctl/tags
   - Should have new version tag
 - [ ] crates.io: https://crates.io/crates/redisctl
   - Should show new version

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,7 @@ services:
   # This is a high-level workflow that replaces multiple manual API calls.
   # ==============================================================================
   redis-enterprise-init:
-    image: redis-developer/redisctl:latest
+    image: ghcr.io/redis-developer/redisctl:latest
     container_name: redis-enterprise-init
     depends_on:
       redis-enterprise:
@@ -116,7 +116,7 @@ services:
   # Create first test database - basic ephemeral cache
   # Configuration: 100MB, no persistence, LRU eviction policy
   redis-enterprise-create-db1:
-    image: redis-developer/redisctl:latest
+    image: ghcr.io/redis-developer/redisctl:latest
     container_name: redis-enterprise-create-db1
     depends_on:
       redis-enterprise-init:
@@ -137,7 +137,7 @@ services:
   # Create second test database - persistent with AOF
   # Configuration: 200MB, AOF persistence, appendfsync-every-sec
   redis-enterprise-create-db2:
-    image: redis-developer/redisctl:latest
+    image: ghcr.io/redis-developer/redisctl:latest
     container_name: redis-enterprise-create-db2
     depends_on:
       redis-enterprise-init:
@@ -167,7 +167,7 @@ services:
   # List all databases to verify creation
   # 👤 HUMAN-FRIENDLY COMMAND
   redis-enterprise-list-dbs:
-    image: redis-developer/redisctl:latest
+    image: ghcr.io/redis-developer/redisctl:latest
     container_name: redis-enterprise-list-dbs
     depends_on:
       redis-enterprise-create-db1:
@@ -188,7 +188,7 @@ services:
   # Get cache database details with JMESPath filtering
   # 👤 HUMAN-FRIENDLY COMMAND (with filtering)
   redis-enterprise-get-cache-db:
-    image: redis-developer/redisctl:latest
+    image: ghcr.io/redis-developer/redisctl:latest
     container_name: redis-enterprise-get-cache-db
     depends_on:
       redis-enterprise-create-db1:
@@ -211,7 +211,7 @@ services:
   # Get persistent database details
   # 👤 HUMAN-FRIENDLY COMMAND (with filtering)
   redis-enterprise-get-persistent-db:
-    image: redis-developer/redisctl:latest
+    image: ghcr.io/redis-developer/redisctl:latest
     container_name: redis-enterprise-get-persistent-db
     depends_on:
       redis-enterprise-create-db2:
@@ -243,7 +243,7 @@ services:
   # Output: Basic cluster details (filtered for key fields)
   # 👤 HUMAN-FRIENDLY COMMAND
   redis-enterprise-cluster-info:
-    image: redis-developer/redisctl:latest
+    image: ghcr.io/redis-developer/redisctl:latest
     container_name: redis-enterprise-cluster-info
     depends_on:
       redis-enterprise-list-dbs:
@@ -262,7 +262,7 @@ services:
   # List nodes in the cluster
   # 👤 HUMAN-FRIENDLY COMMAND
   redis-enterprise-list-nodes:
-    image: redis-developer/redisctl:latest
+    image: ghcr.io/redis-developer/redisctl:latest
     container_name: redis-enterprise-list-nodes
     depends_on:
       redis-enterprise-cluster-info:
@@ -281,7 +281,7 @@ services:
   # Check cluster stats
   # 👤 HUMAN-FRIENDLY COMMAND
   redis-enterprise-stats:
-    image: redis-developer/redisctl:latest
+    image: ghcr.io/redis-developer/redisctl:latest
     container_name: redis-enterprise-stats
     depends_on:
       redis-enterprise-list-nodes:
@@ -308,7 +308,7 @@ services:
   # Get license information
   # 👤 HUMAN-FRIENDLY COMMAND
   redis-enterprise-license:
-    image: redis-developer/redisctl:latest
+    image: ghcr.io/redis-developer/redisctl:latest
     container_name: redis-enterprise-license
     depends_on:
       redis-enterprise-stats:
@@ -330,7 +330,7 @@ services:
   # Get detailed node information
   # 👤 HUMAN-FRIENDLY COMMAND
   redis-enterprise-node-details:
-    image: redis-developer/redisctl:latest
+    image: ghcr.io/redis-developer/redisctl:latest
     container_name: redis-enterprise-node-details
     depends_on:
       redis-enterprise-license:
@@ -349,7 +349,7 @@ services:
   # List all users
   # 👤 HUMAN-FRIENDLY COMMAND
   redis-enterprise-users:
-    image: redis-developer/redisctl:latest
+    image: ghcr.io/redis-developer/redisctl:latest
     container_name: redis-enterprise-users
     depends_on:
       redis-enterprise-node-details:
@@ -368,7 +368,7 @@ services:
   # Get cluster policy
   # 🔧 RAW API COMMAND
   redis-enterprise-policy:
-    image: redis-developer/redisctl:latest
+    image: ghcr.io/redis-developer/redisctl:latest
     container_name: redis-enterprise-policy
     depends_on:
       redis-enterprise-users:
@@ -387,7 +387,7 @@ services:
   # Check for any cluster alerts
   # 🔧 RAW API COMMAND
   redis-enterprise-alerts:
-    image: redis-developer/redisctl:latest
+    image: ghcr.io/redis-developer/redisctl:latest
     container_name: redis-enterprise-alerts
     depends_on:
       redis-enterprise-policy:
@@ -406,7 +406,7 @@ services:
   # Get comprehensive cluster information
   # 👤 HUMAN-FRIENDLY COMMAND
   redis-enterprise-cluster-full:
-    image: redis-developer/redisctl:latest
+    image: ghcr.io/redis-developer/redisctl:latest
     container_name: redis-enterprise-cluster-full
     depends_on:
       redis-enterprise-alerts:

--- a/docs/src/getting-started/docker.md
+++ b/docs/src/getting-started/docker.md
@@ -92,7 +92,7 @@ docker run --rm -it \
   -e REDIS_ENTERPRISE_INSECURE="true" \
   -e REDIS_ENTERPRISE_USER="admin@redis.local" \
   -e REDIS_ENTERPRISE_PASSWORD="Redis123!" \
-  redis-developer/redisctl:latest \
+  ghcr.io/redis-developer/redisctl:latest \
   /bin/sh
 
 # Inside the container, run commands

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -6,13 +6,13 @@ The quickest way to try redisctl with no installation:
 
 ```bash
 # Run commands directly
-docker run --rm redis-developer/redisctl --help
+docker run --rm ghcr.io/redis-developer/redisctl --help
 
 # With environment variables
 docker run --rm \
   -e REDIS_CLOUD_API_KEY="your-key" \
   -e REDIS_CLOUD_SECRET_KEY="your-secret" \
-  redis-developer/redisctl cloud database list
+  ghcr.io/redis-developer/redisctl cloud database list
 ```
 
 ## Homebrew (macOS/Linux)
@@ -40,12 +40,12 @@ brew upgrade redisctl
 
 ## Binary Releases
 
-Download the latest release for your platform from the [GitHub releases page](https://github.com/redis-developer/redisctl/releases).
+Download the latest release for your platform from the [GitHub releases page](https://github.com/ghcr.io/redis-developer/redisctl/releases).
 
 ### Linux/macOS
 ```bash
 # Download the binary (replace VERSION and PLATFORM)
-curl -L https://github.com/redis-developer/redisctl/releases/download/vVERSION/redisctl-PLATFORM.tar.gz | tar xz
+curl -L https://github.com/ghcr.io/redis-developer/redisctl/releases/download/vVERSION/redisctl-PLATFORM.tar.gz | tar xz
 
 # Move to PATH
 sudo mv redisctl /usr/local/bin/
@@ -80,7 +80,7 @@ cargo install redisctl --features secure-storage
 ## From Source
 
 ```bash
-git clone https://github.com/redis-developer/redisctl.git
+git clone https://github.com/ghcr.io/redis-developer/redisctl.git
 cd redisctl
 
 # Basic installation

--- a/docs/src/getting-started/quickstart.md
+++ b/docs/src/getting-started/quickstart.md
@@ -15,7 +15,7 @@ export REDIS_CLOUD_SECRET_KEY="your-secret-key"
 docker run --rm \
   -e REDIS_CLOUD_API_KEY \
   -e REDIS_CLOUD_SECRET_KEY \
-  redis-developer/redisctl cloud subscription list
+  ghcr.io/redis-developer/redisctl cloud subscription list
 ```
 
 ### Redis Enterprise
@@ -33,7 +33,7 @@ docker run --rm \
   -e REDIS_ENTERPRISE_USER \
   -e REDIS_ENTERPRISE_PASSWORD \
   -e REDIS_ENTERPRISE_INSECURE \
-  redis-developer/redisctl enterprise cluster get
+  ghcr.io/redis-developer/redisctl enterprise cluster get
 ```
 
 That's it! You just ran your first redisctl command.

--- a/docs/src/presentation/slides.html
+++ b/docs/src/presentation/slides.html
@@ -101,7 +101,7 @@
                     </h1>
                     <h3>The CLI for Redis Cloud and Enterprise</h3>
                     <p class="small" style="margin-top: 2em">
-                        github.com/redis-developer/redisctl
+                        github.com/ghcr.io/redis-developer/redisctl
                     </p>
                 </section>
 
@@ -500,19 +500,19 @@ Case: https://files.redis.com/f/abc123</code></pre>
                     <h2>Using with Docker</h2>
                     <p>No installation required</p>
                     <pre><code class="language-bash"># Run any command
-docker run --rm redis-developer/redisctl \
+docker run --rm ghcr.io/redis-developer/redisctl \
   cloud subscription list
 
 # With environment variables
 docker run --rm \
   -e REDIS_CLOUD_API_KEY=$KEY \
   -e REDIS_CLOUD_SECRET_KEY=$SECRET \
-  redis-developer/redisctl cloud database list
+  ghcr.io/redis-developer/redisctl cloud database list
 
 # Or mount your config
 docker run --rm \
   -v ~/.config/redisctl:/root/.config/redisctl \
-  redis-developer/redisctl --profile prod cloud database list</code></pre>
+  ghcr.io/redis-developer/redisctl --profile prod cloud database list</code></pre>
                 </section>
 
                 <!-- CI/CD -->
@@ -629,10 +629,10 @@ cargo install redisctl
 cargo install redisctl --features secure-storage
 
 # Docker
-docker run -it redis-developer/redisctl --help
+docker run -it ghcr.io/redis-developer/redisctl --help
 
 # From releases (Linux x86_64)
-curl -L https://github.com/redis-developer/redisctl/releases/latest/download/redisctl-x86_64-unknown-linux-gnu.tar.gz | tar xz
+curl -L https://github.com/ghcr.io/redis-developer/redisctl/releases/latest/download/redisctl-x86_64-unknown-linux-gnu.tar.gz | tar xz
 ./redisctl --help</code></pre>
                 </section>
 
@@ -649,7 +649,7 @@ redisctl profile set mycloud --cloud-api-key $KEY --cloud-secret-key $SECRET
 redisctl cloud subscription list
 redisctl cloud database list --subscription-id 123456</code></pre>
                     <p style="margin-top: 1.5em"><br /></p>
-                    <h3>github.com/redis-developer/redisctl</h3>
+                    <h3>github.com/ghcr.io/redis-developer/redisctl</h3>
                     <p class="small">Docs: joshrotenberg.github.io/redisctl</p>
                 </section>
             </div>

--- a/docs/src/walkthrough/cloud-examples.md
+++ b/docs/src/walkthrough/cloud-examples.md
@@ -13,7 +13,7 @@ export REDIS_CLOUD_SECRET_KEY="your-secret-key"
 alias redisctl='docker run --rm \
   -e REDIS_CLOUD_API_KEY \
   -e REDIS_CLOUD_SECRET_KEY \
-  redis-developer/redisctl'
+  ghcr.io/redis-developer/redisctl'
 ```
 
 ## API Layer Examples

--- a/docs/src/walkthrough/enterprise-examples.md
+++ b/docs/src/walkthrough/enterprise-examples.md
@@ -17,7 +17,7 @@ alias redisctl='docker run --rm \
   -e REDIS_ENTERPRISE_USER \
   -e REDIS_ENTERPRISE_PASSWORD \
   -e REDIS_ENTERPRISE_INSECURE \
-  redis-developer/redisctl'
+  ghcr.io/redis-developer/redisctl'
 ```
 
 ## API Layer Examples


### PR DESCRIPTION
## Summary

Switches Docker image hosting from Docker Hub to GitHub Container Registry (GHCR).

## Changes

### Workflow (.github/workflows/docker.yml)
- Remove Docker Hub login step
- Remove Docker Hub README sync step  
- Update registry to `ghcr.io`
- Simplified tags to GHCR only

### Documentation
- Update all `docker run` examples to use `ghcr.io/redis-developer/redisctl`
- Update docker-compose.yml image references
- Update RELEASE.md checklist

## Benefits
- No Docker Hub account/secrets needed
- Auth handled via built-in `GITHUB_TOKEN`
- Simpler CI configuration
- Images stored alongside code

## New Image Location
```bash
docker pull ghcr.io/redis-developer/redisctl:latest
docker run --rm ghcr.io/redis-developer/redisctl --help
```

## Testing
- `cargo fmt` - pass
- `cargo clippy` - pass