### PR TITLE
fix: use local README.md for crates to fix sdist build

### DIFF
--- a/crates/redis-cloud/Cargo.toml
+++ b/crates/redis-cloud/Cargo.toml
@@ -10,7 +10,7 @@ documentation.workspace = true
 description = "Redis Cloud REST API client library"
 keywords = ["redis", "cloud", "api", "rest", "client"]
 categories = ["api-bindings", "database"]
-readme = "../../README.md"
+readme = "README.md"
 
 
 

--- a/crates/redis-enterprise/Cargo.toml
+++ b/crates/redis-enterprise/Cargo.toml
@@ -10,7 +10,7 @@ documentation.workspace = true
 description = "Redis Enterprise REST API client library"
 keywords = ["redis", "enterprise", "api", "rest", "client"]
 categories = ["api-bindings", "database"]
-readme = "../../README.md"
+readme = "README.md"
 
 
 


### PR DESCRIPTION
The Python sdist build failed because `redis-cloud` and `redis-enterprise` had both a local `README.md` and pointed to `../../README.md` in their Cargo.toml, causing a file conflict during packaging.

This updates both crates to use their local README.md files.

Error was:
```
File redisctl-0.1.0/crates/redis-cloud/README.md was already added from 
/home/runner/work/redisctl/redisctl/crates/redis-cloud/README.md, 
can't add it from /home/runner/work/redisctl/redisctl/README.md
```