### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2800,7 +2800,7 @@ dependencies = [
 
 [[package]]
 name = "redis-cloud"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2824,7 +2824,7 @@ dependencies = [
 
 [[package]]
 name = "redis-enterprise"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2852,7 +2852,7 @@ dependencies = [
 
 [[package]]
 name = "redisctl"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2904,7 +2904,7 @@ dependencies = [
 
 [[package]]
 name = "redisctl-config"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "clap",
  "directories",
@@ -2919,7 +2919,7 @@ dependencies = [
 
 [[package]]
 name = "redisctl-mcp"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/redis-cloud/CHANGELOG.md
+++ b/crates/redis-cloud/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.6](https://github.com/redis-developer/redisctl/compare/redis-cloud-v0.7.5...redis-cloud-v0.7.6) - 2026-01-23
+
+### Fixed
+
+- use local README.md for crates to fix sdist build ([#580](https://github.com/redis-developer/redisctl/pull/580))
+
 ## [0.7.5](https://github.com/redis-developer/redisctl/compare/redis-cloud-v0.7.4...redis-cloud-v0.7.5) - 2025-12-17
 
 ### Fixed

--- a/crates/redis-cloud/Cargo.toml
+++ b/crates/redis-cloud/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-cloud"
-version = "0.7.5"
+version = "0.7.6"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/redis-enterprise/CHANGELOG.md
+++ b/crates/redis-enterprise/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.4](https://github.com/redis-developer/redisctl/compare/redis-enterprise-v0.7.3...redis-enterprise-v0.7.4) - 2026-01-23
+
+### Added
+
+- Add Python bindings via PyO3 ([#578](https://github.com/redis-developer/redisctl/pull/578))
+
+### Fixed
+
+- use local README.md for crates to fix sdist build ([#580](https://github.com/redis-developer/redisctl/pull/580))
+
 ## [0.7.3](https://github.com/redis-developer/redisctl/compare/redis-enterprise-v0.7.2...redis-enterprise-v0.7.3) - 2026-01-12
 
 ### Added

--- a/crates/redis-enterprise/Cargo.toml
+++ b/crates/redis-enterprise/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-enterprise"
-version = "0.7.3"
+version = "0.7.4"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/redisctl-config/CHANGELOG.md
+++ b/crates/redisctl-config/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/redis-developer/redisctl/compare/redisctl-config-v0.2.1...redisctl-config-v0.2.2) - 2026-01-23
+
+### Added
+
+- *(config)* add database profile type for direct Redis connections ([#566](https://github.com/redis-developer/redisctl/pull/566))
+
 ## [0.2.1](https://github.com/redis-developer/redisctl/compare/redisctl-config-v0.2.0...redisctl-config-v0.2.1) - 2025-12-16
 
 ### Other

--- a/crates/redisctl-config/Cargo.toml
+++ b/crates/redisctl-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redisctl-config"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 authors = ["Josh Rotenberg <josh@redislabs.com>"]
 license = "MIT OR Apache-2.0"

--- a/crates/redisctl-mcp/CHANGELOG.md
+++ b/crates/redisctl-mcp/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/redis-developer/redisctl/compare/redisctl-mcp-v0.1.1...redisctl-mcp-v0.1.2) - 2026-01-23
+
+### Added
+
+- *(mcp)* add --database-url CLI option for direct Redis connections ([#574](https://github.com/redis-developer/redisctl/pull/574))
+- *(mcp)* add database tools for direct Redis connections ([#572](https://github.com/redis-developer/redisctl/pull/572))
+
+### Other
+
+- add Python bindings documentation and update CHANGELOGs ([#581](https://github.com/redis-developer/redisctl/pull/581))
+
 ## [0.1.1](https://github.com/redis-developer/redisctl/compare/redisctl-mcp-v0.1.0...redisctl-mcp-v0.1.1) - 2026-01-14
 
 ### Added

--- a/crates/redisctl-mcp/Cargo.toml
+++ b/crates/redisctl-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redisctl-mcp"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
@@ -17,9 +17,9 @@ rmcp = { version = "0.12", features = ["server", "transport-io", "macros"] }
 schemars = "0.8"
 
 # Internal crates
-redisctl-config = { version = "0.2.1", path = "../redisctl-config" }
-redis-cloud = { version = "0.7.5", path = "../redis-cloud" }
-redis-enterprise = { version = "0.7.3", path = "../redis-enterprise" }
+redisctl-config = { version = "0.2.2", path = "../redisctl-config" }
+redis-cloud = { version = "0.7.6", path = "../redis-cloud" }
+redis-enterprise = { version = "0.7.4", path = "../redis-enterprise" }
 
 # Redis client for direct database connections
 redis = { workspace = true }

--- a/crates/redisctl/CHANGELOG.md
+++ b/crates/redisctl/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.6](https://github.com/redis-developer/redisctl/compare/redisctl-v0.7.5...redisctl-v0.7.6) - 2026-01-23
+
+### Added
+
+- Add Python bindings via PyO3 ([#578](https://github.com/redis-developer/redisctl/pull/578))
+- *(mcp)* add --database-url CLI option for direct Redis connections ([#574](https://github.com/redis-developer/redisctl/pull/574))
+- *(mcp)* add database tools for direct Redis connections ([#572](https://github.com/redis-developer/redisctl/pull/572))
+- *(config)* add database profile type for direct Redis connections ([#566](https://github.com/redis-developer/redisctl/pull/566))
+
+### Other
+
+- add Python bindings documentation and update CHANGELOGs ([#581](https://github.com/redis-developer/redisctl/pull/581))
+- add assert_cmd tests for MCP commands ([#570](https://github.com/redis-developer/redisctl/pull/570))
+
 ### Added
 
 - Add Python bindings via PyO3 for `redis-cloud` and `redis-enterprise` libraries ([#578](https://github.com/redis-developer/redisctl/pull/578))

--- a/crates/redisctl/Cargo.toml
+++ b/crates/redisctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redisctl"
-version = "0.7.5"
+version = "0.7.6"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
@@ -18,10 +18,10 @@ path = "src/main.rs"
 
 
 [dependencies]
-redisctl-config = { version = "0.2.1", path = "../redisctl-config" }
-redis-cloud = { version = "0.7.5", path = "../redis-cloud", features = ["tower-integration"] }
-redis-enterprise = { version = "0.7.3", path = "../redis-enterprise", features = ["tower-integration"] }
-redisctl-mcp = { version = "0.1.1", path = "../redisctl-mcp", optional = true }
+redisctl-config = { version = "0.2.2", path = "../redisctl-config" }
+redis-cloud = { version = "0.7.6", path = "../redis-cloud", features = ["tower-integration"] }
+redis-enterprise = { version = "0.7.4", path = "../redis-enterprise", features = ["tower-integration"] }
+redisctl-mcp = { version = "0.1.2", path = "../redisctl-mcp", optional = true }
 files-sdk = { workspace = true, optional = true }
 
 # CLI dependencies


### PR DESCRIPTION



## 🤖 New release

* `redisctl-config`: 0.2.1 -> 0.2.2 (✓ API compatible changes)
* `redis-cloud`: 0.7.5 -> 0.7.6 (✓ API compatible changes)
* `redis-enterprise`: 0.7.3 -> 0.7.4 (✓ API compatible changes)
* `redisctl-mcp`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `redisctl`: 0.7.5 -> 0.7.6 (✓ API compatible changes)
* `redisctl-python`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `redisctl-config`

<blockquote>

## [0.2.2](https://github.com/redis-developer/redisctl/compare/redisctl-config-v0.2.1...redisctl-config-v0.2.2) - 2026-01-23

### Added

- *(config)* add database profile type for direct Redis connections ([#566](https://github.com/redis-developer/redisctl/pull/566))
</blockquote>

## `redis-cloud`

<blockquote>

## [0.7.6](https://github.com/redis-developer/redisctl/compare/redis-cloud-v0.7.5...redis-cloud-v0.7.6) - 2026-01-23

### Fixed

- use local README.md for crates to fix sdist build ([#580](https://github.com/redis-developer/redisctl/pull/580))
</blockquote>

## `redis-enterprise`

<blockquote>

## [0.7.4](https://github.com/redis-developer/redisctl/compare/redis-enterprise-v0.7.3...redis-enterprise-v0.7.4) - 2026-01-23

### Added

- Add Python bindings via PyO3 ([#578](https://github.com/redis-developer/redisctl/pull/578))

### Fixed

- use local README.md for crates to fix sdist build ([#580](https://github.com/redis-developer/redisctl/pull/580))
</blockquote>

## `redisctl-mcp`

<blockquote>

## [0.1.2](https://github.com/redis-developer/redisctl/compare/redisctl-mcp-v0.1.1...redisctl-mcp-v0.1.2) - 2026-01-23

### Added

- *(mcp)* add --database-url CLI option for direct Redis connections ([#574](https://github.com/redis-developer/redisctl/pull/574))
- *(mcp)* add database tools for direct Redis connections ([#572](https://github.com/redis-developer/redisctl/pull/572))

### Other

- add Python bindings documentation and update CHANGELOGs ([#581](https://github.com/redis-developer/redisctl/pull/581))
</blockquote>

## `redisctl`

<blockquote>

## [0.7.6](https://github.com/redis-developer/redisctl/compare/redisctl-v0.7.5...redisctl-v0.7.6) - 2026-01-23

### Added

- Add Python bindings via PyO3 ([#578](https://github.com/redis-developer/redisctl/pull/578))
- *(mcp)* add --database-url CLI option for direct Redis connections ([#574](https://github.com/redis-developer/redisctl/pull/574))
- *(mcp)* add database tools for direct Redis connections ([#572](https://github.com/redis-developer/redisctl/pull/572))
- *(config)* add database profile type for direct Redis connections ([#566](https://github.com/redis-developer/redisctl/pull/566))

### Other

- add Python bindings documentation and update CHANGELOGs ([#581](https://github.com/redis-developer/redisctl/pull/581))
- add assert_cmd tests for MCP commands ([#570](https://github.com/redis-developer/redisctl/pull/570))

### Added

- Add Python bindings via PyO3 for `redis-cloud` and `redis-enterprise` libraries ([#578](https://github.com/redis-developer/redisctl/pull/578))
  - `CloudClient` with async and sync methods for subscriptions and databases
  - `EnterpriseClient` with async and sync methods for cluster, databases, nodes, and users
  - Environment variable support via `from_env()` factory methods
  - Raw API access for unsupported endpoints
  - Available on PyPI: `pip install redisctl`
</blockquote>

## `redisctl-python`

<blockquote>

## [0.1.0] - 2026-01-23

### Added

- Initial release of Python bindings for Redis Cloud and Enterprise APIs
- `CloudClient` for Redis Cloud API
  - Constructor with API key, secret, optional base URL and timeout
  - `from_env()` factory method supporting multiple environment variable names
  - Async methods: `subscriptions()`, `subscription()`, `databases()`, `database()`
  - Sync methods: `subscriptions_sync()`, `subscription_sync()`, `databases_sync()`, `database_sync()`
  - Raw API access: `get()`, `post()`, `put()`, `delete()` (async and sync variants)
- `EnterpriseClient` for Redis Enterprise API
  - Constructor with base URL, username, password, optional insecure flag and timeout
  - `from_env()` factory method
  - Cluster methods: `cluster_info()`, `cluster_stats()`, `license()` (async and sync)
  - Database methods: `databases()`, `database()`, `database_stats()` (async and sync)
  - Node methods: `nodes()`, `node()`, `node_stats()` (async and sync)
  - User methods: `users()`, `user()` (async and sync)
  - Raw API access: `get()`, `post()`, `put()`, `delete()` (async and sync variants)
- `RedisCtlError` exception type for API errors
- Pre-built wheels for:
  - macOS (x86_64 and arm64)
  - Linux (x86_64 and aarch64, glibc)
  - Windows (x86_64)
- Python version support: 3.9, 3.10, 3.11, 3.12, 3.13
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).