### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2528,7 +2528,7 @@ dependencies = [
 
 [[package]]
 name = "redis-cloud"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2552,7 +2552,7 @@ dependencies = [
 
 [[package]]
 name = "redis-enterprise"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2580,7 +2580,7 @@ dependencies = [
 
 [[package]]
 name = "redisctl"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/crates/redis-cloud/CHANGELOG.md
+++ b/crates/redis-cloud/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.5](https://github.com/redis-developer/redisctl/compare/redis-cloud-v0.7.4...redis-cloud-v0.7.5) - 2025-12-17
+
+### Fixed
+
+- correct repository URLs broken by PR #500 ([#506](https://github.com/redis-developer/redisctl/pull/506))
+
+### Other
+
+- update documentation URLs to new hosting location ([#509](https://github.com/redis-developer/redisctl/pull/509))
+
 ## [0.7.4](https://github.com/joshrotenberg/redisctl/compare/redis-cloud-v0.7.3...redis-cloud-v0.7.4) - 2025-12-13
 
 ### Other

--- a/crates/redis-cloud/Cargo.toml
+++ b/crates/redis-cloud/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-cloud"
-version = "0.7.4"
+version = "0.7.5"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/redis-enterprise/CHANGELOG.md
+++ b/crates/redis-enterprise/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.2](https://github.com/redis-developer/redisctl/compare/redis-enterprise-v0.7.1...redis-enterprise-v0.7.2) - 2025-12-17
+
+### Fixed
+
+- support JMESPath backtick string literals and improve module upload error ([#511](https://github.com/redis-developer/redisctl/pull/511))
+
+### Other
+
+- update documentation URLs to new hosting location ([#509](https://github.com/redis-developer/redisctl/pull/509))
+
 ## [0.7.1](https://github.com/redis-developer/redisctl/compare/redis-enterprise-v0.7.0...redis-enterprise-v0.7.1) - 2025-12-16
 
 ### Other

--- a/crates/redis-enterprise/Cargo.toml
+++ b/crates/redis-enterprise/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-enterprise"
-version = "0.7.1"
+version = "0.7.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/redisctl/CHANGELOG.md
+++ b/crates/redisctl/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.3](https://github.com/redis-developer/redisctl/compare/redisctl-v0.7.2...redisctl-v0.7.3) - 2025-12-17
+
+### Added
+
+- add module workflow tools (validate, inspect, package) ([#513](https://github.com/redis-developer/redisctl/pull/513))
+- add module name lookup for module get and database create ([#512](https://github.com/redis-developer/redisctl/pull/512))
+
+### Fixed
+
+- support JMESPath backtick string literals and improve module upload error ([#511](https://github.com/redis-developer/redisctl/pull/511))
+- correct repository URLs broken by PR #500 ([#506](https://github.com/redis-developer/redisctl/pull/506))
+
+### Other
+
+- update documentation URLs to new hosting location ([#509](https://github.com/redis-developer/redisctl/pull/509))
+- release ([#503](https://github.com/redis-developer/redisctl/pull/503))
+
 ## [0.7.2](https://github.com/joshrotenberg/redisctl/compare/redisctl-v0.7.1...redisctl-v0.7.2) - 2025-12-13
 
 ### Added

--- a/crates/redisctl/Cargo.toml
+++ b/crates/redisctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redisctl"
-version = "0.7.2"
+version = "0.7.3"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
@@ -19,8 +19,8 @@ path = "src/main.rs"
 
 [dependencies]
 redisctl-config = { version = "0.2.1", path = "../redisctl-config" }
-redis-cloud = { version = "0.7.4", path = "../redis-cloud", features = ["tower-integration"] }
-redis-enterprise = { version = "0.7.1", path = "../redis-enterprise", features = ["tower-integration"] }
+redis-cloud = { version = "0.7.5", path = "../redis-cloud", features = ["tower-integration"] }
+redis-enterprise = { version = "0.7.2", path = "../redis-enterprise", features = ["tower-integration"] }
 files-sdk = { workspace = true, optional = true }
 
 # CLI dependencies


### PR DESCRIPTION



## 🤖 New release

* `redis-cloud`: 0.7.4 -> 0.7.5 (✓ API compatible changes)
* `redis-enterprise`: 0.7.1 -> 0.7.2 (✓ API compatible changes)
* `redisctl`: 0.7.2 -> 0.7.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `redis-cloud`

<blockquote>

## [0.7.5](https://github.com/redis-developer/redisctl/compare/redis-cloud-v0.7.4...redis-cloud-v0.7.5) - 2025-12-17

### Fixed

- correct repository URLs broken by PR #500 ([#506](https://github.com/redis-developer/redisctl/pull/506))

### Other

- update documentation URLs to new hosting location ([#509](https://github.com/redis-developer/redisctl/pull/509))
</blockquote>

## `redis-enterprise`

<blockquote>

## [0.7.2](https://github.com/redis-developer/redisctl/compare/redis-enterprise-v0.7.1...redis-enterprise-v0.7.2) - 2025-12-17

### Fixed

- support JMESPath backtick string literals and improve module upload error ([#511](https://github.com/redis-developer/redisctl/pull/511))

### Other

- update documentation URLs to new hosting location ([#509](https://github.com/redis-developer/redisctl/pull/509))
</blockquote>

## `redisctl`

<blockquote>

## [0.7.3](https://github.com/redis-developer/redisctl/compare/redisctl-v0.7.2...redisctl-v0.7.3) - 2025-12-17

### Added

- add module workflow tools (validate, inspect, package) ([#513](https://github.com/redis-developer/redisctl/pull/513))
- add module name lookup for module get and database create ([#512](https://github.com/redis-developer/redisctl/pull/512))

### Fixed

- support JMESPath backtick string literals and improve module upload error ([#511](https://github.com/redis-developer/redisctl/pull/511))
- correct repository URLs broken by PR #500 ([#506](https://github.com/redis-developer/redisctl/pull/506))

### Other

- update documentation URLs to new hosting location ([#509](https://github.com/redis-developer/redisctl/pull/509))
- release ([#503](https://github.com/redis-developer/redisctl/pull/503))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).