### PR TITLE
feat(mcp): add Enterprise logs and aggregate stats tools

### DIFF
--- a/crates/redisctl-mcp/src/lib.rs
+++ b/crates/redisctl-mcp/src/lib.rs
@@ -216,6 +216,11 @@ mod tests {
         let _ = tools::enterprise::get_user(state.clone());
         let _ = tools::enterprise::list_alerts(state.clone());
         let _ = tools::enterprise::list_shards(state.clone());
+        // Aggregate Stats
+        let _ = tools::enterprise::get_all_nodes_stats(state.clone());
+        let _ = tools::enterprise::get_all_databases_stats(state.clone());
+        let _ = tools::enterprise::get_shard_stats(state.clone());
+        let _ = tools::enterprise::get_all_shards_stats(state.clone());
     }
 
     #[test]

--- a/crates/redisctl-mcp/src/main.rs
+++ b/crates/redisctl-mcp/src/main.rs
@@ -205,6 +205,12 @@ Redis Enterprise clusters and databases, and direct Redis database operations.
 - list_alerts: List all active alerts
 - list_shards: List database shards
 
+### Redis Enterprise - Aggregate Stats
+- get_all_nodes_stats: Get stats for all nodes in one call
+- get_all_databases_stats: Get stats for all databases in one call
+- get_shard_stats: Get stats for a specific shard
+- get_all_shards_stats: Get stats for all shards in one call
+
 ### Redis Database - Connection
 - redis_ping: Test connectivity
 - redis_info: Get server information
@@ -288,6 +294,11 @@ In HTTP mode with OAuth, credentials can be passed via JWT claims.
         .tool(tools::enterprise::get_user(state.clone()))
         .tool(tools::enterprise::list_alerts(state.clone()))
         .tool(tools::enterprise::list_shards(state.clone()))
+        // Enterprise - Aggregate Stats
+        .tool(tools::enterprise::get_all_nodes_stats(state.clone()))
+        .tool(tools::enterprise::get_all_databases_stats(state.clone()))
+        .tool(tools::enterprise::get_shard_stats(state.clone()))
+        .tool(tools::enterprise::get_all_shards_stats(state.clone()))
         // Redis - Connection
         .tool(tools::redis::ping(state.clone()))
         .tool(tools::redis::info(state.clone()))


### PR DESCRIPTION
## Summary

Add observability tools for Redis Enterprise clusters:

### Logs Tool (#613)
- `list_logs`: Query cluster event logs with time range filtering and pagination

### Aggregate Stats Tools (#614)
- `get_all_nodes_stats`: Stats for all nodes in one call
- `get_all_databases_stats`: Stats for all databases in one call
- `get_shard_stats`: Stats for a specific shard
- `get_all_shards_stats`: Stats for all shards in one call

## Use Cases

**Logs:**
- "Show me all events from the last hour"
- "What happened on this cluster yesterday between 2pm and 4pm?"

**Aggregate Stats:**
- "Show me CPU usage across all nodes"
- "Which databases have the highest latency?"
- "Compare memory usage across all shards"
- "Give me a health overview of this cluster"

## Test plan

- [x] `cargo test -p redisctl-mcp --features test-support` (51 tests pass)
- [x] `cargo clippy --all-targets --all-features` passes
- [x] `cargo fmt --all -- --check` passes

Closes #613
Closes #614