### PR TITLE
feat(mcp): add --database-url CLI option for direct Redis connections

### DIFF
--- a/crates/redisctl-mcp/src/database_tools.rs
+++ b/crates/redisctl-mcp/src/database_tools.rs
@@ -63,6 +63,21 @@ impl DatabaseTools {
         Ok(Self { conn })
     }
 
+    /// Create a new DatabaseTools instance from a direct Redis URL.
+    ///
+    /// URL format: redis[s]://[[username:]password@]host[:port][/db]
+    ///
+    /// This is useful for ad-hoc connections to Redis databases that aren't
+    /// configured as profiles, such as standalone Redis instances.
+    pub async fn new_from_url(url: &str) -> anyhow::Result<Self> {
+        debug!(url = %url.split('@').next_back().unwrap_or("[redacted]"), "Connecting to Redis via URL");
+
+        let client = redis::Client::open(url)?;
+        let conn = ConnectionManager::new(client).await?;
+
+        Ok(Self { conn })
+    }
+
     /// Execute an arbitrary Redis command.
     ///
     /// This is the generic execute function that can run any Redis command.

--- a/crates/redisctl-mcp/src/lib.rs
+++ b/crates/redisctl-mcp/src/lib.rs
@@ -11,7 +11,8 @@
 //!
 //! #[tokio::main]
 //! async fn main() -> anyhow::Result<()> {
-//!     let server = RedisCtlMcp::new(None, true)?; // profile=None, read_only=true
+//!     // profile=None, read_only=true, database_url=None
+//!     let server = RedisCtlMcp::new(None, true, None)?;
 //!     let service = server.serve(stdio()).await?;
 //!     service.waiting().await?;
 //!     Ok(())
@@ -28,17 +29,22 @@ pub use error::McpError;
 pub use server::RedisCtlMcp;
 
 /// Start the MCP server with stdio transport
-pub async fn serve_stdio(profile: Option<&str>, read_only: bool) -> anyhow::Result<()> {
+pub async fn serve_stdio(
+    profile: Option<&str>,
+    read_only: bool,
+    database_url: Option<&str>,
+) -> anyhow::Result<()> {
     use rmcp::{ServiceExt, transport::stdio};
     use tracing::info;
 
     info!(
         profile = profile,
         read_only = read_only,
+        database_url = database_url.map(|_| "[redacted]"),
         "Starting MCP server"
     );
 
-    let server = RedisCtlMcp::new(profile, read_only)?;
+    let server = RedisCtlMcp::new(profile, read_only, database_url)?;
     let service = server.serve(stdio()).await?;
     service.waiting().await?;
 

--- a/crates/redisctl/src/cli/mod.rs
+++ b/crates/redisctl/src/cli/mod.rs
@@ -216,11 +216,23 @@ pub enum McpCommands {
 
     # Enable write operations (destructive operations allowed)
     redisctl mcp serve --allow-writes
+
+    # Connect to a specific Redis database
+    redisctl mcp serve --database-url redis://localhost:6379
+
+    # Full access with database connection
+    redisctl mcp serve --allow-writes --database-url redis://:password@localhost:6379
 ")]
     Serve {
         /// Allow write operations (create, update, delete). Default is read-only.
         #[arg(long)]
         allow_writes: bool,
+
+        /// Redis database URL for direct database operations.
+        /// Format: redis[s]://[[username:]password@]host[:port][/db]
+        /// If not specified, uses the default database profile from config.
+        #[arg(long, env = "REDIS_URL")]
+        database_url: Option<String>,
     },
 
     /// List available MCP tools

--- a/mkdocs-site/docs/mcp/getting-started.md
+++ b/mkdocs-site/docs/mcp/getting-started.md
@@ -83,7 +83,11 @@ redisctl mcp tools
 
 ### Database Connection Options
 
-The `--database-url` flag enables 125+ database tools for direct Redis operations including all data types, Redis Stack modules (Search, JSON, TimeSeries, Bloom), Streams, and Pub/Sub.
+The MCP server provides 125+ database tools for direct Redis operations including all data types, Redis Stack modules (Search, JSON, TimeSeries, Bloom), Streams, and Pub/Sub. You can connect in two ways:
+
+#### Option 1: Direct URL (Recommended for Ad-Hoc Connections)
+
+Use `--database-url` for quick connections to any Redis database:
 
 ```bash
 # Local Redis
@@ -92,12 +96,50 @@ The `--database-url` flag enables 125+ database tools for direct Redis operation
 # With password
 --database-url redis://:mypassword@localhost:6379
 
+# With username and password
+--database-url redis://myuser:mypassword@localhost:6379
+
 # Redis Cloud/Enterprise database
 --database-url redis://default:password@redis-12345.cloud.redislabs.com:12345
 
-# TLS connection
+# TLS connection (use rediss:// scheme)
 --database-url rediss://default:password@redis-12345.cloud.redislabs.com:12345
+
+# Using environment variable
+REDIS_URL=redis://localhost:6379 redisctl mcp serve
 ```
+
+#### Option 2: Database Profile (Recommended for Regular Use)
+
+Configure a database profile in your redisctl config file (`~/.config/redisctl/config.toml` or `~/Library/Application Support/redisctl/config.toml` on macOS):
+
+```toml
+# Default database profile to use when none specified
+default_database_profile = "local-redis"
+
+[profiles.local-redis]
+deployment_type = "database"
+
+[profiles.local-redis.credentials.database]
+host = "localhost"
+port = 6379
+password = "mypassword"  # optional
+tls = false
+username = "default"     # optional, defaults to "default"
+db = 0                   # optional, defaults to 0
+```
+
+Then start the MCP server with that profile:
+
+```bash
+# Uses the default database profile from config
+redisctl mcp serve
+
+# Or specify a profile explicitly
+redisctl -p local-redis mcp serve
+```
+
+**Note**: If both `--database-url` and a database profile are available, the `--database-url` takes precedence.
 
 ## IDE Configuration
 


### PR DESCRIPTION
## Summary

Add support for connecting to Redis databases via URL without requiring a profile. This is useful for ad-hoc connections to standalone Redis instances that aren't configured as profiles.

## Changes

- Add `--database-url` option to `mcp serve` command (also supports `REDIS_URL` env var)
- Add `DatabaseTools::new_from_url()` constructor for URL-based connections
- Update `get_database_tools()` to prefer URL over profile when both available
- Update MCP documentation with both connection approaches (URL and profile-based)
- Add unit test for database_url configuration

## Usage

```bash
# Via command line
redisctl mcp serve --database-url redis://localhost:6379

# Via environment variable
REDIS_URL=redis://localhost:6379 redisctl mcp serve

# With authentication
redisctl mcp serve --database-url redis://:password@localhost:6379

# TLS connection
redisctl mcp serve --database-url rediss://default:password@host:6379
```

The URL format follows the standard Redis URL scheme:
`redis[s]://[[username:]password@]host[:port][/db]`

## Why

Users may want to use the MCP server with a Redis database that isn't managed by Redis Enterprise or Cloud (e.g., a local Redis instance, self-hosted Redis, or third-party managed Redis). This allows quick connections without needing to set up a profile first.