### PR TITLE
chore(mcp): add readme to redisctl-mcp crate

### DIFF
--- a/crates/redisctl-mcp/Cargo.toml
+++ b/crates/redisctl-mcp/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 repository.workspace = true
 homepage.workspace = true
 description = "MCP (Model Context Protocol) server for Redis Cloud and Enterprise"
+readme = "../../README.md"
 keywords = ["redis", "mcp", "ai", "cloud", "enterprise"]
 categories = ["api-bindings", "development-tools"]
 


### PR DESCRIPTION
Adds the top-level README.md to the redisctl-mcp crate for crates.io display.