### PR TITLE
feat(ci): use OIDC Trusted Publishing for crates.io

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -3,6 +3,7 @@ name: Release-plz
 permissions:
   pull-requests: write
   contents: write
+  id-token: write
 
 on:
   push:
@@ -31,4 +32,5 @@ jobs:
         uses: MarcoIeni/release-plz-action@v0.5
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          # Uses OIDC Trusted Publishing - no CARGO_REGISTRY_TOKEN needed
+          # Trusted publishers configured on crates.io for all workspace crates


### PR DESCRIPTION
## Summary

Switches from token-based authentication to OIDC Trusted Publishing for crates.io releases.

## Changes

- Add `id-token: write` permission for OIDC token exchange
- Remove `CARGO_REGISTRY_TOKEN` requirement from workflow
- Release-plz will automatically use OIDC when no token is provided

## Trusted Publishing Configuration

All 4 workspace crates have been configured on crates.io with Trusted Publishers:
- `redisctl`
- `redis-cloud`
- `redis-enterprise`
- `redisctl-config`

Each configured with:
- Repository owner: `redis-developer`
- Repository name: `redisctl`
- Workflow filename: `release-plz.yml`

## Benefits

- No more managing `CARGO_REGISTRY_TOKEN` secrets
- More secure: tokens are short-lived and scoped to this workflow
- Better audit trail for who published what
- Industry best practice for Rust package publishing

## Note

The `RELEASE_TOKEN` secret is still needed for GitHub operations (creating releases, PRs).