### PR TITLE
fix(ci): extract version from tag for Homebrew formula update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -289,12 +289,18 @@ jobs:
     if: ${{ always() && needs.host.result == 'success' && startsWith(needs.plan.outputs.tag, 'redisctl-v') }}
     runs-on: "ubuntu-22.04"
     steps:
+      - name: Extract version from tag
+        id: version
+        run: |
+          TAG="${{ needs.plan.outputs.tag }}"
+          VERSION="${TAG#redisctl-v}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
       - uses: mislav/bump-homebrew-formula-action@v3.2
         with:
           formula-name: redisctl
           formula-path: Formula/redisctl.rb
           base-branch: main
-          tag-name: ${{ needs.plan.outputs.tag }}
+          tag-name: v${{ steps.version.outputs.version }}
           homebrew-tap: redis-developer/homebrew-tap
           download-url: "https://github.com/redis-developer/redisctl/releases/download/${{ needs.plan.outputs.tag }}/redisctl-x86_64-apple-darwin.tar.xz"
         env:


### PR DESCRIPTION
## Problem

The `mislav/bump-homebrew-formula-action` compares the formula version against the `tag-name` parameter to determine if an update is needed. With our tag format `redisctl-v0.7.3`, the action was comparing `0.7.2` (from formula) against `redisctl-v0.7.3` and incorrectly determining that 0.7.2 is newer (string comparison issue with the prefix).

## Solution

Add a step to extract just the version number from the full tag name:
- `redisctl-v0.7.3` → `0.7.3`
- Pass `v0.7.3` to the action's `tag-name` parameter for proper version comparison
- Keep the original tag (`redisctl-v0.7.3`) for the `download-url` since that's where the artifacts are

## Testing

This will be tested on the next release. The workflow syntax is valid.