### PR TITLE
test: add assert_cmd tests for MCP commands

### DIFF
--- a/crates/redisctl/tests/cli_basic_tests.rs
+++ b/crates/redisctl/tests/cli_basic_tests.rs
@@ -4496,3 +4496,233 @@ fn test_enterprise_ldap_mappings_update_requires_at_least_one_field() {
             predicate::str::contains("No enterprise profiles configured"),
         ));
 }
+
+// === MCP COMMAND TESTS ===
+
+#[test]
+fn test_mcp_help() {
+    redisctl()
+        .arg("mcp")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("MCP (Model Context Protocol)"))
+        .stdout(predicate::str::contains("serve"))
+        .stdout(predicate::str::contains("tools"));
+}
+
+#[test]
+fn test_mcp_short_help() {
+    redisctl()
+        .arg("mcp")
+        .arg("-h")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("MCP"));
+}
+
+#[test]
+fn test_mcp_serve_help() {
+    redisctl()
+        .arg("mcp")
+        .arg("serve")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Start the MCP server"))
+        .stdout(predicate::str::contains("--allow-writes"))
+        .stdout(predicate::str::contains("EXAMPLES:"));
+}
+
+#[test]
+fn test_mcp_serve_help_shows_allow_writes_description() {
+    redisctl()
+        .arg("mcp")
+        .arg("serve")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Allow write operations"));
+}
+
+#[test]
+fn test_mcp_serve_help_shows_profile_option() {
+    redisctl()
+        .arg("mcp")
+        .arg("serve")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--profile"));
+}
+
+#[test]
+fn test_mcp_tools_help() {
+    redisctl()
+        .arg("mcp")
+        .arg("tools")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("List available MCP tools"));
+}
+
+#[test]
+fn test_mcp_tools_lists_cloud_tools() {
+    redisctl()
+        .arg("mcp")
+        .arg("tools")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Cloud Tools"))
+        .stdout(predicate::str::contains("cloud_account_get"))
+        .stdout(predicate::str::contains("cloud_subscriptions_list"));
+}
+
+#[test]
+fn test_mcp_tools_lists_enterprise_tools() {
+    redisctl()
+        .arg("mcp")
+        .arg("tools")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Enterprise Tools"))
+        .stdout(predicate::str::contains("enterprise_cluster_get"))
+        .stdout(predicate::str::contains("enterprise_databases_list"));
+}
+
+#[test]
+fn test_mcp_tools_lists_database_tools() {
+    redisctl()
+        .arg("mcp")
+        .arg("tools")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("enterprise_database_create"))
+        .stdout(predicate::str::contains("enterprise_database_update"))
+        .stdout(predicate::str::contains("enterprise_database_delete"));
+}
+
+#[test]
+fn test_mcp_tools_lists_node_tools() {
+    redisctl()
+        .arg("mcp")
+        .arg("tools")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("enterprise_nodes_list"))
+        .stdout(predicate::str::contains("enterprise_node_get"));
+}
+
+#[test]
+fn test_mcp_tools_lists_user_tools() {
+    redisctl()
+        .arg("mcp")
+        .arg("tools")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("enterprise_users_list"))
+        .stdout(predicate::str::contains("enterprise_user_get"));
+}
+
+#[test]
+fn test_mcp_tools_lists_acl_tools() {
+    redisctl()
+        .arg("mcp")
+        .arg("tools")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("enterprise_acls_list"))
+        .stdout(predicate::str::contains("enterprise_acl_create"));
+}
+
+#[test]
+fn test_mcp_tools_lists_role_tools() {
+    redisctl()
+        .arg("mcp")
+        .arg("tools")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("enterprise_roles_list"))
+        .stdout(predicate::str::contains("enterprise_role_create"));
+}
+
+#[test]
+fn test_mcp_tools_shows_write_indicators() {
+    redisctl()
+        .arg("mcp")
+        .arg("tools")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("(write)"));
+}
+
+#[test]
+fn test_mcp_tools_lists_log_tools() {
+    redisctl()
+        .arg("mcp")
+        .arg("tools")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("enterprise_logs_get"));
+}
+
+#[test]
+fn test_mcp_tools_lists_module_tools() {
+    redisctl()
+        .arg("mcp")
+        .arg("tools")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("enterprise_modules_list"));
+}
+
+#[test]
+fn test_mcp_tools_lists_license_tools() {
+    redisctl()
+        .arg("mcp")
+        .arg("tools")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("enterprise_license_get"));
+}
+
+#[test]
+fn test_mcp_tools_lists_crdb_tools() {
+    redisctl()
+        .arg("mcp")
+        .arg("tools")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("enterprise_crdbs_list"))
+        .stdout(predicate::str::contains("enterprise_crdb_get"));
+}
+
+#[test]
+fn test_mcp_tools_lists_debuginfo_tools() {
+    redisctl()
+        .arg("mcp")
+        .arg("tools")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("enterprise_debuginfo_list"));
+}
+
+#[test]
+fn test_mcp_invalid_subcommand() {
+    redisctl()
+        .arg("mcp")
+        .arg("invalid")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("unrecognized subcommand"));
+}
+
+#[test]
+fn test_main_help_shows_mcp_command() {
+    redisctl()
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("mcp"));
+}


### PR DESCRIPTION
## Summary

Adds 21 new CLI tests for the MCP (Model Context Protocol) command, addressing one of the gaps identified in #567.

## Tests Added

### Help Text Tests
- `test_mcp_help` - Main MCP help
- `test_mcp_short_help` - Short help flag
- `test_mcp_serve_help` - Serve subcommand help
- `test_mcp_serve_help_shows_allow_writes_description` - Write mode documentation
- `test_mcp_serve_help_shows_profile_option` - Profile option
- `test_mcp_tools_help` - Tools subcommand help

### Tool Listing Tests
- `test_mcp_tools_lists_cloud_tools` - Cloud API tools
- `test_mcp_tools_lists_enterprise_tools` - Enterprise cluster tools
- `test_mcp_tools_lists_database_tools` - Database CRUD tools
- `test_mcp_tools_lists_node_tools` - Node management tools
- `test_mcp_tools_lists_user_tools` - User management tools
- `test_mcp_tools_lists_acl_tools` - ACL tools
- `test_mcp_tools_lists_role_tools` - Role tools
- `test_mcp_tools_lists_log_tools` - Log tools
- `test_mcp_tools_lists_module_tools` - Module tools
- `test_mcp_tools_lists_license_tools` - License tools
- `test_mcp_tools_lists_crdb_tools` - Active-Active (CRDB) tools
- `test_mcp_tools_lists_debuginfo_tools` - Debug info tools
- `test_mcp_tools_shows_write_indicators` - Write operation markers

### Error Handling
- `test_mcp_invalid_subcommand` - Invalid subcommand error
- `test_main_help_shows_mcp_command` - MCP in main help

## Related Issues

- Partially addresses #567 (assert_cmd CLI test coverage audit)
