### PR TITLE
fix(ci): update cargo-deny to 0.18.9 for CVSS 4.0 support

### DIFF
--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install cargo-deny
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-deny@0.16.2
+          tool: cargo-deny@0.18.9
 
       - name: Run cargo-deny
         run: cargo deny --all-features check ${{ matrix.checks }}


### PR DESCRIPTION
## Problem

The cargo-deny advisories check is failing:

```
failed to load advisory database: parse error: error parsing .../RUSTSEC-2024-0445.md:
TOML parse error at line 8, column 8
cvss = "CVSS:4.0/AV:N/AC:L/AT:P/PR:L/UI:N/VC:L/VI:L/VA:L/SC:N/SI:N/SA:N"
unsupported CVSS version: 4.0
```

The RustSec advisory database now includes advisories with CVSS 4.0 scores, but cargo-deny 0.16.2 doesn't support parsing them.

## Solution

Update cargo-deny from 0.16.2 to 0.18.9, which includes rustsec 0.31 with CVSS 4.0 support.