### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2391,7 +2391,7 @@ dependencies = [
 
 [[package]]
 name = "redis-enterprise"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2466,7 +2466,7 @@ dependencies = [
 
 [[package]]
 name = "redisctl-config"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "clap",
  "directories",

--- a/crates/redis-enterprise/CHANGELOG.md
+++ b/crates/redis-enterprise/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1](https://github.com/redis-developer/redisctl/compare/redis-enterprise-v0.7.0...redis-enterprise-v0.7.1) - 2025-12-16
+
+### Other
+
+- switch to GHCR for Docker images ([#500](https://github.com/redis-developer/redisctl/pull/500))
+- update repository URLs for redis-developer org ([#499](https://github.com/redis-developer/redisctl/pull/499))
+
 ## [0.7.0](https://github.com/joshrotenberg/redisctl/compare/redis-enterprise-v0.6.4...redis-enterprise-v0.7.0) - 2025-12-09
 
 ### Added

--- a/crates/redis-enterprise/Cargo.toml
+++ b/crates/redis-enterprise/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-enterprise"
-version = "0.7.0"
+version = "0.7.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/redisctl-config/CHANGELOG.md
+++ b/crates/redisctl-config/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/redis-developer/redisctl/compare/redisctl-config-v0.2.0...redisctl-config-v0.2.1) - 2025-12-16
+
+### Other
+
+- update repository URLs for redis-developer org ([#499](https://github.com/redis-developer/redisctl/pull/499))
+
 ## [0.2.0](https://github.com/joshrotenberg/redisctl/compare/redisctl-config-v0.1.1...redisctl-config-v0.2.0) - 2025-12-09
 
 ### Added

--- a/crates/redisctl-config/Cargo.toml
+++ b/crates/redisctl-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redisctl-config"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 authors = ["Josh Rotenberg <josh@redislabs.com>"]
 license = "MIT OR Apache-2.0"

--- a/crates/redisctl/Cargo.toml
+++ b/crates/redisctl/Cargo.toml
@@ -18,9 +18,9 @@ path = "src/main.rs"
 
 
 [dependencies]
-redisctl-config = { version = "0.2.0", path = "../redisctl-config" }
+redisctl-config = { version = "0.2.1", path = "../redisctl-config" }
 redis-cloud = { version = "0.7.4", path = "../redis-cloud", features = ["tower-integration"] }
-redis-enterprise = { version = "0.7.0", path = "../redis-enterprise", features = ["tower-integration"] }
+redis-enterprise = { version = "0.7.1", path = "../redis-enterprise", features = ["tower-integration"] }
 files-sdk = { workspace = true, optional = true }
 
 # CLI dependencies


### PR DESCRIPTION



## 🤖 New release

* `redisctl-config`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `redis-enterprise`: 0.7.0 -> 0.7.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `redisctl-config`

<blockquote>

## [0.2.1](https://github.com/redis-developer/redisctl/compare/redisctl-config-v0.2.0...redisctl-config-v0.2.1) - 2025-12-16

### Other

- update repository URLs for redis-developer org ([#499](https://github.com/redis-developer/redisctl/pull/499))
</blockquote>

## `redis-enterprise`

<blockquote>

## [0.7.1](https://github.com/redis-developer/redisctl/compare/redis-enterprise-v0.7.0...redis-enterprise-v0.7.1) - 2025-12-16

### Other

- switch to GHCR for Docker images ([#500](https://github.com/redis-developer/redisctl/pull/500))
- update repository URLs for redis-developer org ([#499](https://github.com/redis-developer/redisctl/pull/499))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).