### PR TITLE
feat(cloud): add first-class params to subscription commands

### DIFF
--- a/crates/redisctl/src/commands/cloud/subscription.rs
+++ b/crates/redisctl/src/commands/cloud/subscription.rs
@@ -79,6 +79,9 @@ pub async fn handle_subscription_command(
         }
         CloudSubscriptionCommands::Update {
             id,
+            name,
+            payment_method,
+            payment_method_id,
             data,
             async_ops,
         } => {
@@ -86,7 +89,10 @@ pub async fn handle_subscription_command(
                 conn_mgr,
                 profile_name,
                 *id,
-                data,
+                name.as_deref(),
+                payment_method.as_deref(),
+                *payment_method_id,
+                data.as_deref(),
                 async_ops,
                 output_format,
                 query,
@@ -126,12 +132,19 @@ pub async fn handle_subscription_command(
             subscription_impl::get_cidr_allowlist(conn_mgr, profile_name, *id, output_format, query)
                 .await
         }
-        CloudSubscriptionCommands::UpdateCidrAllowlist { id, cidrs } => {
+        CloudSubscriptionCommands::UpdateCidrAllowlist {
+            id,
+            cidrs,
+            security_groups,
+            data,
+        } => {
             subscription_impl::update_cidr_allowlist(
                 conn_mgr,
                 profile_name,
                 *id,
                 cidrs,
+                security_groups,
+                data.as_deref(),
                 output_format,
                 query,
             )
@@ -147,12 +160,19 @@ pub async fn handle_subscription_command(
             )
             .await
         }
-        CloudSubscriptionCommands::UpdateMaintenanceWindows { id, data } => {
+        CloudSubscriptionCommands::UpdateMaintenanceWindows {
+            id,
+            mode,
+            windows,
+            data,
+        } => {
             subscription_impl::update_maintenance_windows(
                 conn_mgr,
                 profile_name,
                 *id,
-                data,
+                mode.as_deref(),
+                windows,
+                data.as_deref(),
                 output_format,
                 query,
             )
@@ -162,24 +182,49 @@ pub async fn handle_subscription_command(
             subscription_impl::list_aa_regions(conn_mgr, profile_name, *id, output_format, query)
                 .await
         }
-        CloudSubscriptionCommands::AddAaRegion { id, data } => {
+        CloudSubscriptionCommands::AddAaRegion {
+            id,
+            region,
+            deployment_cidr,
+            vpc_id,
+            resp_version,
+            dry_run,
+            data,
+            async_ops,
+        } => {
             subscription_impl::add_aa_region(
                 conn_mgr,
                 profile_name,
                 *id,
-                data,
+                region.as_deref(),
+                deployment_cidr.as_deref(),
+                vpc_id.as_deref(),
+                resp_version.as_deref(),
+                *dry_run,
+                data.as_deref(),
+                async_ops,
                 output_format,
                 query,
             )
             .await
         }
-        CloudSubscriptionCommands::DeleteAaRegions { id, regions, force } => {
+        CloudSubscriptionCommands::DeleteAaRegions {
+            id,
+            regions,
+            dry_run,
+            data,
+            force,
+            async_ops,
+        } => {
             subscription_impl::delete_aa_regions(
                 conn_mgr,
                 profile_name,
                 *id,
                 regions,
+                *dry_run,
+                data.as_deref(),
                 *force,
+                async_ops,
                 output_format,
                 query,
             )

--- a/crates/redisctl/tests/cli_basic_tests.rs
+++ b/crates/redisctl/tests/cli_basic_tests.rs
@@ -3104,3 +3104,178 @@ fn test_tgw_aa_attachment_update_first_class_params_help() {
         .stdout(predicate::str::contains("--cidr"))
         .stdout(predicate::str::contains("--data"));
 }
+
+// === SUBSCRIPTION FIRST-CLASS PARAMETERS TESTS ===
+
+// Subscription create first-class params tests
+
+#[test]
+fn test_subscription_create_first_class_params_help() {
+    redisctl()
+        .arg("cloud")
+        .arg("subscription")
+        .arg("create")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--name"))
+        .stdout(predicate::str::contains("--dry-run"))
+        .stdout(predicate::str::contains("--deployment-type"))
+        .stdout(predicate::str::contains("--payment-method"))
+        .stdout(predicate::str::contains("--payment-method-id"))
+        .stdout(predicate::str::contains("--memory-storage"))
+        .stdout(predicate::str::contains("--persistent-storage-encryption"))
+        .stdout(predicate::str::contains("--data"));
+}
+
+#[test]
+fn test_subscription_create_has_examples() {
+    redisctl()
+        .arg("cloud")
+        .arg("subscription")
+        .arg("create")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Examples:").or(predicate::str::contains("EXAMPLES:")));
+}
+
+// Subscription update first-class params tests
+
+#[test]
+fn test_subscription_update_first_class_params_help() {
+    redisctl()
+        .arg("cloud")
+        .arg("subscription")
+        .arg("update")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--name"))
+        .stdout(predicate::str::contains("--payment-method"))
+        .stdout(predicate::str::contains("--payment-method-id"))
+        .stdout(predicate::str::contains("--data"));
+}
+
+#[test]
+fn test_subscription_update_requires_id() {
+    redisctl()
+        .arg("cloud")
+        .arg("subscription")
+        .arg("update")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("required"));
+}
+
+// Subscription update-cidr-allowlist first-class params tests
+
+#[test]
+fn test_subscription_update_cidr_allowlist_first_class_params_help() {
+    redisctl()
+        .arg("cloud")
+        .arg("subscription")
+        .arg("update-cidr-allowlist")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--cidr"))
+        .stdout(predicate::str::contains("--security-group"))
+        .stdout(predicate::str::contains("--data"));
+}
+
+#[test]
+fn test_subscription_update_cidr_allowlist_requires_id() {
+    redisctl()
+        .arg("cloud")
+        .arg("subscription")
+        .arg("update-cidr-allowlist")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("required"));
+}
+
+// Subscription update-maintenance-windows first-class params tests
+
+#[test]
+fn test_subscription_update_maintenance_windows_first_class_params_help() {
+    redisctl()
+        .arg("cloud")
+        .arg("subscription")
+        .arg("update-maintenance-windows")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--mode"))
+        .stdout(predicate::str::contains("--window"))
+        .stdout(predicate::str::contains("--data"));
+}
+
+#[test]
+fn test_subscription_update_maintenance_windows_requires_id() {
+    redisctl()
+        .arg("cloud")
+        .arg("subscription")
+        .arg("update-maintenance-windows")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("required"));
+}
+
+// Subscription add-aa-region first-class params tests
+
+#[test]
+fn test_subscription_add_aa_region_first_class_params_help() {
+    redisctl()
+        .arg("cloud")
+        .arg("subscription")
+        .arg("add-aa-region")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--region"))
+        .stdout(predicate::str::contains("--deployment-cidr"))
+        .stdout(predicate::str::contains("--vpc-id"))
+        .stdout(predicate::str::contains("--resp-version"))
+        .stdout(predicate::str::contains("--dry-run"))
+        .stdout(predicate::str::contains("--data"));
+}
+
+#[test]
+fn test_subscription_add_aa_region_requires_id() {
+    redisctl()
+        .arg("cloud")
+        .arg("subscription")
+        .arg("add-aa-region")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("required"));
+}
+
+// Subscription delete-aa-regions first-class params tests
+
+#[test]
+fn test_subscription_delete_aa_regions_first_class_params_help() {
+    redisctl()
+        .arg("cloud")
+        .arg("subscription")
+        .arg("delete-aa-regions")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--region"))
+        .stdout(predicate::str::contains("--dry-run"))
+        .stdout(predicate::str::contains("--data"))
+        .stdout(predicate::str::contains("--force"));
+}
+
+#[test]
+fn test_subscription_delete_aa_regions_requires_id() {
+    redisctl()
+        .arg("cloud")
+        .arg("subscription")
+        .arg("delete-aa-regions")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("required"));
+}

--- a/mkdocs-site/docs/cloud/commands/subscriptions.md
+++ b/mkdocs-site/docs/cloud/commands/subscriptions.md
@@ -11,6 +11,13 @@ Manage Redis Cloud subscriptions.
 | `create` | Create a new subscription |
 | `update` | Update subscription settings |
 | `delete` | Delete a subscription |
+| `get-cidr-allowlist` | Get CIDR allowlist |
+| `update-cidr-allowlist` | Update CIDR allowlist |
+| `get-maintenance-windows` | Get maintenance windows |
+| `update-maintenance-windows` | Update maintenance windows |
+| `list-aa-regions` | List Active-Active regions |
+| `add-aa-region` | Add Active-Active region |
+| `delete-aa-regions` | Delete Active-Active regions |
 
 ## List Subscriptions
 
@@ -39,21 +46,79 @@ redisctl cloud subscription get <subscription-id>
 
 ## Create Subscription
 
+Create a new Pro subscription with first-class parameters for common options.
+
 ```bash
 redisctl cloud subscription create \
   --name "my-subscription" \
-  --cloud-provider AWS \
-  --region us-east-1 \
+  --payment-method credit-card \
+  --payment-method-id 12345 \
+  --data @subscription.json \
   --wait
 ```
 
-### Required Options
+### Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--name` | Subscription name | - |
+| `--dry-run` | Validate without creating | false |
+| `--deployment-type` | single-region or active-active | - |
+| `--payment-method` | credit-card or marketplace | credit-card |
+| `--payment-method-id` | Payment method ID (required for credit-card) | - |
+| `--memory-storage` | ram or ram-and-flash | ram |
+| `--persistent-storage-encryption` | true or false | false |
+| `--data` | JSON file or string with full request body | - |
+
+!!! note
+    The `--data` option is required and must include `cloudProviders` and `databases` arrays. First-class parameters override values in the JSON.
+
+### Examples
+
+```bash
+# Create with JSON file
+redisctl cloud subscription create \
+  --name "prod-subscription" \
+  --data @subscription.json \
+  --wait
+
+# Dry run to validate
+redisctl cloud subscription create \
+  --name "test-subscription" \
+  --dry-run \
+  --data @subscription.json
+```
+
+## Update Subscription
+
+Update subscription settings using first-class parameters.
+
+```bash
+redisctl cloud subscription update <subscription-id> \
+  --name "new-name" \
+  --wait
+```
+
+### Options
 
 | Option | Description |
 |--------|-------------|
-| `--name` | Subscription name |
-| `--cloud-provider` | AWS, GCP, or Azure |
-| `--region` | Cloud region |
+| `--name` | New subscription name |
+| `--payment-method` | credit-card or marketplace |
+| `--payment-method-id` | Payment method ID |
+| `--data` | JSON with additional fields |
+
+### Examples
+
+```bash
+# Rename subscription
+redisctl cloud subscription update 12345 --name "production-redis"
+
+# Change payment method
+redisctl cloud subscription update 12345 \
+  --payment-method credit-card \
+  --payment-method-id 67890
+```
 
 ## Delete Subscription
 
@@ -63,3 +128,167 @@ redisctl cloud subscription delete <subscription-id> --wait
 
 !!! warning
     Deleting a subscription removes all databases within it.
+
+## CIDR Allowlist
+
+### Get CIDR Allowlist
+
+```bash
+redisctl cloud subscription get-cidr-allowlist <subscription-id>
+```
+
+### Update CIDR Allowlist
+
+Update allowed CIDR blocks using first-class parameters.
+
+```bash
+redisctl cloud subscription update-cidr-allowlist <subscription-id> \
+  --cidr "10.0.0.0/24" \
+  --cidr "192.168.1.0/24"
+```
+
+#### Options
+
+| Option | Description |
+|--------|-------------|
+| `--cidr` | CIDR block to allow (repeatable) |
+| `--security-group` | AWS security group ID (repeatable) |
+| `--data` | JSON with full request body |
+
+#### Examples
+
+```bash
+# Allow multiple CIDR blocks
+redisctl cloud subscription update-cidr-allowlist 12345 \
+  --cidr "10.0.0.0/16" \
+  --cidr "172.16.0.0/12"
+
+# Allow AWS security groups
+redisctl cloud subscription update-cidr-allowlist 12345 \
+  --security-group "sg-12345678" \
+  --security-group "sg-87654321"
+
+# Use JSON for complex configurations
+redisctl cloud subscription update-cidr-allowlist 12345 \
+  --data '{"cidrIps": [{"cidr": "10.0.0.0/24", "description": "Office"}]}'
+```
+
+## Maintenance Windows
+
+### Get Maintenance Windows
+
+```bash
+redisctl cloud subscription get-maintenance-windows <subscription-id>
+```
+
+### Update Maintenance Windows
+
+Configure maintenance windows using first-class parameters.
+
+```bash
+redisctl cloud subscription update-maintenance-windows <subscription-id> \
+  --mode manual \
+  --window "Monday:03-07"
+```
+
+#### Options
+
+| Option | Description |
+|--------|-------------|
+| `--mode` | Maintenance mode (automatic or manual) |
+| `--window` | Maintenance window in DAY:HH-HH format (repeatable) |
+| `--data` | JSON with full request body |
+
+#### Examples
+
+```bash
+# Set automatic maintenance
+redisctl cloud subscription update-maintenance-windows 12345 \
+  --mode automatic
+
+# Set manual maintenance with specific windows
+redisctl cloud subscription update-maintenance-windows 12345 \
+  --mode manual \
+  --window "Sunday:02-06" \
+  --window "Wednesday:02-06"
+```
+
+## Active-Active Regions
+
+### List Active-Active Regions
+
+```bash
+redisctl cloud subscription list-aa-regions <subscription-id>
+```
+
+### Add Active-Active Region
+
+Add a new region to an Active-Active subscription.
+
+```bash
+redisctl cloud subscription add-aa-region <subscription-id> \
+  --region "us-west-2" \
+  --deployment-cidr "10.1.0.0/24"
+```
+
+#### Options
+
+| Option | Description |
+|--------|-------------|
+| `--region` | Cloud region to add (required) |
+| `--deployment-cidr` | CIDR for the deployment |
+| `--vpc-id` | VPC ID for the region |
+| `--resp-version` | RESP protocol version |
+| `--dry-run` | Validate without creating |
+| `--data` | JSON with additional fields |
+
+#### Examples
+
+```bash
+# Add region with CIDR
+redisctl cloud subscription add-aa-region 12345 \
+  --region "eu-west-1" \
+  --deployment-cidr "10.2.0.0/24" \
+  --wait
+
+# Dry run to validate
+redisctl cloud subscription add-aa-region 12345 \
+  --region "ap-southeast-1" \
+  --deployment-cidr "10.3.0.0/24" \
+  --dry-run
+```
+
+### Delete Active-Active Regions
+
+Remove regions from an Active-Active subscription.
+
+```bash
+redisctl cloud subscription delete-aa-regions <subscription-id> \
+  --region "us-west-2" \
+  --force
+```
+
+#### Options
+
+| Option | Description |
+|--------|-------------|
+| `--region` | Region to delete (repeatable, at least one required) |
+| `--dry-run` | Validate without deleting |
+| `--data` | JSON with additional fields |
+| `--force` | Skip confirmation prompt |
+
+#### Examples
+
+```bash
+# Delete single region
+redisctl cloud subscription delete-aa-regions 12345 \
+  --region "eu-west-1" \
+  --force \
+  --wait
+
+# Delete multiple regions
+redisctl cloud subscription delete-aa-regions 12345 \
+  --region "ap-southeast-1" \
+  --region "ap-northeast-1" \
+  --force
+```


### PR DESCRIPTION
## Summary

Add first-class CLI parameters for subscription commands, making common operations easier without requiring JSON.

## Changes

### Subscription Update
- `--name`: Subscription name
- `--payment-method`: credit-card or marketplace
- `--payment-method-id`: Payment method ID

### Subscription Update CIDR Allowlist
- `--cidr`: CIDR block to allow (repeatable)
- `--security-group`: AWS security group ID (repeatable)

### Subscription Update Maintenance Windows
- `--mode`: automatic or manual
- `--window`: Maintenance window in DAY:HH-HH format (repeatable)

### Subscription Add AA Region
- `--region`: Cloud region to add
- `--deployment-cidr`: CIDR for the deployment
- `--vpc-id`: VPC ID for the region
- `--resp-version`: RESP protocol version
- `--dry-run`: Validate without creating

### Subscription Delete AA Regions
- `--region`: Region to delete (repeatable)
- `--dry-run`: Validate without deleting

## Examples

```bash
# Update subscription name
redisctl cloud subscription update 12345 --name "new-name"

# Update CIDR allowlist
redisctl cloud subscription update-cidr-allowlist 12345 \
  --cidr "10.0.0.0/24" \
  --cidr "192.168.1.0/24"

# Set maintenance windows
redisctl cloud subscription update-maintenance-windows 12345 \
  --mode manual \
  --window "Sunday:02-06"

# Add AA region
redisctl cloud subscription add-aa-region 12345 \
  --region "eu-west-1" \
  --deployment-cidr "10.2.0.0/24"

# Delete AA regions
redisctl cloud subscription delete-aa-regions 12345 \
  --region "ap-southeast-1" \
  --force
```

## Testing

- Added 12 CLI tests for subscription first-class parameters
- All existing tests pass

## Documentation

- Updated `mkdocs-site/docs/cloud/commands/subscriptions.md` with all new parameters

Closes #538 (partial - subscription commands)