### PR TITLE
feat(cloud): add first-class params to database commands

### DIFF
--- a/crates/redisctl/src/cli/cloud.rs
+++ b/crates/redisctl/src/cli/cloud.rs
@@ -1836,12 +1836,70 @@ pub enum CloudDatabaseCommands {
     },
 
     /// Update database configuration
+    #[command(after_help = "EXAMPLES:
+    # Update database name
+    redisctl cloud database update 123:456 --name new-db-name
+
+    # Increase memory
+    redisctl cloud database update 123:456 --memory 10
+
+    # Change eviction policy
+    redisctl cloud database update 123:456 --eviction-policy allkeys-lru
+
+    # Enable replication
+    redisctl cloud database update 123:456 --replication
+
+    # Multiple changes at once
+    redisctl cloud database update 123:456 \\
+      --memory 20 \\
+      --data-persistence aof-every-1-second \\
+      --wait
+
+    # Advanced: Use JSON for complex updates
+    redisctl cloud database update 123:456 \\
+      --data '{\"alerts\": [{\"name\": \"dataset-size\", \"value\": 80}]}'
+")]
     Update {
         /// Database ID (format: subscription_id:database_id)
         id: String,
-        /// Update configuration as JSON string or @file.json
+
+        /// New database name
         #[arg(long)]
-        data: String,
+        name: Option<String>,
+
+        /// Memory limit in GB
+        #[arg(long)]
+        memory: Option<f64>,
+
+        /// Enable replication for high availability
+        #[arg(long)]
+        replication: Option<bool>,
+
+        /// Data persistence policy
+        /// Options: none, aof-every-1-second, aof-every-write, snapshot-every-1-hour,
+        ///          snapshot-every-6-hours, snapshot-every-12-hours
+        #[arg(long)]
+        data_persistence: Option<String>,
+
+        /// Data eviction policy when memory limit reached
+        /// Options: volatile-lru, volatile-ttl, volatile-random, allkeys-lru,
+        ///          allkeys-lfu, allkeys-random, noeviction, volatile-lfu
+        #[arg(long)]
+        eviction_policy: Option<String>,
+
+        /// Enable OSS Cluster API support
+        #[arg(long)]
+        oss_cluster: Option<bool>,
+
+        /// Regular expression for allowed keys
+        #[arg(long)]
+        regex_rules: Option<String>,
+
+        /// Advanced: Full update configuration as JSON string or @file.json
+        /// CLI flags take precedence over values in JSON
+        #[arg(long)]
+        data: Option<String>,
+
         /// Async operation options
         #[command(flatten)]
         async_ops: crate::commands::cloud::async_utils::AsyncOperationArgs,
@@ -1881,12 +1939,80 @@ pub enum CloudDatabaseCommands {
     },
 
     /// Import data into database
+    #[command(after_help = "EXAMPLES:
+    # Import from S3
+    redisctl cloud database import 123:456 \\
+      --source-type s3 \\
+      --import-from-uri s3://bucket/backup.rdb \\
+      --wait
+
+    # Import from FTP
+    redisctl cloud database import 123:456 \\
+      --source-type ftp \\
+      --import-from-uri ftp://user:pass@server/backup.rdb
+
+    # Import from HTTP
+    redisctl cloud database import 123:456 \\
+      --source-type http \\
+      --import-from-uri https://example.com/backup.rdb
+
+    # Import from AWS S3 with credentials
+    redisctl cloud database import 123:456 \\
+      --source-type aws-s3 \\
+      --import-from-uri s3://bucket/backup.rdb \\
+      --aws-access-key AKIA... \\
+      --aws-secret-key secret
+
+    # Import from Google Cloud Storage
+    redisctl cloud database import 123:456 \\
+      --source-type gcs \\
+      --import-from-uri gs://bucket/backup.rdb
+
+    # Advanced: Use JSON for complex configurations
+    redisctl cloud database import 123:456 \\
+      --data @import-config.json
+")]
     Import {
         /// Database ID (format: subscription_id:database_id)
         id: String,
-        /// Import configuration as JSON string or @file.json
+
+        /// Source type: http, redis, ftp, aws-s3, gcs, azure-blob-storage
         #[arg(long)]
-        data: String,
+        source_type: Option<String>,
+
+        /// URI to import from (S3 URL, HTTP URL, FTP URL, etc.)
+        #[arg(long)]
+        import_from_uri: Option<String>,
+
+        /// AWS access key ID (for aws-s3 source type)
+        #[arg(long)]
+        aws_access_key: Option<String>,
+
+        /// AWS secret access key (for aws-s3 source type)
+        #[arg(long)]
+        aws_secret_key: Option<String>,
+
+        /// GCS client email (for gcs source type)
+        #[arg(long)]
+        gcs_client_email: Option<String>,
+
+        /// GCS private key (for gcs source type)
+        #[arg(long)]
+        gcs_private_key: Option<String>,
+
+        /// Azure storage account name (for azure-blob-storage source type)
+        #[arg(long)]
+        azure_account_name: Option<String>,
+
+        /// Azure storage account key (for azure-blob-storage source type)
+        #[arg(long)]
+        azure_account_key: Option<String>,
+
+        /// Advanced: Full import configuration as JSON string or @file.json
+        /// CLI flags take precedence over values in JSON
+        #[arg(long)]
+        data: Option<String>,
+
         /// Async operation options
         #[command(flatten)]
         async_ops: crate::commands::cloud::async_utils::AsyncOperationArgs,
@@ -1929,12 +2055,28 @@ pub enum CloudDatabaseCommands {
     },
 
     /// Update database tags
+    #[command(after_help = "EXAMPLES:
+    # Set multiple tags at once
+    redisctl cloud database update-tags 123:456 \\
+      --tag env=production \\
+      --tag team=backend \\
+      --tag cost-center=12345
+
+    # Replace all tags using JSON
+    redisctl cloud database update-tags 123:456 \\
+      --data '{\"tags\": [{\"key\": \"env\", \"value\": \"prod\"}]}'
+")]
     UpdateTags {
         /// Database ID (format: subscription_id:database_id)
         id: String,
+
+        /// Tag in key=value format (repeatable)
+        #[arg(long = "tag", value_name = "KEY=VALUE")]
+        tags: Vec<String>,
+
         /// Tags as JSON string or @file.json
         #[arg(long)]
-        data: String,
+        data: Option<String>,
     },
 
     /// Update a single tag value

--- a/crates/redisctl/src/commands/cloud/database.rs
+++ b/crates/redisctl/src/commands/cloud/database.rs
@@ -86,6 +86,13 @@ pub async fn handle_database_command(
         }
         CloudDatabaseCommands::Update {
             id,
+            name,
+            memory,
+            replication,
+            data_persistence,
+            eviction_policy,
+            oss_cluster,
+            regex_rules,
             data,
             async_ops,
         } => {
@@ -93,7 +100,14 @@ pub async fn handle_database_command(
                 conn_mgr,
                 profile_name,
                 id,
-                data,
+                name.as_deref(),
+                *memory,
+                *replication,
+                data_persistence.as_deref(),
+                eviction_policy.as_deref(),
+                *oss_cluster,
+                regex_rules.as_deref(),
+                data.as_deref(),
                 async_ops,
                 output_format,
                 query,
@@ -149,6 +163,14 @@ pub async fn handle_database_command(
         }
         CloudDatabaseCommands::Import {
             id,
+            source_type,
+            import_from_uri,
+            aws_access_key,
+            aws_secret_key,
+            gcs_client_email,
+            gcs_private_key,
+            azure_account_name,
+            azure_account_key,
             data,
             async_ops,
         } => {
@@ -156,7 +178,15 @@ pub async fn handle_database_command(
                 conn_mgr,
                 profile_name,
                 id,
-                data,
+                source_type.as_deref(),
+                import_from_uri.as_deref(),
+                aws_access_key.as_deref(),
+                aws_secret_key.as_deref(),
+                gcs_client_email.as_deref(),
+                gcs_private_key.as_deref(),
+                azure_account_name.as_deref(),
+                azure_account_key.as_deref(),
+                data.as_deref(),
                 async_ops,
                 output_format,
                 query,
@@ -194,12 +224,13 @@ pub async fn handle_database_command(
             )
             .await
         }
-        CloudDatabaseCommands::UpdateTags { id, data } => {
+        CloudDatabaseCommands::UpdateTags { id, tags, data } => {
             super::database_impl::update_tags(
                 conn_mgr,
                 profile_name,
                 id,
-                data,
+                tags,
+                data.as_deref(),
                 output_format,
                 query,
             )

--- a/crates/redisctl/tests/cli_basic_tests.rs
+++ b/crates/redisctl/tests/cli_basic_tests.rs
@@ -3279,3 +3279,132 @@ fn test_subscription_delete_aa_regions_requires_id() {
         .failure()
         .stderr(predicate::str::contains("required"));
 }
+
+// === DATABASE FIRST-CLASS PARAMETERS TESTS ===
+
+// Database update first-class params tests
+
+#[test]
+fn test_database_update_first_class_params_help() {
+    redisctl()
+        .arg("cloud")
+        .arg("database")
+        .arg("update")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--name"))
+        .stdout(predicate::str::contains("--memory"))
+        .stdout(predicate::str::contains("--replication"))
+        .stdout(predicate::str::contains("--data-persistence"))
+        .stdout(predicate::str::contains("--eviction-policy"))
+        .stdout(predicate::str::contains("--oss-cluster"))
+        .stdout(predicate::str::contains("--regex-rules"))
+        .stdout(predicate::str::contains("--data"));
+}
+
+#[test]
+fn test_database_update_has_examples() {
+    redisctl()
+        .arg("cloud")
+        .arg("database")
+        .arg("update")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("EXAMPLES:"));
+}
+
+#[test]
+fn test_database_update_requires_id() {
+    redisctl()
+        .arg("cloud")
+        .arg("database")
+        .arg("update")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("required"));
+}
+
+// Database import first-class params tests
+
+#[test]
+fn test_database_import_first_class_params_help() {
+    redisctl()
+        .arg("cloud")
+        .arg("database")
+        .arg("import")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--source-type"))
+        .stdout(predicate::str::contains("--import-from-uri"))
+        .stdout(predicate::str::contains("--aws-access-key"))
+        .stdout(predicate::str::contains("--aws-secret-key"))
+        .stdout(predicate::str::contains("--gcs-client-email"))
+        .stdout(predicate::str::contains("--gcs-private-key"))
+        .stdout(predicate::str::contains("--azure-account-name"))
+        .stdout(predicate::str::contains("--azure-account-key"))
+        .stdout(predicate::str::contains("--data"));
+}
+
+#[test]
+fn test_database_import_has_examples() {
+    redisctl()
+        .arg("cloud")
+        .arg("database")
+        .arg("import")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("EXAMPLES:"));
+}
+
+#[test]
+fn test_database_import_requires_id() {
+    redisctl()
+        .arg("cloud")
+        .arg("database")
+        .arg("import")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("required"));
+}
+
+// Database update-tags first-class params tests
+
+#[test]
+fn test_database_update_tags_first_class_params_help() {
+    redisctl()
+        .arg("cloud")
+        .arg("database")
+        .arg("update-tags")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--tag"))
+        .stdout(predicate::str::contains("--data"));
+}
+
+#[test]
+fn test_database_update_tags_has_examples() {
+    redisctl()
+        .arg("cloud")
+        .arg("database")
+        .arg("update-tags")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("EXAMPLES:"));
+}
+
+#[test]
+fn test_database_update_tags_requires_id() {
+    redisctl()
+        .arg("cloud")
+        .arg("database")
+        .arg("update-tags")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("required"));
+}

--- a/mkdocs-site/docs/cloud/commands/databases.md
+++ b/mkdocs-site/docs/cloud/commands/databases.md
@@ -5,20 +5,20 @@ Manage databases within Redis Cloud subscriptions.
 ## List Databases
 
 ```bash
-redisctl cloud database list --subscription-id <id>
+redisctl cloud database list --subscription <id>
 ```
 
 ### Examples
 
 ```bash
 # List all databases in a subscription
-redisctl cloud database list --subscription-id 123456
+redisctl cloud database list --subscription 123456
 
 # As JSON
-redisctl cloud database list --subscription-id 123456 -o json
+redisctl cloud database list --subscription 123456 -o json
 
 # Just names and endpoints
-redisctl cloud database list --subscription-id 123456 -o json -q '[].{
+redisctl cloud database list --subscription 123456 -o json -q '[].{
   name: name,
   endpoint: publicEndpoint
 }'
@@ -27,23 +27,23 @@ redisctl cloud database list --subscription-id 123456 -o json -q '[].{
 ## Get Database Details
 
 ```bash
-redisctl cloud database get <subscription-id> <database-id>
+redisctl cloud database get <subscription-id>:<database-id>
 ```
 
 ### Examples
 
 ```bash
 # Full details
-redisctl cloud database get 123456 789
+redisctl cloud database get 123456:789
 
 # Connection info
-redisctl cloud database get 123456 789 -o json -q '{
+redisctl cloud database get 123456:789 -o json -q '{
   endpoint: publicEndpoint,
   password: password
 }'
 
 # Memory and status
-redisctl cloud database get 123456 789 -o json -q '{
+redisctl cloud database get 123456:789 -o json -q '{
   name: name,
   memory_gb: memoryLimitInGb,
   status: status
@@ -52,11 +52,65 @@ redisctl cloud database get 123456 789 -o json -q '{
 
 ## Create Database
 
+Create a database with first-class parameters for common options.
+
 ```bash
 redisctl cloud database create \
-  --subscription-id 123456 \
+  --subscription 123456 \
   --name mydb \
-  --memory-limit-in-gb 1 \
+  --memory 1 \
+  --wait
+```
+
+### Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--subscription` | Subscription ID (required) | - |
+| `--name` | Database name (required) | - |
+| `--memory` | Memory limit in GB | - |
+| `--dataset-size` | Dataset size in GB (alternative to --memory) | - |
+| `--protocol` | Database protocol | redis |
+| `--replication` | Enable replication for HA | false |
+| `--data-persistence` | Persistence policy | - |
+| `--eviction-policy` | Eviction policy | volatile-lru |
+| `--redis-version` | Redis version (e.g., "7.2") | - |
+| `--oss-cluster` | Enable OSS Cluster API | false |
+| `--port` | TCP port (10000-19999) | auto |
+| `--data` | Full JSON configuration | - |
+
+### Examples
+
+```bash
+# Simple database
+redisctl cloud database create \
+  --subscription 123456 \
+  --name mydb \
+  --memory 1
+
+# Production database with high availability
+redisctl cloud database create \
+  --subscription 123456 \
+  --name prod-cache \
+  --memory 10 \
+  --replication \
+  --data-persistence aof-every-1-second
+
+# Advanced: Mix flags with JSON for rare options
+redisctl cloud database create \
+  --subscription 123456 \
+  --name mydb \
+  --memory 5 \
+  --data '{"modules": [{"name": "RedisJSON"}]}'
+```
+
+## Update Database
+
+Update database configuration using first-class parameters.
+
+```bash
+redisctl cloud database update <subscription-id>:<database-id> \
+  --memory 10 \
   --wait
 ```
 
@@ -64,60 +118,142 @@ redisctl cloud database create \
 
 | Option | Description |
 |--------|-------------|
-| `--subscription-id` | Subscription ID (required) |
-| `--name` | Database name |
-| `--memory-limit-in-gb` | Memory size in GB |
-| `--data-eviction-policy` | Eviction policy |
-| `--replication` | Enable replication |
-| `--wait` | Wait for completion |
-| `--data` | Full JSON configuration |
+| `--name` | New database name |
+| `--memory` | Memory limit in GB |
+| `--replication` | Enable/disable replication |
+| `--data-persistence` | Persistence policy |
+| `--eviction-policy` | Eviction policy |
+| `--oss-cluster` | Enable/disable OSS Cluster API |
+| `--regex-rules` | Regular expression for allowed keys |
+| `--data` | Full JSON with additional fields |
 
-### Create with Full Config
-
-```bash
-redisctl cloud database create \
-  --subscription-id 123456 \
-  --data '{
-    "name": "cache",
-    "memoryLimitInGb": 2,
-    "dataEvictionPolicy": "volatile-lru",
-    "replication": true
-  }' \
-  --wait
-```
-
-## Update Database
+### Examples
 
 ```bash
-redisctl cloud database update <subscription-id> <database-id> \
-  --memory-limit-in-gb 2 \
-  --wait
-```
+# Update database name
+redisctl cloud database update 123456:789 --name new-db-name
 
-### Scale Memory
+# Increase memory
+redisctl cloud database update 123456:789 --memory 10
 
-```bash
-redisctl cloud database update 123456 789 \
-  --memory-limit-in-gb 4 \
+# Change eviction policy
+redisctl cloud database update 123456:789 --eviction-policy allkeys-lru
+
+# Enable replication
+redisctl cloud database update 123456:789 --replication true
+
+# Multiple changes at once
+redisctl cloud database update 123456:789 \
+  --memory 20 \
+  --data-persistence aof-every-1-second \
   --wait
+
+# Advanced: Use JSON for complex updates
+redisctl cloud database update 123456:789 \
+  --data '{"alerts": [{"name": "dataset-size", "value": 80}]}'
 ```
 
 ## Delete Database
 
 ```bash
-redisctl cloud database delete <subscription-id> <database-id> --wait
+redisctl cloud database delete <subscription-id>:<database-id> --wait
 ```
 
 !!! warning
-    This permanently deletes the database. Add `--wait` to confirm deletion completes.
+    This permanently deletes the database. Add `--force` to skip confirmation.
+
+## Import Data
+
+Import data into a database using first-class parameters.
+
+```bash
+redisctl cloud database import <subscription-id>:<database-id> \
+  --source-type s3 \
+  --import-from-uri s3://bucket/backup.rdb \
+  --wait
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--source-type` | Source type: http, redis, ftp, aws-s3, gcs, azure-blob-storage |
+| `--import-from-uri` | URI to import from |
+| `--aws-access-key` | AWS access key ID (for aws-s3) |
+| `--aws-secret-key` | AWS secret access key (for aws-s3) |
+| `--gcs-client-email` | GCS client email (for gcs) |
+| `--gcs-private-key` | GCS private key (for gcs) |
+| `--azure-account-name` | Azure storage account name |
+| `--azure-account-key` | Azure storage account key |
+| `--data` | Full JSON configuration |
+
+### Examples
+
+```bash
+# Import from S3
+redisctl cloud database import 123456:789 \
+  --source-type s3 \
+  --import-from-uri s3://bucket/backup.rdb \
+  --wait
+
+# Import from FTP
+redisctl cloud database import 123456:789 \
+  --source-type ftp \
+  --import-from-uri ftp://user:pass@server/backup.rdb
+
+# Import from AWS S3 with credentials
+redisctl cloud database import 123456:789 \
+  --source-type aws-s3 \
+  --import-from-uri s3://bucket/backup.rdb \
+  --aws-access-key AKIA... \
+  --aws-secret-key secret
+
+# Import from Google Cloud Storage
+redisctl cloud database import 123456:789 \
+  --source-type gcs \
+  --import-from-uri gs://bucket/backup.rdb
+```
+
+## Tags
+
+### List Tags
+
+```bash
+redisctl cloud database list-tags <subscription-id>:<database-id>
+```
+
+### Add Tag
+
+```bash
+redisctl cloud database add-tag <subscription-id>:<database-id> \
+  --key env \
+  --value production
+```
+
+### Update Tags
+
+Update multiple tags at once using first-class parameters.
+
+```bash
+redisctl cloud database update-tags <subscription-id>:<database-id> \
+  --tag env=production \
+  --tag team=backend \
+  --tag cost-center=12345
+```
+
+### Delete Tag
+
+```bash
+redisctl cloud database delete-tag <subscription-id>:<database-id> --key env
+```
 
 ## Common Queries
 
 ### Get Connection String
 
 ```bash
-ENDPOINT=$(redisctl cloud database get 123456 789 -o json -q 'publicEndpoint')
-PASSWORD=$(redisctl cloud database get 123456 789 -o json -q 'password')
+ENDPOINT=$(redisctl cloud database get 123456:789 -o json -q 'publicEndpoint')
+PASSWORD=$(redisctl cloud database get 123456:789 -o json -q 'password')
 echo "redis://default:$PASSWORD@$ENDPOINT"
 ```
 
@@ -126,14 +262,14 @@ echo "redis://default:$PASSWORD@$ENDPOINT"
 ```bash
 for sub in $(redisctl cloud subscription list -o json -q '[].id' | jq -r '.[]'); do
   echo "=== Subscription $sub ==="
-  redisctl cloud database list --subscription-id "$sub" -o json -q '[].name'
+  redisctl cloud database list --subscription "$sub" -o json -q '[].name'
 done
 ```
 
 ### Database Size Summary
 
 ```bash
-redisctl cloud database list --subscription-id 123456 -o json -q '[].{
+redisctl cloud database list --subscription 123456 -o json -q '[].{
   name: name,
   memory_gb: memoryLimitInGb,
   status: status


### PR DESCRIPTION
## Summary

Add first-class CLI parameters for database commands, making common operations easier without requiring JSON.

## Changes

### Database Update
- `--name`: New database name
- `--memory`: Memory limit in GB
- `--replication`: Enable/disable replication
- `--data-persistence`: Persistence policy
- `--eviction-policy`: Eviction policy
- `--oss-cluster`: Enable/disable OSS Cluster API
- `--regex-rules`: Regular expression for allowed keys

### Database Import
- `--source-type`: http, redis, ftp, aws-s3, gcs, azure-blob-storage
- `--import-from-uri`: URI to import from
- `--aws-access-key`: AWS access key ID
- `--aws-secret-key`: AWS secret access key
- `--gcs-client-email`: GCS client email
- `--gcs-private-key`: GCS private key
- `--azure-account-name`: Azure storage account name
- `--azure-account-key`: Azure storage account key

### Database Update Tags
- `--tag`: Tag in key=value format (repeatable)

## Examples

```bash
# Update database memory
redisctl cloud database update 123:456 --memory 10 --wait

# Change eviction policy
redisctl cloud database update 123:456 --eviction-policy allkeys-lru

# Import from S3
redisctl cloud database import 123:456 \
  --source-type s3 \
  --import-from-uri s3://bucket/backup.rdb \
  --wait

# Import with AWS credentials
redisctl cloud database import 123:456 \
  --source-type aws-s3 \
  --import-from-uri s3://bucket/backup.rdb \
  --aws-access-key AKIA... \
  --aws-secret-key secret

# Update multiple tags
redisctl cloud database update-tags 123:456 \
  --tag env=production \
  --tag team=backend
```

## Testing

- Added 9 CLI tests for database first-class parameters
- All existing tests pass (270 total)

## Documentation

- Updated `mkdocs-site/docs/cloud/commands/databases.md` with all new parameters