### PR TITLE
feat: add individual getter tools for Cloud and Enterprise

### DIFF
--- a/crates/redisctl-mcp/src/lib.rs
+++ b/crates/redisctl-mcp/src/lib.rs
@@ -182,7 +182,9 @@ mod tests {
         let _ = tools::cloud::get_regions(state.clone());
         let _ = tools::cloud::get_modules(state.clone());
         let _ = tools::cloud::list_account_users(state.clone());
+        let _ = tools::cloud::get_account_user(state.clone());
         let _ = tools::cloud::list_acl_users(state.clone());
+        let _ = tools::cloud::get_acl_user(state.clone());
         let _ = tools::cloud::list_acl_roles(state.clone());
         let _ = tools::cloud::list_redis_rules(state.clone());
         // Logs
@@ -220,7 +222,9 @@ mod tests {
         let _ = tools::enterprise::list_users(state.clone());
         let _ = tools::enterprise::get_user(state.clone());
         let _ = tools::enterprise::list_alerts(state.clone());
+        // Shards
         let _ = tools::enterprise::list_shards(state.clone());
+        let _ = tools::enterprise::get_shard(state.clone());
         // Aggregate Stats
         let _ = tools::enterprise::get_all_nodes_stats(state.clone());
         let _ = tools::enterprise::get_all_databases_stats(state.clone());

--- a/crates/redisctl-mcp/src/main.rs
+++ b/crates/redisctl-mcp/src/main.rs
@@ -170,7 +170,9 @@ Redis Enterprise clusters and databases, and direct Redis database operations.
 - get_regions: Get supported cloud regions
 - get_modules: Get supported Redis modules
 - list_account_users: List team members
+- get_account_user: Get team member details by ID
 - list_acl_users: List database ACL users
+- get_acl_user: Get ACL user details by ID
 - list_acl_roles: List ACL roles
 - list_redis_rules: List Redis ACL rules
 
@@ -209,7 +211,10 @@ Redis Enterprise clusters and databases, and direct Redis database operations.
 - list_enterprise_users: List cluster users
 - get_enterprise_user: Get user details
 - list_alerts: List all active alerts
-- list_shards: List database shards
+
+### Redis Enterprise - Shards
+- list_shards: List database shards (with optional database filter)
+- get_shard: Get shard details by UID
 
 ### Redis Enterprise - Aggregate Stats
 - get_all_nodes_stats: Get stats for all nodes in one call
@@ -294,7 +299,9 @@ In HTTP mode with OAuth, credentials can be passed via JWT claims.
         .tool(tools::cloud::get_regions(state.clone()))
         .tool(tools::cloud::get_modules(state.clone()))
         .tool(tools::cloud::list_account_users(state.clone()))
+        .tool(tools::cloud::get_account_user(state.clone()))
         .tool(tools::cloud::list_acl_users(state.clone()))
+        .tool(tools::cloud::get_acl_user(state.clone()))
         .tool(tools::cloud::list_acl_roles(state.clone()))
         .tool(tools::cloud::list_redis_rules(state.clone()))
         // Cloud - Logs
@@ -326,6 +333,7 @@ In HTTP mode with OAuth, credentials can be passed via JWT claims.
         .tool(tools::enterprise::get_user(state.clone()))
         .tool(tools::enterprise::list_alerts(state.clone()))
         .tool(tools::enterprise::list_shards(state.clone()))
+        .tool(tools::enterprise::get_shard(state.clone()))
         // Enterprise - Aggregate Stats
         .tool(tools::enterprise::get_all_nodes_stats(state.clone()))
         .tool(tools::enterprise::get_all_databases_stats(state.clone()))

--- a/crates/redisctl-mcp/src/tools/cloud.rs
+++ b/crates/redisctl-mcp/src/tools/cloud.rs
@@ -404,6 +404,37 @@ pub fn list_account_users(state: Arc<AppState>) -> Tool {
         .expect("valid tool")
 }
 
+/// Input for getting a specific account user
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct GetAccountUserInput {
+    /// Account user ID
+    pub user_id: i32,
+}
+
+/// Build the get_account_user tool
+pub fn get_account_user(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("get_account_user")
+        .description("Get detailed information about a specific account user (team member) by ID.")
+        .read_only()
+        .idempotent()
+        .handler_with_state(state, |state, input: GetAccountUserInput| async move {
+            let client = state
+                .cloud_client()
+                .await
+                .map_err(|e| ToolError::new(format!("Failed to get Cloud client: {}", e)))?;
+
+            let handler = UserHandler::new(client);
+            let user = handler
+                .get_user_by_id(input.user_id)
+                .await
+                .map_err(|e| ToolError::new(format!("Failed to get account user: {}", e)))?;
+
+            CallToolResult::from_serialize(&user)
+        })
+        .build()
+        .expect("valid tool")
+}
+
 // ============================================================================
 // ACL tools (database-level access control)
 // ============================================================================
@@ -431,6 +462,37 @@ pub fn list_acl_users(state: Arc<AppState>) -> Tool {
                 .map_err(|e| ToolError::new(format!("Failed to list ACL users: {}", e)))?;
 
             CallToolResult::from_serialize(&users)
+        })
+        .build()
+        .expect("valid tool")
+}
+
+/// Input for getting a specific ACL user
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct GetAclUserInput {
+    /// ACL user ID
+    pub user_id: i32,
+}
+
+/// Build the get_acl_user tool
+pub fn get_acl_user(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("get_acl_user")
+        .description("Get detailed information about a specific ACL user by ID.")
+        .read_only()
+        .idempotent()
+        .handler_with_state(state, |state, input: GetAclUserInput| async move {
+            let client = state
+                .cloud_client()
+                .await
+                .map_err(|e| ToolError::new(format!("Failed to get Cloud client: {}", e)))?;
+
+            let handler = AclHandler::new(client);
+            let user = handler
+                .get_user_by_id(input.user_id)
+                .await
+                .map_err(|e| ToolError::new(format!("Failed to get ACL user: {}", e)))?;
+
+            CallToolResult::from_serialize(&user)
         })
         .build()
         .expect("valid tool")


### PR DESCRIPTION
## Summary

- Add individual getter tools to complement existing list tools:
  - Cloud: `get_account_user`, `get_acl_user`
  - Enterprise: `get_shard`
- These allow fetching specific resources by ID when already known, without listing first

## Test plan

- [x] All library tests pass
- [x] All integration tests pass
- [x] Clippy passes without warnings
- [x] Code formatted with rustfmt