### PR TITLE
feat(cli): add first-class params for enterprise role create/update

### DIFF
--- a/crates/redisctl/src/cli/enterprise.rs
+++ b/crates/redisctl/src/cli/enterprise.rs
@@ -1028,19 +1028,61 @@ pub enum EnterpriseRoleCommands {
     },
 
     /// Create custom role
+    #[command(after_help = "EXAMPLES:
+    # Create role with management permission
+    redisctl enterprise role create --name db-admin --management admin
+
+    # Create role with cluster viewer access
+    redisctl enterprise role create --name cluster-viewer --management cluster_viewer
+
+    # Create role with database-specific permissions
+    redisctl enterprise role create --name mydb-admin --management db_viewer --data '{\"bdb_roles\": [{\"bdb_uid\": 1, \"role\": \"admin\"}]}'
+
+    # Advanced: Full configuration via JSON file
+    redisctl enterprise role create --data @role.json
+
+NOTE: First-class parameters override values in --data when both are provided.")]
     Create {
-        /// Role data (JSON file or inline)
-        #[arg(long, value_name = "FILE|JSON")]
-        data: String,
+        /// Role name (required unless using --data)
+        #[arg(long)]
+        name: Option<String>,
+
+        /// Management permission level (admin, db_viewer, db_member, cluster_viewer, cluster_member, none)
+        #[arg(long)]
+        management: Option<String>,
+
+        /// Advanced: Full role configuration as JSON string or @file.json
+        #[arg(long)]
+        data: Option<String>,
     },
 
     /// Update role
+    #[command(after_help = "EXAMPLES:
+    # Update role name
+    redisctl enterprise role update 1 --name new-role-name
+
+    # Update management permission
+    redisctl enterprise role update 1 --management admin
+
+    # Advanced: Full update via JSON file
+    redisctl enterprise role update 1 --data @updates.json
+
+NOTE: First-class parameters override values in --data when both are provided.")]
     Update {
         /// Role ID
         id: u32,
-        /// Update data (JSON file or inline)
-        #[arg(long, value_name = "FILE|JSON")]
-        data: String,
+
+        /// New role name
+        #[arg(long)]
+        name: Option<String>,
+
+        /// Management permission level
+        #[arg(long)]
+        management: Option<String>,
+
+        /// Advanced: Full update configuration as JSON string or @file.json
+        #[arg(long)]
+        data: Option<String>,
     },
 
     /// Delete custom role

--- a/crates/redisctl/src/commands/enterprise/rbac.rs
+++ b/crates/redisctl/src/commands/enterprise/rbac.rs
@@ -133,11 +133,39 @@ pub async fn handle_role_command(
         EnterpriseRoleCommands::Get { id } => {
             rbac_impl::get_role(conn_mgr, profile_name, *id, output_format, query).await
         }
-        EnterpriseRoleCommands::Create { data } => {
-            rbac_impl::create_role(conn_mgr, profile_name, data, output_format, query).await
+        EnterpriseRoleCommands::Create {
+            name,
+            management,
+            data,
+        } => {
+            rbac_impl::create_role(
+                conn_mgr,
+                profile_name,
+                name.as_deref(),
+                management.as_deref(),
+                data.as_deref(),
+                output_format,
+                query,
+            )
+            .await
         }
-        EnterpriseRoleCommands::Update { id, data } => {
-            rbac_impl::update_role(conn_mgr, profile_name, *id, data, output_format, query).await
+        EnterpriseRoleCommands::Update {
+            id,
+            name,
+            management,
+            data,
+        } => {
+            rbac_impl::update_role(
+                conn_mgr,
+                profile_name,
+                *id,
+                name.as_deref(),
+                management.as_deref(),
+                data.as_deref(),
+                output_format,
+                query,
+            )
+            .await
         }
         EnterpriseRoleCommands::Delete { id, force } => {
             rbac_impl::delete_role(conn_mgr, profile_name, *id, *force, output_format, query).await

--- a/crates/redisctl/tests/cli_basic_tests.rs
+++ b/crates/redisctl/tests/cli_basic_tests.rs
@@ -3963,3 +3963,105 @@ fn test_enterprise_user_update_requires_at_least_one_field() {
             predicate::str::contains("No enterprise profiles configured"),
         ));
 }
+
+// Enterprise role create first-class params tests
+
+#[test]
+fn test_enterprise_role_create_first_class_params_help() {
+    redisctl()
+        .arg("enterprise")
+        .arg("role")
+        .arg("create")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--name"))
+        .stdout(predicate::str::contains("--management"))
+        .stdout(predicate::str::contains("--data"));
+}
+
+#[test]
+fn test_enterprise_role_create_has_examples() {
+    redisctl()
+        .arg("enterprise")
+        .arg("role")
+        .arg("create")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("EXAMPLES:"));
+}
+
+#[test]
+fn test_enterprise_role_create_requires_name() {
+    // Without --name, should fail requiring it
+    // Note: In CI without profiles, may fail with profile configuration error instead
+    redisctl()
+        .arg("enterprise")
+        .arg("role")
+        .arg("create")
+        .arg("--management")
+        .arg("admin")
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("--name is required").or(predicate::str::contains(
+                "No enterprise profiles configured",
+            )),
+        );
+}
+
+// Enterprise role update first-class params tests
+
+#[test]
+fn test_enterprise_role_update_first_class_params_help() {
+    redisctl()
+        .arg("enterprise")
+        .arg("role")
+        .arg("update")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--name"))
+        .stdout(predicate::str::contains("--management"))
+        .stdout(predicate::str::contains("--data"));
+}
+
+#[test]
+fn test_enterprise_role_update_has_examples() {
+    redisctl()
+        .arg("enterprise")
+        .arg("role")
+        .arg("update")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("EXAMPLES:"));
+}
+
+#[test]
+fn test_enterprise_role_update_requires_id() {
+    redisctl()
+        .arg("enterprise")
+        .arg("role")
+        .arg("update")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("required"));
+}
+
+#[test]
+fn test_enterprise_role_update_requires_at_least_one_field() {
+    // With only ID provided, should fail at runtime requiring at least one update field
+    // Note: In CI without profiles, may fail with profile configuration error instead
+    redisctl()
+        .arg("enterprise")
+        .arg("role")
+        .arg("update")
+        .arg("1")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("At least one update field").or(
+            predicate::str::contains("No enterprise profiles configured"),
+        ));
+}


### PR DESCRIPTION
## Summary
Add first-class CLI parameters for `enterprise role create` and `enterprise role update` commands to improve UX.

## Changes
- Updated CLI definitions with first-class parameters
- Updated command handler to pass new parameters
- Updated implementation to build request from CLI params
- Added 7 CLI tests

## New Parameters

### Create
| Parameter | Description |
|-----------|-------------|
| `--name` | Role name (required) |
| `--management` | Management permission level (admin, db_viewer, db_member, cluster_viewer, cluster_member, none) |
| `--data` | JSON escape hatch for advanced settings |

### Update
| Parameter | Description |
|-----------|-------------|
| `--name` | New role name |
| `--management` | New management permission level |
| `--data` | JSON escape hatch |

## Example Usage
```bash
# Create role with management permission
redisctl enterprise role create --name db-admin --management admin

# Create role with cluster viewer access
redisctl enterprise role create --name cluster-viewer --management cluster_viewer

# Update role name
redisctl enterprise role update 1 --name new-role-name

# Update management permission
redisctl enterprise role update 1 --management admin
```

Part of #538