### PR TITLE
feat(cli): add first-class params for enterprise CRDB update

### DIFF
--- a/crates/redisctl/src/cli/enterprise.rs
+++ b/crates/redisctl/src/cli/enterprise.rs
@@ -1334,12 +1334,42 @@ pub enum EnterpriseCrdbCommands {
     },
 
     /// Update CRDB configuration
+    #[command(after_help = "EXAMPLES:
+    # Update memory size (1GB)
+    redisctl enterprise crdb update 1 --memory-size 1073741824
+
+    # Enable encryption
+    redisctl enterprise crdb update 1 --encryption true
+
+    # Set data persistence policy
+    redisctl enterprise crdb update 1 --data-persistence aof
+
+    # Update multiple settings
+    redisctl enterprise crdb update 1 --memory-size 2147483648 --replication true
+
+    # Using JSON for advanced configuration
+    redisctl enterprise crdb update 1 --data '{\"causal_consistency\": true}'")]
     Update {
         /// CRDB ID
         id: u32,
-        /// Update configuration as JSON string or @file.json
+        /// Memory size limit in bytes
         #[arg(long)]
-        data: String,
+        memory_size: Option<u64>,
+        /// Enable/disable encryption
+        #[arg(long)]
+        encryption: Option<bool>,
+        /// Data persistence policy (disabled, aof, snapshot)
+        #[arg(long)]
+        data_persistence: Option<String>,
+        /// Enable/disable replication
+        #[arg(long)]
+        replication: Option<bool>,
+        /// Eviction policy (e.g., allkeys-lru, volatile-lru)
+        #[arg(long)]
+        eviction_policy: Option<String>,
+        /// JSON data for advanced configuration (overridden by other flags)
+        #[arg(long)]
+        data: Option<String>,
     },
 
     /// Delete CRDB

--- a/crates/redisctl/src/commands/enterprise/crdb.rs
+++ b/crates/redisctl/src/commands/enterprise/crdb.rs
@@ -24,8 +24,29 @@ pub async fn handle_crdb_command(
         EnterpriseCrdbCommands::Create { data } => {
             crdb_impl::create_crdb(conn_mgr, profile_name, data, output_format, query).await
         }
-        EnterpriseCrdbCommands::Update { id, data } => {
-            crdb_impl::update_crdb(conn_mgr, profile_name, *id, data, output_format, query).await
+        EnterpriseCrdbCommands::Update {
+            id,
+            memory_size,
+            encryption,
+            data_persistence,
+            replication,
+            eviction_policy,
+            data,
+        } => {
+            crdb_impl::update_crdb(
+                conn_mgr,
+                profile_name,
+                *id,
+                *memory_size,
+                *encryption,
+                data_persistence.as_deref(),
+                *replication,
+                eviction_policy.as_deref(),
+                data.as_deref(),
+                output_format,
+                query,
+            )
+            .await
         }
         EnterpriseCrdbCommands::Delete { id, force } => {
             crdb_impl::delete_crdb(conn_mgr, profile_name, *id, *force, output_format, query).await

--- a/crates/redisctl/tests/cli_basic_tests.rs
+++ b/crates/redisctl/tests/cli_basic_tests.rs
@@ -1574,6 +1574,64 @@ fn test_enterprise_cluster_update_requires_at_least_one_field() {
         ));
 }
 
+// Enterprise CRDB update first-class params tests
+
+#[test]
+fn test_enterprise_crdb_update_first_class_params_help() {
+    redisctl()
+        .arg("enterprise")
+        .arg("crdb")
+        .arg("update")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--memory-size"))
+        .stdout(predicate::str::contains("--encryption"))
+        .stdout(predicate::str::contains("--data-persistence"))
+        .stdout(predicate::str::contains("--replication"))
+        .stdout(predicate::str::contains("--eviction-policy"))
+        .stdout(predicate::str::contains("--data"));
+}
+
+#[test]
+fn test_enterprise_crdb_update_has_examples() {
+    redisctl()
+        .arg("enterprise")
+        .arg("crdb")
+        .arg("update")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("EXAMPLES:"));
+}
+
+#[test]
+fn test_enterprise_crdb_update_requires_id() {
+    redisctl()
+        .arg("enterprise")
+        .arg("crdb")
+        .arg("update")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("required"));
+}
+
+#[test]
+fn test_enterprise_crdb_update_requires_at_least_one_field() {
+    // With only ID provided, should fail at runtime requiring at least one update field
+    // Note: In CI without profiles, may fail with profile configuration error instead
+    redisctl()
+        .arg("enterprise")
+        .arg("crdb")
+        .arg("update")
+        .arg("1")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("At least one update field").or(
+            predicate::str::contains("No enterprise profiles configured"),
+        ));
+}
+
 // Error case tests - API commands
 
 #[test]


### PR DESCRIPTION
## Summary

Add first-class CLI parameters for enterprise CRDB (Active-Active) update command, continuing the work from #538.

## Changes

### New Parameters

- `--memory-size`: Memory size limit in bytes
- `--encryption`: Enable/disable encryption
- `--data-persistence`: Data persistence policy (disabled, aof, snapshot)
- `--replication`: Enable/disable replication
- `--eviction-policy`: Eviction policy (e.g., allkeys-lru, volatile-lru)
- `--data`: JSON escape hatch for advanced configurations

### Behavior

- At least one update field is required
- CLI parameters override values in `--data` when both are provided

### Examples

```bash
# Update memory size (1GB)
redisctl enterprise crdb update 1 --memory-size 1073741824

# Enable encryption
redisctl enterprise crdb update 1 --encryption true

# Set data persistence policy
redisctl enterprise crdb update 1 --data-persistence aof

# Update multiple settings
redisctl enterprise crdb update 1 --memory-size 2147483648 --replication true

# Using JSON for advanced configuration
redisctl enterprise crdb update 1 --data '{"causal_consistency": true}'
```

## Testing

- Added 4 CLI tests for the new parameters
- All tests pass

Part of #538