### PR TITLE
fix: correct repository URLs broken by PR #500

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 [![Crates.io](https://img.shields.io/crates/v/redisctl.svg)](https://crates.io/crates/redisctl)
 [![Documentation](https://docs.rs/redisctl/badge.svg)](https://docs.rs/redisctl)
-[![CI](https://github.com/ghcr.io/redis-developer/redisctl/actions/workflows/ci.yml/badge.svg)](https://github.com/ghcr.io/redis-developer/redisctl/actions/workflows/ci.yml)
-[![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](https://github.com/ghcr.io/redis-developer/redisctl#license)
+[![CI](https://github.com/redis-developer/redisctl/actions/workflows/ci.yml/badge.svg)](https://github.com/redis-developer/redisctl/actions/workflows/ci.yml)
+[![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](https://github.com/redis-developer/redisctl#license)
 
 ```bash
 # Create a Redis Cloud subscription with one command
@@ -41,13 +41,13 @@ Managing Redis Cloud and Redis Enterprise through REST APIs means juggling curl 
 
 ```bash
 # Homebrew (macOS/Linux)
-brew install joshrotenberg/brew/redisctl
+brew install redis-developer/homebrew-tap/redisctl
 
 # Cargo
 cargo install redisctl
 
 # Or download from releases
-# https://github.com/ghcr.io/redis-developer/redisctl/releases
+# https://github.com/redis-developer/redisctl/releases
 ```
 
 ### 2. Configure
@@ -85,7 +85,7 @@ redisctl enterprise logs list --follow
 
 **That's it!** You're ready to manage your Redis deployments.
 
-[**Full Documentation →**](https://joshrotenberg.github.io/redisctl/)
+[**Full Documentation →**](https://redis-developer.github.io/redisctl/)
 
 ---
 
@@ -264,7 +264,7 @@ redisctl cloud database get 67890 \
 
 ### Homebrew (macOS/Linux)
 ```bash
-brew install joshrotenberg/brew/redisctl
+brew install redis-developer/homebrew-tap/redisctl
 ```
 
 ### Cargo (Rust)
@@ -277,7 +277,7 @@ cargo install redisctl --features secure-storage
 ```
 
 ### Binary Releases
-Download the latest release for your platform from [GitHub Releases](https://github.com/ghcr.io/redis-developer/redisctl/releases).
+Download the latest release for your platform from [GitHub Releases](https://github.com/redis-developer/redisctl/releases).
 
 Binaries are available for:
 - macOS (Intel and Apple Silicon)
@@ -411,13 +411,13 @@ redisctl enterprise cluster get -o yaml
 
 ## Documentation
 
-**[Complete Documentation](https://joshrotenberg.github.io/redisctl/)**
+**[Complete Documentation](https://redis-developer.github.io/redisctl/)**
 
-- [Getting Started Guide](https://joshrotenberg.github.io/redisctl/getting-started/)
-- [Command Reference](https://joshrotenberg.github.io/redisctl/reference/)
-- [Configuration Guide](https://joshrotenberg.github.io/redisctl/configuration/)
-- [Workflow Examples](https://joshrotenberg.github.io/redisctl/workflows/)
-- [Troubleshooting](https://joshrotenberg.github.io/redisctl/troubleshooting/)
+- [Getting Started Guide](https://redis-developer.github.io/redisctl/getting-started/)
+- [Command Reference](https://redis-developer.github.io/redisctl/reference/)
+- [Configuration Guide](https://redis-developer.github.io/redisctl/configuration/)
+- [Workflow Examples](https://redis-developer.github.io/redisctl/workflows/)
+- [Troubleshooting](https://redis-developer.github.io/redisctl/troubleshooting/)
 
 ---
 
@@ -433,11 +433,11 @@ Individual crate changelogs:
 
 ## Contributing
 
-Contributions welcome! See our [Contributing Guide](https://joshrotenberg.github.io/redisctl/developer/contributing.html).
+Contributions welcome! See our [Contributing Guide](https://redis-developer.github.io/redisctl/developer/contributing.html).
 
 ```bash
 # Clone and build
-git clone https://github.com/ghcr.io/redis-developer/redisctl.git
+git clone https://github.com/redis-developer/redisctl.git
 cd redisctl
 cargo build --release
 
@@ -463,6 +463,6 @@ at your option.
 
 ## Support
 
-- [Documentation](https://joshrotenberg.github.io/redisctl/)
-- [Issue Tracker](https://github.com/ghcr.io/redis-developer/redisctl/issues)
-- [Discussions](https://github.com/ghcr.io/redis-developer/redisctl/discussions)
+- [Documentation](https://redis-developer.github.io/redisctl/)
+- [Issue Tracker](https://github.com/redis-developer/redisctl/issues)
+- [Discussions](https://github.com/redis-developer/redisctl/discussions)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -73,7 +73,7 @@ After workflows complete, verify:
 
 - [ ] GitHub Release: https://github.com/redis-developer/redisctl/releases
   - Should have binaries for all platforms
-- [ ] Docker Hub: https://ghcr.io/redis-developer/redisctl/tags
+- [ ] GHCR: https://github.com/redis-developer/redisctl/pkgs/container/redisctl
   - Should have new version tag
 - [ ] crates.io: https://crates.io/crates/redisctl
   - Should show new version

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -21,10 +21,10 @@ The easiest way to install on macOS or Linux:
 
 ```bash
 # Install directly (automatically taps the repository)
-brew install joshrotenberg/brew/redisctl
+brew install redis-developer/homebrew-tap/redisctl
 
 # Or tap first, then install
-brew tap joshrotenberg/brew
+brew tap redis-developer/homebrew-tap
 brew install redisctl
 ```
 
@@ -40,12 +40,12 @@ brew upgrade redisctl
 
 ## Binary Releases
 
-Download the latest release for your platform from the [GitHub releases page](https://github.com/ghcr.io/redis-developer/redisctl/releases).
+Download the latest release for your platform from the [GitHub releases page](https://github.com/redis-developer/redisctl/releases).
 
 ### Linux/macOS
 ```bash
 # Download the binary (replace VERSION and PLATFORM)
-curl -L https://github.com/ghcr.io/redis-developer/redisctl/releases/download/vVERSION/redisctl-PLATFORM.tar.gz | tar xz
+curl -L https://github.com/redis-developer/redisctl/releases/download/vVERSION/redisctl-PLATFORM.tar.gz | tar xz
 
 # Move to PATH
 sudo mv redisctl /usr/local/bin/
@@ -80,7 +80,7 @@ cargo install redisctl --features secure-storage
 ## From Source
 
 ```bash
-git clone https://github.com/ghcr.io/redis-developer/redisctl.git
+git clone https://github.com/redis-developer/redisctl.git
 cd redisctl
 
 # Basic installation

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -37,7 +37,7 @@ redisctl cloud database create --subscription $SUB --name mydb --wait
 docker run ghcr.io/redis-developer/redisctl:latest --help
 
 # macOS/Linux
-brew install joshrotenberg/brew/redisctl
+brew install redis-developer/homebrew-tap/redisctl
 
 # Or download from GitHub releases
 ```

--- a/docs/src/presentation/slides.html
+++ b/docs/src/presentation/slides.html
@@ -101,7 +101,7 @@
                     </h1>
                     <h3>The CLI for Redis Cloud and Enterprise</h3>
                     <p class="small" style="margin-top: 2em">
-                        github.com/ghcr.io/redis-developer/redisctl
+                        github.com/redis-developer/redisctl
                     </p>
                 </section>
 
@@ -620,7 +620,7 @@ docker run --rm \
                 <section>
                     <h2>Installation</h2>
                     <pre><code class="language-bash"># Homebrew (macOS/Linux)
-brew install joshrotenberg/brew/redisctl
+brew install redis-developer/homebrew-tap/redisctl
 
 # Cargo (from source)
 cargo install redisctl
@@ -632,7 +632,7 @@ cargo install redisctl --features secure-storage
 docker run -it ghcr.io/redis-developer/redisctl --help
 
 # From releases (Linux x86_64)
-curl -L https://github.com/ghcr.io/redis-developer/redisctl/releases/latest/download/redisctl-x86_64-unknown-linux-gnu.tar.gz | tar xz
+curl -L https://github.com/redis-developer/redisctl/releases/latest/download/redisctl-x86_64-unknown-linux-gnu.tar.gz | tar xz
 ./redisctl --help</code></pre>
                 </section>
 
@@ -640,7 +640,7 @@ curl -L https://github.com/ghcr.io/redis-developer/redisctl/releases/latest/down
                 <section class="center">
                     <h2>Get Started</h2>
                     <pre><code class="language-bash"># Install
-brew install joshrotenberg/brew/redisctl
+brew install redis-developer/homebrew-tap/redisctl
 
 # Setup profile
 redisctl profile set mycloud --cloud-api-key $KEY --cloud-secret-key $SECRET
@@ -649,8 +649,8 @@ redisctl profile set mycloud --cloud-api-key $KEY --cloud-secret-key $SECRET
 redisctl cloud subscription list
 redisctl cloud database list --subscription-id 123456</code></pre>
                     <p style="margin-top: 1.5em"><br /></p>
-                    <h3>github.com/ghcr.io/redis-developer/redisctl</h3>
-                    <p class="small">Docs: joshrotenberg.github.io/redisctl</p>
+                    <h3>github.com/redis-developer/redisctl</h3>
+                    <p class="small">Docs: redis-developer.github.io/redisctl</p>
                 </section>
             </div>
         </div>


### PR DESCRIPTION
## Summary

PR #500 accidentally corrupted GitHub repository URLs by adding `ghcr.io/` to them. The `ghcr.io/` prefix is only valid for Docker image references (e.g., `ghcr.io/redis-developer/redisctl`), not GitHub repository URLs.

This PR fixes:
- GitHub repository URLs (remove errant `ghcr.io/` from `github.com/ghcr.io/redis-developer/...`)
- Homebrew tap references (`joshrotenberg/brew` → `redis-developer/homebrew-tap`)
- Documentation URLs (`joshrotenberg.github.io/redisctl` → `redis-developer.github.io/redisctl`)
- GHCR link format in RELEASE.md checklist

## Files Changed
- README.md
- RELEASE.md
- docs/src/getting-started/installation.md
- docs/src/introduction.md
- docs/src/presentation/slides.html

## Test plan
- [ ] Verify all links in README.md resolve correctly
- [ ] Verify documentation builds without broken links
- [ ] Verify `brew install redis-developer/homebrew-tap/redisctl` works

