### PR TITLE
feat: add MCP server for AI integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,6 +713,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -862,6 +896,12 @@ checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -1529,6 +1569,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2149,6 +2195,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pastey"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+
+[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2620,6 +2672,7 @@ dependencies = [
  "redis-cloud",
  "redis-enterprise",
  "redisctl-config",
+ "redisctl-mcp",
  "regex",
  "rpassword",
  "serde",
@@ -2659,6 +2712,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "redisctl-mcp"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "redis-cloud",
+ "redis-enterprise",
+ "redisctl-config",
+ "rmcp",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2676,6 +2747,26 @@ dependencies = [
  "getrandom 0.2.16",
  "libredox",
  "thiserror 2.0.17",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2765,6 +2856,41 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rmcp"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528d42f8176e6e5e71ea69182b17d1d0a19a6b3b894b564678b74cd7cab13cfa"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "chrono",
+ "futures",
+ "pastey",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars 1.2.0",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3f81daaa494eb8e985c9462f7d6ce1ab05e5299f48aafd76cdd3d8b060e6f59"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2919,6 +3045,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive 0.8.22",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54e910108742c57a770f492731f99be216a52fadd361b06c8fb59d74ccc267d2"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive 1.2.0",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4908ad288c5035a8eb12cfdf0d49270def0a268ee162b75eeee0f85d155a7c45"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3008,6 +3184,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,12 +5,14 @@ members = [
     "crates/redis-cloud",
     "crates/redis-enterprise",
     "crates/redisctl",
+    "crates/redisctl-mcp",
 ]
 default-members = [
     "crates/redisctl-config",
     "crates/redis-cloud",
     "crates/redis-enterprise",
     "crates/redisctl",
+    "crates/redisctl-mcp",
 ]
 
 # External dependencies (not part of workspace)

--- a/crates/redis-enterprise/src/bdb.rs
+++ b/crates/redis-enterprise/src/bdb.rs
@@ -341,8 +341,12 @@ pub struct DatabaseInfo {
 
     // Modules and features
     pub module_list: Option<Vec<Value>>,
-    pub search: Option<bool>,
-    pub timeseries: Option<bool>,
+    /// Search configuration - can be bool or object depending on API version
+    #[serde(default)]
+    pub search: Option<Value>,
+    /// Timeseries configuration - can be bool or object depending on API version
+    #[serde(default)]
+    pub timeseries: Option<Value>,
 
     // BigStore/Flash storage settings
     pub bigstore: Option<bool>,

--- a/crates/redisctl-mcp/Cargo.toml
+++ b/crates/redisctl-mcp/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "redisctl-mcp"
+version = "0.1.0"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "MCP (Model Context Protocol) server for Redis Cloud and Enterprise"
+keywords = ["redis", "mcp", "ai", "cloud", "enterprise"]
+categories = ["api-bindings", "development-tools"]
+
+[dependencies]
+# MCP SDK
+rmcp = { version = "0.12", features = ["server", "transport-io", "macros"] }
+schemars = "0.8"
+
+# Internal crates
+redisctl-config = { version = "0.2.1", path = "../redisctl-config" }
+redis-cloud = { version = "0.7.5", path = "../redis-cloud" }
+redis-enterprise = { version = "0.7.2", path = "../redis-enterprise" }
+
+# Core dependencies
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tracing = { workspace = true }
+async-trait = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }

--- a/crates/redisctl-mcp/src/cloud_tools.rs
+++ b/crates/redisctl-mcp/src/cloud_tools.rs
@@ -1,0 +1,133 @@
+//! Cloud tools implementation
+//!
+//! Wraps Redis Cloud API client operations for MCP tool invocation.
+
+use redis_cloud::{AccountHandler, CloudClient, DatabaseHandler, SubscriptionHandler, TaskHandler};
+use redisctl_config::Config;
+use rmcp::{ErrorData as RmcpError, model::*};
+use tracing::debug;
+
+/// Cloud tools wrapper
+#[derive(Clone)]
+pub struct CloudTools {
+    client: CloudClient,
+}
+
+impl CloudTools {
+    /// Create new Cloud tools instance
+    pub fn new(profile: Option<&str>) -> anyhow::Result<Self> {
+        let config = Config::load()?;
+
+        // Resolve profile name: explicit > default > error
+        let profile_name = match profile {
+            Some(name) => name.to_string(),
+            None => config.resolve_cloud_profile(None)?,
+        };
+
+        debug!(profile = %profile_name, "Loading Cloud client from profile");
+
+        let profile_config = config
+            .profiles
+            .get(&profile_name)
+            .ok_or_else(|| anyhow::anyhow!("Cloud profile '{}' not found", profile_name))?;
+
+        let (api_key, api_secret, api_url) = profile_config
+            .cloud_credentials()
+            .ok_or_else(|| anyhow::anyhow!("Profile '{}' is not a Cloud profile", profile_name))?;
+
+        let client = CloudClient::builder()
+            .api_key(api_key)
+            .api_secret(api_secret)
+            .base_url(api_url.to_string())
+            .build()?;
+
+        Ok(Self { client })
+    }
+
+    fn to_result(&self, value: serde_json::Value) -> Result<CallToolResult, RmcpError> {
+        Ok(CallToolResult::success(vec![Content::text(
+            serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string()),
+        )]))
+    }
+
+    fn to_error(&self, err: impl std::fmt::Display) -> RmcpError {
+        RmcpError::internal_error(err.to_string(), None)
+    }
+
+    /// Get account information
+    pub async fn get_account(&self) -> Result<CallToolResult, RmcpError> {
+        let handler = AccountHandler::new(self.client.clone());
+        let account = handler
+            .get_current_account()
+            .await
+            .map_err(|e| self.to_error(e))?;
+        self.to_result(serde_json::to_value(account).map_err(|e| self.to_error(e))?)
+    }
+
+    /// List all subscriptions
+    pub async fn list_subscriptions(&self) -> Result<CallToolResult, RmcpError> {
+        let handler = SubscriptionHandler::new(self.client.clone());
+        let subs = handler
+            .get_all_subscriptions()
+            .await
+            .map_err(|e| self.to_error(e))?;
+        self.to_result(serde_json::to_value(subs).map_err(|e| self.to_error(e))?)
+    }
+
+    /// Get a specific subscription
+    pub async fn get_subscription(
+        &self,
+        subscription_id: i64,
+    ) -> Result<CallToolResult, RmcpError> {
+        let handler = SubscriptionHandler::new(self.client.clone());
+        let sub = handler
+            .get_subscription_by_id(subscription_id as i32)
+            .await
+            .map_err(|e| self.to_error(e))?;
+        self.to_result(serde_json::to_value(sub).map_err(|e| self.to_error(e))?)
+    }
+
+    /// List databases in a subscription
+    pub async fn list_databases(&self, subscription_id: i64) -> Result<CallToolResult, RmcpError> {
+        let handler = DatabaseHandler::new(self.client.clone());
+        let dbs = handler
+            .get_subscription_databases(subscription_id as i32, None, None)
+            .await
+            .map_err(|e| self.to_error(e))?;
+        self.to_result(serde_json::to_value(dbs).map_err(|e| self.to_error(e))?)
+    }
+
+    /// Get a specific database
+    pub async fn get_database(
+        &self,
+        subscription_id: i64,
+        database_id: i64,
+    ) -> Result<CallToolResult, RmcpError> {
+        let handler = DatabaseHandler::new(self.client.clone());
+        let db = handler
+            .get_subscription_database_by_id(subscription_id as i32, database_id as i32)
+            .await
+            .map_err(|e| self.to_error(e))?;
+        self.to_result(serde_json::to_value(db).map_err(|e| self.to_error(e))?)
+    }
+
+    /// List tasks
+    pub async fn list_tasks(&self) -> Result<CallToolResult, RmcpError> {
+        let handler = TaskHandler::new(self.client.clone());
+        let tasks = handler
+            .get_all_tasks()
+            .await
+            .map_err(|e| self.to_error(e))?;
+        self.to_result(serde_json::to_value(tasks).map_err(|e| self.to_error(e))?)
+    }
+
+    /// Get a specific task
+    pub async fn get_task(&self, task_id: &str) -> Result<CallToolResult, RmcpError> {
+        let handler = TaskHandler::new(self.client.clone());
+        let task = handler
+            .get_task_by_id(task_id.to_string())
+            .await
+            .map_err(|e| self.to_error(e))?;
+        self.to_result(serde_json::to_value(task).map_err(|e| self.to_error(e))?)
+    }
+}

--- a/crates/redisctl-mcp/src/enterprise_tools.rs
+++ b/crates/redisctl-mcp/src/enterprise_tools.rs
@@ -1,0 +1,166 @@
+//! Enterprise tools implementation
+//!
+//! Wraps Redis Enterprise API client operations for MCP tool invocation.
+
+use redis_enterprise::{
+    AlertHandler, BdbHandler, ClusterHandler, CreateDatabaseRequest, EnterpriseClient,
+    LicenseHandler, LogsHandler, NodeHandler, ShardHandler, StatsHandler,
+};
+use redisctl_config::Config;
+use rmcp::{ErrorData as RmcpError, model::*};
+use tracing::debug;
+
+/// Enterprise tools wrapper
+#[derive(Clone)]
+pub struct EnterpriseTools {
+    client: EnterpriseClient,
+}
+
+impl EnterpriseTools {
+    /// Create new Enterprise tools instance
+    pub fn new(profile: Option<&str>) -> anyhow::Result<Self> {
+        let config = Config::load()?;
+
+        // Resolve profile name: explicit > default > error
+        let profile_name = match profile {
+            Some(name) => name.to_string(),
+            None => config.resolve_enterprise_profile(None)?,
+        };
+
+        debug!(profile = %profile_name, "Loading Enterprise client from profile");
+
+        let profile_config = config
+            .profiles
+            .get(&profile_name)
+            .ok_or_else(|| anyhow::anyhow!("Enterprise profile '{}' not found", profile_name))?;
+
+        let (url, username, password, insecure) =
+            profile_config.enterprise_credentials().ok_or_else(|| {
+                anyhow::anyhow!("Profile '{}' is not an Enterprise profile", profile_name)
+            })?;
+
+        let mut builder = EnterpriseClient::builder()
+            .base_url(url)
+            .username(username)
+            .insecure(insecure);
+
+        if let Some(pwd) = password {
+            builder = builder.password(pwd);
+        }
+
+        let client = builder.build()?;
+
+        Ok(Self { client })
+    }
+
+    fn to_result(&self, value: serde_json::Value) -> Result<CallToolResult, RmcpError> {
+        Ok(CallToolResult::success(vec![Content::text(
+            serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string()),
+        )]))
+    }
+
+    fn to_error(&self, err: impl std::fmt::Display) -> RmcpError {
+        RmcpError::internal_error(err.to_string(), None)
+    }
+
+    /// Get cluster information
+    pub async fn get_cluster(&self) -> Result<CallToolResult, RmcpError> {
+        let handler = ClusterHandler::new(self.client.clone());
+        let cluster = handler.info().await.map_err(|e| self.to_error(e))?;
+        self.to_result(serde_json::to_value(cluster).map_err(|e| self.to_error(e))?)
+    }
+
+    /// List all nodes
+    pub async fn list_nodes(&self) -> Result<CallToolResult, RmcpError> {
+        let handler = NodeHandler::new(self.client.clone());
+        let nodes = handler.list().await.map_err(|e| self.to_error(e))?;
+        self.to_result(serde_json::to_value(nodes).map_err(|e| self.to_error(e))?)
+    }
+
+    /// Get a specific node
+    pub async fn get_node(&self, node_id: i64) -> Result<CallToolResult, RmcpError> {
+        let handler = NodeHandler::new(self.client.clone());
+        let node = handler
+            .get(node_id as u32)
+            .await
+            .map_err(|e| self.to_error(e))?;
+        self.to_result(serde_json::to_value(node).map_err(|e| self.to_error(e))?)
+    }
+
+    /// List all databases
+    pub async fn list_databases(&self) -> Result<CallToolResult, RmcpError> {
+        let handler = BdbHandler::new(self.client.clone());
+        let dbs = handler.list().await.map_err(|e| self.to_error(e))?;
+        self.to_result(serde_json::to_value(dbs).map_err(|e| self.to_error(e))?)
+    }
+
+    /// Get a specific database
+    pub async fn get_database(&self, database_id: i64) -> Result<CallToolResult, RmcpError> {
+        let handler = BdbHandler::new(self.client.clone());
+        let db = handler
+            .get(database_id as u32)
+            .await
+            .map_err(|e| self.to_error(e))?;
+        self.to_result(serde_json::to_value(db).map_err(|e| self.to_error(e))?)
+    }
+
+    /// Get database statistics
+    pub async fn get_database_stats(&self, database_id: i64) -> Result<CallToolResult, RmcpError> {
+        let handler = StatsHandler::new(self.client.clone());
+        let stats = handler
+            .database(database_id as u32, None)
+            .await
+            .map_err(|e| self.to_error(e))?;
+        self.to_result(serde_json::to_value(stats).map_err(|e| self.to_error(e))?)
+    }
+
+    /// List all shards
+    pub async fn list_shards(&self) -> Result<CallToolResult, RmcpError> {
+        let handler = ShardHandler::new(self.client.clone());
+        let shards = handler.list().await.map_err(|e| self.to_error(e))?;
+        self.to_result(serde_json::to_value(shards).map_err(|e| self.to_error(e))?)
+    }
+
+    /// List active alerts
+    pub async fn list_alerts(&self) -> Result<CallToolResult, RmcpError> {
+        let handler = AlertHandler::new(self.client.clone());
+        let alerts = handler.list().await.map_err(|e| self.to_error(e))?;
+        self.to_result(serde_json::to_value(alerts).map_err(|e| self.to_error(e))?)
+    }
+
+    /// Get cluster logs
+    pub async fn get_logs(&self) -> Result<CallToolResult, RmcpError> {
+        let handler = LogsHandler::new(self.client.clone());
+        let logs = handler.list(None).await.map_err(|e| self.to_error(e))?;
+        self.to_result(serde_json::to_value(logs).map_err(|e| self.to_error(e))?)
+    }
+
+    /// Get license information
+    pub async fn get_license(&self) -> Result<CallToolResult, RmcpError> {
+        let handler = LicenseHandler::new(self.client.clone());
+        let license = handler.get().await.map_err(|e| self.to_error(e))?;
+        self.to_result(serde_json::to_value(license).map_err(|e| self.to_error(e))?)
+    }
+
+    /// Create a new database
+    pub async fn create_database(
+        &self,
+        name: &str,
+        memory_size_mb: Option<u64>,
+    ) -> Result<CallToolResult, RmcpError> {
+        let handler = BdbHandler::new(self.client.clone());
+
+        let memory_size = memory_size_mb.unwrap_or(100) * 1024 * 1024; // Default 100MB
+
+        let request = CreateDatabaseRequest::builder()
+            .name(name)
+            .memory_size(memory_size)
+            .build();
+
+        let db = handler
+            .create(request)
+            .await
+            .map_err(|e| self.to_error(e))?;
+        self.to_result(serde_json::to_value(db).map_err(|e| self.to_error(e))?)
+    }
+}

--- a/crates/redisctl-mcp/src/error.rs
+++ b/crates/redisctl-mcp/src/error.rs
@@ -1,0 +1,43 @@
+//! Error types for the MCP server
+
+use thiserror::Error;
+
+/// Errors that can occur in the MCP server
+#[derive(Error, Debug)]
+pub enum McpError {
+    /// Configuration error
+    #[error("Configuration error: {0}")]
+    Configuration(String),
+
+    /// Cloud API error
+    #[error("Cloud API error: {0}")]
+    CloudApi(String),
+
+    /// Enterprise API error
+    #[error("Enterprise API error: {0}")]
+    EnterpriseApi(String),
+
+    /// Tool execution error
+    #[error("Tool execution error: {0}")]
+    ToolExecution(String),
+
+    /// Invalid parameters
+    #[error("Invalid parameters: {0}")]
+    InvalidParameters(String),
+
+    /// Operation not permitted in read-only mode
+    #[error("Operation not permitted: server is in read-only mode")]
+    ReadOnlyMode,
+}
+
+impl From<anyhow::Error> for McpError {
+    fn from(err: anyhow::Error) -> Self {
+        McpError::ToolExecution(err.to_string())
+    }
+}
+
+impl From<redisctl_config::ConfigError> for McpError {
+    fn from(err: redisctl_config::ConfigError) -> Self {
+        McpError::Configuration(err.to_string())
+    }
+}

--- a/crates/redisctl-mcp/src/lib.rs
+++ b/crates/redisctl-mcp/src/lib.rs
@@ -1,0 +1,45 @@
+//! MCP (Model Context Protocol) server for Redis Cloud and Enterprise
+//!
+//! This crate provides an MCP server that exposes Redis Cloud and Enterprise
+//! management operations as tools for AI systems.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use redisctl_mcp::RedisCtlMcp;
+//! use rmcp::{ServiceExt, transport::stdio};
+//!
+//! #[tokio::main]
+//! async fn main() -> anyhow::Result<()> {
+//!     let server = RedisCtlMcp::new()?;
+//!     let service = server.serve(stdio()).await?;
+//!     service.waiting().await?;
+//!     Ok(())
+//! }
+//! ```
+
+pub mod cloud_tools;
+pub mod enterprise_tools;
+pub mod error;
+pub mod server;
+
+pub use error::McpError;
+pub use server::RedisCtlMcp;
+
+/// Start the MCP server with stdio transport
+pub async fn serve_stdio(profile: Option<&str>, read_only: bool) -> anyhow::Result<()> {
+    use rmcp::{ServiceExt, transport::stdio};
+    use tracing::info;
+
+    info!(
+        profile = profile,
+        read_only = read_only,
+        "Starting MCP server"
+    );
+
+    let server = RedisCtlMcp::new(profile, read_only)?;
+    let service = server.serve(stdio()).await?;
+    service.waiting().await?;
+
+    Ok(())
+}

--- a/crates/redisctl-mcp/src/server.rs
+++ b/crates/redisctl-mcp/src/server.rs
@@ -1,0 +1,388 @@
+//! MCP server implementation for Redis Cloud and Enterprise
+
+use std::sync::Arc;
+
+use rmcp::{
+    ErrorData as RmcpError, RoleServer, ServerHandler, handler::server::router::tool::ToolRouter,
+    handler::server::wrapper::Parameters, model::*, schemars, service::RequestContext, tool,
+    tool_handler, tool_router,
+};
+use serde::Deserialize;
+use tokio::sync::RwLock;
+use tracing::{debug, info};
+
+use crate::cloud_tools::CloudTools;
+use crate::enterprise_tools::EnterpriseTools;
+
+/// Configuration for the MCP server
+#[derive(Debug, Clone)]
+pub struct ServerConfig {
+    /// Profile name to use for credentials
+    pub profile: Option<String>,
+    /// Whether the server is in read-only mode
+    pub read_only: bool,
+}
+
+/// MCP server for Redis Cloud and Enterprise management
+///
+/// This server exposes Redis Cloud and Enterprise operations as MCP tools
+/// that can be invoked by AI systems.
+#[derive(Clone)]
+pub struct RedisCtlMcp {
+    config: Arc<ServerConfig>,
+    tool_router: ToolRouter<RedisCtlMcp>,
+    cloud_tools: Arc<RwLock<Option<CloudTools>>>,
+    enterprise_tools: Arc<RwLock<Option<EnterpriseTools>>>,
+}
+
+// Parameter structs for tools that need arguments
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct SubscriptionIdParam {
+    /// The subscription ID
+    pub subscription_id: i64,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct DatabaseIdParam {
+    /// The subscription ID
+    pub subscription_id: i64,
+    /// The database ID
+    pub database_id: i64,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct TaskIdParam {
+    /// The task ID
+    pub task_id: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct NodeIdParam {
+    /// The node ID
+    pub node_id: i64,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct EnterpriseDatabaseIdParam {
+    /// The database ID (uid)
+    pub database_id: i64,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct CreateEnterpriseDatabaseParam {
+    /// Name for the new database
+    pub name: String,
+    /// Memory size in MB (default: 100)
+    #[serde(default)]
+    pub memory_size_mb: Option<u64>,
+}
+
+impl RedisCtlMcp {
+    /// Create a new MCP server instance
+    pub fn new(profile: Option<&str>, read_only: bool) -> anyhow::Result<Self> {
+        let config = Arc::new(ServerConfig {
+            profile: profile.map(String::from),
+            read_only,
+        });
+
+        info!(
+            profile = ?config.profile,
+            read_only = config.read_only,
+            "Initializing RedisCtlMcp server"
+        );
+
+        Ok(Self {
+            config,
+            tool_router: Self::tool_router(),
+            cloud_tools: Arc::new(RwLock::new(None)),
+            enterprise_tools: Arc::new(RwLock::new(None)),
+        })
+    }
+
+    /// Get server configuration
+    pub fn config(&self) -> &ServerConfig {
+        &self.config
+    }
+
+    /// Initialize Cloud tools lazily
+    async fn get_cloud_tools(&self) -> Result<CloudTools, RmcpError> {
+        let mut guard = self.cloud_tools.write().await;
+        if guard.is_none() {
+            debug!("Initializing Cloud tools");
+            let tools = CloudTools::new(self.config.profile.as_deref())
+                .map_err(|e| RmcpError::internal_error(e.to_string(), None))?;
+            *guard = Some(tools);
+        }
+        Ok(guard.clone().unwrap())
+    }
+
+    /// Initialize Enterprise tools lazily
+    async fn get_enterprise_tools(&self) -> Result<EnterpriseTools, RmcpError> {
+        let mut guard = self.enterprise_tools.write().await;
+        if guard.is_none() {
+            debug!("Initializing Enterprise tools");
+            let tools = EnterpriseTools::new(self.config.profile.as_deref())
+                .map_err(|e| RmcpError::internal_error(e.to_string(), None))?;
+            *guard = Some(tools);
+        }
+        Ok(guard.clone().unwrap())
+    }
+}
+
+#[tool_router]
+impl RedisCtlMcp {
+    // =========================================================================
+    // Cloud Tools - Read Only
+    // =========================================================================
+
+    #[tool(
+        description = "Get Redis Cloud account information including account ID, name, and settings"
+    )]
+    async fn cloud_account_get(&self) -> Result<CallToolResult, RmcpError> {
+        info!("Tool called: cloud_account_get");
+        let tools = self.get_cloud_tools().await?;
+        tools.get_account().await
+    }
+
+    #[tool(description = "List all Redis Cloud subscriptions in the account")]
+    async fn cloud_subscriptions_list(&self) -> Result<CallToolResult, RmcpError> {
+        info!("Tool called: cloud_subscriptions_list");
+        let tools = self.get_cloud_tools().await?;
+        tools.list_subscriptions().await
+    }
+
+    #[tool(description = "Get detailed information about a specific Redis Cloud subscription")]
+    async fn cloud_subscription_get(
+        &self,
+        Parameters(params): Parameters<SubscriptionIdParam>,
+    ) -> Result<CallToolResult, RmcpError> {
+        info!(
+            subscription_id = params.subscription_id,
+            "Tool called: cloud_subscription_get"
+        );
+        let tools = self.get_cloud_tools().await?;
+        tools.get_subscription(params.subscription_id).await
+    }
+
+    #[tool(description = "List all databases in a specific Redis Cloud subscription")]
+    async fn cloud_databases_list(
+        &self,
+        Parameters(params): Parameters<SubscriptionIdParam>,
+    ) -> Result<CallToolResult, RmcpError> {
+        info!(
+            subscription_id = params.subscription_id,
+            "Tool called: cloud_databases_list"
+        );
+        let tools = self.get_cloud_tools().await?;
+        tools.list_databases(params.subscription_id).await
+    }
+
+    #[tool(description = "Get detailed information about a specific Redis Cloud database")]
+    async fn cloud_database_get(
+        &self,
+        Parameters(params): Parameters<DatabaseIdParam>,
+    ) -> Result<CallToolResult, RmcpError> {
+        info!(
+            subscription_id = params.subscription_id,
+            database_id = params.database_id,
+            "Tool called: cloud_database_get"
+        );
+        let tools = self.get_cloud_tools().await?;
+        tools
+            .get_database(params.subscription_id, params.database_id)
+            .await
+    }
+
+    #[tool(description = "List recent async tasks in the Redis Cloud account")]
+    async fn cloud_tasks_list(&self) -> Result<CallToolResult, RmcpError> {
+        info!("Tool called: cloud_tasks_list");
+        let tools = self.get_cloud_tools().await?;
+        tools.list_tasks().await
+    }
+
+    #[tool(description = "Get the status of a specific Redis Cloud async task")]
+    async fn cloud_task_get(
+        &self,
+        Parameters(params): Parameters<TaskIdParam>,
+    ) -> Result<CallToolResult, RmcpError> {
+        info!(task_id = %params.task_id, "Tool called: cloud_task_get");
+        let tools = self.get_cloud_tools().await?;
+        tools.get_task(&params.task_id).await
+    }
+
+    // =========================================================================
+    // Enterprise Tools - Read Only
+    // =========================================================================
+
+    #[tool(
+        description = "Get Redis Enterprise cluster information including name, version, and node count"
+    )]
+    async fn enterprise_cluster_get(&self) -> Result<CallToolResult, RmcpError> {
+        info!("Tool called: enterprise_cluster_get");
+        let tools = self.get_enterprise_tools().await?;
+        tools.get_cluster().await
+    }
+
+    #[tool(description = "List all nodes in the Redis Enterprise cluster with their status")]
+    async fn enterprise_nodes_list(&self) -> Result<CallToolResult, RmcpError> {
+        info!("Tool called: enterprise_nodes_list");
+        let tools = self.get_enterprise_tools().await?;
+        tools.list_nodes().await
+    }
+
+    #[tool(description = "Get detailed information about a specific Redis Enterprise node")]
+    async fn enterprise_node_get(
+        &self,
+        Parameters(params): Parameters<NodeIdParam>,
+    ) -> Result<CallToolResult, RmcpError> {
+        info!(node_id = params.node_id, "Tool called: enterprise_node_get");
+        let tools = self.get_enterprise_tools().await?;
+        tools.get_node(params.node_id).await
+    }
+
+    #[tool(description = "List all databases (BDBs) in the Redis Enterprise cluster")]
+    async fn enterprise_databases_list(&self) -> Result<CallToolResult, RmcpError> {
+        info!("Tool called: enterprise_databases_list");
+        let tools = self.get_enterprise_tools().await?;
+        tools.list_databases().await
+    }
+
+    #[tool(
+        description = "Get detailed information about a specific Redis Enterprise database (BDB)"
+    )]
+    async fn enterprise_database_get(
+        &self,
+        Parameters(params): Parameters<EnterpriseDatabaseIdParam>,
+    ) -> Result<CallToolResult, RmcpError> {
+        info!(
+            database_id = params.database_id,
+            "Tool called: enterprise_database_get"
+        );
+        let tools = self.get_enterprise_tools().await?;
+        tools.get_database(params.database_id).await
+    }
+
+    #[tool(description = "Get performance statistics for a specific Redis Enterprise database")]
+    async fn enterprise_database_stats(
+        &self,
+        Parameters(params): Parameters<EnterpriseDatabaseIdParam>,
+    ) -> Result<CallToolResult, RmcpError> {
+        info!(
+            database_id = params.database_id,
+            "Tool called: enterprise_database_stats"
+        );
+        let tools = self.get_enterprise_tools().await?;
+        tools.get_database_stats(params.database_id).await
+    }
+
+    #[tool(description = "List all shards across all databases in the Redis Enterprise cluster")]
+    async fn enterprise_shards_list(&self) -> Result<CallToolResult, RmcpError> {
+        info!("Tool called: enterprise_shards_list");
+        let tools = self.get_enterprise_tools().await?;
+        tools.list_shards().await
+    }
+
+    #[tool(description = "List active alerts in the Redis Enterprise cluster")]
+    async fn enterprise_alerts_list(&self) -> Result<CallToolResult, RmcpError> {
+        info!("Tool called: enterprise_alerts_list");
+        let tools = self.get_enterprise_tools().await?;
+        tools.list_alerts().await
+    }
+
+    #[tool(description = "Get recent event logs from the Redis Enterprise cluster")]
+    async fn enterprise_logs_get(&self) -> Result<CallToolResult, RmcpError> {
+        info!("Tool called: enterprise_logs_get");
+        let tools = self.get_enterprise_tools().await?;
+        tools.get_logs().await
+    }
+
+    #[tool(
+        description = "Get Redis Enterprise license information including expiration and capacity"
+    )]
+    async fn enterprise_license_get(&self) -> Result<CallToolResult, RmcpError> {
+        info!("Tool called: enterprise_license_get");
+        let tools = self.get_enterprise_tools().await?;
+        tools.get_license().await
+    }
+
+    // =========================================================================
+    // Enterprise Tools - Write Operations
+    // =========================================================================
+
+    #[tool(
+        description = "Create a new Redis Enterprise database. Requires name, optionally memory_size_mb (default 100) and port."
+    )]
+    async fn enterprise_database_create(
+        &self,
+        Parameters(params): Parameters<CreateEnterpriseDatabaseParam>,
+    ) -> Result<CallToolResult, RmcpError> {
+        info!(
+            name = %params.name,
+            memory_size_mb = ?params.memory_size_mb,
+            "Tool called: enterprise_database_create"
+        );
+
+        // Check read-only mode
+        if self.config.read_only {
+            return Err(RmcpError::invalid_request(
+                "Server is in read-only mode. Use --read-only=false to enable write operations.",
+                None,
+            ));
+        }
+
+        let tools = self.get_enterprise_tools().await?;
+        tools
+            .create_database(&params.name, params.memory_size_mb)
+            .await
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for RedisCtlMcp {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo {
+            protocol_version: ProtocolVersion::V_2024_11_05,
+            capabilities: ServerCapabilities::builder().enable_tools().build(),
+            server_info: Implementation::from_build_env(),
+            instructions: Some(
+                "Redis Cloud and Enterprise management tools. \
+                Use cloud_* tools for Redis Cloud operations and \
+                enterprise_* tools for Redis Enterprise operations. \
+                All tools are currently read-only."
+                    .to_string(),
+            ),
+        }
+    }
+
+    async fn initialize(
+        &self,
+        _request: InitializeRequestParam,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<InitializeResult, RmcpError> {
+        info!("MCP client connected, initializing session");
+        Ok(self.get_info())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_server_creation() {
+        let server = RedisCtlMcp::new(None, true);
+        assert!(server.is_ok());
+        let server = server.unwrap();
+        assert!(server.config().read_only);
+        assert!(server.config().profile.is_none());
+    }
+
+    #[test]
+    fn test_server_with_profile() {
+        let server = RedisCtlMcp::new(Some("test-profile"), false);
+        assert!(server.is_ok());
+        let server = server.unwrap();
+        assert!(!server.config().read_only);
+        assert_eq!(server.config().profile, Some("test-profile".to_string()));
+    }
+}

--- a/crates/redisctl/Cargo.toml
+++ b/crates/redisctl/Cargo.toml
@@ -21,6 +21,7 @@ path = "src/main.rs"
 redisctl-config = { version = "0.2.1", path = "../redisctl-config" }
 redis-cloud = { version = "0.7.5", path = "../redis-cloud", features = ["tower-integration"] }
 redis-enterprise = { version = "0.7.2", path = "../redis-enterprise", features = ["tower-integration"] }
+redisctl-mcp = { version = "0.1.0", path = "../redisctl-mcp", optional = true }
 files-sdk = { workspace = true, optional = true }
 
 # CLI dependencies
@@ -68,11 +69,12 @@ pager = "0.16"
 
 # Conditional dependencies for feature-gated binaries
 [features]
-default = ["full", "secure-storage"]
+default = ["full", "secure-storage", "mcp"]
 full = ["cloud", "enterprise", "upload"]
 cloud = []
 enterprise = []
 upload = ["dep:files-sdk"]
+mcp = ["dep:redisctl-mcp"]
 # Note: secure-storage may not work on musl targets due to keyring native dependencies
 # Build with --no-default-features --features full for musl
 secure-storage = ["redisctl-config/secure-storage", "dep:keyring"]

--- a/crates/redisctl/src/cli/mod.rs
+++ b/crates/redisctl/src/cli/mod.rs
@@ -191,6 +191,36 @@ pub enum Commands {
         #[arg(value_enum)]
         shell: Shell,
     },
+
+    /// MCP (Model Context Protocol) server for AI integration
+    #[cfg(feature = "mcp")]
+    #[command(subcommand)]
+    Mcp(McpCommands),
+}
+
+/// MCP server commands
+#[cfg(feature = "mcp")]
+#[derive(Subcommand, Debug)]
+pub enum McpCommands {
+    /// Start the MCP server (stdio transport)
+    #[command(after_help = "EXAMPLES:
+    # Start MCP server in read-only mode (default)
+    redisctl mcp serve
+
+    # Start with specific profile
+    redisctl mcp serve --profile production
+
+    # Enable write operations (destructive operations allowed)
+    redisctl mcp serve --allow-writes
+")]
+    Serve {
+        /// Allow write operations (create, update, delete). Default is read-only.
+        #[arg(long)]
+        allow_writes: bool,
+    },
+
+    /// List available MCP tools
+    Tools,
 }
 
 /// Supported shells for completion generation

--- a/crates/redisctl/src/main.rs
+++ b/crates/redisctl/src/main.rs
@@ -154,6 +154,9 @@ async fn execute_command(cli: &Cli, conn_mgr: &ConnectionManager) -> Result<(), 
             )
             .await
         }
+
+        #[cfg(feature = "mcp")]
+        Commands::Mcp(mcp_cmd) => execute_mcp_command(cli, mcp_cmd).await,
     };
 
     let duration = start.elapsed();
@@ -216,6 +219,57 @@ fn format_command(command: &Commands) -> String {
                 Get { profile } => format!("files-key get {:?}", profile),
                 Remove { .. } => "files-key remove".to_string(),
             }
+        }
+        #[cfg(feature = "mcp")]
+        Commands::Mcp(cmd) => {
+            use cli::McpCommands::*;
+            match cmd {
+                Serve { allow_writes } => format!("mcp serve (allow_writes={})", allow_writes),
+                Tools => "mcp tools".to_string(),
+            }
+        }
+    }
+}
+
+#[cfg(feature = "mcp")]
+async fn execute_mcp_command(cli: &Cli, mcp_cmd: &cli::McpCommands) -> Result<(), RedisCtlError> {
+    use cli::McpCommands::*;
+
+    match mcp_cmd {
+        Serve { allow_writes } => {
+            let read_only = !allow_writes;
+            debug!("Starting MCP server (read_only={})", read_only);
+            redisctl_mcp::serve_stdio(cli.profile.as_deref(), read_only)
+                .await
+                .map_err(|e| RedisCtlError::Configuration(e.to_string()))
+        }
+        Tools => {
+            println!("Available MCP Tools:");
+            println!();
+            println!("Cloud Tools:");
+            println!("  cloud_account_get        - Get Redis Cloud account information");
+            println!("  cloud_subscriptions_list - List all Redis Cloud subscriptions");
+            println!("  cloud_subscription_get   - Get details of a specific subscription");
+            println!("  cloud_databases_list     - List databases in a subscription");
+            println!("  cloud_database_get       - Get details of a specific database");
+            println!("  cloud_tasks_list         - List recent async tasks");
+            println!("  cloud_task_get           - Get status of a specific task");
+            println!();
+            println!("Enterprise Tools:");
+            println!("  enterprise_cluster_get      - Get cluster information");
+            println!("  enterprise_nodes_list       - List all cluster nodes");
+            println!("  enterprise_node_get         - Get details of a specific node");
+            println!("  enterprise_databases_list   - List all databases (BDBs)");
+            println!("  enterprise_database_get     - Get details of a specific database");
+            println!("  enterprise_database_stats   - Get database statistics");
+            println!("  enterprise_shards_list      - List all shards");
+            println!("  enterprise_alerts_list      - List active alerts");
+            println!("  enterprise_logs_get         - Get cluster event logs");
+            println!("  enterprise_license_get      - Get license information");
+            println!();
+            println!("Enterprise Tools (Write - requires --allow-writes):");
+            println!("  enterprise_database_create  - Create a new database");
+            Ok(())
         }
     }
 }

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -69,6 +69,10 @@
   - [Configure Replication](./cookbook/enterprise/configure-replication.md)
   - [Configure Redis ACLs](./cookbook/enterprise/configure-redis-acls.md)
 
+# Integrations
+
+- [MCP Server (AI Integration)](./integrations/mcp.md)
+
 # Reference
 
 - [Environment Variables](./reference/environment-variables.md)

--- a/docs/src/integrations/mcp.md
+++ b/docs/src/integrations/mcp.md
@@ -1,0 +1,185 @@
+# MCP Server (AI Integration)
+
+redisctl includes a built-in [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that enables AI assistants like Claude to manage your Redis deployments through natural language.
+
+## Overview
+
+The MCP server exposes redisctl functionality as tools that AI systems can discover and invoke. This allows you to:
+
+- Ask an AI to "list all my Redis databases"
+- Request "create a new 256MB database called cache-db"
+- Query "what's the status of my cluster nodes"
+
+All operations use your existing redisctl profiles for authentication.
+
+## Quick Start
+
+```bash
+# Start the MCP server (read-only mode, safe for exploration)
+redisctl -p my-profile mcp serve
+
+# Enable write operations (create, update, delete)
+redisctl -p my-profile mcp serve --allow-writes
+
+# List available tools
+redisctl mcp tools
+```
+
+## Configuring Claude Desktop
+
+Add the following to your Claude Desktop configuration file:
+
+**macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+**Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+
+```json
+{
+  "mcpServers": {
+    "redisctl": {
+      "command": "/path/to/redisctl",
+      "args": ["-p", "my-profile", "mcp", "serve"]
+    }
+  }
+}
+```
+
+For write operations:
+```json
+{
+  "mcpServers": {
+    "redisctl": {
+      "command": "/path/to/redisctl",
+      "args": ["-p", "my-profile", "mcp", "serve", "--allow-writes"]
+    }
+  }
+}
+```
+
+## Configuring Claude Code
+
+Add to your project's `.mcp.json` or global MCP settings:
+
+```json
+{
+  "mcpServers": {
+    "redisctl": {
+      "command": "redisctl",
+      "args": ["-p", "my-profile", "mcp", "serve", "--allow-writes"]
+    }
+  }
+}
+```
+
+## Available Tools
+
+### Redis Cloud Tools
+
+| Tool | Description |
+|------|-------------|
+| `cloud_account_get` | Get account information |
+| `cloud_subscriptions_list` | List all subscriptions |
+| `cloud_subscription_get` | Get subscription details |
+| `cloud_databases_list` | List databases in a subscription |
+| `cloud_database_get` | Get database details |
+| `cloud_tasks_list` | List recent async tasks |
+| `cloud_task_get` | Get task status |
+
+### Redis Enterprise Tools
+
+| Tool | Description |
+|------|-------------|
+| `enterprise_cluster_get` | Get cluster information |
+| `enterprise_nodes_list` | List all cluster nodes |
+| `enterprise_node_get` | Get node details |
+| `enterprise_databases_list` | List all databases |
+| `enterprise_database_get` | Get database details |
+| `enterprise_database_stats` | Get database statistics |
+| `enterprise_database_create` | Create a new database *(write)* |
+| `enterprise_shards_list` | List all shards |
+| `enterprise_alerts_list` | List active alerts |
+| `enterprise_logs_get` | Get cluster event logs |
+| `enterprise_license_get` | Get license information |
+
+## Example Conversations
+
+Once configured, you can interact naturally with your Redis infrastructure:
+
+> **You**: What databases do I have in my enterprise cluster?
+>
+> **Claude**: *uses enterprise_databases_list*
+> You have 2 databases:
+> - `default-db` (uid: 1) - 1GB, active
+> - `cache-db` (uid: 2) - 256MB, active
+
+> **You**: Create a new database called session-store with 512MB
+>
+> **Claude**: *uses enterprise_database_create*
+> Created database `session-store` (uid: 3) with 512MB memory. Status: active.
+
+> **You**: Show me any active alerts
+>
+> **Claude**: *uses enterprise_alerts_list*
+> No active alerts in your cluster.
+
+## Security Considerations
+
+### Read-Only Mode (Default)
+
+By default, the MCP server runs in read-only mode. This prevents any destructive operations and is recommended for:
+
+- Exploring your infrastructure
+- Monitoring and reporting
+- Learning about your deployments
+
+### Write Mode
+
+Use `--allow-writes` only when you need to create or modify resources. Consider:
+
+- Using separate profiles for read-only vs write access
+- Running write-enabled servers only in development environments
+- Reviewing AI-suggested changes before confirming
+
+### Profile-Based Authentication
+
+The MCP server uses your existing redisctl profiles, which means:
+
+- Credentials are never exposed to the AI
+- You control which environments are accessible
+- Standard profile security applies (keyring support, etc.)
+
+## Troubleshooting
+
+### Server won't start
+
+```bash
+# Check your profile works
+redisctl -p my-profile enterprise cluster get
+
+# Verify MCP feature is enabled
+redisctl mcp tools
+```
+
+### Claude can't find the server
+
+1. Ensure the path to redisctl is absolute in your config
+2. Restart Claude Desktop after config changes
+3. Check Claude's MCP logs for connection errors
+
+### Operations timing out
+
+The MCP server inherits redisctl's timeout settings. For slow operations:
+
+```bash
+# Enterprise operations may need longer timeouts
+redisctl -p my-profile mcp serve --allow-writes
+```
+
+## Protocol Details
+
+The MCP server uses:
+
+- **Transport**: stdio (standard input/output)
+- **Protocol Version**: 2024-11-05
+- **Capabilities**: Tools only (no resources or prompts currently)
+
+For MCP protocol details, see the [MCP Specification](https://spec.modelcontextprotocol.io/).

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -12,6 +12,7 @@ redisctl provides:
 - **Profile Management** - Secure credential storage
 - **Structured Output** - JSON, YAML, or Table with JMESPath
 - **Library-First Architecture** - Reusable components
+- **AI Integration** - Built-in [MCP server](./integrations/mcp.md) for Claude and other AI assistants
 
 ## Quick Example
 


### PR DESCRIPTION
## Summary

Add a new `redisctl-mcp` crate that provides a Model Context Protocol (MCP) server enabling AI assistants like Claude to manage Redis deployments.

Closes #475

## What's Included

### Phase 1: Read-Only Tools + Database Create

**Cloud Tools (7 read-only):**
- `cloud_account_get` - Get account information
- `cloud_subscriptions_list` - List all subscriptions
- `cloud_subscription_get` - Get subscription details
- `cloud_databases_list` - List databases in a subscription
- `cloud_database_get` - Get database details
- `cloud_tasks_list` - List recent async tasks
- `cloud_task_get` - Get task status

**Enterprise Tools (10 read-only + 1 write):**
- `enterprise_cluster_get` - Get cluster information
- `enterprise_nodes_list` - List all cluster nodes
- `enterprise_node_get` - Get node details
- `enterprise_databases_list` - List all databases
- `enterprise_database_get` - Get database details
- `enterprise_database_stats` - Get database statistics
- `enterprise_shards_list` - List all shards
- `enterprise_alerts_list` - List active alerts
- `enterprise_logs_get` - Get cluster event logs
- `enterprise_license_get` - Get license information
- `enterprise_database_create` - Create a new database *(write)*

## Usage

```bash
# Start MCP server (read-only mode, default)
redisctl -p my-profile mcp serve

# Enable write operations
redisctl -p my-profile mcp serve --allow-writes

# List available tools
redisctl mcp tools
```

## Claude Desktop Configuration

```json
{
  "mcpServers": {
    "redisctl": {
      "command": "/path/to/redisctl",
      "args": ["-p", "my-profile", "mcp", "serve"]
    }
  }
}
```

## Other Changes

- **Documentation**: Added `docs/src/integrations/mcp.md` with full usage guide
- **Bug fix**: Changed `search` and `timeseries` fields in `redis-enterprise` crate from `Option<bool>` to `Option<Value>` to handle API responses that return objects

## Testing

Tested with live Redis Enterprise cluster:
- All read tools work correctly
- Database creation works via MCP
- Read-only mode properly blocks write operations

## Next Steps (Future PRs)

- Add more write operations (delete, update)
- Add Cloud write operations
- Add resource support for prompts/context
