### PR TITLE
feat(cli): add first-class params for enterprise node update

### DIFF
--- a/crates/redisctl/src/cli/enterprise.rs
+++ b/crates/redisctl/src/cli/enterprise.rs
@@ -701,12 +701,36 @@ pub enum EnterpriseNodeCommands {
     },
 
     /// Update node configuration
+    #[command(after_help = "EXAMPLES:
+    # Update node to accept new shards
+    redisctl enterprise node update 1 --accept-servers true
+
+    # Set node's external address
+    redisctl enterprise node update 1 --external-addr 10.0.0.1
+
+    # Set rack ID for rack awareness
+    redisctl enterprise node update 1 --rack-id rack1
+
+    # Update multiple settings
+    redisctl enterprise node update 1 --accept-servers false --rack-id rack2
+
+    # Using JSON for advanced configuration
+    redisctl enterprise node update 1 --data '{\"max_redis_servers\": 200}'")]
     Update {
         /// Node ID
         id: u32,
-        /// Update data (JSON file or inline)
+        /// Whether node accepts new shards
+        #[arg(long)]
+        accept_servers: Option<bool>,
+        /// External IP addresses (can be specified multiple times)
+        #[arg(long)]
+        external_addr: Option<Vec<String>>,
+        /// Rack ID for rack-aware placement
+        #[arg(long)]
+        rack_id: Option<String>,
+        /// JSON data for advanced configuration (overridden by other flags)
         #[arg(long, value_name = "FILE|JSON")]
-        data: String,
+        data: Option<String>,
     },
 
     /// Get node status

--- a/crates/redisctl/src/commands/enterprise/node.rs
+++ b/crates/redisctl/src/commands/enterprise/node.rs
@@ -29,8 +29,25 @@ pub async fn handle_node_command(
         EnterpriseNodeCommands::Remove { id, force } => {
             node_impl::remove_node(conn_mgr, profile_name, *id, *force, output_format, query).await
         }
-        EnterpriseNodeCommands::Update { id, data } => {
-            node_impl::update_node(conn_mgr, profile_name, *id, data, output_format, query).await
+        EnterpriseNodeCommands::Update {
+            id,
+            accept_servers,
+            external_addr,
+            rack_id,
+            data,
+        } => {
+            node_impl::update_node(
+                conn_mgr,
+                profile_name,
+                *id,
+                *accept_servers,
+                external_addr.clone(),
+                rack_id.as_deref(),
+                data.as_deref(),
+                output_format,
+                query,
+            )
+            .await
         }
 
         // Node Status & Health

--- a/crates/redisctl/tests/cli_basic_tests.rs
+++ b/crates/redisctl/tests/cli_basic_tests.rs
@@ -1474,6 +1474,62 @@ fn test_enterprise_acl_update_requires_at_least_one_field() {
         ));
 }
 
+// Enterprise node update first-class params tests
+
+#[test]
+fn test_enterprise_node_update_first_class_params_help() {
+    redisctl()
+        .arg("enterprise")
+        .arg("node")
+        .arg("update")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--accept-servers"))
+        .stdout(predicate::str::contains("--external-addr"))
+        .stdout(predicate::str::contains("--rack-id"))
+        .stdout(predicate::str::contains("--data"));
+}
+
+#[test]
+fn test_enterprise_node_update_has_examples() {
+    redisctl()
+        .arg("enterprise")
+        .arg("node")
+        .arg("update")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("EXAMPLES:"));
+}
+
+#[test]
+fn test_enterprise_node_update_requires_id() {
+    redisctl()
+        .arg("enterprise")
+        .arg("node")
+        .arg("update")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("required"));
+}
+
+#[test]
+fn test_enterprise_node_update_requires_at_least_one_field() {
+    // With only ID provided, should fail at runtime requiring at least one update field
+    // Note: In CI without profiles, may fail with profile configuration error instead
+    redisctl()
+        .arg("enterprise")
+        .arg("node")
+        .arg("update")
+        .arg("1")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("At least one update field").or(
+            predicate::str::contains("No enterprise profiles configured"),
+        ));
+}
+
 // Error case tests - API commands
 
 #[test]


### PR DESCRIPTION
## Summary

Add first-class CLI parameters for enterprise node update command, continuing the work from #538.

## Changes

### New Parameters

- `--accept-servers`: Whether node accepts new shards (bool)
- `--external-addr`: External IP addresses (can be specified multiple times)
- `--rack-id`: Rack ID for rack-aware placement
- `--data`: JSON escape hatch for advanced configurations

### Behavior

- At least one update field is required
- CLI parameters override values in `--data` when both are provided

### Examples

```bash
# Update node to accept new shards
redisctl enterprise node update 1 --accept-servers true

# Set node's external address
redisctl enterprise node update 1 --external-addr 10.0.0.1

# Set rack ID for rack awareness
redisctl enterprise node update 1 --rack-id rack1

# Update multiple settings
redisctl enterprise node update 1 --accept-servers false --rack-id rack2

# Using JSON for advanced configuration
redisctl enterprise node update 1 --data '{"max_redis_servers": 200}'
```

## Testing

- Added 4 CLI tests for the new parameters
- All tests pass

Part of #538