### PR TITLE
ci: improve Python publish workflow and testing

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -6,9 +6,9 @@ on:
   workflow_dispatch:
     inputs:
       target:
-        description: 'Publish target'
+        description: "Publish target"
         required: true
-        default: 'testpypi'
+        default: "testpypi"
         type: choice
         options:
           - testpypi
@@ -17,9 +17,38 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+# Only run on Python-specific releases (tag format: v*-python or python-v*)
+# For workflow_dispatch, always run
+concurrency:
+  group: python-publish-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  # Check if this is a Python release (skip CLI-only releases)
+  check-release:
+    name: Check if Python release
+    runs-on: ubuntu-latest
+    outputs:
+      should_publish: ${{ steps.check.outputs.should_publish }}
+    steps:
+      - name: Check release tag
+        id: check
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "should_publish=true" >> $GITHUB_OUTPUT
+            echo "Manual trigger - will publish"
+          elif [[ "${{ github.ref }}" == *"-python"* ]] || [[ "${{ github.ref }}" == *"python-"* ]]; then
+            echo "should_publish=true" >> $GITHUB_OUTPUT
+            echo "Python release tag detected - will publish"
+          else
+            echo "should_publish=false" >> $GITHUB_OUTPUT
+            echo "Not a Python release tag - skipping"
+          fi
+
   build-linux:
     name: Build - Linux (${{ matrix.target }})
+    needs: check-release
+    if: needs.check-release.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -37,7 +66,7 @@ jobs:
         with:
           target: ${{ matrix.target }}
           args: --release --out dist
-          sccache: 'true'
+          sccache: "true"
           manylinux: auto
           working-directory: crates/redisctl-python
 
@@ -49,6 +78,8 @@ jobs:
 
   build-macos:
     name: Build - macOS (${{ matrix.target }})
+    needs: check-release
+    if: needs.check-release.outputs.should_publish == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -70,7 +101,7 @@ jobs:
         with:
           target: ${{ matrix.target }}
           args: --release --out dist
-          sccache: 'true'
+          sccache: "true"
           working-directory: crates/redisctl-python
 
       - name: Upload wheels
@@ -81,6 +112,8 @@ jobs:
 
   build-windows:
     name: Build - Windows
+    needs: check-release
+    if: needs.check-release.outputs.should_publish == 'true'
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -94,7 +127,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           args: --release --out dist
-          sccache: 'true'
+          sccache: "true"
           working-directory: crates/redisctl-python
 
       - name: Upload wheels
@@ -105,6 +138,8 @@ jobs:
 
   build-sdist:
     name: Build source distribution
+    needs: check-release
+    if: needs.check-release.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -124,13 +159,14 @@ jobs:
 
   publish:
     name: Publish to ${{ github.event.inputs.target || 'pypi' }}
-    needs: [build-linux, build-macos, build-windows, build-sdist]
+    needs: [check-release, build-linux, build-macos, build-windows, build-sdist]
+    if: needs.check-release.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
     environment:
       name: ${{ github.event.inputs.target || 'pypi' }}
       url: ${{ github.event.inputs.target == 'testpypi' && 'https://test.pypi.org/project/redisctl/' || 'https://pypi.org/project/redisctl/' }}
     permissions:
-      id-token: write  # Required for trusted publishing
+      id-token: write # Required for trusted publishing
     steps:
       - name: Download all wheels
         uses: actions/download-artifact@v4

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -159,18 +159,22 @@ jobs:
           name: wheel-windows-x86_64
           path: target/wheels/*.whl
 
-  # Run Python tests
+  # Run Python tests across multiple versions
   test:
-    name: Python Tests
+    name: Python Tests (${{ matrix.python-version }})
     needs: build-linux
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Set up Python
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
 
       - name: Download wheel
         uses: actions/download-artifact@v4
@@ -185,7 +189,7 @@ jobs:
 
       - name: Run tests
         working-directory: crates/redisctl-python
-        run: pytest tests/ -v || echo "No tests yet - skipping"
+        run: pytest tests/ -v
 
   # Status check
   python-ci-status:

--- a/crates/redisctl-python/pyproject.toml
+++ b/crates/redisctl-python/pyproject.toml
@@ -43,7 +43,7 @@ dev = [
 ]
 
 [tool.maturin]
-features = ["pyo3/extension-module"]
+features = ["pyo3/extension-module", "pyo3/abi3-py39"]
 python-source = "python"
 module-name = "redisctl"
 


### PR DESCRIPTION
## Summary

Improve the Python package CI/CD pipeline for more robust releases and testing.

## Changes

### 1. Enable abi3-py39 (pyproject.toml)
- Builds a single wheel per platform that works with Python 3.9+
- Reduces the number of wheels to build and publish
- Ensures compatibility across all supported Python versions

### 2. Release Tag Filtering (python-publish.yml)
- Added `check-release` job that filters releases
- Only triggers publish on tags containing `python` (e.g., `v0.1.0-python`, `python-v0.1.0`)
- Manual workflow_dispatch always runs
- Prevents accidental publish on CLI-only releases

### 3. Python Version Test Matrix (python.yml)
- Tests now run against Python 3.9, 3.10, 3.11, 3.12, and 3.13
- Uses `fail-fast: false` to see all version failures
- Validates abi3 wheel works across all versions

### 4. Concurrency Control
- Added concurrency group to prevent duplicate publish runs

## Testing

- CI will validate the workflow syntax
- Python tests will run with the new version matrix