### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2620,7 +2620,7 @@ dependencies = [
 
 [[package]]
 name = "redis-enterprise"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2648,7 +2648,7 @@ dependencies = [
 
 [[package]]
 name = "redisctl"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/crates/redis-enterprise/CHANGELOG.md
+++ b/crates/redis-enterprise/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.3](https://github.com/redis-developer/redisctl/compare/redis-enterprise-v0.7.2...redis-enterprise-v0.7.3) - 2026-01-12
+
+### Added
+
+- add MCP server for AI integration ([#531](https://github.com/redis-developer/redisctl/pull/531))
+
 ## [0.7.2](https://github.com/redis-developer/redisctl/compare/redis-enterprise-v0.7.1...redis-enterprise-v0.7.2) - 2025-12-17
 
 ### Fixed

--- a/crates/redis-enterprise/Cargo.toml
+++ b/crates/redis-enterprise/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-enterprise"
-version = "0.7.2"
+version = "0.7.3"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/redisctl-mcp/CHANGELOG.md
+++ b/crates/redisctl-mcp/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/redis-developer/redisctl/releases/tag/redisctl-mcp-v0.1.0) - 2026-01-12
+
+### Added
+
+- add MCP server for AI integration ([#531](https://github.com/redis-developer/redisctl/pull/531))

--- a/crates/redisctl-mcp/Cargo.toml
+++ b/crates/redisctl-mcp/Cargo.toml
@@ -18,7 +18,7 @@ schemars = "0.8"
 # Internal crates
 redisctl-config = { version = "0.2.1", path = "../redisctl-config" }
 redis-cloud = { version = "0.7.5", path = "../redis-cloud" }
-redis-enterprise = { version = "0.7.2", path = "../redis-enterprise" }
+redis-enterprise = { version = "0.7.3", path = "../redis-enterprise" }
 
 # Core dependencies
 anyhow = { workspace = true }

--- a/crates/redisctl/CHANGELOG.md
+++ b/crates/redisctl/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.4](https://github.com/redis-developer/redisctl/compare/redisctl-v0.7.3...redisctl-v0.7.4) - 2026-01-12
+
+### Added
+
+- add MCP server for AI integration ([#531](https://github.com/redis-developer/redisctl/pull/531))
+
+### Other
+
+- add Enterprise CLI Docker integration tests ([#523](https://github.com/redis-developer/redisctl/pull/523))
+
 ## [0.7.3](https://github.com/redis-developer/redisctl/compare/redisctl-v0.7.2...redisctl-v0.7.3) - 2025-12-17
 
 ### Added

--- a/crates/redisctl/Cargo.toml
+++ b/crates/redisctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redisctl"
-version = "0.7.3"
+version = "0.7.4"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
@@ -20,7 +20,7 @@ path = "src/main.rs"
 [dependencies]
 redisctl-config = { version = "0.2.1", path = "../redisctl-config" }
 redis-cloud = { version = "0.7.5", path = "../redis-cloud", features = ["tower-integration"] }
-redis-enterprise = { version = "0.7.2", path = "../redis-enterprise", features = ["tower-integration"] }
+redis-enterprise = { version = "0.7.3", path = "../redis-enterprise", features = ["tower-integration"] }
 redisctl-mcp = { version = "0.1.0", path = "../redisctl-mcp", optional = true }
 files-sdk = { workspace = true, optional = true }
 


### PR DESCRIPTION



## 🤖 New release

* `redis-enterprise`: 0.7.2 -> 0.7.3 (✓ API compatible changes)
* `redisctl-mcp`: 0.1.0
* `redisctl`: 0.7.3 -> 0.7.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `redis-enterprise`

<blockquote>

## [0.7.3](https://github.com/redis-developer/redisctl/compare/redis-enterprise-v0.7.2...redis-enterprise-v0.7.3) - 2026-01-12

### Added

- add MCP server for AI integration ([#531](https://github.com/redis-developer/redisctl/pull/531))
</blockquote>

## `redisctl-mcp`

<blockquote>

## [0.1.0](https://github.com/redis-developer/redisctl/releases/tag/redisctl-mcp-v0.1.0) - 2026-01-12

### Added

- add MCP server for AI integration ([#531](https://github.com/redis-developer/redisctl/pull/531))
</blockquote>

## `redisctl`

<blockquote>

## [0.7.4](https://github.com/redis-developer/redisctl/compare/redisctl-v0.7.3...redisctl-v0.7.4) - 2026-01-12

### Added

- add MCP server for AI integration ([#531](https://github.com/redis-developer/redisctl/pull/531))

### Other

- add Enterprise CLI Docker integration tests ([#523](https://github.com/redis-developer/redisctl/pull/523))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).