### PR TITLE
feat(mcp): add profile management tools

### DIFF
--- a/crates/redisctl-mcp/src/lib.rs
+++ b/crates/redisctl-mcp/src/lib.rs
@@ -239,6 +239,44 @@ mod tests {
     }
 
     #[test]
+    fn test_profile_tools_build() {
+        let state = Arc::new(AppState::new(CredentialSource::Profile(None), true, None).unwrap());
+
+        // Verify all profile tools build successfully
+        // Read operations
+        let _ = tools::profile::list_profiles(state.clone());
+        let _ = tools::profile::show_profile(state.clone());
+        let _ = tools::profile::config_path(state.clone());
+        let _ = tools::profile::validate_config(state.clone());
+        // Write operations
+        let _ = tools::profile::set_default_cloud(state.clone());
+        let _ = tools::profile::set_default_enterprise(state.clone());
+        let _ = tools::profile::delete_profile(state.clone());
+    }
+
+    #[test]
+    fn test_profile_input_deserialization() {
+        // ListProfilesInput
+        let input: tools::profile::ListProfilesInput = serde_json::from_str("{}").unwrap();
+        let _ = input;
+
+        // ShowProfileInput
+        let input: tools::profile::ShowProfileInput =
+            serde_json::from_str(r#"{"name": "my-profile"}"#).unwrap();
+        assert_eq!(input.name, "my-profile");
+
+        // SetDefaultCloudInput
+        let input: tools::profile::SetDefaultCloudInput =
+            serde_json::from_str(r#"{"name": "cloud-profile"}"#).unwrap();
+        assert_eq!(input.name, "cloud-profile");
+
+        // DeleteProfileInput
+        let input: tools::profile::DeleteProfileInput =
+            serde_json::from_str(r#"{"name": "old-profile"}"#).unwrap();
+        assert_eq!(input.name, "old-profile");
+    }
+
+    #[test]
     fn test_cloud_input_deserialization() {
         // ListSubscriptionsInput
         let input: tools::cloud::ListSubscriptionsInput = serde_json::from_str("{}").unwrap();

--- a/crates/redisctl-mcp/src/main.rs
+++ b/crates/redisctl-mcp/src/main.rs
@@ -219,6 +219,17 @@ Redis Enterprise clusters and databases, and direct Redis database operations.
 - redis_smembers: Get set members
 - redis_zrange: Get sorted set range
 
+### Profile Management - Read
+- profile_list: List all configured profiles
+- profile_show: Show profile details (credentials masked)
+- profile_path: Show configuration file path
+- profile_validate: Validate configuration file
+
+### Profile Management - Write (requires --read-only=false)
+- profile_set_default_cloud: Set default Cloud profile
+- profile_set_default_enterprise: Set default Enterprise profile
+- profile_delete: Delete a profile
+
 ## Authentication
 
 In stdio mode, credentials are resolved from redisctl profiles.
@@ -282,7 +293,16 @@ In HTTP mode with OAuth, credentials can be passed via JWT claims.
         .tool(tools::redis::hgetall(state.clone()))
         .tool(tools::redis::lrange(state.clone()))
         .tool(tools::redis::smembers(state.clone()))
-        .tool(tools::redis::zrange(state.clone()));
+        .tool(tools::redis::zrange(state.clone()))
+        // Profile Management - Read
+        .tool(tools::profile::list_profiles(state.clone()))
+        .tool(tools::profile::show_profile(state.clone()))
+        .tool(tools::profile::config_path(state.clone()))
+        .tool(tools::profile::validate_config(state.clone()))
+        // Profile Management - Write
+        .tool(tools::profile::set_default_cloud(state.clone()))
+        .tool(tools::profile::set_default_enterprise(state.clone()))
+        .tool(tools::profile::delete_profile(state.clone()));
 
     Ok(router)
 }

--- a/crates/redisctl-mcp/src/tools/mod.rs
+++ b/crates/redisctl-mcp/src/tools/mod.rs
@@ -2,4 +2,5 @@
 
 pub mod cloud;
 pub mod enterprise;
+pub mod profile;
 pub mod redis;

--- a/crates/redisctl-mcp/src/tools/profile.rs
+++ b/crates/redisctl-mcp/src/tools/profile.rs
@@ -1,0 +1,536 @@
+//! Profile management tools for redisctl configuration
+
+use std::sync::Arc;
+
+use redisctl_config::{Config, DeploymentType, ProfileCredentials};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use tower_mcp::{CallToolResult, Error as McpError, Tool, ToolBuilder, ToolError};
+
+use crate::state::AppState;
+
+// ============================================================================
+// Read Operations
+// ============================================================================
+
+/// Input for listing profiles (no required parameters)
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ListProfilesInput {}
+
+/// Profile summary for list output
+#[derive(Debug, Serialize)]
+struct ProfileSummary {
+    name: String,
+    deployment_type: String,
+    is_default: bool,
+}
+
+/// Build the profile_list tool
+pub fn list_profiles(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("profile_list")
+        .description("List all configured redisctl profiles with their types and default status")
+        .read_only()
+        .idempotent()
+        .handler_with_state(state, |_state, _input: ListProfilesInput| async move {
+            let config = Config::load()
+                .map_err(|e| ToolError::new(format!("Failed to load config: {}", e)))?;
+
+            let profiles: Vec<ProfileSummary> = config
+                .list_profiles()
+                .iter()
+                .map(|(name, profile)| {
+                    let deployment_type = match profile.deployment_type {
+                        DeploymentType::Cloud => "cloud",
+                        DeploymentType::Enterprise => "enterprise",
+                        DeploymentType::Database => "database",
+                    };
+
+                    let is_default = match profile.deployment_type {
+                        DeploymentType::Cloud => config.default_cloud.as_ref() == Some(name),
+                        DeploymentType::Enterprise => {
+                            config.default_enterprise.as_ref() == Some(name)
+                        }
+                        DeploymentType::Database => config.default_database.as_ref() == Some(name),
+                    };
+
+                    ProfileSummary {
+                        name: (*name).clone(),
+                        deployment_type: deployment_type.to_string(),
+                        is_default,
+                    }
+                })
+                .collect();
+
+            if profiles.is_empty() {
+                return Ok(CallToolResult::text(
+                    "No profiles configured. Use 'redisctl profile set' to create one.",
+                ));
+            }
+
+            // Format as a nice table-like output
+            let mut output = format!("Found {} profile(s):\n\n", profiles.len());
+            for p in &profiles {
+                let default_marker = if p.is_default { " (default)" } else { "" };
+                output.push_str(&format!(
+                    "- {}: {}{}\n",
+                    p.name, p.deployment_type, default_marker
+                ));
+            }
+
+            Ok(CallToolResult::text(output))
+        })
+        .build()
+        .expect("valid tool")
+}
+
+/// Input for showing a specific profile
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ShowProfileInput {
+    /// Name of the profile to show
+    pub name: String,
+}
+
+/// Masked profile details for output
+#[derive(Debug, Serialize)]
+struct MaskedProfileDetails {
+    name: String,
+    deployment_type: String,
+    is_default: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cloud: Option<MaskedCloudCredentials>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    enterprise: Option<MaskedEnterpriseCredentials>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    database: Option<MaskedDatabaseCredentials>,
+}
+
+#[derive(Debug, Serialize)]
+struct MaskedCloudCredentials {
+    api_key: String,
+    api_secret: String,
+    api_url: String,
+}
+
+#[derive(Debug, Serialize)]
+struct MaskedEnterpriseCredentials {
+    url: String,
+    username: String,
+    password: String,
+    insecure: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct MaskedDatabaseCredentials {
+    host: String,
+    port: u16,
+    password: String,
+    tls: bool,
+    username: String,
+    database: u8,
+}
+
+/// Mask a credential value, showing only first/last chars
+fn mask_credential(value: &str) -> String {
+    if value.is_empty() {
+        return "(not set)".to_string();
+    }
+    if value.starts_with("keyring:") || value.starts_with("${") {
+        // Show reference type but not the actual reference
+        if value.starts_with("keyring:") {
+            return "(keyring)".to_string();
+        }
+        return "(env var)".to_string();
+    }
+    if value.len() <= 8 {
+        return "****".to_string();
+    }
+    format!("{}...{}", &value[..2], &value[value.len() - 2..])
+}
+
+/// Build the profile_show tool
+pub fn show_profile(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("profile_show")
+        .description("Show details of a specific profile. Credentials are masked for security.")
+        .read_only()
+        .idempotent()
+        .handler_with_state(state, |_state, input: ShowProfileInput| async move {
+            let config = Config::load()
+                .map_err(|e| ToolError::new(format!("Failed to load config: {}", e)))?;
+
+            let profile = config
+                .profiles
+                .get(&input.name)
+                .ok_or_else(|| ToolError::new(format!("Profile '{}' not found", input.name)))?;
+
+            let deployment_type = match profile.deployment_type {
+                DeploymentType::Cloud => "cloud",
+                DeploymentType::Enterprise => "enterprise",
+                DeploymentType::Database => "database",
+            };
+
+            let is_default = match profile.deployment_type {
+                DeploymentType::Cloud => config.default_cloud.as_ref() == Some(&input.name),
+                DeploymentType::Enterprise => {
+                    config.default_enterprise.as_ref() == Some(&input.name)
+                }
+                DeploymentType::Database => config.default_database.as_ref() == Some(&input.name),
+            };
+
+            let (cloud, enterprise, database) = match &profile.credentials {
+                ProfileCredentials::Cloud {
+                    api_key,
+                    api_secret,
+                    api_url,
+                } => (
+                    Some(MaskedCloudCredentials {
+                        api_key: mask_credential(api_key),
+                        api_secret: mask_credential(api_secret),
+                        api_url: api_url.clone(),
+                    }),
+                    None,
+                    None,
+                ),
+                ProfileCredentials::Enterprise {
+                    url,
+                    username,
+                    password,
+                    insecure,
+                } => (
+                    None,
+                    Some(MaskedEnterpriseCredentials {
+                        url: url.clone(),
+                        username: username.clone(),
+                        password: password
+                            .as_ref()
+                            .map(|p| mask_credential(p))
+                            .unwrap_or_else(|| "(not set)".to_string()),
+                        insecure: *insecure,
+                    }),
+                    None,
+                ),
+                ProfileCredentials::Database {
+                    host,
+                    port,
+                    password,
+                    tls,
+                    username,
+                    database,
+                } => (
+                    None,
+                    None,
+                    Some(MaskedDatabaseCredentials {
+                        host: host.clone(),
+                        port: *port,
+                        password: password
+                            .as_ref()
+                            .map(|p| mask_credential(p))
+                            .unwrap_or_else(|| "(not set)".to_string()),
+                        tls: *tls,
+                        username: username.clone(),
+                        database: *database,
+                    }),
+                ),
+            };
+
+            let details = MaskedProfileDetails {
+                name: input.name,
+                deployment_type: deployment_type.to_string(),
+                is_default,
+                cloud,
+                enterprise,
+                database,
+            };
+
+            CallToolResult::from_serialize(&details)
+        })
+        .build()
+        .expect("valid tool")
+}
+
+/// Input for getting config path (no required parameters)
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ConfigPathInput {}
+
+/// Build the profile_path tool
+pub fn config_path(_state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("profile_path")
+        .description("Show the path to the redisctl configuration file")
+        .read_only()
+        .idempotent()
+        .handler(|_input: ConfigPathInput| async move {
+            let path = Config::config_path()
+                .map_err(|e| ToolError::new(format!("Failed to get config path: {}", e)))?;
+
+            let exists = path.exists();
+            let output = format!(
+                "Configuration file: {}\nExists: {}",
+                path.display(),
+                if exists { "yes" } else { "no" }
+            );
+
+            Ok(CallToolResult::text(output))
+        })
+        .build()
+        .expect("valid tool")
+}
+
+/// Input for validating config (no required parameters)
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ValidateConfigInput {}
+
+/// Build the profile_validate tool
+pub fn validate_config(_state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("profile_validate")
+        .description("Validate the redisctl configuration file and check for common issues")
+        .read_only()
+        .idempotent()
+        .handler(|_input: ValidateConfigInput| async move {
+            let path = Config::config_path()
+                .map_err(|e| ToolError::new(format!("Failed to get config path: {}", e)))?;
+
+            if !path.exists() {
+                return Ok(CallToolResult::text(format!(
+                    "Configuration file not found at: {}\n\nThis is normal if you haven't created any profiles yet.\nUse 'redisctl profile set' to create a profile.",
+                    path.display()
+                )));
+            }
+
+            // Try to load the config
+            let config = match Config::load() {
+                Ok(c) => c,
+                Err(e) => {
+                    return Ok(CallToolResult::text(format!(
+                        "Configuration file is INVALID:\n\nPath: {}\nError: {}",
+                        path.display(),
+                        e
+                    )));
+                }
+            };
+
+            // Check for issues
+            let mut issues: Vec<String> = Vec::new();
+            let mut warnings: Vec<String> = Vec::new();
+
+            // Check if defaults reference valid profiles
+            if let Some(ref default) = config.default_cloud
+                && !config.profiles.contains_key(default)
+            {
+                issues.push(format!(
+                    "default_cloud '{}' references non-existent profile",
+                    default
+                ));
+            }
+            if let Some(ref default) = config.default_enterprise
+                && !config.profiles.contains_key(default)
+            {
+                issues.push(format!(
+                    "default_enterprise '{}' references non-existent profile",
+                    default
+                ));
+            }
+            if let Some(ref default) = config.default_database
+                && !config.profiles.contains_key(default)
+            {
+                issues.push(format!(
+                    "default_database '{}' references non-existent profile",
+                    default
+                ));
+            }
+
+            // Check for profiles without passwords (warning only)
+            for (name, profile) in &config.profiles {
+                if !profile.has_password() {
+                    match profile.deployment_type {
+                        DeploymentType::Enterprise => {
+                            warnings.push(format!(
+                                "Profile '{}' has no password set (will prompt interactively)",
+                                name
+                            ));
+                        }
+                        DeploymentType::Database => {
+                            // Database without password might be intentional
+                        }
+                        DeploymentType::Cloud => {
+                            // Cloud uses API key/secret, not password
+                        }
+                    }
+                }
+            }
+
+            // Build output
+            let mut output = format!(
+                "Configuration file: {}\nStatus: VALID\n\nProfiles: {}\n",
+                path.display(),
+                config.profiles.len()
+            );
+
+            if !issues.is_empty() {
+                output.push_str("\nIssues:\n");
+                for issue in &issues {
+                    output.push_str(&format!("  - {}\n", issue));
+                }
+            }
+
+            if !warnings.is_empty() {
+                output.push_str("\nWarnings:\n");
+                for warning in &warnings {
+                    output.push_str(&format!("  - {}\n", warning));
+                }
+            }
+
+            if issues.is_empty() && warnings.is_empty() {
+                output.push_str("\nNo issues found.");
+            }
+
+            Ok(CallToolResult::text(output))
+        })
+        .build()
+        .expect("valid tool")
+}
+
+// ============================================================================
+// Write Operations (require !read_only)
+// ============================================================================
+
+/// Input for setting default cloud profile
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SetDefaultCloudInput {
+    /// Name of the profile to set as default cloud profile
+    pub name: String,
+}
+
+/// Build the profile_set_default_cloud tool
+pub fn set_default_cloud(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("profile_set_default_cloud")
+        .description("Set the default profile for Cloud commands. Requires write access.")
+        .idempotent()
+        .handler_with_state(state, |state, input: SetDefaultCloudInput| async move {
+            // Check write permission
+            if !state.is_write_allowed() {
+                return Err(McpError::tool("Write operations require --read-only=false"));
+            }
+
+            let mut config = Config::load()
+                .map_err(|e| ToolError::new(format!("Failed to load config: {}", e)))?;
+
+            // Verify profile exists and is a cloud profile
+            let profile = config
+                .profiles
+                .get(&input.name)
+                .ok_or_else(|| ToolError::new(format!("Profile '{}' not found", input.name)))?;
+
+            if !matches!(profile.deployment_type, DeploymentType::Cloud) {
+                return Err(McpError::tool(format!(
+                    "Profile '{}' is not a cloud profile (type: {:?})",
+                    input.name, profile.deployment_type
+                )));
+            }
+
+            config.default_cloud = Some(input.name.clone());
+            config
+                .save()
+                .map_err(|e| ToolError::new(format!("Failed to save config: {}", e)))?;
+
+            Ok(CallToolResult::text(format!(
+                "Default cloud profile set to '{}'",
+                input.name
+            )))
+        })
+        .build()
+        .expect("valid tool")
+}
+
+/// Input for setting default enterprise profile
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SetDefaultEnterpriseInput {
+    /// Name of the profile to set as default enterprise profile
+    pub name: String,
+}
+
+/// Build the profile_set_default_enterprise tool
+pub fn set_default_enterprise(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("profile_set_default_enterprise")
+        .description("Set the default profile for Enterprise commands. Requires write access.")
+        .idempotent()
+        .handler_with_state(
+            state,
+            |state, input: SetDefaultEnterpriseInput| async move {
+                // Check write permission
+                if !state.is_write_allowed() {
+                    return Err(McpError::tool("Write operations require --read-only=false"));
+                }
+
+                let mut config = Config::load()
+                    .map_err(|e| ToolError::new(format!("Failed to load config: {}", e)))?;
+
+                // Verify profile exists and is an enterprise profile
+                let profile = config
+                    .profiles
+                    .get(&input.name)
+                    .ok_or_else(|| ToolError::new(format!("Profile '{}' not found", input.name)))?;
+
+                if !matches!(profile.deployment_type, DeploymentType::Enterprise) {
+                    return Err(McpError::tool(format!(
+                        "Profile '{}' is not an enterprise profile (type: {:?})",
+                        input.name, profile.deployment_type
+                    )));
+                }
+
+                config.default_enterprise = Some(input.name.clone());
+                config
+                    .save()
+                    .map_err(|e| ToolError::new(format!("Failed to save config: {}", e)))?;
+
+                Ok(CallToolResult::text(format!(
+                    "Default enterprise profile set to '{}'",
+                    input.name
+                )))
+            },
+        )
+        .build()
+        .expect("valid tool")
+}
+
+/// Input for deleting a profile
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct DeleteProfileInput {
+    /// Name of the profile to delete
+    pub name: String,
+}
+
+/// Build the profile_delete tool
+pub fn delete_profile(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("profile_delete")
+        .description("Delete a profile from the configuration. Requires write access.")
+        .handler_with_state(state, |state, input: DeleteProfileInput| async move {
+            // Check write permission
+            if !state.is_write_allowed() {
+                return Err(McpError::tool("Write operations require --read-only=false"));
+            }
+
+            let mut config = Config::load()
+                .map_err(|e| ToolError::new(format!("Failed to load config: {}", e)))?;
+
+            // Check if profile exists
+            if !config.profiles.contains_key(&input.name) {
+                return Err(McpError::tool(format!(
+                    "Profile '{}' not found",
+                    input.name
+                )));
+            }
+
+            // Remove the profile (also clears defaults if this was a default)
+            config.remove_profile(&input.name);
+
+            config
+                .save()
+                .map_err(|e| ToolError::new(format!("Failed to save config: {}", e)))?;
+
+            Ok(CallToolResult::text(format!(
+                "Profile '{}' deleted",
+                input.name
+            )))
+        })
+        .build()
+        .expect("valid tool")
+}


### PR DESCRIPTION
## Summary
Add 7 new MCP tools for managing redisctl profiles, enabling AI agents to view and modify profile configuration.

## New Tools

### Read Operations (always available)
| Tool | Description |
|------|-------------|
| `profile_list` | List all configured profiles with types and default status |
| `profile_show` | Show profile details with masked credentials |
| `profile_path` | Show configuration file path |
| `profile_validate` | Validate config and check for common issues |

### Write Operations (require `--read-only=false`)
| Tool | Description |
|------|-------------|
| `profile_set_default_cloud` | Set default Cloud profile |
| `profile_set_default_enterprise` | Set default Enterprise profile |
| `profile_delete` | Delete a profile |

## Security
- Credentials are masked in all output (showing only first/last chars)
- keyring references shown as `(keyring)`
- env var references shown as `(env var)`
- Write operations require explicit opt-in via `--read-only=false` flag

## Tests
- Added `test_profile_tools_build` to verify all tools build correctly
- Added `test_profile_input_deserialization` to verify input types

Closes #530