### PR TITLE
fix(ci): add crates-io environment for Trusted Publishing

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -18,6 +18,7 @@ jobs:
   release-plz:
     name: Release-plz
     runs-on: ubuntu-latest
+    environment: crates-io
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

Trusted Publishing failed with:
```
The Trusted Publishing config for repository `redis-developer/redisctl` requires an environment, 
but the JWT does not specify one. Expected environments: `crates-io`
```

## Solution

Add `environment: crates-io` to the release-plz job.

## Required Action

**You must create a `crates-io` environment in GitHub repo settings:**

1. Go to Settings > Environments
2. Click "New environment"
3. Name it exactly: `crates-io`
4. No additional protection rules needed (optional: add reviewers for extra security)

After creating the environment and merging this PR, the next release-plz run should work.