### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2852,7 +2852,7 @@ dependencies = [
 
 [[package]]
 name = "redisctl"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/crates/redisctl/CHANGELOG.md
+++ b/crates/redisctl/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.7](https://github.com/redis-developer/redisctl/compare/redisctl-v0.7.6...redisctl-v0.7.7) - 2026-01-23
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.7.6](https://github.com/redis-developer/redisctl/compare/redisctl-v0.7.5...redisctl-v0.7.6) - 2026-01-23
 
 ### Added

--- a/crates/redisctl/Cargo.toml
+++ b/crates/redisctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redisctl"
-version = "0.7.6"
+version = "0.7.7"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `redisctl`: 0.7.6 -> 0.7.7 (✓ API compatible changes)
* `redisctl-python`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `redisctl`

<blockquote>

## [0.7.7](https://github.com/redis-developer/redisctl/compare/redisctl-v0.7.6...redisctl-v0.7.7) - 2026-01-23

### Other

- update Cargo.toml dependencies
</blockquote>

## `redisctl-python`

<blockquote>

## [0.1.0] - 2026-01-23

### Added

- Initial release of Python bindings for Redis Cloud and Enterprise APIs
- `CloudClient` for Redis Cloud API
  - Constructor with API key, secret, optional base URL and timeout
  - `from_env()` factory method supporting multiple environment variable names
  - Async methods: `subscriptions()`, `subscription()`, `databases()`, `database()`
  - Sync methods: `subscriptions_sync()`, `subscription_sync()`, `databases_sync()`, `database_sync()`
  - Raw API access: `get()`, `post()`, `put()`, `delete()` (async and sync variants)
- `EnterpriseClient` for Redis Enterprise API
  - Constructor with base URL, username, password, optional insecure flag and timeout
  - `from_env()` factory method
  - Cluster methods: `cluster_info()`, `cluster_stats()`, `license()` (async and sync)
  - Database methods: `databases()`, `database()`, `database_stats()` (async and sync)
  - Node methods: `nodes()`, `node()`, `node_stats()` (async and sync)
  - User methods: `users()`, `user()` (async and sync)
  - Raw API access: `get()`, `post()`, `put()`, `delete()` (async and sync variants)
- `RedisCtlError` exception type for API errors
- Pre-built wheels for:
  - macOS (x86_64 and arm64)
  - Linux (x86_64 and aarch64, glibc)
  - Windows (x86_64)
- Python version support: 3.9, 3.10, 3.11, 3.12, 3.13
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).