### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2826,7 +2826,7 @@ dependencies = [
 
 [[package]]
 name = "redisctl"
-version = "0.7.7"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2899,7 +2899,7 @@ dependencies = [
 
 [[package]]
 name = "redisctl-mcp"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/redisctl-core/CHANGELOG.md
+++ b/crates/redisctl-core/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/redis-developer/redisctl/releases/tag/redisctl-core-v0.1.0) - 2026-02-25
+
+### Added
+
+- *(cli)* cargo-style diagnostic error formatting ([#671](https://github.com/redis-developer/redisctl/pull/671))
+- *(cli)* infer platform from profile — make cloud/enterprise prefix optional ([#668](https://github.com/redis-developer/redisctl/pull/668))
+- *(mcp)* add Cloud database flush operation ([#633](https://github.com/redis-developer/redisctl/pull/633))
+- *(mcp)* add Enterprise database write operations ([#632](https://github.com/redis-developer/redisctl/pull/632))
+- [**breaking**] implement Layer 2 architecture in redisctl-core ([#630](https://github.com/redis-developer/redisctl/pull/630))
+
+### Other
+
+- consolidate workspace dependencies ([#640](https://github.com/redis-developer/redisctl/pull/640))

--- a/crates/redisctl-mcp/CHANGELOG.md
+++ b/crates/redisctl-mcp/CHANGELOG.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/redis-developer/redisctl/compare/redisctl-mcp-v0.2.0...redisctl-mcp-v0.3.0) - 2026-02-25
+
+### Added
+
+- *(mcp)* auto-detect toolsets from config profiles ([#667](https://github.com/redis-developer/redisctl/pull/667))
+- *(mcp)* modular router with feature flags and runtime toolset selection ([#656](https://github.com/redis-developer/redisctl/pull/656))
+- *(mcp)* default to read-only mode ([#655](https://github.com/redis-developer/redisctl/pull/655))
+- *(mcp)* add multi-profile support for Cloud tools ([#654](https://github.com/redis-developer/redisctl/pull/654))
+- *(mcp)* add multi-profile support for Enterprise tools ([#651](https://github.com/redis-developer/redisctl/pull/651)) ([#652](https://github.com/redis-developer/redisctl/pull/652))
+- *(mcp)* add create_subscription tool for Cloud ([#643](https://github.com/redis-developer/redisctl/pull/643))
+- *(mcp)* add Enterprise license, cluster, and certificate management tools ([#636](https://github.com/redis-developer/redisctl/pull/636))
+- *(mcp)* add Enterprise Redis ACL tools ([#635](https://github.com/redis-developer/redisctl/pull/635))
+- *(mcp)* add Cloud certificate and Enterprise roles tools ([#634](https://github.com/redis-developer/redisctl/pull/634))
+- *(mcp)* add Cloud database flush operation ([#633](https://github.com/redis-developer/redisctl/pull/633))
+- *(mcp)* add Enterprise database write operations ([#632](https://github.com/redis-developer/redisctl/pull/632))
+- [**breaking**] implement Layer 2 architecture in redisctl-core ([#630](https://github.com/redis-developer/redisctl/pull/630))
+- add custom CA certificate support for Kubernetes deployments ([#624](https://github.com/redis-developer/redisctl/pull/624))
+- *(mcp)* upgrade tower-mcp to 0.3.4 ([#622](https://github.com/redis-developer/redisctl/pull/622))
+- add filtering support and new Redis diagnostic tools ([#621](https://github.com/redis-developer/redisctl/pull/621))
+- add individual getter tools for Cloud and Enterprise resources ([#620](https://github.com/redis-developer/redisctl/pull/620))
+- add MCP resources and prompts to redisctl-mcp ([#619](https://github.com/redis-developer/redisctl/pull/619))
+- *(mcp)* add read-only tool filter using CapabilityFilter ([#618](https://github.com/redis-developer/redisctl/pull/618))
+- *(mcp)* add historical stats, Cloud logs, debug info, and modules tools ([#617](https://github.com/redis-developer/redisctl/pull/617))
+- *(mcp)* add Enterprise logs and aggregate stats tools ([#616](https://github.com/redis-developer/redisctl/pull/616))
+- *(mcp)* add Enterprise license tools ([#615](https://github.com/redis-developer/redisctl/pull/615))
+- *(mcp)* add mock testing support for cloud and enterprise tools ([#611](https://github.com/redis-developer/redisctl/pull/611))
+- *(mcp)* add profile management tools ([#609](https://github.com/redis-developer/redisctl/pull/609))
+
+### Fixed
+
+- pre-release cleanup — cfg-gate warnings and stale doc versions ([#676](https://github.com/redis-developer/redisctl/pull/676))
+- *(mcp)* wrap array results in JSON objects for structuredContent compliance ([#653](https://github.com/redis-developer/redisctl/pull/653))
+- *(mcp)* normalize 'default' profile to use configured default ([#608](https://github.com/redis-developer/redisctl/pull/608))
+
+### Other
+
+- *(mcp)* bump tower-mcp to 0.5.0 ([#658](https://github.com/redis-developer/redisctl/pull/658))
+- consolidate workspace dependencies ([#640](https://github.com/redis-developer/redisctl/pull/640))
+- upgrade tower-mcp to 0.2.3 and use from_serialize() ([#607](https://github.com/redis-developer/redisctl/pull/607))
+
 ## [0.1.2](https://github.com/redis-developer/redisctl/compare/redisctl-mcp-v0.1.1...redisctl-mcp-v0.1.2) - 2026-01-23
 
 ### Added

--- a/crates/redisctl-mcp/Cargo.toml
+++ b/crates/redisctl-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redisctl-mcp"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/redisctl/CHANGELOG.md
+++ b/crates/redisctl/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/redis-developer/redisctl/compare/redisctl-v0.7.7...redisctl-v0.8.0) - 2026-02-25
+
+### Added
+
+- *(cli)* support name@version syntax for --module flag ([#675](https://github.com/redis-developer/redisctl/pull/675))
+- *(cli)* group `profile list` output by deployment type ([#674](https://github.com/redis-developer/redisctl/pull/674))
+- *(cli)* cargo-style diagnostic error formatting ([#671](https://github.com/redis-developer/redisctl/pull/671))
+- *(cli)* infer platform from profile — make cloud/enterprise prefix optional ([#668](https://github.com/redis-developer/redisctl/pull/668))
+- *(mcp)* add Enterprise license, cluster, and certificate management tools ([#636](https://github.com/redis-developer/redisctl/pull/636))
+- [**breaking**] implement Layer 2 architecture in redisctl-core ([#630](https://github.com/redis-developer/redisctl/pull/630))
+- add 'db open' command to spawn redis-cli with profile credentials ([#627](https://github.com/redis-developer/redisctl/pull/627))
+- add custom CA certificate support for Kubernetes deployments ([#624](https://github.com/redis-developer/redisctl/pull/624))
+- [**breaking**] rewrite redisctl-mcp using tower-mcp framework ([#597](https://github.com/redis-developer/redisctl/pull/597))
+- update to redis-enterprise 0.8 ([#600](https://github.com/redis-developer/redisctl/pull/600))
+- update to redis-cloud 0.9 ([#599](https://github.com/redis-developer/redisctl/pull/599))
+- add one-shot cost-report export command ([#595](https://github.com/redis-developer/redisctl/pull/595))
+
+### Fixed
+
+- handle rate limits (429) and processing-completed state in task polling ([#587](https://github.com/redis-developer/redisctl/pull/587))
+
+### Other
+
+- update examples for prefix-free CLI commands ([#673](https://github.com/redis-developer/redisctl/pull/673))
+- document Docker as zero-install MCP option ([#647](https://github.com/redis-developer/redisctl/pull/647)) ([#659](https://github.com/redis-developer/redisctl/pull/659))
+- consolidate workspace dependencies ([#640](https://github.com/redis-developer/redisctl/pull/640))
+- [**breaking**] extract redis-cloud and redis-enterprise to standalone repos ([#596](https://github.com/redis-developer/redisctl/pull/596))
+
 ## [0.7.7](https://github.com/redis-developer/redisctl/compare/redisctl-v0.7.6...redisctl-v0.7.7) - 2026-01-23
 
 ### Other

--- a/crates/redisctl/Cargo.toml
+++ b/crates/redisctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redisctl"
-version = "0.7.7"
+version = "0.8.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `redisctl-core`: 0.1.0
* `redisctl`: 0.7.7 -> 0.8.0 (⚠ API breaking changes)
* `redisctl-mcp`: 0.2.0 -> 0.3.0 (⚠ API breaking changes)

### ⚠ `redisctl` breaking changes

```text
--- failure feature_missing: package feature removed or renamed ---

Description:
A feature has been removed from this package's Cargo.toml. This will break downstream crates which enable that feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/feature_missing.ron

Failed in:
  feature mcp in the package's Cargo.toml
```

### ⚠ `redisctl-mcp` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field GetBackupStatusInput.profile in /tmp/.tmpR8RRgE/redisctl/crates/redisctl-mcp/src/tools/cloud.rs:675
  field ListUsersInput.profile in /tmp/.tmpR8RRgE/redisctl/crates/redisctl-mcp/src/tools/enterprise.rs:423
  field GetDatabaseInput.profile in /tmp/.tmpR8RRgE/redisctl/crates/redisctl-mcp/src/tools/cloud.rs:139
  field GetClusterStatsInput.profile in /tmp/.tmpR8RRgE/redisctl/crates/redisctl-mcp/src/tools/enterprise.rs:579
  field GetClusterStatsInput.interval in /tmp/.tmpR8RRgE/redisctl/crates/redisctl-mcp/src/tools/enterprise.rs:582
  field GetClusterStatsInput.start_time in /tmp/.tmpR8RRgE/redisctl/crates/redisctl-mcp/src/tools/enterprise.rs:585
  field GetClusterStatsInput.end_time in /tmp/.tmpR8RRgE/redisctl/crates/redisctl-mcp/src/tools/enterprise.rs:588
  field ListShardsInput.profile in /tmp/.tmpR8RRgE/redisctl/crates/redisctl-mcp/src/tools/enterprise.rs:922
  field GetRegionsInput.profile in /tmp/.tmpR8RRgE/redisctl/crates/redisctl-mcp/src/tools/cloud.rs:300
  field GetSlowLogInput.profile in /tmp/.tmpR8RRgE/redisctl/crates/redisctl-mcp/src/tools/cloud.rs:720
  field GetAccountInput.profile in /tmp/.tmpR8RRgE/redisctl/crates/redisctl-mcp/src/tools/cloud.rs:177
  field GetModulesInput.profile in /tmp/.tmpR8RRgE/redisctl/crates/redisctl-mcp/src/tools/cloud.rs:336
  field GetClusterInput.profile in /tmp/.tmpR8RRgE/redisctl/crates/redisctl-mcp/src/tools/enterprise.rs:36
  field ListTasksInput.profile in /tmp/.tmpR8RRgE/redisctl/crates/redisctl-mcp/src/tools/cloud.rs:376
  field ListDatabasesInput.profile in /tmp/.tmpR8RRgE/redisctl/crates/redisctl-mcp/src/tools/cloud.rs:99
  field ListAclUsersInput.profile in /tmp/.tmpR8RRgE/redisctl/crates/redisctl-mcp/src/tools/cloud.rs:526
  field ListSubscriptionsInput.profile in /tmp/.tmpR8RRgE/redisctl/crates/redisctl-mcp/src/tools/cloud.rs:27
  field GetDatabaseInput.profile in /tmp/.tmpR8RRgE/redisctl/crates/redisctl-mcp/src/tools/enterprise.rs:301
  field GetUserInput.profile in /tmp/.tmpR8RRgE/redisctl/crates/redisctl-mcp/src/tools/enterprise.rs:459
  field ListNodesInput.profile in /tmp/.tmpR8RRgE/redisctl/crates/redisctl-mcp/src/tools/enterprise.rs:339
  field GetDatabaseStatsInput.profile in /tmp/.tmpR8RRgE/redisctl/crates/redisctl-mcp/src/tools/enterprise.rs:640
  field GetDatabaseStatsInput.interval in /tmp/.tmpR8RRgE/redisctl/crates/redisctl-mcp/src/tools/enterprise.rs:645
  field GetDatabaseStatsInput.start_time in /tmp/.tmpR8RRgE/redisctl/crates/redisctl-mcp/src/tools/enterprise.rs:648
  field GetDatabaseStatsInput.end_time in /tmp/.tmpR8RRgE/redisctl/crates/redisctl-mcp/src/tools/enterprise.rs:651
  field ListAlertsInput.profile in /tmp/.tmpR8RRgE/redisctl/crates/redisctl-mcp/src/tools/enterprise.rs:503
  field GetTaskInput.profile in /tmp/.tmpR8RRgE/redisctl/crates/redisctl-mcp/src/tools/cloud.rs:412
  field ListAccountUsersInput.profile in /tmp/.tmpR8RRgE/redisctl/crates/redisctl-mcp/src/tools/cloud.rs:450
  field ListAclRolesInput.profile in /tmp/.tmpR8RRgE/redisctl/crates/redisctl-mcp/src/tools/cloud.rs:596
  field GetSubscriptionInput.profile in /tmp/.tmpR8RRgE/redisctl/crates/redisctl-mcp/src/tools/cloud.rs:63
  field GetTagsInput.profile in /tmp/.tmpR8RRgE/redisctl/crates/redisctl-mcp/src/tools/cloud.rs:760
  field ListRedisRulesInput.profile in /tmp/.tmpR8RRgE/redisctl/crates/redisctl-mcp/src/tools/cloud.rs:630
  field GetNodeInput.profile in /tmp/.tmpR8RRgE/redisctl/crates/redisctl-mcp/src/tools/enterprise.rs:379
  field GetDatabaseEndpointsInput.profile in /tmp/.tmpR8RRgE/redisctl/crates/redisctl-mcp/src/tools/enterprise.rs:1015
  field ListDatabaseAlertsInput.profile in /tmp/.tmpR8RRgE/redisctl/crates/redisctl-mcp/src/tools/enterprise.rs:539
  field GetNodeStatsInput.profile in /tmp/.tmpR8RRgE/redisctl/crates/redisctl-mcp/src/tools/enterprise.rs:702
  field GetNodeStatsInput.interval in /tmp/.tmpR8RRgE/redisctl/crates/redisctl-mcp/src/tools/enterprise.rs:707
  field GetNodeStatsInput.start_time in /tmp/.tmpR8RRgE/redisctl/crates/redisctl-mcp/src/tools/enterprise.rs:710
  field GetNodeStatsInput.end_time in /tmp/.tmpR8RRgE/redisctl/crates/redisctl-mcp/src/tools/enterprise.rs:713
  field ListDatabasesInput.profile in /tmp/.tmpR8RRgE/redisctl/crates/redisctl-mcp/src/tools/enterprise.rs:234
  field ListDatabasesInput.status_filter in /tmp/.tmpR8RRgE/redisctl/crates/redisctl-mcp/src/tools/enterprise.rs:240

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant CredentialSource:Profiles in /tmp/.tmpR8RRgE/redisctl/crates/redisctl-mcp/src/state.rs:22
  variant CredentialSource:Profiles in /tmp/.tmpR8RRgE/redisctl/crates/redisctl-mcp/src/state.rs:22

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_missing.ron

Failed in:
  variant CredentialSource::Profile, previously in file /tmp/.tmpzn5QlD/redisctl-mcp/src/state.rs:14
  variant CredentialSource::Profile, previously in file /tmp/.tmpzn5QlD/redisctl-mcp/src/state.rs:14
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `redisctl-core`

<blockquote>

## [0.1.0](https://github.com/redis-developer/redisctl/releases/tag/redisctl-core-v0.1.0) - 2026-02-25

### Added

- *(cli)* cargo-style diagnostic error formatting ([#671](https://github.com/redis-developer/redisctl/pull/671))
- *(cli)* infer platform from profile — make cloud/enterprise prefix optional ([#668](https://github.com/redis-developer/redisctl/pull/668))
- *(mcp)* add Cloud database flush operation ([#633](https://github.com/redis-developer/redisctl/pull/633))
- *(mcp)* add Enterprise database write operations ([#632](https://github.com/redis-developer/redisctl/pull/632))
- [**breaking**] implement Layer 2 architecture in redisctl-core ([#630](https://github.com/redis-developer/redisctl/pull/630))

### Other

- consolidate workspace dependencies ([#640](https://github.com/redis-developer/redisctl/pull/640))
</blockquote>

## `redisctl`

<blockquote>

## [0.8.0](https://github.com/redis-developer/redisctl/compare/redisctl-v0.7.7...redisctl-v0.8.0) - 2026-02-25

### Added

- *(cli)* support name@version syntax for --module flag ([#675](https://github.com/redis-developer/redisctl/pull/675))
- *(cli)* group `profile list` output by deployment type ([#674](https://github.com/redis-developer/redisctl/pull/674))
- *(cli)* cargo-style diagnostic error formatting ([#671](https://github.com/redis-developer/redisctl/pull/671))
- *(cli)* infer platform from profile — make cloud/enterprise prefix optional ([#668](https://github.com/redis-developer/redisctl/pull/668))
- *(mcp)* add Enterprise license, cluster, and certificate management tools ([#636](https://github.com/redis-developer/redisctl/pull/636))
- [**breaking**] implement Layer 2 architecture in redisctl-core ([#630](https://github.com/redis-developer/redisctl/pull/630))
- add 'db open' command to spawn redis-cli with profile credentials ([#627](https://github.com/redis-developer/redisctl/pull/627))
- add custom CA certificate support for Kubernetes deployments ([#624](https://github.com/redis-developer/redisctl/pull/624))
- [**breaking**] rewrite redisctl-mcp using tower-mcp framework ([#597](https://github.com/redis-developer/redisctl/pull/597))
- update to redis-enterprise 0.8 ([#600](https://github.com/redis-developer/redisctl/pull/600))
- update to redis-cloud 0.9 ([#599](https://github.com/redis-developer/redisctl/pull/599))
- add one-shot cost-report export command ([#595](https://github.com/redis-developer/redisctl/pull/595))

### Fixed

- handle rate limits (429) and processing-completed state in task polling ([#587](https://github.com/redis-developer/redisctl/pull/587))

### Other

- update examples for prefix-free CLI commands ([#673](https://github.com/redis-developer/redisctl/pull/673))
- document Docker as zero-install MCP option ([#647](https://github.com/redis-developer/redisctl/pull/647)) ([#659](https://github.com/redis-developer/redisctl/pull/659))
- consolidate workspace dependencies ([#640](https://github.com/redis-developer/redisctl/pull/640))
- [**breaking**] extract redis-cloud and redis-enterprise to standalone repos ([#596](https://github.com/redis-developer/redisctl/pull/596))
</blockquote>

## `redisctl-mcp`

<blockquote>

## [0.3.0](https://github.com/redis-developer/redisctl/compare/redisctl-mcp-v0.2.0...redisctl-mcp-v0.3.0) - 2026-02-25

### Added

- *(mcp)* auto-detect toolsets from config profiles ([#667](https://github.com/redis-developer/redisctl/pull/667))
- *(mcp)* modular router with feature flags and runtime toolset selection ([#656](https://github.com/redis-developer/redisctl/pull/656))
- *(mcp)* default to read-only mode ([#655](https://github.com/redis-developer/redisctl/pull/655))
- *(mcp)* add multi-profile support for Cloud tools ([#654](https://github.com/redis-developer/redisctl/pull/654))
- *(mcp)* add multi-profile support for Enterprise tools ([#651](https://github.com/redis-developer/redisctl/pull/651)) ([#652](https://github.com/redis-developer/redisctl/pull/652))
- *(mcp)* add create_subscription tool for Cloud ([#643](https://github.com/redis-developer/redisctl/pull/643))
- *(mcp)* add Enterprise license, cluster, and certificate management tools ([#636](https://github.com/redis-developer/redisctl/pull/636))
- *(mcp)* add Enterprise Redis ACL tools ([#635](https://github.com/redis-developer/redisctl/pull/635))
- *(mcp)* add Cloud certificate and Enterprise roles tools ([#634](https://github.com/redis-developer/redisctl/pull/634))
- *(mcp)* add Cloud database flush operation ([#633](https://github.com/redis-developer/redisctl/pull/633))
- *(mcp)* add Enterprise database write operations ([#632](https://github.com/redis-developer/redisctl/pull/632))
- [**breaking**] implement Layer 2 architecture in redisctl-core ([#630](https://github.com/redis-developer/redisctl/pull/630))
- add custom CA certificate support for Kubernetes deployments ([#624](https://github.com/redis-developer/redisctl/pull/624))
- *(mcp)* upgrade tower-mcp to 0.3.4 ([#622](https://github.com/redis-developer/redisctl/pull/622))
- add filtering support and new Redis diagnostic tools ([#621](https://github.com/redis-developer/redisctl/pull/621))
- add individual getter tools for Cloud and Enterprise resources ([#620](https://github.com/redis-developer/redisctl/pull/620))
- add MCP resources and prompts to redisctl-mcp ([#619](https://github.com/redis-developer/redisctl/pull/619))
- *(mcp)* add read-only tool filter using CapabilityFilter ([#618](https://github.com/redis-developer/redisctl/pull/618))
- *(mcp)* add historical stats, Cloud logs, debug info, and modules tools ([#617](https://github.com/redis-developer/redisctl/pull/617))
- *(mcp)* add Enterprise logs and aggregate stats tools ([#616](https://github.com/redis-developer/redisctl/pull/616))
- *(mcp)* add Enterprise license tools ([#615](https://github.com/redis-developer/redisctl/pull/615))
- *(mcp)* add mock testing support for cloud and enterprise tools ([#611](https://github.com/redis-developer/redisctl/pull/611))
- *(mcp)* add profile management tools ([#609](https://github.com/redis-developer/redisctl/pull/609))

### Fixed

- pre-release cleanup — cfg-gate warnings and stale doc versions ([#676](https://github.com/redis-developer/redisctl/pull/676))
- *(mcp)* wrap array results in JSON objects for structuredContent compliance ([#653](https://github.com/redis-developer/redisctl/pull/653))
- *(mcp)* normalize 'default' profile to use configured default ([#608](https://github.com/redis-developer/redisctl/pull/608))

### Other

- *(mcp)* bump tower-mcp to 0.5.0 ([#658](https://github.com/redis-developer/redisctl/pull/658))
- consolidate workspace dependencies ([#640](https://github.com/redis-developer/redisctl/pull/640))
- upgrade tower-mcp to 0.2.3 and use from_serialize() ([#607](https://github.com/redis-developer/redisctl/pull/607))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).