### PR TITLE
feat: add MCP resources and prompts to redisctl-mcp

### DIFF
--- a/crates/redisctl-mcp/src/lib.rs
+++ b/crates/redisctl-mcp/src/lib.rs
@@ -39,6 +39,8 @@
 //! ```
 
 pub mod error;
+pub mod prompts;
+pub mod resources;
 pub mod state;
 pub mod tools;
 

--- a/crates/redisctl-mcp/src/main.rs
+++ b/crates/redisctl-mcp/src/main.rs
@@ -12,6 +12,8 @@ use tracing::info;
 use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 
 mod error;
+mod prompts;
+mod resources;
 mod state;
 mod tools;
 
@@ -255,6 +257,21 @@ Redis Enterprise clusters and databases, and direct Redis database operations.
 - profile_set_default_enterprise: Set default Enterprise profile
 - profile_delete: Delete a profile
 
+## Resources
+
+Read-only data accessible via URI:
+- redis://config/path - Configuration file path
+- redis://profiles - List of configured profiles
+- redis://help - Usage instructions and help
+
+## Prompts
+
+Pre-built templates for common workflows:
+- troubleshoot_database - Diagnose database issues
+- analyze_performance - Analyze performance metrics
+- capacity_planning - Help with capacity planning
+- migration_planning - Plan Redis migrations
+
 ## Authentication
 
 In stdio mode, credentials are resolved from redisctl profiles.
@@ -346,7 +363,16 @@ In HTTP mode with OAuth, credentials can be passed via JWT claims.
         // Profile Management - Write
         .tool(tools::profile::set_default_cloud(state.clone()))
         .tool(tools::profile::set_default_enterprise(state.clone()))
-        .tool(tools::profile::delete_profile(state.clone()));
+        .tool(tools::profile::delete_profile(state.clone()))
+        // Resources
+        .resource(resources::config_path_resource())
+        .resource(resources::profiles_resource())
+        .resource(resources::help_resource())
+        // Prompts
+        .prompt(prompts::troubleshoot_database_prompt())
+        .prompt(prompts::analyze_performance_prompt())
+        .prompt(prompts::capacity_planning_prompt())
+        .prompt(prompts::migration_planning_prompt());
 
     // Apply read-only filter if enabled
     // This hides write tools entirely from tools/list and returns "method not found"

--- a/crates/redisctl-mcp/src/prompts.rs
+++ b/crates/redisctl-mcp/src/prompts.rs
@@ -1,0 +1,315 @@
+//! MCP Prompts for Redis management workflows
+//!
+//! Prompts provide pre-built templates for common Redis operations.
+
+use std::collections::HashMap;
+
+use tower_mcp::prompt::{Prompt, PromptBuilder};
+use tower_mcp::protocol::{Content, GetPromptResult, PromptMessage, PromptRole};
+
+/// Build a prompt for troubleshooting database issues
+pub fn troubleshoot_database_prompt() -> Prompt {
+    PromptBuilder::new("troubleshoot_database")
+        .description("Generate a troubleshooting workflow for a Redis database")
+        .required_arg("database_name", "Name or ID of the database to troubleshoot")
+        .optional_arg("symptoms", "Description of the issue or symptoms observed")
+        .handler(|args: HashMap<String, String>| async move {
+            let db_name = args.get("database_name").cloned().unwrap_or_default();
+            let symptoms = args.get("symptoms").cloned().unwrap_or_default();
+
+            let prompt_text = if symptoms.is_empty() {
+                format!(
+                    r#"I need to troubleshoot a Redis database named "{}".
+
+Please help me diagnose potential issues by:
+
+1. First, check the database status and basic connectivity using redis_ping
+2. Get database information with redis_info to check memory, connections, and replication
+3. Check for slow queries using get_slow_log (if Redis Cloud) or redis_info with the slowlog section
+4. Look at the key distribution with redis_dbsize and redis_keys with a sample pattern
+5. Check client connections with redis_client_list
+
+Based on the results, identify any issues and suggest remediation steps."#,
+                    db_name
+                )
+            } else {
+                format!(
+                    r#"I need to troubleshoot a Redis database named "{}".
+
+**Reported symptoms**: {}
+
+Please help me diagnose this issue by:
+
+1. First, check the database status and basic connectivity using redis_ping
+2. Get database information with redis_info focusing on sections relevant to the symptoms
+3. Check for slow queries that might be causing the issue
+4. Examine memory usage and eviction policies if memory-related
+5. Check replication lag if replication-related
+
+Based on the results and the reported symptoms, identify the root cause and suggest specific remediation steps."#,
+                    db_name, symptoms
+                )
+            };
+
+            Ok(GetPromptResult {
+                description: Some(format!("Troubleshoot database: {}", db_name)),
+                messages: vec![PromptMessage {
+                    role: PromptRole::User,
+                    content: Content::Text {
+                        text: prompt_text,
+                        annotations: None,
+                    },
+                }],
+            })
+        })
+}
+
+/// Build a prompt for analyzing performance metrics
+pub fn analyze_performance_prompt() -> Prompt {
+    PromptBuilder::new("analyze_performance")
+        .description("Analyze Redis performance metrics and suggest optimizations")
+        .optional_arg(
+            "focus",
+            "Specific area to focus on (memory, latency, throughput)",
+        )
+        .handler(|args: HashMap<String, String>| async move {
+            let focus = args.get("focus").cloned().unwrap_or_default();
+
+            let prompt_text = if focus.is_empty() {
+                r#"I need to analyze the performance of my Redis deployment.
+
+Please help me by:
+
+1. Get overall cluster or database statistics to understand the current state
+2. Check memory usage patterns and fragmentation ratio
+3. Look at operation throughput and latency metrics
+4. Examine connection patterns and client distribution
+5. Review any slow queries in the slow log
+
+Based on the analysis, provide:
+- A summary of current performance characteristics
+- Identification of any bottlenecks or issues
+- Specific recommendations for optimization
+- Priority order for implementing changes"#
+                    .to_string()
+            } else {
+                format!(
+                    r#"I need to analyze the {} performance of my Redis deployment.
+
+Please focus specifically on {} metrics by:
+
+1. Gathering relevant statistics for {}
+2. Comparing against best practices and benchmarks
+3. Identifying any anomalies or issues
+4. Suggesting specific optimizations for {}
+
+Provide actionable recommendations with expected impact."#,
+                    focus, focus, focus, focus
+                )
+            };
+
+            Ok(GetPromptResult {
+                description: Some("Analyze Redis performance".to_string()),
+                messages: vec![PromptMessage {
+                    role: PromptRole::User,
+                    content: Content::Text {
+                        text: prompt_text,
+                        annotations: None,
+                    },
+                }],
+            })
+        })
+}
+
+/// Build a prompt for capacity planning
+pub fn capacity_planning_prompt() -> Prompt {
+    PromptBuilder::new("capacity_planning")
+        .description("Help with Redis capacity planning and scaling decisions")
+        .required_arg("current_usage", "Description of current usage patterns")
+        .optional_arg("growth_rate", "Expected growth rate (e.g., '20% monthly')")
+        .handler(|args: HashMap<String, String>| async move {
+            let current_usage = args.get("current_usage").cloned().unwrap_or_default();
+            let growth_rate = args.get("growth_rate").cloned().unwrap_or_default();
+
+            let growth_section = if growth_rate.is_empty() {
+                String::new()
+            } else {
+                format!("\n**Expected growth rate**: {}\n", growth_rate)
+            };
+
+            let prompt_text = format!(
+                r#"I need help with capacity planning for my Redis deployment.
+
+**Current usage**: {}{}
+
+Please help me by:
+
+1. First, gather current metrics:
+   - Memory usage and limits
+   - Key count and data size distribution
+   - Operation throughput (ops/sec)
+   - Connection count and patterns
+
+2. Analyze the data to determine:
+   - Current utilization percentage
+   - Memory efficiency (fragmentation, overhead)
+   - Headroom for growth
+
+3. Based on the analysis, provide:
+   - Projected resource needs over 3, 6, and 12 months
+   - Recommended scaling strategy (vertical vs horizontal)
+   - Cost optimization opportunities
+   - Warning thresholds to monitor"#,
+                current_usage, growth_section
+            );
+
+            Ok(GetPromptResult {
+                description: Some("Redis capacity planning".to_string()),
+                messages: vec![PromptMessage {
+                    role: PromptRole::User,
+                    content: Content::Text {
+                        text: prompt_text,
+                        annotations: None,
+                    },
+                }],
+            })
+        })
+}
+
+/// Build a prompt for migration planning
+pub fn migration_planning_prompt() -> Prompt {
+    PromptBuilder::new("migration_planning")
+        .description("Plan a Redis migration between environments or providers")
+        .required_arg("source", "Source environment description")
+        .required_arg("target", "Target environment description")
+        .handler(|args: HashMap<String, String>| async move {
+            let source = args.get("source").cloned().unwrap_or_default();
+            let target = args.get("target").cloned().unwrap_or_default();
+
+            let prompt_text = format!(
+                r#"I need to plan a Redis migration.
+
+**Source**: {}
+**Target**: {}
+
+Please help me create a migration plan by:
+
+1. First, analyze the source environment:
+   - Get database configuration and size
+   - Check data types and key patterns used
+   - Identify any Redis modules in use
+   - Note persistence and replication settings
+
+2. Assess compatibility with the target:
+   - Version compatibility
+   - Feature parity
+   - Module availability
+   - Network and security requirements
+
+3. Create a migration plan including:
+   - Pre-migration checklist
+   - Data migration approach (snapshot vs live sync)
+   - Cutover strategy with minimal downtime
+   - Rollback plan
+   - Validation steps post-migration
+
+4. Identify risks and mitigation strategies"#,
+                source, target
+            );
+
+            Ok(GetPromptResult {
+                description: Some("Redis migration planning".to_string()),
+                messages: vec![PromptMessage {
+                    role: PromptRole::User,
+                    content: Content::Text {
+                        text: prompt_text,
+                        annotations: None,
+                    },
+                }],
+            })
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_troubleshoot_prompt() {
+        let prompt = troubleshoot_database_prompt();
+        assert_eq!(prompt.name, "troubleshoot_database");
+        assert_eq!(prompt.arguments.len(), 2);
+        assert!(prompt.arguments[0].required);
+        assert!(!prompt.arguments[1].required);
+
+        let mut args = HashMap::new();
+        args.insert("database_name".to_string(), "my-cache".to_string());
+        args.insert("symptoms".to_string(), "high latency".to_string());
+
+        let result = prompt.get(args).await.unwrap();
+        assert_eq!(result.messages.len(), 1);
+        match &result.messages[0].content {
+            Content::Text { text, .. } => {
+                assert!(text.contains("my-cache"));
+                assert!(text.contains("high latency"));
+            }
+            _ => panic!("Expected text content"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_analyze_performance_prompt() {
+        let prompt = analyze_performance_prompt();
+        assert_eq!(prompt.name, "analyze_performance");
+
+        let result = prompt.get(HashMap::new()).await.unwrap();
+        match &result.messages[0].content {
+            Content::Text { text, .. } => {
+                assert!(text.contains("performance"));
+            }
+            _ => panic!("Expected text content"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_capacity_planning_prompt() {
+        let prompt = capacity_planning_prompt();
+        assert_eq!(prompt.name, "capacity_planning");
+        assert!(prompt.arguments[0].required);
+
+        let mut args = HashMap::new();
+        args.insert(
+            "current_usage".to_string(),
+            "2GB memory, 100k keys".to_string(),
+        );
+
+        let result = prompt.get(args).await.unwrap();
+        match &result.messages[0].content {
+            Content::Text { text, .. } => {
+                assert!(text.contains("2GB memory"));
+            }
+            _ => panic!("Expected text content"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_migration_planning_prompt() {
+        let prompt = migration_planning_prompt();
+        assert_eq!(prompt.name, "migration_planning");
+        assert_eq!(prompt.arguments.len(), 2);
+        assert!(prompt.arguments.iter().all(|a| a.required));
+
+        let mut args = HashMap::new();
+        args.insert("source".to_string(), "AWS ElastiCache".to_string());
+        args.insert("target".to_string(), "Redis Cloud".to_string());
+
+        let result = prompt.get(args).await.unwrap();
+        match &result.messages[0].content {
+            Content::Text { text, .. } => {
+                assert!(text.contains("AWS ElastiCache"));
+                assert!(text.contains("Redis Cloud"));
+            }
+            _ => panic!("Expected text content"),
+        }
+    }
+}

--- a/crates/redisctl-mcp/src/resources.rs
+++ b/crates/redisctl-mcp/src/resources.rs
@@ -1,0 +1,151 @@
+//! MCP Resources for Redis management
+//!
+//! Resources expose read-only data that can be fetched by URI.
+
+use redisctl_config::Config;
+use tower_mcp::protocol::{ReadResourceResult, ResourceContent};
+use tower_mcp::resource::{Resource, ResourceBuilder};
+
+/// Build a resource exposing the current configuration path
+pub fn config_path_resource() -> Resource {
+    ResourceBuilder::new("redis://config/path")
+        .name("Configuration Path")
+        .description("Path to the redisctl configuration file")
+        .mime_type("text/plain")
+        .handler(|| async {
+            let path = Config::config_path()
+                .map(|p: std::path::PathBuf| p.display().to_string())
+                .unwrap_or_else(|_| "(no config path available)".to_string());
+
+            Ok(ReadResourceResult {
+                contents: vec![ResourceContent {
+                    uri: "redis://config/path".to_string(),
+                    mime_type: Some("text/plain".to_string()),
+                    text: Some(path),
+                    blob: None,
+                }],
+            })
+        })
+}
+
+/// Build a resource exposing the list of configured profiles
+pub fn profiles_resource() -> Resource {
+    ResourceBuilder::new("redis://profiles")
+        .name("Profiles")
+        .description("List of configured redisctl profiles")
+        .mime_type("application/json")
+        .handler(|| async {
+            let profiles = match Config::load() {
+                Ok(config) => {
+                    let profile_names: Vec<&String> = config.profiles.keys().collect();
+                    serde_json::json!({
+                        "profiles": profile_names,
+                        "default_cloud": config.default_cloud,
+                        "default_enterprise": config.default_enterprise
+                    })
+                    .to_string()
+                }
+                Err(e) => serde_json::json!({"error": e.to_string()}).to_string(),
+            };
+
+            Ok(ReadResourceResult {
+                contents: vec![ResourceContent {
+                    uri: "redis://profiles".to_string(),
+                    mime_type: Some("application/json".to_string()),
+                    text: Some(profiles),
+                    blob: None,
+                }],
+            })
+        })
+}
+
+/// Build a resource exposing server instructions/help
+pub fn help_resource() -> Resource {
+    ResourceBuilder::new("redis://help")
+        .name("Help")
+        .description("Usage instructions for the Redis MCP server")
+        .mime_type("text/markdown")
+        .text(
+            r#"# Redis MCP Server Help
+
+## Tool Categories
+
+### Redis Cloud
+- **Subscriptions**: list_subscriptions, get_subscription
+- **Databases**: list_databases, get_database, get_backup_status, get_slow_log
+- **Account**: get_account, list_account_users
+- **Tasks**: list_tasks, get_task
+
+### Redis Enterprise
+- **Cluster**: get_cluster, get_cluster_stats
+- **License**: get_license, get_license_usage
+- **Databases**: list_enterprise_databases, get_enterprise_database
+- **Nodes**: list_nodes, get_node, get_node_stats
+- **Modules**: list_modules, get_module
+
+### Direct Redis
+- **Connection**: redis_ping, redis_info, redis_dbsize
+- **Keys**: redis_keys, redis_get, redis_type, redis_ttl
+- **Data Structures**: redis_hgetall, redis_lrange, redis_smembers, redis_zrange
+
+## Prompts
+
+Use prompts for common workflows:
+- `troubleshoot_database` - Diagnose database issues
+- `analyze_performance` - Analyze performance metrics
+- `capacity_planning` - Help with capacity planning decisions
+- `migration_planning` - Plan Redis migrations between environments
+
+## Resources
+
+- `redis://config/path` - Configuration file location
+- `redis://profiles` - List of configured profiles
+- `redis://help` - This help text
+"#,
+        )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_help_resource() {
+        let resource = help_resource();
+        assert_eq!(resource.uri, "redis://help");
+        assert_eq!(resource.name, "Help");
+
+        let result = resource.read().await.unwrap();
+        assert_eq!(result.contents.len(), 1);
+        assert!(
+            result.contents[0]
+                .text
+                .as_ref()
+                .unwrap()
+                .contains("Redis MCP Server")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_config_path_resource() {
+        let resource = config_path_resource();
+        assert_eq!(resource.uri, "redis://config/path");
+
+        let result = resource.read().await.unwrap();
+        assert_eq!(result.contents.len(), 1);
+        // Should return either a path or error message
+        assert!(result.contents[0].text.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_profiles_resource() {
+        let resource = profiles_resource();
+        assert_eq!(resource.uri, "redis://profiles");
+
+        let result = resource.read().await.unwrap();
+        assert_eq!(result.contents.len(), 1);
+        // Should return JSON (either profiles or error)
+        let text = result.contents[0].text.as_ref().unwrap();
+        assert!(text.starts_with('{'));
+    }
+}


### PR DESCRIPTION
## Summary

- Add three MCP resources exposing read-only data via URI:
  - `redis://config/path` - configuration file location
  - `redis://profiles` - list of configured profiles  
  - `redis://help` - usage instructions and help

- Add four MCP prompts for common Redis workflows:
  - `troubleshoot_database` - diagnose database issues
  - `analyze_performance` - analyze performance metrics
  - `capacity_planning` - help with capacity planning decisions
  - `migration_planning` - plan Redis migrations between environments

## Test plan

- [x] All unit tests pass
- [x] All integration tests pass
- [x] Clippy passes without warnings
- [x] Code formatted with rustfmt