### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2648,7 +2648,7 @@ dependencies = [
 
 [[package]]
 name = "redisctl"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2713,7 +2713,7 @@ dependencies = [
 
 [[package]]
 name = "redisctl-mcp"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/redisctl-mcp/CHANGELOG.md
+++ b/crates/redisctl-mcp/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/redis-developer/redisctl/compare/redisctl-mcp-v0.1.0...redisctl-mcp-v0.1.1) - 2026-01-14
+
+### Added
+
+- *(mcp)* add Private Link, Transit Gateway, BDB Groups, OCSP, and Suffixes tools ([#561](https://github.com/redis-developer/redisctl/pull/561))
+- *(mcp)* add VPC Peering, Cloud Accounts, and CRDB Tasks tools ([#560](https://github.com/redis-developer/redisctl/pull/560))
+- *(mcp)* add 25 new tools for enterprise and cloud operations ([#559](https://github.com/redis-developer/redisctl/pull/559))
+
+### Other
+
+- *(mcp)* add readme to redisctl-mcp crate ([#534](https://github.com/redis-developer/redisctl/pull/534))
+- *(redisctl)* release v0.7.4 ([#517](https://github.com/redis-developer/redisctl/pull/517))
+
 ## [0.1.0](https://github.com/redis-developer/redisctl/releases/tag/redisctl-mcp-v0.1.0) - 2026-01-12
 
 ### Added

--- a/crates/redisctl-mcp/Cargo.toml
+++ b/crates/redisctl-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redisctl-mcp"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/redisctl/CHANGELOG.md
+++ b/crates/redisctl/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.5](https://github.com/redis-developer/redisctl/compare/redisctl-v0.7.4...redisctl-v0.7.5) - 2026-01-14
+
+### Added
+
+- *(enterprise)* add first-class params for all remaining commands ([#558](https://github.com/redis-developer/redisctl/pull/558))
+- *(enterprise)* add first-class params for job-scheduler, bdb-group, suffix, migration ([#556](https://github.com/redis-developer/redisctl/pull/556))
+- *(enterprise)* add first-class params for LDAP mapping create/update ([#554](https://github.com/redis-developer/redisctl/pull/554))
+- *(cli)* add first-class params for enterprise CRDB update ([#553](https://github.com/redis-developer/redisctl/pull/553))
+- *(cli)* add first-class params for enterprise cluster update ([#552](https://github.com/redis-developer/redisctl/pull/552))
+- *(cli)* add first-class params for enterprise node update ([#551](https://github.com/redis-developer/redisctl/pull/551))
+- *(cli)* add first-class params for enterprise ACL create/update ([#550](https://github.com/redis-developer/redisctl/pull/550))
+- *(cli)* add first-class params for enterprise role create/update ([#549](https://github.com/redis-developer/redisctl/pull/549))
+- *(cli)* add first-class params for enterprise user create/update ([#548](https://github.com/redis-developer/redisctl/pull/548))
+- *(cli)* add first-class params for enterprise database update ([#547](https://github.com/redis-developer/redisctl/pull/547))
+- *(cli)* add first-class params for database update-aa-regions ([#546](https://github.com/redis-developer/redisctl/pull/546))
+- *(cloud)* add first-class CLI params for provider-account commands ([#545](https://github.com/redis-developer/redisctl/pull/545))
+- *(cloud)* add first-class CLI params for fixed-subscription commands ([#544](https://github.com/redis-developer/redisctl/pull/544))
+- *(cloud)* add first-class CLI params for fixed-database commands ([#543](https://github.com/redis-developer/redisctl/pull/543))
+- *(cloud)* add first-class params to database commands ([#542](https://github.com/redis-developer/redisctl/pull/542))
+- *(cloud)* add first-class params to subscription commands ([#541](https://github.com/redis-developer/redisctl/pull/541))
+- *(cloud)* add first-class CLI params for all connectivity commands ([#540](https://github.com/redis-developer/redisctl/pull/540))
+
 ## [0.7.4](https://github.com/redis-developer/redisctl/compare/redisctl-v0.7.3...redisctl-v0.7.4) - 2026-01-12
 
 ### Added

--- a/crates/redisctl/Cargo.toml
+++ b/crates/redisctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redisctl"
-version = "0.7.4"
+version = "0.7.5"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
@@ -21,7 +21,7 @@ path = "src/main.rs"
 redisctl-config = { version = "0.2.1", path = "../redisctl-config" }
 redis-cloud = { version = "0.7.5", path = "../redis-cloud", features = ["tower-integration"] }
 redis-enterprise = { version = "0.7.3", path = "../redis-enterprise", features = ["tower-integration"] }
-redisctl-mcp = { version = "0.1.0", path = "../redisctl-mcp", optional = true }
+redisctl-mcp = { version = "0.1.1", path = "../redisctl-mcp", optional = true }
 files-sdk = { workspace = true, optional = true }
 
 # CLI dependencies


### PR DESCRIPTION



## 🤖 New release

* `redisctl-mcp`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `redisctl`: 0.7.4 -> 0.7.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `redisctl-mcp`

<blockquote>

## [0.1.1](https://github.com/redis-developer/redisctl/compare/redisctl-mcp-v0.1.0...redisctl-mcp-v0.1.1) - 2026-01-14

### Added

- *(mcp)* add Private Link, Transit Gateway, BDB Groups, OCSP, and Suffixes tools ([#561](https://github.com/redis-developer/redisctl/pull/561))
- *(mcp)* add VPC Peering, Cloud Accounts, and CRDB Tasks tools ([#560](https://github.com/redis-developer/redisctl/pull/560))
- *(mcp)* add 25 new tools for enterprise and cloud operations ([#559](https://github.com/redis-developer/redisctl/pull/559))

### Other

- *(mcp)* add readme to redisctl-mcp crate ([#534](https://github.com/redis-developer/redisctl/pull/534))
- *(redisctl)* release v0.7.4 ([#517](https://github.com/redis-developer/redisctl/pull/517))
</blockquote>

## `redisctl`

<blockquote>

## [0.7.5](https://github.com/redis-developer/redisctl/compare/redisctl-v0.7.4...redisctl-v0.7.5) - 2026-01-14

### Added

- *(enterprise)* add first-class params for all remaining commands ([#558](https://github.com/redis-developer/redisctl/pull/558))
- *(enterprise)* add first-class params for job-scheduler, bdb-group, suffix, migration ([#556](https://github.com/redis-developer/redisctl/pull/556))
- *(enterprise)* add first-class params for LDAP mapping create/update ([#554](https://github.com/redis-developer/redisctl/pull/554))
- *(cli)* add first-class params for enterprise CRDB update ([#553](https://github.com/redis-developer/redisctl/pull/553))
- *(cli)* add first-class params for enterprise cluster update ([#552](https://github.com/redis-developer/redisctl/pull/552))
- *(cli)* add first-class params for enterprise node update ([#551](https://github.com/redis-developer/redisctl/pull/551))
- *(cli)* add first-class params for enterprise ACL create/update ([#550](https://github.com/redis-developer/redisctl/pull/550))
- *(cli)* add first-class params for enterprise role create/update ([#549](https://github.com/redis-developer/redisctl/pull/549))
- *(cli)* add first-class params for enterprise user create/update ([#548](https://github.com/redis-developer/redisctl/pull/548))
- *(cli)* add first-class params for enterprise database update ([#547](https://github.com/redis-developer/redisctl/pull/547))
- *(cli)* add first-class params for database update-aa-regions ([#546](https://github.com/redis-developer/redisctl/pull/546))
- *(cloud)* add first-class CLI params for provider-account commands ([#545](https://github.com/redis-developer/redisctl/pull/545))
- *(cloud)* add first-class CLI params for fixed-subscription commands ([#544](https://github.com/redis-developer/redisctl/pull/544))
- *(cloud)* add first-class CLI params for fixed-database commands ([#543](https://github.com/redis-developer/redisctl/pull/543))
- *(cloud)* add first-class params to database commands ([#542](https://github.com/redis-developer/redisctl/pull/542))
- *(cloud)* add first-class params to subscription commands ([#541](https://github.com/redis-developer/redisctl/pull/541))
- *(cloud)* add first-class CLI params for all connectivity commands ([#540](https://github.com/redis-developer/redisctl/pull/540))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).