### PR TITLE
feat(cli): add first-class params for enterprise user create/update

### DIFF
--- a/crates/redisctl/src/cli/enterprise.rs
+++ b/crates/redisctl/src/cli/enterprise.rs
@@ -861,19 +861,109 @@ pub enum EnterpriseUserCommands {
     },
 
     /// Create new user
+    #[command(after_help = "EXAMPLES:
+    # Create user with email and password
+    redisctl enterprise user create --email admin@example.com --password secret123 --role admin
+
+    # Create user with display name
+    redisctl enterprise user create --email user@example.com --password secret123 --role db_viewer --name \"John Doe\"
+
+    # Create user with email alerts enabled
+    redisctl enterprise user create --email ops@example.com --password secret123 --role db_member --email-alerts
+
+    # Create user with RBAC role IDs
+    redisctl enterprise user create --email rbac@example.com --password secret123 --role db_viewer --role-uid 1 --role-uid 2
+
+    # Advanced: Full configuration via JSON file
+    redisctl enterprise user create --data @user.json
+
+NOTE: First-class parameters override values in --data when both are provided.")]
     Create {
-        /// User data (JSON file or inline)
-        #[arg(long, value_name = "FILE|JSON")]
-        data: String,
+        /// User's email address (used as login)
+        #[arg(long)]
+        email: Option<String>,
+
+        /// User's password
+        #[arg(long)]
+        password: Option<String>,
+
+        /// User's role (admin, db_viewer, db_member, cluster_viewer, cluster_member, none)
+        #[arg(long)]
+        role: Option<String>,
+
+        /// User's display name
+        #[arg(long)]
+        name: Option<String>,
+
+        /// Enable email alerts for this user
+        #[arg(long)]
+        email_alerts: bool,
+
+        /// Role UID for RBAC (can be repeated)
+        #[arg(long = "role-uid")]
+        role_uids: Vec<u32>,
+
+        /// Authentication method (regular, external, certificate)
+        #[arg(long)]
+        auth_method: Option<String>,
+
+        /// Advanced: Full user configuration as JSON string or @file.json
+        #[arg(long)]
+        data: Option<String>,
     },
 
     /// Update user
+    #[command(after_help = "EXAMPLES:
+    # Update user's name
+    redisctl enterprise user update 1 --name \"Jane Doe\"
+
+    # Update user's role
+    redisctl enterprise user update 1 --role admin
+
+    # Update user's password
+    redisctl enterprise user update 1 --password newsecret123
+
+    # Enable email alerts
+    redisctl enterprise user update 1 --email-alerts true
+
+    # Update RBAC role assignments
+    redisctl enterprise user update 1 --role-uid 1 --role-uid 3
+
+    # Advanced: Full update via JSON file
+    redisctl enterprise user update 1 --data @updates.json
+
+NOTE: First-class parameters override values in --data when both are provided.")]
     Update {
         /// User ID
         id: u32,
-        /// Update data (JSON file or inline)
-        #[arg(long, value_name = "FILE|JSON")]
-        data: String,
+
+        /// New email address
+        #[arg(long)]
+        email: Option<String>,
+
+        /// New password
+        #[arg(long)]
+        password: Option<String>,
+
+        /// New role
+        #[arg(long)]
+        role: Option<String>,
+
+        /// New display name
+        #[arg(long)]
+        name: Option<String>,
+
+        /// Enable/disable email alerts
+        #[arg(long)]
+        email_alerts: Option<bool>,
+
+        /// Role UID for RBAC (can be repeated, replaces existing)
+        #[arg(long = "role-uid")]
+        role_uids: Vec<u32>,
+
+        /// Advanced: Full update configuration as JSON string or @file.json
+        #[arg(long)]
+        data: Option<String>,
     },
 
     /// Delete user

--- a/crates/redisctl/src/commands/enterprise/rbac.rs
+++ b/crates/redisctl/src/commands/enterprise/rbac.rs
@@ -25,11 +25,57 @@ pub async fn handle_user_command(
         EnterpriseUserCommands::Get { id } => {
             rbac_impl::get_user(conn_mgr, profile_name, *id, output_format, query).await
         }
-        EnterpriseUserCommands::Create { data } => {
-            rbac_impl::create_user(conn_mgr, profile_name, data, output_format, query).await
+        EnterpriseUserCommands::Create {
+            email,
+            password,
+            role,
+            name,
+            email_alerts,
+            role_uids,
+            auth_method,
+            data,
+        } => {
+            rbac_impl::create_user(
+                conn_mgr,
+                profile_name,
+                email.as_deref(),
+                password.as_deref(),
+                role.as_deref(),
+                name.as_deref(),
+                *email_alerts,
+                role_uids,
+                auth_method.as_deref(),
+                data.as_deref(),
+                output_format,
+                query,
+            )
+            .await
         }
-        EnterpriseUserCommands::Update { id, data } => {
-            rbac_impl::update_user(conn_mgr, profile_name, *id, data, output_format, query).await
+        EnterpriseUserCommands::Update {
+            id,
+            email,
+            password,
+            role,
+            name,
+            email_alerts,
+            role_uids,
+            data,
+        } => {
+            rbac_impl::update_user(
+                conn_mgr,
+                profile_name,
+                *id,
+                email.as_deref(),
+                password.as_deref(),
+                role.as_deref(),
+                name.as_deref(),
+                *email_alerts,
+                role_uids,
+                data.as_deref(),
+                output_format,
+                query,
+            )
+            .await
         }
         EnterpriseUserCommands::Delete { id, force } => {
             rbac_impl::delete_user(conn_mgr, profile_name, *id, *force, output_format, query).await

--- a/crates/redisctl/tests/cli_basic_tests.rs
+++ b/crates/redisctl/tests/cli_basic_tests.rs
@@ -3850,3 +3850,116 @@ fn test_enterprise_database_update_requires_at_least_one_field() {
             predicate::str::contains("No enterprise profiles configured"),
         ));
 }
+
+// Enterprise user create first-class params tests
+
+#[test]
+fn test_enterprise_user_create_first_class_params_help() {
+    redisctl()
+        .arg("enterprise")
+        .arg("user")
+        .arg("create")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--email"))
+        .stdout(predicate::str::contains("--password"))
+        .stdout(predicate::str::contains("--role"))
+        .stdout(predicate::str::contains("--name"))
+        .stdout(predicate::str::contains("--email-alerts"))
+        .stdout(predicate::str::contains("--role-uid"))
+        .stdout(predicate::str::contains("--auth-method"))
+        .stdout(predicate::str::contains("--data"));
+}
+
+#[test]
+fn test_enterprise_user_create_has_examples() {
+    redisctl()
+        .arg("enterprise")
+        .arg("user")
+        .arg("create")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("EXAMPLES:"));
+}
+
+#[test]
+fn test_enterprise_user_create_requires_email() {
+    // Without --email, should fail requiring it
+    // Note: In CI without profiles, may fail with profile configuration error instead
+    redisctl()
+        .arg("enterprise")
+        .arg("user")
+        .arg("create")
+        .arg("--password")
+        .arg("secret")
+        .arg("--role")
+        .arg("admin")
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("--email is required").or(predicate::str::contains(
+                "No enterprise profiles configured",
+            )),
+        );
+}
+
+// Enterprise user update first-class params tests
+
+#[test]
+fn test_enterprise_user_update_first_class_params_help() {
+    redisctl()
+        .arg("enterprise")
+        .arg("user")
+        .arg("update")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--email"))
+        .stdout(predicate::str::contains("--password"))
+        .stdout(predicate::str::contains("--role"))
+        .stdout(predicate::str::contains("--name"))
+        .stdout(predicate::str::contains("--email-alerts"))
+        .stdout(predicate::str::contains("--role-uid"))
+        .stdout(predicate::str::contains("--data"));
+}
+
+#[test]
+fn test_enterprise_user_update_has_examples() {
+    redisctl()
+        .arg("enterprise")
+        .arg("user")
+        .arg("update")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("EXAMPLES:"));
+}
+
+#[test]
+fn test_enterprise_user_update_requires_id() {
+    redisctl()
+        .arg("enterprise")
+        .arg("user")
+        .arg("update")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("required"));
+}
+
+#[test]
+fn test_enterprise_user_update_requires_at_least_one_field() {
+    // With only ID provided, should fail at runtime requiring at least one update field
+    // Note: In CI without profiles, may fail with profile configuration error instead
+    redisctl()
+        .arg("enterprise")
+        .arg("user")
+        .arg("update")
+        .arg("1")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("At least one update field").or(
+            predicate::str::contains("No enterprise profiles configured"),
+        ));
+}


### PR DESCRIPTION
## Summary
Add first-class CLI parameters for `enterprise user create` and `enterprise user update` commands to improve UX.

## Changes
- Updated CLI definitions with first-class parameters
- Updated command handler to pass new parameters
- Updated implementation to build request from CLI params
- Added 7 CLI tests

## New Parameters

### Create
| Parameter | Description |
|-----------|-------------|
| `--email` | User's email address (required) |
| `--password` | User's password (required) |
| `--role` | User's role (required) |
| `--name` | User's display name |
| `--email-alerts` | Enable email alerts |
| `--role-uid` | Role UID for RBAC (repeatable) |
| `--auth-method` | Authentication method |
| `--data` | JSON escape hatch |

### Update
| Parameter | Description |
|-----------|-------------|
| `--email` | New email address |
| `--password` | New password |
| `--role` | New role |
| `--name` | New display name |
| `--email-alerts` | Enable/disable email alerts |
| `--role-uid` | Role UID for RBAC (repeatable) |
| `--data` | JSON escape hatch |

## Example Usage
```bash
# Create user with email and password
redisctl enterprise user create --email admin@example.com --password secret123 --role admin

# Create user with display name
redisctl enterprise user create --email user@example.com --password secret123 --role db_viewer --name "John Doe"

# Update user's name
redisctl enterprise user update 1 --name "Jane Doe"

# Update user's role
redisctl enterprise user update 1 --role admin
```

Part of #538