### PR TITLE
feat(cloud): add first-class CLI params for fixed-subscription commands

### DIFF
--- a/crates/redisctl/src/cli/cloud.rs
+++ b/crates/redisctl/src/cli/cloud.rs
@@ -1302,19 +1302,87 @@ pub enum CloudFixedSubscriptionCommands {
         id: i32,
     },
     /// Create a new fixed subscription
+    #[command(after_help = "EXAMPLES:
+    # Create subscription with name and plan ID
+    redisctl cloud fixed-subscription create --name my-cache --plan-id 12345 --wait
+
+    # Create with specific payment method
+    redisctl cloud fixed-subscription create \\
+      --name prod-cache \\
+      --plan-id 12345 \\
+      --payment-method credit-card \\
+      --payment-method-id 67890
+
+    # Create using JSON for full control
+    redisctl cloud fixed-subscription create \\
+      --data '{\"name\": \"my-cache\", \"planId\": 12345}'
+")]
     Create {
-        /// JSON file with subscription configuration (use @filename or - for stdin)
-        file: String,
+        /// Subscription name
+        #[arg(long)]
+        name: Option<String>,
+
+        /// Plan ID from list-plans
+        #[arg(long)]
+        plan_id: Option<i32>,
+
+        /// Payment method (credit-card or marketplace)
+        #[arg(long)]
+        payment_method: Option<String>,
+
+        /// Payment method ID (required for credit-card)
+        #[arg(long)]
+        payment_method_id: Option<i32>,
+
+        /// JSON data (string or @filename)
+        #[arg(long)]
+        data: Option<String>,
+
         /// Async operation options
         #[command(flatten)]
         async_ops: crate::commands::cloud::async_utils::AsyncOperationArgs,
     },
     /// Update fixed subscription
+    #[command(after_help = "EXAMPLES:
+    # Rename subscription
+    redisctl cloud fixed-subscription update 123456 --name new-name
+
+    # Change plan
+    redisctl cloud fixed-subscription update 123456 --plan-id 67890 --wait
+
+    # Change payment method
+    redisctl cloud fixed-subscription update 123456 \\
+      --payment-method credit-card \\
+      --payment-method-id 11111
+
+    # Update using JSON
+    redisctl cloud fixed-subscription update 123456 \\
+      --data '{\"name\": \"new-name\"}'
+")]
     Update {
         /// Subscription ID
         id: i32,
-        /// JSON file with update configuration (use @filename or - for stdin)
-        file: String,
+
+        /// New subscription name
+        #[arg(long)]
+        name: Option<String>,
+
+        /// New plan ID
+        #[arg(long)]
+        plan_id: Option<i32>,
+
+        /// Payment method (credit-card or marketplace)
+        #[arg(long)]
+        payment_method: Option<String>,
+
+        /// Payment method ID (required for credit-card)
+        #[arg(long)]
+        payment_method_id: Option<i32>,
+
+        /// JSON data (string or @filename)
+        #[arg(long)]
+        data: Option<String>,
+
         /// Async operation options
         #[command(flatten)]
         async_ops: crate::commands::cloud::async_utils::AsyncOperationArgs,

--- a/crates/redisctl/src/commands/cloud/fixed_subscription.rs
+++ b/crates/redisctl/src/commands/cloud/fixed_subscription.rs
@@ -4,15 +4,27 @@
 
 use crate::cli::{CloudFixedSubscriptionCommands, OutputFormat};
 use crate::commands::cloud::async_utils::handle_async_response;
-use crate::commands::cloud::utils::{
-    confirm_action, handle_output, print_formatted_output, read_file_input,
-};
+use crate::commands::cloud::utils::{confirm_action, handle_output, print_formatted_output};
 use crate::connection::ConnectionManager;
-use crate::error::Result as CliResult;
+use crate::error::{RedisCtlError, Result as CliResult};
 use anyhow::Context;
 use redis_cloud::fixed::subscriptions::{
     FixedSubscriptionCreateRequest, FixedSubscriptionHandler, FixedSubscriptionUpdateRequest,
 };
+
+/// Read JSON data from string or file (prefixed with @)
+fn read_json_data(data: &str) -> CliResult<serde_json::Value> {
+    let json_str = if let Some(file_path) = data.strip_prefix('@') {
+        std::fs::read_to_string(file_path).map_err(|e| RedisCtlError::InvalidInput {
+            message: format!("Failed to read file {}: {}", file_path, e),
+        })?
+    } else {
+        data.to_string()
+    };
+    serde_json::from_str(&json_str).map_err(|e| RedisCtlError::InvalidInput {
+        message: format!("Invalid JSON: {}", e),
+    })
+}
 
 /// Handle fixed subscription commands
 pub async fn handle_fixed_subscription_command(
@@ -118,10 +130,56 @@ pub async fn handle_fixed_subscription_command(
             Ok(())
         }
 
-        CloudFixedSubscriptionCommands::Create { file, async_ops } => {
-            let json_string = read_file_input(file)?;
-            let request: FixedSubscriptionCreateRequest =
-                serde_json::from_str(&json_string).context("Invalid subscription configuration")?;
+        CloudFixedSubscriptionCommands::Create {
+            name,
+            plan_id,
+            payment_method,
+            payment_method_id,
+            data,
+            async_ops,
+        } => {
+            // Start with data from --data if provided, otherwise empty object
+            let mut request_value = if let Some(data_str) = data {
+                read_json_data(data_str)?
+            } else {
+                serde_json::json!({})
+            };
+
+            let request_obj =
+                request_value
+                    .as_object_mut()
+                    .ok_or_else(|| RedisCtlError::InvalidInput {
+                        message: "JSON data must be an object".to_string(),
+                    })?;
+
+            // Apply first-class params (override JSON values)
+            if let Some(n) = name {
+                request_obj.insert("name".to_string(), serde_json::json!(n));
+            }
+            if let Some(p) = plan_id {
+                request_obj.insert("planId".to_string(), serde_json::json!(p));
+            }
+            if let Some(pm) = payment_method {
+                request_obj.insert("paymentMethod".to_string(), serde_json::json!(pm));
+            }
+            if let Some(pm_id) = payment_method_id {
+                request_obj.insert("paymentMethodId".to_string(), serde_json::json!(pm_id));
+            }
+
+            // Validate required fields
+            if !request_obj.contains_key("name") {
+                return Err(RedisCtlError::InvalidInput {
+                    message: "--name is required (or provide via --data JSON)".to_string(),
+                });
+            }
+            if !request_obj.contains_key("planId") {
+                return Err(RedisCtlError::InvalidInput {
+                    message: "--plan-id is required (or provide via --data JSON)".to_string(),
+                });
+            }
+
+            let request: FixedSubscriptionCreateRequest = serde_json::from_value(request_value)
+                .context("Invalid subscription configuration")?;
 
             let result = handler
                 .create(&request)
@@ -145,12 +203,50 @@ pub async fn handle_fixed_subscription_command(
 
         CloudFixedSubscriptionCommands::Update {
             id,
-            file,
+            name,
+            plan_id,
+            payment_method,
+            payment_method_id,
+            data,
             async_ops,
         } => {
-            let json_string = read_file_input(file)?;
+            // Start with data from --data if provided, otherwise empty object
+            let mut request_value = if let Some(data_str) = data {
+                read_json_data(data_str)?
+            } else {
+                serde_json::json!({})
+            };
+
+            let request_obj =
+                request_value
+                    .as_object_mut()
+                    .ok_or_else(|| RedisCtlError::InvalidInput {
+                        message: "JSON data must be an object".to_string(),
+                    })?;
+
+            // Apply first-class params (override JSON values)
+            if let Some(n) = name {
+                request_obj.insert("name".to_string(), serde_json::json!(n));
+            }
+            if let Some(p) = plan_id {
+                request_obj.insert("planId".to_string(), serde_json::json!(p));
+            }
+            if let Some(pm) = payment_method {
+                request_obj.insert("paymentMethod".to_string(), serde_json::json!(pm));
+            }
+            if let Some(pm_id) = payment_method_id {
+                request_obj.insert("paymentMethodId".to_string(), serde_json::json!(pm_id));
+            }
+
+            // Validate that we have at least one field to update
+            if request_obj.is_empty() {
+                return Err(RedisCtlError::InvalidInput {
+                    message: "At least one update field is required (--name, --plan-id, --payment-method, --payment-method-id, or --data)".to_string(),
+                });
+            }
+
             let request: FixedSubscriptionUpdateRequest =
-                serde_json::from_str(&json_string).context("Invalid update configuration")?;
+                serde_json::from_value(request_value).context("Invalid update configuration")?;
 
             let result = handler
                 .update(*id, &request)

--- a/crates/redisctl/tests/cli_basic_tests.rs
+++ b/crates/redisctl/tests/cli_basic_tests.rs
@@ -3577,3 +3577,74 @@ fn test_fixed_database_update_tags_requires_ids() {
         .failure()
         .stderr(predicate::str::contains("required"));
 }
+
+// Fixed subscription create first-class params tests
+
+#[test]
+fn test_fixed_subscription_create_first_class_params_help() {
+    redisctl()
+        .arg("cloud")
+        .arg("fixed-subscription")
+        .arg("create")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--name"))
+        .stdout(predicate::str::contains("--plan-id"))
+        .stdout(predicate::str::contains("--payment-method"))
+        .stdout(predicate::str::contains("--payment-method-id"))
+        .stdout(predicate::str::contains("--data"));
+}
+
+#[test]
+fn test_fixed_subscription_create_has_examples() {
+    redisctl()
+        .arg("cloud")
+        .arg("fixed-subscription")
+        .arg("create")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("EXAMPLES:"));
+}
+
+// Fixed subscription update first-class params tests
+
+#[test]
+fn test_fixed_subscription_update_first_class_params_help() {
+    redisctl()
+        .arg("cloud")
+        .arg("fixed-subscription")
+        .arg("update")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--name"))
+        .stdout(predicate::str::contains("--plan-id"))
+        .stdout(predicate::str::contains("--payment-method"))
+        .stdout(predicate::str::contains("--payment-method-id"))
+        .stdout(predicate::str::contains("--data"));
+}
+
+#[test]
+fn test_fixed_subscription_update_has_examples() {
+    redisctl()
+        .arg("cloud")
+        .arg("fixed-subscription")
+        .arg("update")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("EXAMPLES:"));
+}
+
+#[test]
+fn test_fixed_subscription_update_requires_id() {
+    redisctl()
+        .arg("cloud")
+        .arg("fixed-subscription")
+        .arg("update")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("required"));
+}

--- a/mkdocs-site/docs/cloud/commands/fixed-subscriptions.md
+++ b/mkdocs-site/docs/cloud/commands/fixed-subscriptions.md
@@ -9,6 +9,7 @@ Manage Redis Cloud Essentials (fixed) subscriptions.
 | `list` | List all Essentials subscriptions |
 | `get` | Get subscription details |
 | `create` | Create a new subscription |
+| `update` | Update subscription settings |
 | `delete` | Delete a subscription |
 | `list-plans` | List available plans |
 
@@ -81,7 +82,7 @@ redisctl cloud fixed-subscription list-plans -o json -q '[].{
 
 ## Create Subscription
 
-Create a new Essentials subscription.
+Create a new Essentials subscription with first-class parameters.
 
 ```bash
 redisctl cloud fixed-subscription create \
@@ -96,8 +97,9 @@ redisctl cloud fixed-subscription create \
 |--------|-------------|
 | `--name` | Subscription name (required) |
 | `--plan-id` | Plan ID from list-plans (required) |
-| `--payment-method-id` | Payment method ID |
-| `--data` | Full JSON configuration |
+| `--payment-method` | Payment method (credit-card or marketplace) |
+| `--payment-method-id` | Payment method ID (required for credit-card) |
+| `--data` | JSON with additional fields |
 
 ### Examples
 
@@ -112,7 +114,51 @@ redisctl cloud fixed-subscription create \
 redisctl cloud fixed-subscription create \
   --name prod-cache \
   --plan-id 12345 \
+  --payment-method credit-card \
   --payment-method-id 67890
+
+# Use JSON for full control
+redisctl cloud fixed-subscription create \
+  --data '{"name": "my-cache", "planId": 12345}'
+```
+
+## Update Subscription
+
+Update subscription settings using first-class parameters.
+
+```bash
+redisctl cloud fixed-subscription update <subscription-id> \
+  --name new-name \
+  --wait
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--name` | New subscription name |
+| `--plan-id` | New plan ID |
+| `--payment-method` | Payment method (credit-card or marketplace) |
+| `--payment-method-id` | Payment method ID |
+| `--data` | JSON with additional fields |
+
+### Examples
+
+```bash
+# Rename subscription
+redisctl cloud fixed-subscription update 123456 --name new-name
+
+# Change plan
+redisctl cloud fixed-subscription update 123456 --plan-id 67890 --wait
+
+# Change payment method
+redisctl cloud fixed-subscription update 123456 \
+  --payment-method credit-card \
+  --payment-method-id 11111
+
+# Update using JSON
+redisctl cloud fixed-subscription update 123456 \
+  --data '{"name": "new-name"}'
 ```
 
 ## Delete Subscription


### PR DESCRIPTION
## Summary

Add first-class CLI parameters to fixed-subscription commands to replace raw JSON input with discoverable flags.

## Changes

### fixed-subscription create
- `--name`: Subscription name (required)
- `--plan-id`: Plan ID from list-plans (required)
- `--payment-method`: Payment method (credit-card or marketplace)
- `--payment-method-id`: Payment method ID (required for credit-card)

### fixed-subscription update
- `--name`: New subscription name
- `--plan-id`: New plan ID
- `--payment-method`: Payment method
- `--payment-method-id`: Payment method ID

### Documentation
- Updated `fixed-subscriptions.md` with new first-class params and examples
- Added update command documentation

## Design

All commands retain `--data` as escape hatch for advanced use cases. CLI params override JSON values when both provided. Examples added via `after_help`.

## Testing

- Added 5 CLI tests for first-class params
- All tests pass

Closes part of #538