### PR TITLE
fix(ci): use full tag name for Homebrew formula updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -285,26 +285,18 @@ jobs:
     needs:
       - plan
       - host
-    if: ${{ always() && needs.host.result == 'success' }}
+    # Only run for redisctl releases (not redis-cloud, redis-enterprise, or redisctl-config)
+    if: ${{ always() && needs.host.result == 'success' && startsWith(needs.plan.outputs.tag, 'redisctl-v') }}
     runs-on: "ubuntu-22.04"
     steps:
-      - name: Extract version from tag
-        id: extract_version
-        run: |
-          TAG="${{ needs.plan.outputs.tag }}"
-          # Remove 'redisctl-v' prefix to get version (e.g., redisctl-v0.7.1 -> 0.7.1)
-          VERSION="${TAG#redisctl-v}"
-          # Add 'v' prefix for Homebrew (e.g., 0.7.1 -> v0.7.1)
-          echo "version=v${VERSION}" >> $GITHUB_OUTPUT
-          echo "Extracted version: v${VERSION}"
-
       - uses: mislav/bump-homebrew-formula-action@v3.2
         with:
           formula-name: redisctl
           formula-path: Formula/redisctl.rb
           base-branch: main
-          tag-name: ${{ steps.extract_version.outputs.version }}
+          tag-name: ${{ needs.plan.outputs.tag }}
           homebrew-tap: redis-developer/homebrew-tap
+          download-url: "https://github.com/redis-developer/redisctl/releases/download/${{ needs.plan.outputs.tag }}/redisctl-x86_64-apple-darwin.tar.xz"
         env:
           COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
 


### PR DESCRIPTION
## Summary

The Homebrew formula auto-update was failing with HTTP 404 because the action was looking for release assets at tag `v0.7.2` when the actual release tag is `redisctl-v0.7.2`.

## Changes

- Pass the full tag directly to `mislav/bump-homebrew-formula-action` instead of stripping and re-prefixing
- Add explicit `download-url` to ensure correct asset resolution
- Add condition to only run for `redisctl-v*` tags (skips redis-cloud, redis-enterprise, and redisctl-config releases which don't have Homebrew formulas)

## Test plan

- [ ] Merge this PR
- [ ] Re-run the failed `redisctl-v0.7.2` release workflow
- [ ] Verify Homebrew formula is updated to 0.7.2

