### PR TITLE
chore: upgrade tower-mcp to 0.2.3 and use from_serialize()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,7 +548,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -950,7 +950,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1097,7 +1097,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1553,7 +1553,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -1754,7 +1754,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2572,7 +2572,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -2609,7 +2609,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -3090,7 +3090,7 @@ dependencies = [
  "errno 0.3.14",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3691,7 +3691,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4035,9 +4035,9 @@ checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-mcp"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fccdd2600ed5269efd91e1d33b0a8ce05e3f5f605486b616959a369c879f003f"
+checksum = "e3e6a7d8698791df9a41e21ae968ca4fb3c14fe100dc0400d33afbd3fdc7d339"
 dependencies = [
  "async-trait",
  "axum",
@@ -4600,7 +4600,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/crates/redisctl-mcp/Cargo.toml
+++ b/crates/redisctl-mcp/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 # MCP framework
-tower-mcp = { version = "0.2", features = ["http", "oauth"] }
+tower-mcp = { version = "0.2.3", features = ["http", "oauth"] }
 schemars = "1.2"
 
 # Internal crates

--- a/crates/redisctl-mcp/src/tools/cloud.rs
+++ b/crates/redisctl-mcp/src/tools/cloud.rs
@@ -32,10 +32,7 @@ pub fn list_subscriptions(state: Arc<AppState>) -> Tool {
                 .await
                 .map_err(|e| ToolError::new(format!("Failed to list subscriptions: {}", e)))?;
 
-            let output = serde_json::to_string_pretty(&account_subs)
-                .map_err(|e| ToolError::new(format!("Failed to serialize: {}", e)))?;
-
-            Ok(CallToolResult::text(output))
+            CallToolResult::from_serialize(&account_subs)
         })
         .build()
         .expect("valid tool")
@@ -66,10 +63,7 @@ pub fn get_subscription(state: Arc<AppState>) -> Tool {
                 .await
                 .map_err(|e| ToolError::new(format!("Failed to get subscription: {}", e)))?;
 
-            let output = serde_json::to_string_pretty(&subscription)
-                .map_err(|e| ToolError::new(format!("Failed to serialize: {}", e)))?;
-
-            Ok(CallToolResult::text(output))
+            CallToolResult::from_serialize(&subscription)
         })
         .build()
         .expect("valid tool")
@@ -102,10 +96,7 @@ pub fn list_databases(state: Arc<AppState>) -> Tool {
                 .await
                 .map_err(|e| ToolError::new(format!("Failed to list databases: {}", e)))?;
 
-            let output = serde_json::to_string_pretty(&databases)
-                .map_err(|e| ToolError::new(format!("Failed to serialize: {}", e)))?;
-
-            Ok(CallToolResult::text(output))
+            CallToolResult::from_serialize(&databases)
         })
         .build()
         .expect("valid tool")
@@ -138,10 +129,7 @@ pub fn get_database(state: Arc<AppState>) -> Tool {
                 .await
                 .map_err(|e| ToolError::new(format!("Failed to get database: {}", e)))?;
 
-            let output = serde_json::to_string_pretty(&database)
-                .map_err(|e| ToolError::new(format!("Failed to serialize: {}", e)))?;
-
-            Ok(CallToolResult::text(output))
+            CallToolResult::from_serialize(&database)
         })
         .build()
         .expect("valid tool")
@@ -173,10 +161,7 @@ pub fn get_account(state: Arc<AppState>) -> Tool {
                 .await
                 .map_err(|e| ToolError::new(format!("Failed to get account: {}", e)))?;
 
-            let output = serde_json::to_string_pretty(&account)
-                .map_err(|e| ToolError::new(format!("Failed to serialize: {}", e)))?;
-
-            Ok(CallToolResult::text(output))
+            CallToolResult::from_serialize(&account)
         })
         .build()
         .expect("valid tool")
@@ -210,10 +195,7 @@ pub fn get_regions(state: Arc<AppState>) -> Tool {
                 .await
                 .map_err(|e| ToolError::new(format!("Failed to get regions: {}", e)))?;
 
-            let output = serde_json::to_string_pretty(&regions)
-                .map_err(|e| ToolError::new(format!("Failed to serialize: {}", e)))?;
-
-            Ok(CallToolResult::text(output))
+            CallToolResult::from_serialize(&regions)
         })
         .build()
         .expect("valid tool")
@@ -243,10 +225,7 @@ pub fn get_modules(state: Arc<AppState>) -> Tool {
                 .await
                 .map_err(|e| ToolError::new(format!("Failed to get modules: {}", e)))?;
 
-            let output = serde_json::to_string_pretty(&modules)
-                .map_err(|e| ToolError::new(format!("Failed to serialize: {}", e)))?;
-
-            Ok(CallToolResult::text(output))
+            CallToolResult::from_serialize(&modules)
         })
         .build()
         .expect("valid tool")
@@ -278,10 +257,7 @@ pub fn list_tasks(state: Arc<AppState>) -> Tool {
                 .await
                 .map_err(|e| ToolError::new(format!("Failed to list tasks: {}", e)))?;
 
-            let output = serde_json::to_string_pretty(&tasks)
-                .map_err(|e| ToolError::new(format!("Failed to serialize: {}", e)))?;
-
-            Ok(CallToolResult::text(output))
+            CallToolResult::from_serialize(&tasks)
         })
         .build()
         .expect("valid tool")
@@ -312,10 +288,7 @@ pub fn get_task(state: Arc<AppState>) -> Tool {
                 .await
                 .map_err(|e| ToolError::new(format!("Failed to get task: {}", e)))?;
 
-            let output = serde_json::to_string_pretty(&task)
-                .map_err(|e| ToolError::new(format!("Failed to serialize: {}", e)))?;
-
-            Ok(CallToolResult::text(output))
+            CallToolResult::from_serialize(&task)
         })
         .build()
         .expect("valid tool")
@@ -349,10 +322,7 @@ pub fn list_account_users(state: Arc<AppState>) -> Tool {
                 .await
                 .map_err(|e| ToolError::new(format!("Failed to list users: {}", e)))?;
 
-            let output = serde_json::to_string_pretty(&users)
-                .map_err(|e| ToolError::new(format!("Failed to serialize: {}", e)))?;
-
-            Ok(CallToolResult::text(output))
+            CallToolResult::from_serialize(&users)
         })
         .build()
         .expect("valid tool")
@@ -384,10 +354,7 @@ pub fn list_acl_users(state: Arc<AppState>) -> Tool {
                 .await
                 .map_err(|e| ToolError::new(format!("Failed to list ACL users: {}", e)))?;
 
-            let output = serde_json::to_string_pretty(&users)
-                .map_err(|e| ToolError::new(format!("Failed to serialize: {}", e)))?;
-
-            Ok(CallToolResult::text(output))
+            CallToolResult::from_serialize(&users)
         })
         .build()
         .expect("valid tool")
@@ -415,10 +382,7 @@ pub fn list_acl_roles(state: Arc<AppState>) -> Tool {
                 .await
                 .map_err(|e| ToolError::new(format!("Failed to list ACL roles: {}", e)))?;
 
-            let output = serde_json::to_string_pretty(&roles)
-                .map_err(|e| ToolError::new(format!("Failed to serialize: {}", e)))?;
-
-            Ok(CallToolResult::text(output))
+            CallToolResult::from_serialize(&roles)
         })
         .build()
         .expect("valid tool")
@@ -446,10 +410,7 @@ pub fn list_redis_rules(state: Arc<AppState>) -> Tool {
                 .await
                 .map_err(|e| ToolError::new(format!("Failed to list Redis rules: {}", e)))?;
 
-            let output = serde_json::to_string_pretty(&rules)
-                .map_err(|e| ToolError::new(format!("Failed to serialize: {}", e)))?;
-
-            Ok(CallToolResult::text(output))
+            CallToolResult::from_serialize(&rules)
         })
         .build()
         .expect("valid tool")
@@ -493,10 +454,7 @@ pub fn get_backup_status(state: Arc<AppState>) -> Tool {
                 .await
                 .map_err(|e| ToolError::new(format!("Failed to get backup status: {}", e)))?;
 
-            let output = serde_json::to_string_pretty(&status)
-                .map_err(|e| ToolError::new(format!("Failed to serialize: {}", e)))?;
-
-            Ok(CallToolResult::text(output))
+            CallToolResult::from_serialize(&status)
         })
         .build()
         .expect("valid tool")
@@ -534,10 +492,7 @@ pub fn get_slow_log(state: Arc<AppState>) -> Tool {
                 .await
                 .map_err(|e| ToolError::new(format!("Failed to get slow log: {}", e)))?;
 
-            let output = serde_json::to_string_pretty(&log)
-                .map_err(|e| ToolError::new(format!("Failed to serialize: {}", e)))?;
-
-            Ok(CallToolResult::text(output))
+            CallToolResult::from_serialize(&log)
         })
         .build()
         .expect("valid tool")
@@ -570,10 +525,7 @@ pub fn get_tags(state: Arc<AppState>) -> Tool {
                 .await
                 .map_err(|e| ToolError::new(format!("Failed to get tags: {}", e)))?;
 
-            let output = serde_json::to_string_pretty(&tags)
-                .map_err(|e| ToolError::new(format!("Failed to serialize: {}", e)))?;
-
-            Ok(CallToolResult::text(output))
+            CallToolResult::from_serialize(&tags)
         })
         .build()
         .expect("valid tool")

--- a/crates/redisctl-mcp/src/tools/enterprise.rs
+++ b/crates/redisctl-mcp/src/tools/enterprise.rs
@@ -39,10 +39,7 @@ pub fn get_cluster(state: Arc<AppState>) -> Tool {
                 .await
                 .map_err(|e| ToolError::new(format!("Failed to get cluster info: {}", e)))?;
 
-            let output = serde_json::to_string_pretty(&cluster)
-                .map_err(|e| ToolError::new(format!("Failed to serialize: {}", e)))?;
-
-            Ok(CallToolResult::text(output))
+            CallToolResult::from_serialize(&cluster)
         })
         .build()
         .expect("valid tool")
@@ -130,10 +127,7 @@ pub fn get_database(state: Arc<AppState>) -> Tool {
                 .await
                 .map_err(|e| ToolError::new(format!("Failed to get database: {}", e)))?;
 
-            let output = serde_json::to_string_pretty(&database)
-                .map_err(|e| ToolError::new(format!("Failed to serialize: {}", e)))?;
-
-            Ok(CallToolResult::text(output))
+            CallToolResult::from_serialize(&database)
         })
         .build()
         .expect("valid tool")
@@ -212,10 +206,7 @@ pub fn get_node(state: Arc<AppState>) -> Tool {
                 .await
                 .map_err(|e| ToolError::new(format!("Failed to get node: {}", e)))?;
 
-            let output = serde_json::to_string_pretty(&node)
-                .map_err(|e| ToolError::new(format!("Failed to serialize: {}", e)))?;
-
-            Ok(CallToolResult::text(output))
+            CallToolResult::from_serialize(&node)
         })
         .build()
         .expect("valid tool")
@@ -294,10 +285,7 @@ pub fn get_user(state: Arc<AppState>) -> Tool {
                 .await
                 .map_err(|e| ToolError::new(format!("Failed to get user: {}", e)))?;
 
-            let output = serde_json::to_string_pretty(&user)
-                .map_err(|e| ToolError::new(format!("Failed to serialize: {}", e)))?;
-
-            Ok(CallToolResult::text(output))
+            CallToolResult::from_serialize(&user)
         })
         .build()
         .expect("valid tool")
@@ -329,10 +317,7 @@ pub fn list_alerts(state: Arc<AppState>) -> Tool {
                 .await
                 .map_err(|e| ToolError::new(format!("Failed to list alerts: {}", e)))?;
 
-            let output = serde_json::to_string_pretty(&alerts)
-                .map_err(|e| ToolError::new(format!("Failed to serialize: {}", e)))?;
-
-            Ok(CallToolResult::text(output))
+            CallToolResult::from_serialize(&alerts)
         })
         .build()
         .expect("valid tool")
@@ -363,10 +348,7 @@ pub fn list_database_alerts(state: Arc<AppState>) -> Tool {
                 .await
                 .map_err(|e| ToolError::new(format!("Failed to list database alerts: {}", e)))?;
 
-            let output = serde_json::to_string_pretty(&alerts)
-                .map_err(|e| ToolError::new(format!("Failed to serialize: {}", e)))?;
-
-            Ok(CallToolResult::text(output))
+            CallToolResult::from_serialize(&alerts)
         })
         .build()
         .expect("valid tool")
@@ -398,10 +380,7 @@ pub fn get_cluster_stats(state: Arc<AppState>) -> Tool {
                 .await
                 .map_err(|e| ToolError::new(format!("Failed to get cluster stats: {}", e)))?;
 
-            let output = serde_json::to_string_pretty(&stats)
-                .map_err(|e| ToolError::new(format!("Failed to serialize: {}", e)))?;
-
-            Ok(CallToolResult::text(output))
+            CallToolResult::from_serialize(&stats)
         })
         .build()
         .expect("valid tool")
@@ -434,10 +413,7 @@ pub fn get_database_stats(state: Arc<AppState>) -> Tool {
                 .await
                 .map_err(|e| ToolError::new(format!("Failed to get database stats: {}", e)))?;
 
-            let output = serde_json::to_string_pretty(&stats)
-                .map_err(|e| ToolError::new(format!("Failed to serialize: {}", e)))?;
-
-            Ok(CallToolResult::text(output))
+            CallToolResult::from_serialize(&stats)
         })
         .build()
         .expect("valid tool")
@@ -468,10 +444,7 @@ pub fn get_node_stats(state: Arc<AppState>) -> Tool {
                 .await
                 .map_err(|e| ToolError::new(format!("Failed to get node stats: {}", e)))?;
 
-            let output = serde_json::to_string_pretty(&stats)
-                .map_err(|e| ToolError::new(format!("Failed to serialize: {}", e)))?;
-
-            Ok(CallToolResult::text(output))
+            CallToolResult::from_serialize(&stats)
         })
         .build()
         .expect("valid tool")
@@ -516,10 +489,7 @@ pub fn list_shards(state: Arc<AppState>) -> Tool {
                     .map_err(|e| ToolError::new(format!("Failed to list shards: {}", e)))?
             };
 
-            let output = serde_json::to_string_pretty(&shards)
-                .map_err(|e| ToolError::new(format!("Failed to serialize: {}", e)))?;
-
-            Ok(CallToolResult::text(output))
+            CallToolResult::from_serialize(&shards)
         })
         .build()
         .expect("valid tool")
@@ -557,10 +527,7 @@ pub fn get_database_endpoints(state: Arc<AppState>) -> Tool {
                     .await
                     .map_err(|e| ToolError::new(format!("Failed to get endpoints: {}", e)))?;
 
-                let output = serde_json::to_string_pretty(&endpoints)
-                    .map_err(|e| ToolError::new(format!("Failed to serialize: {}", e)))?;
-
-                Ok(CallToolResult::text(output))
+                CallToolResult::from_serialize(&endpoints)
             },
         )
         .build()


### PR DESCRIPTION
## Summary
- Upgrade tower-mcp from 0.2 to 0.2.3
- Refactor tools to use `CallToolResult::from_serialize()` instead of manual serialization
- Reduces boilerplate code (net -81 lines)

## Changes
- **cloud.rs**: 16 tools refactored to use `from_serialize()`
- **enterprise.rs**: 11 tools refactored to use `from_serialize()`
- Preserved custom text output for list tools that return human-readable summaries (list_databases, list_nodes, list_users)

Closes #605
Closes #606