### PR TITLE
fix(mcp): normalize 'default' profile to use configured default

### DIFF
--- a/crates/redisctl-mcp/src/lib.rs
+++ b/crates/redisctl-mcp/src/lib.rs
@@ -114,6 +114,55 @@ mod tests {
     }
 
     #[test]
+    fn test_app_state_default_profile_normalized() {
+        // Passing "default" as profile name should be treated as None (use configured default)
+        let state = AppState::new(
+            CredentialSource::Profile(Some("default".to_string())),
+            true,
+            None,
+        )
+        .unwrap();
+
+        // Verify the credential source was normalized to None
+        match &state.credential_source {
+            CredentialSource::Profile(None) => {} // expected
+            other => panic!("Expected Profile(None), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_app_state_default_profile_case_insensitive() {
+        // "DEFAULT" should also be normalized to None
+        let state = AppState::new(
+            CredentialSource::Profile(Some("DEFAULT".to_string())),
+            true,
+            None,
+        )
+        .unwrap();
+
+        match &state.credential_source {
+            CredentialSource::Profile(None) => {} // expected
+            other => panic!("Expected Profile(None), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_app_state_explicit_profile_preserved() {
+        // Non-"default" profile names should be preserved
+        let state = AppState::new(
+            CredentialSource::Profile(Some("my-profile".to_string())),
+            true,
+            None,
+        )
+        .unwrap();
+
+        match &state.credential_source {
+            CredentialSource::Profile(Some(name)) if name == "my-profile" => {} // expected
+            other => panic!("Expected Profile(Some(\"my-profile\")), got {:?}", other),
+        }
+    }
+
+    #[test]
     fn test_cloud_tools_build() {
         let state = Arc::new(AppState::new(CredentialSource::Profile(None), true, None).unwrap());
 

--- a/crates/redisctl-mcp/src/state.rs
+++ b/crates/redisctl-mcp/src/state.rs
@@ -46,6 +46,14 @@ impl AppState {
         read_only: bool,
         database_url: Option<String>,
     ) -> Result<Self> {
+        // Normalize credential source: treat "default" as None (use configured default)
+        let credential_source = match credential_source {
+            CredentialSource::Profile(Some(ref name)) if name.eq_ignore_ascii_case("default") => {
+                CredentialSource::Profile(None)
+            }
+            other => other,
+        };
+
         // Load config if using profile-based auth
         let config = match &credential_source {
             CredentialSource::Profile(_) => Config::load().ok(),


### PR DESCRIPTION
## Summary
- Treat `--profile default` as meaning "use the configured default profile" rather than looking for a profile literally named "default"
- Normalization is case-insensitive (`DEFAULT`, `Default`, etc. all work)

## Problem
Users configuring their MCP client (e.g., Claude Desktop) often set `--profile default` expecting it to use their configured default profile. Instead, the server looked for a profile literally named "default", resulting in:

```
Error: Cloud profile 'default' not found
```

## Solution
In `AppState::new()`, normalize `CredentialSource::Profile(Some("default"))` to `CredentialSource::Profile(None)`, which triggers the standard default profile resolution logic:
1. Check for `default_cloud` / `default_enterprise` in config
2. Fall back to first profile of matching type

## Tests
Added 3 new tests:
- `test_app_state_default_profile_normalized` - "default" becomes None
- `test_app_state_default_profile_case_insensitive` - "DEFAULT" also works
- `test_app_state_explicit_profile_preserved` - other names preserved

Fixes #537