### PR TITLE
docs: improve markdown consistency across mkdocs site

### DIFF
--- a/mkdocs-site/docs/cloud/commands/index.md
+++ b/mkdocs-site/docs/cloud/commands/index.md
@@ -15,7 +15,7 @@ All Redis Cloud CLI commands.
 
 ## Getting Help
 
-``` bash
+```bash
 # List all cloud commands
 redisctl cloud --help
 
@@ -36,7 +36,7 @@ All commands support:
 
 ## Examples
 
-``` bash
+```bash
 # List subscriptions as table
 redisctl cloud subscription list
 

--- a/mkdocs-site/docs/cloud/index.md
+++ b/mkdocs-site/docs/cloud/index.md
@@ -4,11 +4,11 @@ Redis Cloud is Redis's fully managed database service. redisctl provides complet
 
 ## Three-Tier Access
 
-``` mermaid
+```mermaid
 graph LR
     A[API Layer] --> B[Commands]
     B --> C[Workflows]
-    
+
     style A fill:#e5c07b,color:#000
     style B fill:#98c379,color:#000
     style C fill:#61afef,color:#000

--- a/mkdocs-site/docs/common/async-operations.md
+++ b/mkdocs-site/docs/common/async-operations.md
@@ -12,7 +12,7 @@ Many Redis API operations are asynchronous:
 
 Without redisctl, you'd write polling loops:
 
-``` bash
+```bash
 # The old way - don't do this
 TASK_ID=$(curl ... | jq -r '.taskId')
 while true; do
@@ -26,7 +26,7 @@ done
 
 Add `--wait` to any create/update/delete command:
 
-``` bash
+```bash
 # Create and wait for completion
 redisctl cloud subscription create \
   --name prod \
@@ -39,21 +39,21 @@ redisctl cloud subscription create \
 
 ## How It Works
 
-``` mermaid
+```mermaid
 sequenceDiagram
     participant User
     participant redisctl
     participant API
-    
+
     User->>redisctl: create --wait
     redisctl->>API: POST /subscriptions
     API-->>redisctl: taskId: abc123
-    
+
     loop Poll until complete
         redisctl->>API: GET /tasks/abc123
         API-->>redisctl: status: processing
     end
-    
+
     API-->>redisctl: status: completed
     redisctl-->>User: Subscription created (ID: 12345)
 ```
@@ -64,7 +64,7 @@ sequenceDiagram
 
 Set maximum wait time:
 
-``` bash
+```bash
 # Wait up to 10 minutes
 redisctl cloud subscription create \
   --name prod \
@@ -78,7 +78,7 @@ Default timeout varies by operation type.
 
 Control how often to check status:
 
-``` bash
+```bash
 # Check every 5 seconds instead of default
 redisctl cloud database create \
   --subscription-id 123 \
@@ -91,7 +91,7 @@ redisctl cloud database create \
 
 Without `--wait`, commands return immediately with a task ID:
 
-``` bash
+```bash
 redisctl cloud subscription create --name prod --cloud-provider AWS --region us-east-1
 ```
 
@@ -104,19 +104,19 @@ Use 'redisctl cloud task get abc123-def456' to check status
 
 ### Get Task Details
 
-``` bash
+```bash
 redisctl cloud task get abc123-def456
 ```
 
 ### List Recent Tasks
 
-``` bash
+```bash
 redisctl cloud task list
 ```
 
 ### Wait for Existing Task
 
-``` bash
+```bash
 # Start waiting for a task that's already running
 redisctl cloud task wait abc123-def456
 ```
@@ -125,7 +125,7 @@ redisctl cloud task wait abc123-def456
 
 ### Sequential Operations
 
-``` bash
+```bash
 # Create subscription, then database
 SUB_ID=$(redisctl cloud subscription create \
   --name prod \
@@ -143,7 +143,7 @@ redisctl cloud database create \
 
 ### Parallel Operations
 
-``` bash
+```bash
 # Start multiple operations
 redisctl cloud database create --subscription-id 123 --name db1 &
 redisctl cloud database create --subscription-id 123 --name db2 &
@@ -155,7 +155,7 @@ wait
 
 ## CI/CD Example
 
-``` yaml
+```yaml
 - name: Create database
   run: |
     redisctl cloud database create \
@@ -165,7 +165,7 @@ wait
       --wait \
       --wait-timeout 300 \
       -o json > database.json
-    
+
     echo "REDIS_HOST=$(jq -r '.publicEndpoint' database.json)" >> $GITHUB_ENV
 ```
 
@@ -173,7 +173,7 @@ wait
 
 If an async operation fails, `--wait` returns a non-zero exit code:
 
-``` bash
+```bash
 if ! redisctl cloud subscription create --name prod --wait; then
   echo "Subscription creation failed"
   exit 1

--- a/mkdocs-site/docs/common/index.md
+++ b/mkdocs-site/docs/common/index.md
@@ -6,7 +6,7 @@ Features shared across Redis Cloud and Redis Enterprise commands.
 
 redisctl is built around four layers of functionality:
 
-``` mermaid
+```mermaid
 graph TB
     subgraph "Layer 4: Workflows"
         W[Multi-step orchestration]
@@ -20,9 +20,9 @@ graph TB
     subgraph "Layer 1: Profiles"
         P[Credential management]
     end
-    
+
     P --> R --> H --> W
-    
+
     style W fill:#61afef,color:#000
     style H fill:#98c379,color:#000
     style R fill:#e5c07b,color:#000

--- a/mkdocs-site/docs/common/jmespath.md
+++ b/mkdocs-site/docs/common/jmespath.md
@@ -6,7 +6,7 @@ Filter, transform, and reshape command output.
 
 [JMESPath](https://jmespath.org/) is a query language for JSON. redisctl includes an extended implementation with 300+ functions.
 
-``` bash
+```bash
 # Basic: get all subscription names
 redisctl cloud subscription list -o json -q '[].name'
 
@@ -21,7 +21,7 @@ redisctl cloud subscription list -o json -q '{
 
 ### Select Fields
 
-``` bash
+```bash
 # Single field from each item
 redisctl cloud subscription list -o json -q '[].name'
 ["prod-sub", "dev-sub", "staging-sub"]
@@ -33,7 +33,7 @@ redisctl cloud subscription list -o json -q '[].{name: name, id: id}'
 
 ### Filter Results
 
-``` bash
+```bash
 # Databases over 1GB
 redisctl enterprise database list -o json -q '[?memory_size > `1073741824`]'
 
@@ -46,7 +46,7 @@ redisctl cloud subscription list -o json -q "[?contains(name, 'prod')]"
 
 ### Slice Arrays
 
-``` bash
+```bash
 # First 3 results
 redisctl cloud subscription list -o json -q '[:3]'
 
@@ -61,7 +61,7 @@ redisctl cloud subscription list -o json -q '[5:15]'
 
 ### Count
 
-``` bash
+```bash
 # Total subscriptions
 redisctl cloud subscription list -o json -q 'length(@)'
 42
@@ -75,7 +75,7 @@ redisctl enterprise database list -o json -q '{
 
 ### Sum, Min, Max, Avg
 
-``` bash
+```bash
 # Total memory across all databases
 redisctl enterprise database list -o json -q 'sum([].memory_size)'
 
@@ -89,7 +89,7 @@ redisctl enterprise database list -o json -q '{
 
 ### Unique Values
 
-``` bash
+```bash
 # Unique cloud providers
 redisctl cloud subscription list -o json -q '[].cloudDetails[0].provider | unique(@)'
 ["AWS", "GCP", "Azure"]
@@ -102,7 +102,7 @@ redisctl cloud subscription list -o json -q '[].cloudDetails[0].regions[0].regio
 
 Chain operations with `|`:
 
-``` bash
+```bash
 # Filter -> Project -> Sort -> Limit
 redisctl cloud subscription list -o json -q "
   [?status == 'active']
@@ -114,7 +114,7 @@ redisctl cloud subscription list -o json -q "
 
 ## String Functions
 
-``` bash
+```bash
 # Uppercase names
 redisctl cloud subscription list -o json -q '[].name | map(&upper(@), @)'
 
@@ -134,7 +134,7 @@ redisctl uses [jmespath-community](https://jmespath.site/) with 300+ functions:
 
 ### Formatting
 
-``` bash
+```bash
 # Human-readable bytes
 redisctl enterprise database list -o json -q '[].{
   name: name,
@@ -145,7 +145,7 @@ redisctl enterprise database list -o json -q '[].{
 
 ### Date/Time
 
-``` bash
+```bash
 # Add timestamp to output
 redisctl enterprise cluster get -o json -q '{
   cluster: name,
@@ -155,7 +155,7 @@ redisctl enterprise cluster get -o json -q '{
 
 ### Fuzzy Matching
 
-``` bash
+```bash
 # Find similar names (Levenshtein distance)
 redisctl cloud subscription list -o json -q "[].{
   name: name,
@@ -165,7 +165,7 @@ redisctl cloud subscription list -o json -q "[].{
 
 ### Type Checking
 
-``` bash
+```bash
 # Inspect field types
 redisctl enterprise database list -o json -q '[0] | {
   uid_type: type_of(uid),
@@ -178,7 +178,7 @@ redisctl enterprise database list -o json -q '[0] | {
 
 ### Cost Analysis
 
-``` bash
+```bash
 # Subscriptions with total size
 redisctl cloud subscription list -o json -q '[].{
   name: name,
@@ -189,7 +189,7 @@ redisctl cloud subscription list -o json -q '[].{
 
 ### Health Check
 
-``` bash
+```bash
 # Nodes with issues
 redisctl enterprise node list -o json -q "[?status != 'active'].{
   id: uid,
@@ -200,7 +200,7 @@ redisctl enterprise node list -o json -q "[?status != 'active'].{
 
 ### Inventory Report
 
-``` bash
+```bash
 # Database summary by type
 redisctl enterprise database list -o json -q '{
   total: length(@),

--- a/mkdocs-site/docs/common/output-formats.md
+++ b/mkdocs-site/docs/common/output-formats.md
@@ -14,7 +14,7 @@ Control how redisctl displays results.
 
 Human-readable tables with aligned columns:
 
-``` bash
+```bash
 redisctl enterprise database list
 ```
 
@@ -29,11 +29,11 @@ ID  Name           Memory     Status  Endpoints
 
 Structured data for scripting and automation:
 
-``` bash
+```bash
 redisctl enterprise database list -o json
 ```
 
-``` json
+```json
 [
   {
     "uid": 1,
@@ -53,17 +53,17 @@ redisctl enterprise database list -o json
 
 JSON is pretty-printed by default. For compact output, pipe through `jq -c`:
 
-``` bash
+```bash
 redisctl cloud subscription list -o json | jq -c '.[]'
 ```
 
 ## YAML Output
 
-``` bash
+```bash
 redisctl enterprise cluster get -o yaml
 ```
 
-``` yaml
+```yaml
 name: production-cluster
 uid: abc123
 nodes:
@@ -79,12 +79,12 @@ nodes:
 
 Use `-q` to filter before output formatting:
 
-``` bash
+```bash
 # Get just names as JSON array
 redisctl cloud subscription list -o json -q '[].name'
 ```
 
-``` json
+```json
 ["prod-sub", "dev-sub", "staging-sub"]
 ```
 
@@ -94,7 +94,7 @@ See [JMESPath Queries](jmespath.md) for more examples.
 
 ### Extract Single Value
 
-``` bash
+```bash
 # Get cluster name
 CLUSTER=$(redisctl enterprise cluster get -o json -q 'name')
 echo "Connected to: $CLUSTER"
@@ -102,7 +102,7 @@ echo "Connected to: $CLUSTER"
 
 ### Loop Over Results
 
-``` bash
+```bash
 # Process each database
 redisctl enterprise database list -o json -q '[].uid' | jq -r '.[]' | while read uid; do
   echo "Processing database $uid"
@@ -112,7 +112,7 @@ done
 
 ### Conditional Logic
 
-``` bash
+```bash
 # Check if any database is inactive
 INACTIVE=$(redisctl enterprise database list -o json -q "[?status!='active'] | length(@)")
 if [ "$INACTIVE" -gt 0 ]; then
@@ -124,7 +124,7 @@ fi
 
 JSON output is essential for CI/CD pipelines:
 
-``` yaml
+```yaml
 # GitHub Actions example
 - name: Get database endpoint
   id: db

--- a/mkdocs-site/docs/common/profiles.md
+++ b/mkdocs-site/docs/common/profiles.md
@@ -15,7 +15,7 @@ Instead of juggling environment variables or passing credentials on every comman
 
 ### Redis Cloud
 
-``` bash
+```bash
 redisctl profile set my-cloud \
   --cloud-api-key "your-api-key" \
   --cloud-secret-key "your-secret-key"
@@ -23,7 +23,7 @@ redisctl profile set my-cloud \
 
 ### Redis Enterprise
 
-``` bash
+```bash
 redisctl profile set my-enterprise \
   --enterprise-url "https://cluster.example.com:9443" \
   --enterprise-user "admin@cluster.local" \
@@ -34,7 +34,7 @@ redisctl profile set my-enterprise \
 
 A profile can have both Cloud and Enterprise credentials:
 
-``` bash
+```bash
 redisctl profile set prod \
   --cloud-api-key "$CLOUD_KEY" \
   --cloud-secret-key "$CLOUD_SECRET" \
@@ -47,14 +47,14 @@ redisctl profile set prod \
 
 ### Per-Command
 
-``` bash
+```bash
 redisctl --profile prod cloud subscription list
 redisctl --profile dev enterprise cluster get
 ```
 
 ### Default Profile
 
-``` bash
+```bash
 # Set the default
 redisctl profile set-default prod
 
@@ -66,7 +66,7 @@ redisctl cloud subscription list
 
 Environment variables override profile settings:
 
-``` bash
+```bash
 # Profile says one thing, env var wins
 export REDIS_CLOUD_API_KEY="override-key"
 redisctl --profile prod cloud subscription list  # Uses override-key
@@ -76,7 +76,7 @@ redisctl --profile prod cloud subscription list  # Uses override-key
 
 ### List All Profiles
 
-``` bash
+```bash
 redisctl profile list
 ```
 
@@ -89,13 +89,13 @@ Profiles:
 
 ### Show Profile Details
 
-``` bash
+```bash
 redisctl profile show prod
 ```
 
 ### Delete a Profile
 
-``` bash
+```bash
 redisctl profile delete dev
 ```
 
@@ -108,7 +108,7 @@ redisctl profile delete dev
 
 Store credentials in macOS Keychain, Windows Credential Manager, or Linux Secret Service:
 
-``` bash
+```bash
 # Requires the secure-storage feature
 cargo install redisctl --features secure-storage
 
@@ -121,7 +121,7 @@ redisctl profile set prod \
 
 The config file only stores a reference:
 
-``` toml
+```toml
 [profiles.prod]
 cloud_api_key = "keyring:prod-cloud-api-key"
 cloud_secret_key = "keyring:prod-cloud-secret-key"
@@ -131,7 +131,7 @@ cloud_secret_key = "keyring:prod-cloud-secret-key"
 
 Store references to environment variables:
 
-``` bash
+```bash
 redisctl profile set prod \
   --cloud-api-key '${REDIS_CLOUD_API_KEY}' \
   --cloud-secret-key '${REDIS_CLOUD_SECRET_KEY}'
@@ -149,7 +149,7 @@ Variables are resolved at runtime. Great for CI/CD where secrets are injected.
 
 ## Example Configuration
 
-``` toml
+```toml
 default_profile = "prod"
 
 [profiles.prod]

--- a/mkdocs-site/docs/common/raw-api.md
+++ b/mkdocs-site/docs/common/raw-api.md
@@ -15,7 +15,7 @@ The `api` command gives you direct access to Redis REST APIs:
 
 ### Redis Cloud
 
-``` bash
+```bash
 # GET request
 redisctl api cloud get /subscriptions
 
@@ -29,7 +29,7 @@ redisctl api cloud post /subscriptions/123/databases \
 
 ### Redis Enterprise
 
-``` bash
+```bash
 # GET cluster info
 redisctl api enterprise get /v1/cluster
 
@@ -51,7 +51,7 @@ redisctl api enterprise post /v1/bdbs \
 | `patch` | Update resources (partial) |
 | `delete` | Remove resources |
 
-``` bash
+```bash
 redisctl api cloud get /subscriptions
 redisctl api cloud post /subscriptions --body '{...}'
 redisctl api cloud put /subscriptions/123 --body '{...}'
@@ -62,7 +62,7 @@ redisctl api cloud delete /subscriptions/123
 
 Some endpoints accept query parameters:
 
-``` bash
+```bash
 # Cloud API with query params (append to path)
 redisctl api cloud get "/subscriptions?limit=10&offset=0"
 ```
@@ -71,14 +71,14 @@ redisctl api cloud get "/subscriptions?limit=10&offset=0"
 
 ### Inline JSON
 
-``` bash
+```bash
 redisctl api cloud post /subscriptions/123/databases \
   --body '{"name": "mydb", "memoryLimitInGb": 1}'
 ```
 
 ### From File
 
-``` bash
+```bash
 # Create a JSON file
 cat > database.json << 'EOF'
 {
@@ -97,13 +97,13 @@ redisctl api cloud post /subscriptions/123/databases \
 
 ### Raw JSON
 
-``` bash
+```bash
 redisctl api cloud get /subscriptions -o json
 ```
 
 ### With JMESPath
 
-``` bash
+```bash
 # Get specific fields
 redisctl api cloud get /subscriptions -q '[].{id: id, name: name}'
 
@@ -119,13 +119,13 @@ redisctl api cloud get /subscriptions -q 'length(@)'
 <div class="grid" markdown>
 
 **Raw API**
-``` bash
+```bash
 redisctl api cloud get /subscriptions/123456/databases \
   -q '[].{id: databaseId, name: name}'
 ```
 
 **Human Command**
-``` bash
+```bash
 redisctl cloud database list \
   --subscription-id 123456 \
   -o json -q '[].{id: databaseId, name: name}'
@@ -157,7 +157,7 @@ Check the official API documentation:
 
 ### Explore Interactively
 
-``` bash
+```bash
 # Start broad
 redisctl api cloud get /subscriptions -o json | head -50
 
@@ -172,13 +172,13 @@ redisctl api cloud get /subscriptions/123456/databases -o json
 
 ### Cloud: Get Account Info
 
-``` bash
+```bash
 redisctl api cloud get /accounts -o json -q '[0]'
 ```
 
 ### Cloud: List All Database Endpoints
 
-``` bash
+```bash
 redisctl api cloud get /subscriptions -o json -q '[].{
   sub: name,
   databases: databases[].{name: name, endpoint: publicEndpoint}
@@ -187,7 +187,7 @@ redisctl api cloud get /subscriptions -o json -q '[].{
 
 ### Enterprise: Node Status
 
-``` bash
+```bash
 redisctl api enterprise get /v1/nodes -o json -q '[].{
   id: uid,
   addr: addr,
@@ -198,6 +198,6 @@ redisctl api enterprise get /v1/nodes -o json -q '[].{
 
 ### Enterprise: Cluster Alerts
 
-``` bash
+```bash
 redisctl api enterprise get /v1/cluster/alerts -o json
 ```

--- a/mkdocs-site/docs/cookbook/cloud/acls.md
+++ b/mkdocs-site/docs/cookbook/cloud/acls.md
@@ -94,7 +94,7 @@ redisctl cloud acl create --subscription-id "$SUB_ID" --data '{
 
 echo "Creating write ACL..."
 redisctl cloud acl create --subscription-id "$SUB_ID" --data '{
-  "name": "app-writer", 
+  "name": "app-writer",
   "redisRules": ["+@all", "-@admin", "-@dangerous"]
 }'
 

--- a/mkdocs-site/docs/cookbook/enterprise/cluster-health.md
+++ b/mkdocs-site/docs/cookbook/enterprise/cluster-health.md
@@ -20,7 +20,7 @@ redisctl enterprise node list -o json -q '[].{
   status: status
 }'
 
-# Database status  
+# Database status
 redisctl enterprise database list -o json -q '[].{
   uid: uid,
   name: name,

--- a/mkdocs-site/docs/cookbook/index.md
+++ b/mkdocs-site/docs/cookbook/index.md
@@ -25,22 +25,22 @@ Step-by-step guides for common tasks.
 ### Common Patterns
 
 **List and filter:**
-``` bash
+```bash
 redisctl cloud subscription list -o json -q '[?status == `active`].name'
 ```
 
 **Create and wait:**
-``` bash
+```bash
 redisctl cloud database create --subscription-id 123 --name mydb --wait
 ```
 
 **Export to file:**
-``` bash
+```bash
 redisctl enterprise cluster get -o json > cluster-backup.json
 ```
 
 **Loop over results:**
-``` bash
+```bash
 for id in $(redisctl enterprise database list -o json -q '[].uid' | jq -r '.[]'); do
   echo "Database $id:"
   redisctl enterprise database get "$id"

--- a/mkdocs-site/docs/developer/architecture.md
+++ b/mkdocs-site/docs/developer/architecture.md
@@ -122,7 +122,7 @@ pub async fn handle_async_response(
     if !wait {
         return Ok(response);
     }
-    
+
     let task_id = response["taskId"].as_str()?;
     poll_until_complete(client, task_id, timeout).await
 }

--- a/mkdocs-site/docs/developer/contributing.md
+++ b/mkdocs-site/docs/developer/contributing.md
@@ -131,7 +131,7 @@ fn test_parse_database_id() {
 #[tokio::test]
 async fn test_database_list() {
     let mock_server = MockServer::start().await;
-    
+
     Mock::given(method("GET"))
         .and(path("/v1/subscriptions/123/databases"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!([
@@ -139,7 +139,7 @@ async fn test_database_list() {
         ])))
         .mount(&mock_server)
         .await;
-    
+
     // Test against mock
 }
 ```

--- a/mkdocs-site/docs/developer/index.md
+++ b/mkdocs-site/docs/developer/index.md
@@ -23,12 +23,12 @@ async fn main() -> anyhow::Result<()> {
         "your-api-key",
         "your-secret-key",
     );
-    
+
     let subscriptions = client.subscriptions().list().await?;
     for sub in subscriptions {
         println!("{}: {}", sub.id, sub.name);
     }
-    
+
     Ok(())
 }
 ```

--- a/mkdocs-site/docs/developer/libraries.md
+++ b/mkdocs-site/docs/developer/libraries.md
@@ -33,16 +33,16 @@ async fn main() -> anyhow::Result<()> {
         std::env::var("REDIS_CLOUD_API_KEY")?,
         std::env::var("REDIS_CLOUD_SECRET_KEY")?,
     );
-    
+
     // List subscriptions
     let subscriptions = client.subscriptions().list().await?;
     for sub in subscriptions {
         println!("{}: {}", sub.id, sub.name);
     }
-    
+
     // Get databases
     let databases = client.databases().list(subscription_id).await?;
-    
+
     Ok(())
 }
 ```
@@ -72,17 +72,17 @@ async fn main() -> anyhow::Result<()> {
         .password("password")
         .insecure(true)  // For self-signed certs
         .build()?;
-    
+
     // Get cluster info
     let cluster = client.cluster().get().await?;
     println!("Cluster: {} ({})", cluster.name, cluster.version);
-    
+
     // List databases
     let databases = client.databases().list().await?;
     for db in databases {
         println!("  {}: {}", db.uid, db.name);
     }
-    
+
     Ok(())
 }
 ```
@@ -106,15 +106,15 @@ use redisctl_config::{Config, Profile};
 fn main() -> anyhow::Result<()> {
     // Load config
     let config = Config::load()?;
-    
+
     // Get default profile
     let profile = config.default_profile()?;
-    
+
     // Access credentials
     if let Some(key) = profile.cloud_api_key() {
         println!("Cloud API key: {}...", &key[..8]);
     }
-    
+
     Ok(())
 }
 ```
@@ -130,16 +130,16 @@ use std::fs::File;
 async fn backup_config(client: &RedisEnterpriseClient) -> anyhow::Result<()> {
     let cluster = client.cluster().get().await?;
     let databases = client.databases().list().await?;
-    
+
     let backup = serde_json::json!({
         "cluster": cluster,
         "databases": databases,
         "timestamp": chrono::Utc::now(),
     });
-    
+
     let file = File::create("backup.json")?;
     serde_json::to_writer_pretty(file, &backup)?;
-    
+
     Ok(())
 }
 ```
@@ -151,12 +151,12 @@ use redis_enterprise::RedisEnterpriseClient;
 
 async fn collect_metrics(client: &RedisEnterpriseClient) -> anyhow::Result<()> {
     let nodes = client.nodes().list().await?;
-    
+
     for node in nodes {
-        prometheus::gauge!("redis_node_shards", node.shard_count as f64, 
+        prometheus::gauge!("redis_node_shards", node.shard_count as f64,
             "node" => node.uid.to_string());
     }
-    
+
     Ok(())
 }
 ```

--- a/mkdocs-site/docs/enterprise/commands/index.md
+++ b/mkdocs-site/docs/enterprise/commands/index.md
@@ -16,7 +16,7 @@ All Redis Enterprise CLI commands.
 
 ## Getting Help
 
-``` bash
+```bash
 # List all enterprise commands
 redisctl enterprise --help
 
@@ -37,7 +37,7 @@ All commands support:
 
 ## Examples
 
-``` bash
+```bash
 # Get cluster info
 redisctl enterprise cluster get
 

--- a/mkdocs-site/docs/enterprise/index.md
+++ b/mkdocs-site/docs/enterprise/index.md
@@ -4,11 +4,11 @@ Redis Enterprise is Redis's self-managed database platform for on-premises or cl
 
 ## Three-Tier Access
 
-``` mermaid
+```mermaid
 graph LR
     A[API Layer] --> B[Commands]
     B --> C[Workflows]
-    
+
     style A fill:#e5c07b,color:#000
     style B fill:#98c379,color:#000
     style C fill:#61afef,color:#000

--- a/mkdocs-site/docs/enterprise/operations/index.md
+++ b/mkdocs-site/docs/enterprise/operations/index.md
@@ -6,7 +6,7 @@ Operational tools for Redis Enterprise clusters.
 
 Generate diagnostic packages for Redis Support:
 
-``` bash
+```bash
 # Basic support package
 redisctl enterprise support-package cluster
 
@@ -23,7 +23,7 @@ redisctl enterprise support-package cluster --optimize --upload
 
 Collect debugging information:
 
-``` bash
+```bash
 # All debug info
 redisctl enterprise debuginfo all
 
@@ -37,7 +37,7 @@ redisctl enterprise debuginfo node 1
 
 ### Health Check Script
 
-``` bash
+```bash
 #!/bin/bash
 # Quick cluster health check
 
@@ -56,7 +56,7 @@ redisctl enterprise alert list -o json -q 'length(@)'
 
 ### Backup Configuration
 
-``` bash
+```bash
 # Export cluster config
 redisctl enterprise cluster get -o json > cluster-config.json
 

--- a/mkdocs-site/docs/enterprise/operations/support-package.md
+++ b/mkdocs-site/docs/enterprise/operations/support-package.md
@@ -199,7 +199,7 @@ redisctl enterprise support-package cluster -o json
   if: failure()
   run: |
     result=$(redisctl enterprise support-package cluster --optimize -o json)
-    
+
     if [ $(echo "$result" | jq -r '.success') = "true" ]; then
       file=$(echo "$result" | jq -r '.file_path')
       echo "Package created: $file"

--- a/mkdocs-site/docs/getting-started/authentication.md
+++ b/mkdocs-site/docs/getting-started/authentication.md
@@ -19,7 +19,7 @@ redisctl supports three credential sources, in order of precedence:
 | `REDIS_CLOUD_API_KEY` | API account key |
 | `REDIS_CLOUD_SECRET_KEY` | API secret key |
 
-``` bash
+```bash
 export REDIS_CLOUD_API_KEY="your-api-key"
 export REDIS_CLOUD_SECRET_KEY="your-secret-key"
 redisctl cloud subscription list
@@ -34,7 +34,7 @@ redisctl cloud subscription list
 | `REDIS_ENTERPRISE_PASSWORD` | Admin password |
 | `REDIS_ENTERPRISE_INSECURE` | Skip TLS verification (`true`/`false`) |
 
-``` bash
+```bash
 export REDIS_ENTERPRISE_URL="https://cluster.example.com:9443"
 export REDIS_ENTERPRISE_USER="admin@cluster.local"
 export REDIS_ENTERPRISE_PASSWORD="your-password"
@@ -47,7 +47,7 @@ Profiles store credentials for multiple environments. Much better than juggling 
 
 ### Create a Profile
 
-``` bash
+```bash
 # Redis Cloud profile
 redisctl profile set prod-cloud \
   --cloud-api-key "$API_KEY" \
@@ -62,7 +62,7 @@ redisctl profile set prod-enterprise \
 
 ### Use a Profile
 
-``` bash
+```bash
 # Specify profile per command
 redisctl --profile prod-cloud cloud subscription list
 
@@ -73,7 +73,7 @@ redisctl cloud subscription list  # Uses prod-cloud
 
 ### List Profiles
 
-``` bash
+```bash
 redisctl profile list
 ```
 
@@ -86,7 +86,7 @@ redisctl profile list
 
 Store credentials in your operating system's keychain:
 
-``` bash
+```bash
 # Requires secure-storage feature
 cargo install redisctl --features secure-storage
 
@@ -101,7 +101,7 @@ redisctl profile set prod \
 
 Reference environment variables instead of storing values:
 
-``` bash
+```bash
 redisctl profile set prod \
   --cloud-api-key '${REDIS_CLOUD_API_KEY}' \
   --cloud-secret-key '${REDIS_CLOUD_SECRET_KEY}'
@@ -120,7 +120,7 @@ Profiles are stored in:
 
 Example:
 
-``` toml
+```toml
 default_profile = "prod"
 
 [profiles.prod]

--- a/mkdocs-site/docs/getting-started/docker.md
+++ b/mkdocs-site/docs/getting-started/docker.md
@@ -4,7 +4,7 @@ Run redisctl without installing anything.
 
 ## Quick Start
 
-``` bash
+```bash
 docker run ghcr.io/redis-developer/redisctl --help
 ```
 
@@ -12,7 +12,7 @@ docker run ghcr.io/redis-developer/redisctl --help
 
 ### Environment Variables
 
-``` bash
+```bash
 docker run --rm \
   -e REDIS_CLOUD_API_KEY \
   -e REDIS_CLOUD_SECRET_KEY \
@@ -23,7 +23,7 @@ docker run --rm \
 
 If you have a local configuration:
 
-``` bash
+```bash
 docker run --rm \
   -v ~/.config/redisctl:/root/.config/redisctl:ro \
   ghcr.io/redis-developer/redisctl --profile prod cloud subscription list
@@ -40,7 +40,7 @@ Add to your shell profile (`~/.bashrc`, `~/.zshrc`, etc.):
       -e REDIS_CLOUD_API_KEY \
       -e REDIS_CLOUD_SECRET_KEY \
       ghcr.io/redis-developer/redisctl'
-    
+
     # Usage
     redisctl-cloud cloud subscription list
     ```
@@ -54,7 +54,7 @@ Add to your shell profile (`~/.bashrc`, `~/.zshrc`, etc.):
       -e REDIS_ENTERPRISE_PASSWORD \
       -e REDIS_ENTERPRISE_INSECURE \
       ghcr.io/redis-developer/redisctl'
-    
+
     # Usage
     redisctl-enterprise enterprise cluster get
     ```
@@ -65,7 +65,7 @@ Add to your shell profile (`~/.bashrc`, `~/.zshrc`, etc.):
     alias redisctl='docker run --rm \
       -v ~/.config/redisctl:/root/.config/redisctl:ro \
       ghcr.io/redis-developer/redisctl'
-    
+
     # Usage
     redisctl --profile prod cloud database list
     ```
@@ -74,7 +74,7 @@ Add to your shell profile (`~/.bashrc`, `~/.zshrc`, etc.):
 
 Mount a volume to save command output:
 
-``` bash
+```bash
 docker run --rm \
   -e REDIS_ENTERPRISE_URL \
   -e REDIS_ENTERPRISE_USER \
@@ -92,14 +92,14 @@ docker run --rm \
 | `0.7.3` | Specific version |
 | `0.7` | Latest patch in minor version |
 
-``` bash
+```bash
 # Pin to specific version
 docker run ghcr.io/redis-developer/redisctl:0.7.3 --version
 ```
 
 ## CI/CD Example
 
-``` yaml
+```yaml
 # GitHub Actions
 - name: List databases
   run: |

--- a/mkdocs-site/docs/getting-started/installation.md
+++ b/mkdocs-site/docs/getting-started/installation.md
@@ -6,13 +6,13 @@ Multiple ways to install redisctl depending on your platform and preferences.
 
 The easiest way to install on macOS or Linux:
 
-``` bash
+```bash
 brew install redis-developer/homebrew-tap/redisctl
 ```
 
 To upgrade:
 
-``` bash
+```bash
 brew upgrade redisctl
 ```
 
@@ -20,13 +20,13 @@ brew upgrade redisctl
 
 Run without installing anything:
 
-``` bash
+```bash
 docker run ghcr.io/redis-developer/redisctl --help
 ```
 
 For frequent use, create an alias:
 
-``` bash
+```bash
 alias redisctl='docker run --rm -e REDIS_CLOUD_API_KEY -e REDIS_CLOUD_SECRET_KEY ghcr.io/redis-developer/redisctl'
 ```
 
@@ -36,13 +36,13 @@ See the [Docker guide](docker.md) for more details.
 
 If you have Rust installed:
 
-``` bash
+```bash
 cargo install redisctl
 ```
 
 With secure credential storage (OS keyring support):
 
-``` bash
+```bash
 cargo install redisctl --features secure-storage
 ```
 
@@ -84,7 +84,7 @@ Download pre-built binaries from [GitHub Releases](https://github.com/redis-deve
 
 ## Verify Installation
 
-``` bash
+```bash
 redisctl --version
 ```
 

--- a/mkdocs-site/docs/getting-started/quickstart.md
+++ b/mkdocs-site/docs/getting-started/quickstart.md
@@ -6,7 +6,7 @@ Get running in 60 seconds with Docker.
 
 ### Redis Cloud
 
-``` bash
+```bash
 # Set your credentials
 export REDIS_CLOUD_API_KEY="your-api-key"
 export REDIS_CLOUD_SECRET_KEY="your-secret-key"
@@ -23,7 +23,7 @@ docker run --rm \
 
 ### Redis Enterprise
 
-``` bash
+```bash
 # Set your credentials
 export REDIS_ENTERPRISE_URL="https://cluster.example.com:9443"
 export REDIS_ENTERPRISE_USER="admin@cluster.local"
@@ -51,7 +51,7 @@ That's it! You just ran your first redisctl command.
 
 ### List Resources
 
-``` bash
+```bash
 # Cloud: List all subscriptions
 redisctl cloud subscription list
 
@@ -69,7 +69,7 @@ redisctl enterprise database list
 
 Add `-o json` to any command for structured output:
 
-``` bash
+```bash
 redisctl cloud subscription list -o json
 ```
 
@@ -77,7 +77,7 @@ redisctl cloud subscription list -o json
 
 Use `-q` to query and filter results:
 
-``` bash
+```bash
 # Get just subscription names
 redisctl cloud subscription list -o json -q '[].name'
 

--- a/mkdocs-site/docs/index.md
+++ b/mkdocs-site/docs/index.md
@@ -51,7 +51,7 @@ hide:
 
 redisctl is the **first** command-line tool for managing Redis Cloud and Redis Enterprise deployments. Before redisctl, operators had to use web UIs or write fragile bash scripts with curl and polling loops.
 
-``` bash
+```bash
 # Before redisctl
 curl -s -X POST "https://api.redislabs.com/v1/subscriptions/123/databases" \
   -H "x-api-key: $KEY" -H "x-api-secret-key: $SECRET" \
@@ -90,12 +90,12 @@ redisctl cloud database create --subscription 123 --name mydb --wait
 
 redisctl provides four layers of functionality:
 
-``` mermaid
+```mermaid
 graph LR
     A[Profiles] --> B[Raw API]
     B --> C[Human Commands]
     C --> D[Workflows]
-    
+
     style A fill:#dc382d,color:#fff
     style B fill:#e5c07b,color:#000
     style C fill:#98c379,color:#000

--- a/mkdocs-site/docs/reference/environment-variables.md
+++ b/mkdocs-site/docs/reference/environment-variables.md
@@ -43,7 +43,7 @@ Complete reference of environment variables supported by redisctl.
     ```bash
     export REDIS_CLOUD_API_KEY="your-key"
     export REDIS_CLOUD_SECRET_KEY="your-secret"
-    
+
     redisctl cloud subscription list
     ```
 
@@ -54,7 +54,7 @@ Complete reference of environment variables supported by redisctl.
     export REDIS_ENTERPRISE_USER="admin@cluster.local"
     export REDIS_ENTERPRISE_PASSWORD="password"
     export REDIS_ENTERPRISE_INSECURE="true"
-    
+
     redisctl enterprise cluster get
     ```
 

--- a/mkdocs-site/docs/reference/rladmin.md
+++ b/mkdocs-site/docs/reference/rladmin.md
@@ -52,7 +52,7 @@ They're **complementary tools** - use both!
     ```bash
     # 1. SSH to node
     ssh admin@cluster-node
-    
+
     # 2. Get info (text output, need to parse)
     rladmin info bdb 1 | grep memory | awk '{print $2}'
     ```
@@ -77,7 +77,7 @@ They're **complementary tools** - use both!
 
     ```bash
     redisctl enterprise database list
-    
+
     # Or with filtering
     redisctl enterprise database list -o json -q '[?status==`active`].name'
     ```
@@ -89,13 +89,13 @@ They're **complementary tools** - use both!
     ```bash
     # 1. SSH to node
     ssh admin@cluster-node
-    
+
     # 2. Generate package
     rladmin cluster debug_info
-    
+
     # 3. Copy to local machine
     scp admin@node:/tmp/debug*.tar.gz ./
-    
+
     # 4. Manually upload via web browser
     # Total time: 10+ minutes
     ```
@@ -105,7 +105,7 @@ They're **complementary tools** - use both!
     ```bash
     # One command from your laptop
     redisctl enterprise support-package cluster --optimize --upload
-    
+
     # Total time: 30 seconds
     ```
 

--- a/mkdocs-site/docs/reference/security.md
+++ b/mkdocs-site/docs/reference/security.md
@@ -29,7 +29,7 @@ redisctl profile set prod \
 
 Credentials are stored in:
 - **macOS:** Keychain
-- **Windows:** Credential Manager  
+- **Windows:** Credential Manager
 - **Linux:** Secret Service (GNOME Keyring, KWallet)
 
 **Pros:** Encrypted, OS-managed, survives reboots

--- a/mkdocs-site/docs/reference/shell-completions.md
+++ b/mkdocs-site/docs/reference/shell-completions.md
@@ -17,10 +17,10 @@ Supported shells: `bash`, `zsh`, `fish`, `powershell`
     ```bash
     # Create completions directory if needed
     mkdir -p ~/.local/share/bash-completion/completions
-    
+
     # Generate and install
     redisctl completions bash > ~/.local/share/bash-completion/completions/redisctl
-    
+
     # Reload shell or source the file
     source ~/.local/share/bash-completion/completions/redisctl
     ```
@@ -30,13 +30,13 @@ Supported shells: `bash`, `zsh`, `fish`, `powershell`
     ```bash
     # Create completions directory if needed
     mkdir -p ~/.zfunc
-    
+
     # Add to fpath (add this to ~/.zshrc)
     fpath=(~/.zfunc $fpath)
-    
+
     # Generate completions
     redisctl completions zsh > ~/.zfunc/_redisctl
-    
+
     # Rebuild completion cache
     rm -f ~/.zcompdump; compinit
     ```
@@ -46,7 +46,7 @@ Supported shells: `bash`, `zsh`, `fish`, `powershell`
     ```bash
     # Generate and install
     redisctl completions fish > ~/.config/fish/completions/redisctl.fish
-    
+
     # Reload shell
     source ~/.config/fish/completions/redisctl.fish
     ```
@@ -56,7 +56,7 @@ Supported shells: `bash`, `zsh`, `fish`, `powershell`
     ```powershell
     # Add to profile
     redisctl completions powershell >> $PROFILE
-    
+
     # Reload profile
     . $PROFILE
     ```


### PR DESCRIPTION
## Summary

This PR improves markdown consistency across the MkDocs documentation site.

## Changes

- **Fix code block language specifiers**: Remove spaces between backticks and language (e.g., ```` bash`` -> ````bash``)
- **Remove trailing whitespace**: Clean up all markdown files
- **Standardize formatting**: Ensure consistent code block formatting throughout

## Files Changed

28 markdown files updated with formatting improvements.

## Testing

- All cargo tests pass
- cargo fmt check passes
- cargo clippy passes