### PR TITLE
feat: update to redis-cloud 0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2649,14 +2649,16 @@ dependencies = [
 
 [[package]]
 name = "redis-cloud"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914e6574a6eefa8ce00761621ffd022972741001b1bab5604365d7c3a00a6556"
+checksum = "5c094414e6173191faba96c054f052e09d535c143223a41f9ed0adb24189332e"
 dependencies = [
  "anyhow",
+ "async-stream",
  "async-trait",
  "base64 0.22.1",
  "chrono",
+ "futures-core",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ redis = { version = "0.27", features = ["tokio-comp", "tokio-rustls-comp", "conn
 redisctl-config = { path = "crates/redisctl-config" }
 
 # External crates (from crates.io)
-redis-cloud = "0.8"
+redis-cloud = "0.9"
 redis-enterprise = "0.7"
 
 # Windows CI workaround - ensure these are available in workspace

--- a/crates/redisctl-mcp/src/cloud_tools.rs
+++ b/crates/redisctl-mcp/src/cloud_tools.rs
@@ -192,7 +192,6 @@ impl CloudTools {
             payment_method: None,
             payment_method_id: payment_method_id.map(|id| id as i32),
             command_type: None,
-            extra: Value::Null,
         };
         let result = handler
             .create(&request)

--- a/crates/redisctl/src/commands/cloud/connectivity/tgw.rs
+++ b/crates/redisctl/src/commands/cloud/connectivity/tgw.rs
@@ -13,7 +13,6 @@ use crate::error::Result as CliResult;
 use anyhow::Context;
 use redis_cloud::CloudClient;
 use redis_cloud::connectivity::transit_gateway::{TgwAttachmentRequest, TransitGatewayHandler};
-use serde_json::Value;
 
 /// Parameters for TGW attachment create/update operations
 #[derive(Debug, Default)]
@@ -308,7 +307,6 @@ fn build_tgw_attachment_request(
         aws_account_id: attachment_params.aws_account_id.clone(),
         tgw_id: attachment_params.tgw_id.clone(),
         cidrs,
-        extra: Value::Object(serde_json::Map::new()),
     })
 }
 

--- a/crates/redisctl/src/commands/cloud/fixed_database.rs
+++ b/crates/redisctl/src/commands/cloud/fixed_database.rs
@@ -313,7 +313,6 @@ pub async fn handle_fixed_database_command(
                 database_id: Some(database_id),
                 adhoc_backup_path: None,
                 command_type: None,
-                extra: serde_json::Value::Null,
             };
 
             let result = handler
@@ -497,7 +496,6 @@ pub async fn handle_fixed_database_command(
                 command_type: None,
                 key: key.clone(),
                 value: value.clone(),
-                extra: serde_json::Value::Null,
             };
 
             let result = handler
@@ -585,7 +583,6 @@ pub async fn handle_fixed_database_command(
                 command_type: None,
                 key: Some(key.clone()),
                 value: value.clone(),
-                extra: serde_json::Value::Null,
             };
 
             let result = handler


### PR DESCRIPTION
## Summary

- Update redis-cloud dependency from 0.8 to 0.9
- Remove deprecated `extra` field from all request types (5 locations)
- Refactor private_link.rs to use typed request structs with `PrincipalType` enum
- Clean up unused imports

## Changes

### Removed `extra` field from:
- `FixedSubscriptionCreateRequest` in cloud_tools.rs
- `FixedDatabaseBackupRequest`, `DatabaseTagCreateRequest`, `DatabaseTagUpdateRequest` in fixed_database.rs
- `TgwAttachmentRequest` in tgw.rs

### Refactored private_link.rs:
- Now uses typed `PrivateLinkCreateRequest`, `PrivateLinkAddPrincipalRequest`, `PrivateLinkRemovePrincipalRequest`
- Added `parse_principal_type()` to convert CLI strings to `PrincipalType` enum
- Supports: `aws-account`, `organization`, `organization-unit`, `iam-role`, `iam-user`, `service-principal`

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib --all-features` (69 + 17 + 5 tests pass)
- [x] `cargo test --test '*' --all-features` (363 + 29 + 42 + 5 tests pass)

Closes #598