### PR TITLE
feat: add module name lookup for module get and database create

### DIFF
--- a/crates/redisctl/src/cli/enterprise.rs
+++ b/crates/redisctl/src/cli/enterprise.rs
@@ -368,6 +368,10 @@ pub enum EnterpriseDatabaseCommands {
     # With specific port
     redisctl enterprise database create --name service-db --memory 1073741824 --port 12000
 
+    # With modules (auto-resolves name to module)
+    redisctl enterprise database create --name search-db --memory 1073741824 \\
+      --module search --module ReJSON
+
     # Complete configuration from file
     redisctl enterprise database create --data @database.json
 
@@ -423,6 +427,11 @@ NOTE: Memory size is in bytes. Common values:
         /// Redis password for authentication
         #[arg(long)]
         redis_password: Option<String>,
+
+        /// Module to enable (by name, can be repeated). Use 'module list' to see available modules.
+        /// Format: module_name or module_name:args (e.g., --module search --module ReJSON)
+        #[arg(long = "module", value_name = "NAME[:ARGS]")]
+        modules: Vec<String>,
 
         /// Advanced: Full database configuration as JSON string or @file.json
         #[arg(long)]

--- a/crates/redisctl/src/commands/enterprise/database.rs
+++ b/crates/redisctl/src/commands/enterprise/database.rs
@@ -35,6 +35,7 @@ pub async fn handle_database_command(
             proxy_policy,
             crdb,
             redis_password,
+            modules,
             data,
             dry_run,
         } => {
@@ -52,6 +53,7 @@ pub async fn handle_database_command(
                 proxy_policy.as_deref(),
                 *crdb,
                 redis_password.as_deref(),
+                modules,
                 data.as_deref(),
                 *dry_run,
                 output_format,

--- a/crates/redisctl/src/commands/enterprise/module.rs
+++ b/crates/redisctl/src/commands/enterprise/module.rs
@@ -1,4 +1,4 @@
-use clap::Subcommand;
+use clap::{ArgGroup, Subcommand};
 
 #[derive(Debug, Subcommand)]
 pub enum ModuleCommands {
@@ -6,10 +6,16 @@ pub enum ModuleCommands {
     #[command(visible_alias = "ls")]
     List,
 
-    /// Get module details
+    /// Get module details by UID or name
+    #[command(group(ArgGroup::new("identifier").required(true).args(["uid", "name"])))]
     Get {
         /// Module UID
-        uid: String,
+        #[arg(conflicts_with = "name")]
+        uid: Option<String>,
+
+        /// Module name (e.g., "ReJSON", "search")
+        #[arg(long, conflicts_with = "uid")]
+        name: Option<String>,
     },
 
     /// Upload new module


### PR DESCRIPTION
## Summary

This PR adds the ability to look up modules by name instead of UID, making it easier to work with modules in Redis Enterprise.

### Feature 1: `--name` flag for `enterprise module get`

Look up modules by name instead of requiring the UID:

```bash
# Before (required UID)
redisctl enterprise module get abc123-uid

# After (can use name)
redisctl enterprise module get --name ReJSON
redisctl enterprise module get --name search
```

Features:
- Case-insensitive matching
- Helpful suggestions on partial matches (e.g., "Did you mean: ReJSON, RedisJSON?")
- Clear error with version info if multiple modules match

### Feature 2: `--module` flag for `enterprise database create`

Specify modules by name when creating a database:

```bash
# Before (required JSON with module_list)
redisctl enterprise database create --name mydb --memory 1073741824 \
  --data '{"module_list": [{"module_name": "search"}, {"module_name": "ReJSON"}]}'

# After (simple flags)
redisctl enterprise database create --name mydb --memory 1073741824 \
  --module search --module ReJSON
```

Features:
- Auto-resolves module names to the proper `module_list` format
- Supports module args via colon syntax: `--module search:ARGS`
- Can be repeated for multiple modules
- Case-insensitive matching with helpful error messages
- Validates modules exist before creating database

## Testing

- All existing tests pass
- Manually tested CLI help output shows new options correctly

## Files Changed

- `crates/redisctl/src/cli/enterprise.rs` - Added `--module` flag to database create
- `crates/redisctl/src/commands/enterprise/module.rs` - Added `--name` flag to module get
- `crates/redisctl/src/commands/enterprise/module_impl.rs` - Module name resolution logic
- `crates/redisctl/src/commands/enterprise/database.rs` - Pass modules to create handler
- `crates/redisctl/src/commands/enterprise/database_impl.rs` - Module resolution in database create
