### PR TITLE
feat(cli): add first-class params for enterprise cluster update

### DIFF
--- a/crates/redisctl/src/cli/enterprise.rs
+++ b/crates/redisctl/src/cli/enterprise.rs
@@ -207,10 +207,34 @@ pub enum EnterpriseClusterCommands {
     Get,
 
     /// Update cluster configuration
+    #[command(after_help = "EXAMPLES:
+    # Update cluster name
+    redisctl enterprise cluster update --name my-cluster
+
+    # Enable email alerts
+    redisctl enterprise cluster update --email-alerts true
+
+    # Enable rack awareness
+    redisctl enterprise cluster update --rack-aware true
+
+    # Update multiple settings
+    redisctl enterprise cluster update --email-alerts true --rack-aware true
+
+    # Using JSON for advanced configuration
+    redisctl enterprise cluster update --data '{\"cm_session_timeout_minutes\": 30}'")]
     Update {
-        /// Cluster configuration data (JSON file or inline)
+        /// Cluster name
+        #[arg(long)]
+        name: Option<String>,
+        /// Enable/disable email alerts
+        #[arg(long)]
+        email_alerts: Option<bool>,
+        /// Enable/disable rack awareness
+        #[arg(long)]
+        rack_aware: Option<bool>,
+        /// JSON data for advanced configuration (overridden by other flags)
         #[arg(long, value_name = "FILE|JSON")]
-        data: String,
+        data: Option<String>,
     },
 
     /// Get cluster policies

--- a/crates/redisctl/src/commands/enterprise/cluster.rs
+++ b/crates/redisctl/src/commands/enterprise/cluster.rs
@@ -20,8 +20,23 @@ pub async fn handle_cluster_command(
         EnterpriseClusterCommands::Get => {
             cluster_impl::get_cluster(conn_mgr, profile_name, output_format, query).await
         }
-        EnterpriseClusterCommands::Update { data } => {
-            cluster_impl::update_cluster(conn_mgr, profile_name, data, output_format, query).await
+        EnterpriseClusterCommands::Update {
+            name,
+            email_alerts,
+            rack_aware,
+            data,
+        } => {
+            cluster_impl::update_cluster(
+                conn_mgr,
+                profile_name,
+                name.as_deref(),
+                *email_alerts,
+                *rack_aware,
+                data.as_deref(),
+                output_format,
+                query,
+            )
+            .await
         }
         EnterpriseClusterCommands::GetPolicy => {
             cluster_impl::get_cluster_policy(conn_mgr, profile_name, output_format, query).await

--- a/crates/redisctl/tests/cli_basic_tests.rs
+++ b/crates/redisctl/tests/cli_basic_tests.rs
@@ -1530,6 +1530,50 @@ fn test_enterprise_node_update_requires_at_least_one_field() {
         ));
 }
 
+// Enterprise cluster update first-class params tests
+
+#[test]
+fn test_enterprise_cluster_update_first_class_params_help() {
+    redisctl()
+        .arg("enterprise")
+        .arg("cluster")
+        .arg("update")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--name"))
+        .stdout(predicate::str::contains("--email-alerts"))
+        .stdout(predicate::str::contains("--rack-aware"))
+        .stdout(predicate::str::contains("--data"));
+}
+
+#[test]
+fn test_enterprise_cluster_update_has_examples() {
+    redisctl()
+        .arg("enterprise")
+        .arg("cluster")
+        .arg("update")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("EXAMPLES:"));
+}
+
+#[test]
+fn test_enterprise_cluster_update_requires_at_least_one_field() {
+    // With no fields provided, should fail at runtime requiring at least one update field
+    // Note: In CI without profiles, may fail with profile configuration error instead
+    redisctl()
+        .arg("enterprise")
+        .arg("cluster")
+        .arg("update")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("At least one update field").or(
+            predicate::str::contains("No enterprise profiles configured"),
+        ));
+}
+
 // Error case tests - API commands
 
 #[test]


### PR DESCRIPTION
## Summary

Add first-class CLI parameters for enterprise cluster update command, continuing the work from #538.

## Changes

### New Parameters

- `--name`: Cluster name
- `--email-alerts`: Enable/disable email alerts
- `--rack-aware`: Enable/disable rack awareness
- `--data`: JSON escape hatch for advanced configurations

### Behavior

- At least one update field is required
- CLI parameters override values in `--data` when both are provided

### Examples

```bash
# Update cluster name
redisctl enterprise cluster update --name my-cluster

# Enable email alerts
redisctl enterprise cluster update --email-alerts true

# Enable rack awareness
redisctl enterprise cluster update --rack-aware true

# Update multiple settings
redisctl enterprise cluster update --email-alerts true --rack-aware true

# Using JSON for advanced configuration
redisctl enterprise cluster update --data '{"cm_session_timeout_minutes": 30}'
```

## Testing

- Added 3 CLI tests for the new parameters
- All tests pass

Part of #538