### PR TITLE
feat(docs): auto-deploy documentation to redis-field-engineering/redisctl-docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -158,3 +158,40 @@ jobs:
           fi
 
           echo "Documentation checks passed!"
+
+  # Deploy documentation to redis-field-engineering/redisctl-docs
+  deploy:
+    name: Deploy Documentation
+    runs-on: ubuntu-latest
+    needs: [mdbook]
+    # Only deploy on push to main, not on PRs
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Cache mdBook
+        uses: actions/cache@v4
+        id: mdbook-cache
+        with:
+          path: ~/.cargo/bin/mdbook
+          key: ${{ runner.os }}-mdbook-0.4.40
+
+      - name: Install mdBook
+        if: steps.mdbook-cache.outputs.cache-hit != 'true'
+        run: |
+          curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.40/mdbook-v0.4.40-x86_64-unknown-linux-gnu.tar.gz | tar -xz
+          mkdir -p ~/.cargo/bin
+          mv mdbook ~/.cargo/bin/mdbook
+          chmod +x ~/.cargo/bin/mdbook
+
+      - name: Build documentation
+        run: cd docs && mdbook build
+
+      - name: Deploy to redisctl-docs
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
+        with:
+          personal_token: ${{ secrets.DOCS_DEPLOY_TOKEN }}
+          external_repository: redis-field-engineering/redisctl-docs
+          publish_branch: gh-pages
+          publish_dir: ./docs/book
+          commit_message: "docs: update from redis-developer/redisctl@${{ github.sha }}"


### PR DESCRIPTION
## Summary

Adds automatic documentation deployment to `redis-field-engineering/redisctl-docs` since `redis-developer` GitHub Pages redirects to redis.io.

## Changes

Adds a `deploy` job to the docs workflow that:
- Runs only on push to main (not PRs)
- Builds mdBook documentation
- Pushes built HTML to `redis-field-engineering/redisctl-docs` `gh-pages` branch
- Uses `DOCS_DEPLOY_TOKEN` secret for cross-org repository access

## Setup Required

- [x] Create `redis-field-engineering/redisctl-docs` repo
- [x] Add `DOCS_DEPLOY_TOKEN` secret to `redis-developer/redisctl`
- [ ] Enable GitHub Pages on `redis-field-engineering/redisctl-docs` (Settings → Pages → gh-pages branch)

## Result

Documentation will be available at:
https://redis-field-engineering.github.io/redisctl-docs/

## Test plan

- [ ] Merge this PR
- [ ] Verify docs workflow runs and deploys successfully
- [ ] Verify docs are accessible at the new URL

