### PR TITLE
chore: bump jmespath-extensions to v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,6 +692,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1228,12 +1249,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
-
-[[package]]
 name = "hashlink"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1541,7 +1556,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.0",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -1657,15 +1672,16 @@ dependencies = [
 
 [[package]]
 name = "jmespath_extensions"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95ee2950a69b6aea207537220d40a00a7ddb5a259faefdc32cd01d7402d8e41"
+checksum = "bb97d4fa7894bdc291623de3ee35a22988c6e897a7b08cda4b8dc870a0d52354"
 dependencies = [
  "aho-corasick",
  "base64 0.22.1",
  "chrono",
  "chrono-tz",
  "crc32fast",
+ "csv",
  "geoutils",
  "hex",
  "hmac",

--- a/crates/redisctl/Cargo.toml
+++ b/crates/redisctl/Cargo.toml
@@ -51,7 +51,7 @@ thiserror = { workspace = true }
 serde_yaml = { workspace = true }
 comfy-table = { workspace = true }
 jmespath = { workspace = true }
-jmespath_extensions = { version = "0.6", features = ["full"] }
+jmespath_extensions = { version = "0.7", features = ["full"] }
 config = { workspace = true }
 
 # Keyring for Files.com API key storage (separate from profile credentials)

--- a/docs/src/common-features/jmespath-queries.md
+++ b/docs/src/common-features/jmespath-queries.md
@@ -330,7 +330,7 @@ redisctl enterprise database get 1 -q 'json_diff(current_config, desired_config)
 | Object | `keys`, `values`, `pick`, `omit`, `deep_merge` |
 | Math | `round`, `floor`, `ceil`, `sum`, `avg`, `max`, `min`, `stddev` |
 | Type | `type_of`, `is_array`, `is_string`, `to_boolean` |
-| Utility | `if`, `coalesce`, `default`, `now` |
+| Utility | `if`, `coalesce`, `default`, `now`, `env` |
 | DateTime | `format_date`, `time_ago`, `relative_time`, `is_weekend` |
 | Duration | `format_duration`, `parse_duration` |
 | Network | `is_private_ip`, `cidr_contains`, `ip_to_int` |
@@ -342,6 +342,7 @@ redisctl enterprise database get 1 -q 'json_diff(current_config, desired_config)
 | Semver | `semver_compare`, `semver_satisfies`, `semver_parse` |
 | Fuzzy | `levenshtein`, `soundex`, `jaro_winkler` |
 | JSON Patch | `json_diff`, `json_patch`, `json_merge_patch` |
+| Format | `to_csv`, `to_tsv`, `to_csv_table`, `pretty`, `html_escape` |
 
 For the complete list, see the [jmespath-extensions documentation](https://docs.rs/jmespath_extensions).
 


### PR DESCRIPTION
## Summary

Update jmespath-extensions from v0.6 to v0.7.0.

## New Functions Available

From [jmespath-extensions v0.7.0](https://github.com/joshrotenberg/jmespath-extensions/releases/tag/v0.7.0):

### CSV/TSV Formatting
- `to_csv(array)` - Convert array to CSV row
- `to_tsv(array)` - Convert array to TSV row
- `to_csv_rows(array_of_arrays)` - Convert arrays to multi-line CSV
- `to_csv_table(array_of_objects, columns?)` - Convert objects to CSV table with headers

### Utility Functions
- `pretty(value)` - Pretty-print JSON
- `html_escape(string)` - Escape HTML entities
- `env(name)` - Access environment variables

## Documentation Updates

- Converted remaining `jq @csv` examples to use native JMESPath `to_csv()` and `to_csv_table()`
- Added Format category to function reference table

## Example

```bash
# Before (required jq)
redisctl enterprise usage-report get -q 'databases' | \
  jq -r '(.[] | [.name, .memory_mb]) | @csv'

# After (native JMESPath)
redisctl enterprise usage-report get -q '
  to_csv_table(databases, [\`"name"\`, \`"memory_mb"\`])
' --raw
```