### PR TITLE
feat(mcp): add Enterprise license tools

### DIFF
--- a/crates/redisctl-mcp/src/lib.rs
+++ b/crates/redisctl-mcp/src/lib.rs
@@ -196,6 +196,9 @@ mod tests {
         // Cluster
         let _ = tools::enterprise::get_cluster(state.clone());
         let _ = tools::enterprise::get_cluster_stats(state.clone());
+        // License
+        let _ = tools::enterprise::get_license(state.clone());
+        let _ = tools::enterprise::get_license_usage(state.clone());
         // Databases
         let _ = tools::enterprise::list_databases(state.clone());
         let _ = tools::enterprise::get_database(state.clone());

--- a/crates/redisctl-mcp/src/main.rs
+++ b/crates/redisctl-mcp/src/main.rs
@@ -180,6 +180,10 @@ Redis Enterprise clusters and databases, and direct Redis database operations.
 - get_cluster: Get cluster information
 - get_cluster_stats: Get cluster statistics
 
+### Redis Enterprise - License
+- get_license: Get license information (type, expiration, features)
+- get_license_usage: Get license utilization (shards, nodes, RAM vs limits)
+
 ### Redis Enterprise - Databases
 - list_enterprise_databases: List all databases
 - get_enterprise_database: Get database details
@@ -261,6 +265,9 @@ In HTTP mode with OAuth, credentials can be passed via JWT claims.
         // Enterprise - Cluster
         .tool(tools::enterprise::get_cluster(state.clone()))
         .tool(tools::enterprise::get_cluster_stats(state.clone()))
+        // Enterprise - License
+        .tool(tools::enterprise::get_license(state.clone()))
+        .tool(tools::enterprise::get_license_usage(state.clone()))
         // Enterprise - Databases
         .tool(tools::enterprise::list_databases(state.clone()))
         .tool(tools::enterprise::get_database(state.clone()))


### PR DESCRIPTION
## Summary

Add MCP tools for querying Redis Enterprise license information, enabling multi-cluster license management through natural language queries.

## Use Case

Customer with 16 Redis Enterprise clusters currently must manually check each console or SSH to run `rladmin` on each node. With these tools and profiles configured for each cluster, users can:

- "Fetch the status of all my licenses, build a chart sorted by expiring soonest"
- "Which clusters have licenses expiring in the next 30 days?"
- "Show me license utilization across all clusters"

## Tools Added

| Tool | Description |
|------|-------------|
| `get_license` | Get license info (type, expiration date, cluster name, owner, features) |
| `get_license_usage` | Get utilization stats (shards used/limit, nodes used/limit, RAM used/limit) |

## Test plan

- [x] `cargo test -p redisctl-mcp --features test-support` (45 tests pass)
- [x] `cargo clippy --all-targets --all-features` passes
- [x] `cargo fmt --all -- --check` passes

Closes #612