### PR TITLE
feat(cloud): add first-class CLI params for provider-account commands

### DIFF
--- a/crates/redisctl/src/cli/cloud.rs
+++ b/crates/redisctl/src/cli/cloud.rs
@@ -1418,22 +1418,106 @@ pub enum CloudProviderAccountCommands {
         account_id: i32,
     },
     /// Create a new cloud provider account
+    #[command(after_help = "EXAMPLES:
+    # Create AWS cloud account with credentials
+    redisctl cloud provider-account create \\
+      --name 'Production AWS' \\
+      --provider AWS \\
+      --access-key-id AKIA... \\
+      --access-secret-key secret \\
+      --console-username admin@example.com \\
+      --console-password mypassword \\
+      --sign-in-login-url https://console.aws.amazon.com
+
+    # Create using JSON file (for GCP service account)
+    redisctl cloud provider-account create --data @gcp-service-account.json
+
+    # Create with JSON string
+    redisctl cloud provider-account create \\
+      --data '{\"name\": \"My Account\", \"provider\": \"AWS\", ...}'
+")]
     Create {
-        /// JSON file containing the cloud account configuration
-        /// For GCP, this should be the service account JSON file
-        /// Use @filename to read from file
-        file: String,
+        /// Account display name
+        #[arg(long)]
+        name: Option<String>,
+
+        /// Cloud provider (AWS, GCP, Azure)
+        #[arg(long)]
+        provider: Option<String>,
+
+        /// Cloud provider access key ID
+        #[arg(long)]
+        access_key_id: Option<String>,
+
+        /// Cloud provider secret access key
+        #[arg(long)]
+        access_secret_key: Option<String>,
+
+        /// Cloud provider console username
+        #[arg(long)]
+        console_username: Option<String>,
+
+        /// Cloud provider console password
+        #[arg(long)]
+        console_password: Option<String>,
+
+        /// Cloud provider console login URL
+        #[arg(long)]
+        sign_in_login_url: Option<String>,
+
+        /// JSON data (string or @filename) - use for GCP service account JSON
+        #[arg(long)]
+        data: Option<String>,
+
         /// Async operation arguments
         #[command(flatten)]
         async_ops: crate::commands::cloud::async_utils::AsyncOperationArgs,
     },
     /// Update a cloud provider account
+    #[command(after_help = "EXAMPLES:
+    # Update account name
+    redisctl cloud provider-account update 123 --name 'New Name'
+
+    # Update credentials
+    redisctl cloud provider-account update 123 \\
+      --access-key-id AKIA... \\
+      --access-secret-key newsecret
+
+    # Update using JSON
+    redisctl cloud provider-account update 123 --data @updated-config.json
+")]
     Update {
         /// Cloud account ID
         account_id: i32,
-        /// JSON file containing updated cloud account configuration
-        /// Use @filename to read from file
-        file: String,
+
+        /// New account display name
+        #[arg(long)]
+        name: Option<String>,
+
+        /// New access key ID
+        #[arg(long)]
+        access_key_id: Option<String>,
+
+        /// New secret access key
+        #[arg(long)]
+        access_secret_key: Option<String>,
+
+        /// New console username
+        #[arg(long)]
+        console_username: Option<String>,
+
+        /// New console password
+        #[arg(long)]
+        console_password: Option<String>,
+
+        /// New console login URL
+        #[arg(long)]
+        sign_in_login_url: Option<String>,
+
+        /// JSON data (string or @filename)
+        #[arg(long)]
+        data: Option<String>,
+
         /// Async operation arguments
         #[command(flatten)]
         async_ops: crate::commands::cloud::async_utils::AsyncOperationArgs,

--- a/crates/redisctl/src/commands/cloud/cloud_account.rs
+++ b/crates/redisctl/src/commands/cloud/cloud_account.rs
@@ -1,7 +1,9 @@
 #![allow(dead_code)]
 
 use crate::cli::{CloudProviderAccountCommands, OutputFormat};
-use crate::commands::cloud::cloud_account_impl::{self, CloudAccountOperationParams};
+use crate::commands::cloud::cloud_account_impl::{
+    self, CloudAccountOperationParams, CreateParams, UpdateParams,
+};
 use crate::connection::ConnectionManager;
 use crate::error::Result as CliResult;
 
@@ -21,20 +23,15 @@ pub async fn handle_cloud_account_command(
         CloudProviderAccountCommands::Get { account_id } => {
             cloud_account_impl::handle_get(&client, *account_id, output_format, query).await
         }
-        CloudProviderAccountCommands::Create { file, async_ops } => {
-            let params = CloudAccountOperationParams {
-                conn_mgr,
-                profile_name,
-                client: &client,
-                async_ops,
-                output_format,
-                query,
-            };
-            cloud_account_impl::handle_create(&params, file).await
-        }
-        CloudProviderAccountCommands::Update {
-            account_id,
-            file,
+        CloudProviderAccountCommands::Create {
+            name,
+            provider,
+            access_key_id,
+            access_secret_key,
+            console_username,
+            console_password,
+            sign_in_login_url,
+            data,
             async_ops,
         } => {
             let params = CloudAccountOperationParams {
@@ -45,7 +42,47 @@ pub async fn handle_cloud_account_command(
                 output_format,
                 query,
             };
-            cloud_account_impl::handle_update(&params, *account_id, file).await
+            let create_params = CreateParams {
+                name: name.as_deref(),
+                provider: provider.as_deref(),
+                access_key_id: access_key_id.as_deref(),
+                access_secret_key: access_secret_key.as_deref(),
+                console_username: console_username.as_deref(),
+                console_password: console_password.as_deref(),
+                sign_in_login_url: sign_in_login_url.as_deref(),
+                data: data.as_deref(),
+            };
+            cloud_account_impl::handle_create(&params, &create_params).await
+        }
+        CloudProviderAccountCommands::Update {
+            account_id,
+            name,
+            access_key_id,
+            access_secret_key,
+            console_username,
+            console_password,
+            sign_in_login_url,
+            data,
+            async_ops,
+        } => {
+            let params = CloudAccountOperationParams {
+                conn_mgr,
+                profile_name,
+                client: &client,
+                async_ops,
+                output_format,
+                query,
+            };
+            let update_params = UpdateParams {
+                name: name.as_deref(),
+                access_key_id: access_key_id.as_deref(),
+                access_secret_key: access_secret_key.as_deref(),
+                console_username: console_username.as_deref(),
+                console_password: console_password.as_deref(),
+                sign_in_login_url: sign_in_login_url.as_deref(),
+                data: data.as_deref(),
+            };
+            cloud_account_impl::handle_update(&params, *account_id, &update_params).await
         }
         CloudProviderAccountCommands::Delete {
             account_id,

--- a/crates/redisctl/tests/cli_basic_tests.rs
+++ b/crates/redisctl/tests/cli_basic_tests.rs
@@ -3648,3 +3648,79 @@ fn test_fixed_subscription_update_requires_id() {
         .failure()
         .stderr(predicate::str::contains("required"));
 }
+
+// Provider account create first-class params tests
+
+#[test]
+fn test_provider_account_create_first_class_params_help() {
+    redisctl()
+        .arg("cloud")
+        .arg("provider-account")
+        .arg("create")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--name"))
+        .stdout(predicate::str::contains("--provider"))
+        .stdout(predicate::str::contains("--access-key-id"))
+        .stdout(predicate::str::contains("--access-secret-key"))
+        .stdout(predicate::str::contains("--console-username"))
+        .stdout(predicate::str::contains("--console-password"))
+        .stdout(predicate::str::contains("--sign-in-login-url"))
+        .stdout(predicate::str::contains("--data"));
+}
+
+#[test]
+fn test_provider_account_create_has_examples() {
+    redisctl()
+        .arg("cloud")
+        .arg("provider-account")
+        .arg("create")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("EXAMPLES:"));
+}
+
+// Provider account update first-class params tests
+
+#[test]
+fn test_provider_account_update_first_class_params_help() {
+    redisctl()
+        .arg("cloud")
+        .arg("provider-account")
+        .arg("update")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--name"))
+        .stdout(predicate::str::contains("--access-key-id"))
+        .stdout(predicate::str::contains("--access-secret-key"))
+        .stdout(predicate::str::contains("--console-username"))
+        .stdout(predicate::str::contains("--console-password"))
+        .stdout(predicate::str::contains("--sign-in-login-url"))
+        .stdout(predicate::str::contains("--data"));
+}
+
+#[test]
+fn test_provider_account_update_has_examples() {
+    redisctl()
+        .arg("cloud")
+        .arg("provider-account")
+        .arg("update")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("EXAMPLES:"));
+}
+
+#[test]
+fn test_provider_account_update_requires_id() {
+    redisctl()
+        .arg("cloud")
+        .arg("provider-account")
+        .arg("update")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("required"));
+}


### PR DESCRIPTION
## Summary

Add first-class CLI parameters to provider-account commands to replace raw JSON input with discoverable flags.

## Changes

### provider-account create
- `--name`: Account display name
- `--provider`: Cloud provider (AWS, GCP, Azure)
- `--access-key-id`: Cloud provider access key ID
- `--access-secret-key`: Cloud provider secret access key
- `--console-username`: Cloud provider console username
- `--console-password`: Cloud provider console password
- `--sign-in-login-url`: Cloud provider console login URL

### provider-account update
Same params as create (except `--provider`).

## Design

- All commands retain `--data` as escape hatch for advanced use cases
- GCP service account JSON files can still be passed via `--data @service-account.json`
- CLI params override JSON values when both provided
- Examples added via `after_help`

## Testing

- Added 5 CLI tests for first-class params
- All tests pass

Closes part of #538