### PR TITLE
feat(cli): add first-class params for enterprise ACL create/update

### DIFF
--- a/crates/redisctl/src/cli/enterprise.rs
+++ b/crates/redisctl/src/cli/enterprise.rs
@@ -1122,19 +1122,72 @@ pub enum EnterpriseAclCommands {
     },
 
     /// Create ACL
+    #[command(after_help = "EXAMPLES:
+    # Create ACL with full access
+    redisctl enterprise acl create --name full-access --acl '+@all ~*'
+
+    # Create ACL with read-only access
+    redisctl enterprise acl create --name read-only --acl '+@read ~*' --description 'Read-only access'
+
+    # Create ACL with specific key patterns
+    redisctl enterprise acl create --name app-acl --acl '+@all ~app:*'
+
+    # Advanced: Full configuration via JSON file
+    redisctl enterprise acl create --data @acl.json
+
+NOTE: First-class parameters override values in --data when both are provided.")]
     Create {
-        /// ACL data (JSON file or inline)
-        #[arg(long, value_name = "FILE|JSON")]
-        data: String,
+        /// ACL name (required unless using --data)
+        #[arg(long)]
+        name: Option<String>,
+
+        /// ACL rules string (e.g., '+@all ~*')
+        #[arg(long)]
+        acl: Option<String>,
+
+        /// Description of the ACL
+        #[arg(long)]
+        description: Option<String>,
+
+        /// Advanced: Full ACL configuration as JSON string or @file.json
+        #[arg(long)]
+        data: Option<String>,
     },
 
     /// Update ACL
+    #[command(after_help = "EXAMPLES:
+    # Update ACL name
+    redisctl enterprise acl update 1 --name new-acl-name
+
+    # Update ACL rules
+    redisctl enterprise acl update 1 --acl '+@read +@write ~*'
+
+    # Update description
+    redisctl enterprise acl update 1 --description 'Updated description'
+
+    # Advanced: Full update via JSON file
+    redisctl enterprise acl update 1 --data @updates.json
+
+NOTE: First-class parameters override values in --data when both are provided.")]
     Update {
         /// ACL ID
         id: u32,
-        /// Update data (JSON file or inline)
-        #[arg(long, value_name = "FILE|JSON")]
-        data: String,
+
+        /// New ACL name
+        #[arg(long)]
+        name: Option<String>,
+
+        /// New ACL rules string
+        #[arg(long)]
+        acl: Option<String>,
+
+        /// New description
+        #[arg(long)]
+        description: Option<String>,
+
+        /// Advanced: Full update configuration as JSON string or @file.json
+        #[arg(long)]
+        data: Option<String>,
     },
 
     /// Delete ACL

--- a/crates/redisctl/src/commands/enterprise/rbac.rs
+++ b/crates/redisctl/src/commands/enterprise/rbac.rs
@@ -193,11 +193,43 @@ pub async fn handle_acl_command(
         EnterpriseAclCommands::Get { id } => {
             rbac_impl::get_acl(conn_mgr, profile_name, *id, output_format, query).await
         }
-        EnterpriseAclCommands::Create { data } => {
-            rbac_impl::create_acl(conn_mgr, profile_name, data, output_format, query).await
+        EnterpriseAclCommands::Create {
+            name,
+            acl,
+            description,
+            data,
+        } => {
+            rbac_impl::create_acl(
+                conn_mgr,
+                profile_name,
+                name.as_deref(),
+                acl.as_deref(),
+                description.as_deref(),
+                data.as_deref(),
+                output_format,
+                query,
+            )
+            .await
         }
-        EnterpriseAclCommands::Update { id, data } => {
-            rbac_impl::update_acl(conn_mgr, profile_name, *id, data, output_format, query).await
+        EnterpriseAclCommands::Update {
+            id,
+            name,
+            acl,
+            description,
+            data,
+        } => {
+            rbac_impl::update_acl(
+                conn_mgr,
+                profile_name,
+                *id,
+                name.as_deref(),
+                acl.as_deref(),
+                description.as_deref(),
+                data.as_deref(),
+                output_format,
+                query,
+            )
+            .await
         }
         EnterpriseAclCommands::Delete { id, force } => {
             rbac_impl::delete_acl(conn_mgr, profile_name, *id, *force, output_format, query).await

--- a/crates/redisctl/tests/cli_basic_tests.rs
+++ b/crates/redisctl/tests/cli_basic_tests.rs
@@ -1351,6 +1351,129 @@ fn test_enterprise_database_update_missing_data() {
         ));
 }
 
+// Enterprise ACL create first-class params tests
+
+#[test]
+fn test_enterprise_acl_create_first_class_params_help() {
+    redisctl()
+        .arg("enterprise")
+        .arg("acl")
+        .arg("create")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--name"))
+        .stdout(predicate::str::contains("--acl"))
+        .stdout(predicate::str::contains("--description"))
+        .stdout(predicate::str::contains("--data"));
+}
+
+#[test]
+fn test_enterprise_acl_create_has_examples() {
+    redisctl()
+        .arg("enterprise")
+        .arg("acl")
+        .arg("create")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("EXAMPLES:"));
+}
+
+#[test]
+fn test_enterprise_acl_create_requires_name() {
+    // Without --name, should fail requiring it
+    // Note: In CI without profiles, may fail with profile configuration error instead
+    redisctl()
+        .arg("enterprise")
+        .arg("acl")
+        .arg("create")
+        .arg("--acl")
+        .arg("+@all ~*")
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("--name is required").or(predicate::str::contains(
+                "No enterprise profiles configured",
+            )),
+        );
+}
+
+#[test]
+fn test_enterprise_acl_create_requires_acl() {
+    // Without --acl, should fail requiring it
+    // Note: In CI without profiles, may fail with profile configuration error instead
+    redisctl()
+        .arg("enterprise")
+        .arg("acl")
+        .arg("create")
+        .arg("--name")
+        .arg("test-acl")
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("--acl is required").or(predicate::str::contains(
+                "No enterprise profiles configured",
+            )),
+        );
+}
+
+// Enterprise ACL update first-class params tests
+
+#[test]
+fn test_enterprise_acl_update_first_class_params_help() {
+    redisctl()
+        .arg("enterprise")
+        .arg("acl")
+        .arg("update")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--name"))
+        .stdout(predicate::str::contains("--acl"))
+        .stdout(predicate::str::contains("--description"))
+        .stdout(predicate::str::contains("--data"));
+}
+
+#[test]
+fn test_enterprise_acl_update_has_examples() {
+    redisctl()
+        .arg("enterprise")
+        .arg("acl")
+        .arg("update")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("EXAMPLES:"));
+}
+
+#[test]
+fn test_enterprise_acl_update_requires_id() {
+    redisctl()
+        .arg("enterprise")
+        .arg("acl")
+        .arg("update")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("required"));
+}
+
+#[test]
+fn test_enterprise_acl_update_requires_at_least_one_field() {
+    // With only ID provided, should fail at runtime requiring at least one update field
+    // Note: In CI without profiles, may fail with profile configuration error instead
+    redisctl()
+        .arg("enterprise")
+        .arg("acl")
+        .arg("update")
+        .arg("1")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("At least one update field").or(
+            predicate::str::contains("No enterprise profiles configured"),
+        ));
+}
+
 // Error case tests - API commands
 
 #[test]


### PR DESCRIPTION
## Summary

Add first-class CLI parameters for enterprise ACL create and update commands, continuing the work from #538.

## Changes

### New Parameters

**ACL Create:**
- `--name`: ACL name (required)
- `--acl`: ACL rules string, e.g., `+@all ~*` (required)
- `--description`: Optional description
- `--data`: JSON escape hatch for advanced configurations

**ACL Update:**
- `--name`: Update ACL name
- `--acl`: Update ACL rules
- `--description`: Update description
- `--data`: JSON escape hatch

### Behavior

- For create, `--name` and `--acl` are required when not using `--data`
- For update, at least one update field is required
- If name or acl are not provided during update, current values are preserved by fetching the existing ACL
- CLI parameters override values in `--data` when both are provided

### Examples

```bash
# Create ACL with full access
redisctl enterprise acl create --name full-access --acl '+@all ~*'

# Create read-only ACL
redisctl enterprise acl create --name read-only --acl '+@read ~*' --description 'Read-only access'

# Update ACL name
redisctl enterprise acl update 1 --name new-name

# Update ACL rules
redisctl enterprise acl update 1 --acl '+@read +@write ~keys:*'
```

## Testing

- Added 8 CLI tests for the new parameters
- All tests pass

Part of #538