### PR TITLE
feat: update to redis-enterprise 0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2673,9 +2673,9 @@ dependencies = [
 
 [[package]]
 name = "redis-enterprise"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b08073b6d4d2d80b6a3f65081f7fe2eb04a66938c5ee6cdf5cf043e00a397e"
+checksum = "4bb6f23898eccceae21caf7fcedc4efd43785adb5e4077785d21d3586897e1c6"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ redisctl-config = { path = "crates/redisctl-config" }
 
 # External crates (from crates.io)
 redis-cloud = "0.9"
-redis-enterprise = "0.7"
+redis-enterprise = "0.8"
 
 # Windows CI workaround - ensure these are available in workspace
 shellexpand = "3.1"


### PR DESCRIPTION
## Summary

- Update redis-enterprise dependency from 0.7 to 0.8
- Remove usage of deprecated `extra` field from User and RoleInfo types

## Changes

### rbac_impl.rs
- `user.extra.get("role_uids")` -> `user.role_uids` (now a proper `Option<Vec<u32>>` field)
- `role.extra.get("permissions")` -> use typed fields: `management`, `data_access`, `bdb_roles`, `cluster_roles`
- Cleaner filter using `is_some_and()` for checking role membership

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib --all-features` (91 tests pass)
- [x] `cargo test --test '*' --all-features` (443 tests pass)