### PR TITLE
feat: add custom CA certificate support for Kubernetes deployments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,6 +405,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -985,7 +991,7 @@ version = "0.10.2"
 source = "git+https://github.com/joshrotenberg/docker-wrapper#e122332360311e4acf4914ab4b8c97bc84b30ac1"
 dependencies = [
  "async-trait",
- "reqwest",
+ "reqwest 0.12.23",
  "serde",
  "serde_json",
  "thiserror 2.0.17",
@@ -1124,7 +1130,7 @@ checksum = "2e1b158d0e399fe9f99e4b6ba8ba979b0536e0133a4c1270ac3386f00104336e"
 dependencies = [
  "async-stream",
  "futures",
- "reqwest",
+ "reqwest 0.12.23",
  "serde",
  "serde_json",
  "thiserror 2.0.17",
@@ -1840,6 +1846,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2113,7 +2141,7 @@ dependencies = [
  "libc",
  "log",
  "openssl",
- "openssl-probe",
+ "openssl-probe 0.1.6",
  "openssl-sys",
  "schannel",
  "security-framework 2.11.1",
@@ -2248,6 +2276,12 @@ name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
@@ -2585,6 +2619,7 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.3",
  "lru-slab",
@@ -2727,7 +2762,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls",
- "rustls-native-certs",
+ "rustls-native-certs 0.7.3",
  "rustls-pemfile",
  "rustls-pki-types",
  "ryu",
@@ -2741,9 +2776,9 @@ dependencies = [
 
 [[package]]
 name = "redis-cloud"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9400bdd3bd0190609c61189ab25d748763b0cfec427830e7af61eff6fb6bf9f8"
+checksum = "6d6246c4814b96180bf438ccad7868d12e1fb5b740d0781021ae10ff02e4a1cf"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2751,7 +2786,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "futures-core",
- "reqwest",
+ "reqwest 0.13.1",
  "serde",
  "serde_json",
  "serde_path_to_error",
@@ -2766,9 +2801,9 @@ dependencies = [
 
 [[package]]
 name = "redis-enterprise"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413a4b0e2a73bffae1b05b8fa4556c0f90e90b4b149e652fb1228d6a4cffa685"
+checksum = "5d25bfbf45a3fca09ae24a9452cc519aa7725af04528b3f54cd213ab674bbaac"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2776,7 +2811,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "futures",
- "reqwest",
+ "reqwest 0.13.1",
  "serde",
  "serde_json",
  "serde_path_to_error",
@@ -2959,7 +2994,6 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-core",
- "futures-util",
  "h2",
  "http",
  "http-body",
@@ -2971,7 +3005,6 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
- "mime_guess",
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
@@ -2993,6 +3026,45 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04e9018c9d814e5f30cc16a0f03271aeab3571e609612d9fe78c1aa8d11c2f62"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -3102,6 +3174,7 @@ version = "0.23.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd3c25631629d034ce7cd9940adc9d45762d46de2b0f57193c4443b92c6d4d40"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -3116,11 +3189,23 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
 dependencies = [
- "openssl-probe",
+ "openssl-probe 0.1.6",
  "rustls-pemfile",
  "rustls-pki-types",
  "schannel",
  "security-framework 2.11.1",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe 0.2.1",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.5.1",
 ]
 
 [[package]]
@@ -3143,11 +3228,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs 0.8.3",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework 3.5.1",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e10b3f4191e8a80e6b43eebabfac91e5dcecebb27a71f04e820c47ec41d314bf"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted 0.9.0",
@@ -4014,9 +4127,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.6"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "bitflags",
  "bytes",
@@ -4553,6 +4666,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4708,6 +4830,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -4740,6 +4871,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -4777,6 +4923,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -4789,6 +4941,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4798,6 +4956,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4825,6 +4989,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -4834,6 +5004,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4849,6 +5025,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -4858,6 +5040,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,8 +97,8 @@ redis = { version = "0.27", features = ["tokio-comp", "tokio-rustls-comp", "conn
 redisctl-config = { path = "crates/redisctl-config" }
 
 # External crates
-redis-cloud = "0.9.1"
-redis-enterprise = "0.8.1"
+redis-cloud = "0.9.2"
+redis-enterprise = "0.8.2"
 
 # Windows CI workaround - ensure these are available in workspace
 shellexpand = "3.1"

--- a/crates/redisctl-mcp/Cargo.toml
+++ b/crates/redisctl-mcp/Cargo.toml
@@ -53,7 +53,7 @@ test-support = []
 
 [dev-dependencies]
 tokio = { workspace = true }
-redis-cloud = { version = "0.9.1", features = ["test-support"] }
-redis-enterprise = { version = "0.8.1", features = ["test-support"] }
+redis-cloud = { version = "0.9.2", features = ["test-support"] }
+redis-enterprise = { version = "0.8.2", features = ["test-support"] }
 wiremock = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/redisctl-mcp/src/state.rs
+++ b/crates/redisctl-mcp/src/state.rs
@@ -185,7 +185,7 @@ impl AppState {
                     .with_context(|| format!("Profile '{}' not found", resolved_profile_name))?;
 
                 // Get credentials
-                let (url, username, password, insecure) = profile
+                let (url, username, password, insecure, ca_cert) = profile
                     .resolve_enterprise_credentials()
                     .context("Failed to resolve enterprise credentials")?
                     .context("No enterprise credentials in profile")?;
@@ -197,6 +197,10 @@ impl AppState {
 
                 if let Some(pwd) = password {
                     builder = builder.password(&pwd);
+                }
+
+                if let Some(cert_path) = ca_cert {
+                    builder = builder.ca_cert(&cert_path);
                 }
 
                 builder.build().context("Failed to build Enterprise client")

--- a/crates/redisctl-mcp/src/tools/profile.rs
+++ b/crates/redisctl-mcp/src/tools/profile.rs
@@ -121,6 +121,8 @@ struct MaskedEnterpriseCredentials {
     username: String,
     password: String,
     insecure: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ca_cert: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -203,6 +205,7 @@ pub fn show_profile(state: Arc<AppState>) -> Tool {
                         username,
                         password,
                         insecure,
+                        ca_cert,
                     } => (
                         None,
                         Some(MaskedEnterpriseCredentials {
@@ -213,6 +216,7 @@ pub fn show_profile(state: Arc<AppState>) -> Tool {
                                 .map(|p| mask_credential(p))
                                 .unwrap_or_else(|| "(not set)".to_string()),
                             insecure: *insecure,
+                            ca_cert: ca_cert.clone(),
                         }),
                         None,
                     ),

--- a/crates/redisctl/src/cli/mod.rs
+++ b/crates/redisctl/src/cli/mod.rs
@@ -253,6 +253,7 @@ impl std::fmt::Display for HttpMethod {
 
 /// Profile management commands
 #[derive(Subcommand, Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum ProfileCommands {
     /// List all configured profiles
     #[command(visible_alias = "ls", visible_alias = "l")]
@@ -340,6 +341,10 @@ pub enum ProfileCommands {
         /// Allow insecure connections (for Enterprise profiles)
         #[arg(long)]
         insecure: bool,
+
+        /// Path to custom CA certificate for TLS verification (for Enterprise/Kubernetes profiles)
+        #[arg(long)]
+        ca_cert: Option<String>,
 
         /// Redis host (for Database profiles)
         #[arg(long, required_if_eq("type", "database"))]

--- a/docs/docs/reference/environment-variables.md
+++ b/docs/docs/reference/environment-variables.md
@@ -18,6 +18,7 @@ Complete reference of environment variables supported by redisctl.
 | `REDIS_ENTERPRISE_USER` | Username | `admin@cluster.local` |
 | `REDIS_ENTERPRISE_PASSWORD` | Password | `your-password` |
 | `REDIS_ENTERPRISE_INSECURE` | Allow self-signed certs | `true` or `false` |
+| `REDIS_ENTERPRISE_CA_CERT` | Path to custom CA certificate (for Kubernetes/self-signed) | `/path/to/ca.pem` |
 
 ## Files.com (Support Package Upload)
 
@@ -54,6 +55,18 @@ Complete reference of environment variables supported by redisctl.
     export REDIS_ENTERPRISE_USER="admin@cluster.local"
     export REDIS_ENTERPRISE_PASSWORD="password"
     export REDIS_ENTERPRISE_INSECURE="true"
+
+    redisctl enterprise cluster get
+    ```
+
+=== "Redis Enterprise (Kubernetes)"
+
+    ```bash
+    # Use custom CA certificate for Kubernetes deployments
+    export REDIS_ENTERPRISE_URL="https://rec-api.redis.svc:9443"
+    export REDIS_ENTERPRISE_USER="admin@cluster.local"
+    export REDIS_ENTERPRISE_PASSWORD="password"
+    export REDIS_ENTERPRISE_CA_CERT="/var/run/secrets/redis/ca.crt"
 
     redisctl enterprise cluster get
     ```

--- a/docs/docs/reference/security.md
+++ b/docs/docs/reference/security.md
@@ -127,6 +127,36 @@ redisctl profile show prod
 cat ~/.config/redisctl/config.toml
 ```
 
+## TLS Certificate Configuration
+
+### Kubernetes Deployments
+
+Redis Enterprise clusters deployed on Kubernetes typically use self-signed certificates. Instead of disabling TLS verification with `REDIS_ENTERPRISE_INSECURE=true`, you can provide the cluster's CA certificate for secure connections:
+
+```bash
+# Extract CA cert from Kubernetes secret
+kubectl get secret rec-proxy-cert -o jsonpath='{.data.ca\.crt}' | base64 -d > ca.crt
+
+# Use the CA cert for verification
+export REDIS_ENTERPRISE_CA_CERT="./ca.crt"
+export REDIS_ENTERPRISE_URL="https://rec-api.redis.svc:9443"
+export REDIS_ENTERPRISE_USER="admin@cluster.local"
+export REDIS_ENTERPRISE_PASSWORD="password"
+
+redisctl enterprise cluster get
+```
+
+### When to Use Each Option
+
+| Option | Use Case |
+|--------|----------|
+| `REDIS_ENTERPRISE_CA_CERT` | Kubernetes, self-signed certs where you have the CA |
+| `REDIS_ENTERPRISE_INSECURE=true` | Local development, testing only |
+| Neither | Production clusters with trusted certificates |
+
+!!! warning "Avoid Insecure Mode in Production"
+    Using `REDIS_ENTERPRISE_INSECURE=true` disables all certificate verification and should only be used for local development. For Kubernetes deployments, always use `REDIS_ENTERPRISE_CA_CERT` with the cluster's CA certificate.
+
 ## Revoking Credentials
 
 ### Redis Cloud


### PR DESCRIPTION
## Summary

Adds support for custom CA certificates when connecting to Redis Enterprise clusters, enabling secure TLS connections to Kubernetes-deployed clusters that use self-signed certificates.

Closes #579 (Phase 1: Custom CA Certificate Support)

## Changes

- Add `REDIS_ENTERPRISE_CA_CERT` environment variable for specifying a custom CA certificate path
- Add `--ca-cert` CLI argument to `redisctl profile set` command
- Add `ca_cert` field to Enterprise profile configuration
- Update `redis-cloud` to 0.9.2 and `redis-enterprise` to 0.8.2 (includes reqwest 0.13 upgrade)
- Document the new feature in environment variables and security reference docs

## Usage

### Via Environment Variable
```bash
export REDIS_ENTERPRISE_URL="https://rec-api.redis.svc:9443"
export REDIS_ENTERPRISE_USER="admin@cluster.local"
export REDIS_ENTERPRISE_PASSWORD="password"
export REDIS_ENTERPRISE_CA_CERT="/var/run/secrets/redis/ca.crt"

redisctl enterprise cluster get
```

### Via Profile
```bash
redisctl profile set k8s-cluster \
  --type enterprise \
  --url "https://rec-api.redis.svc:9443" \
  --username "admin" \
  --password "secret" \
  --ca-cert "/path/to/ca.crt"
```

Or manually edit the config:
```toml
[profiles.k8s-cluster]
deployment_type = "enterprise"
url = "https://rec-api.redis.svc:9443"
username = "admin"
ca_cert = "/path/to/ca.crt"
```

## Why This Matters

Redis Enterprise on Kubernetes uses self-signed certificates by default. Previously, users had to use `REDIS_ENTERPRISE_INSECURE=true` which disables all certificate verification. Now they can provide the cluster's CA certificate for proper TLS validation.

## Test Plan

- [x] Tested with local Docker Compose Redis Enterprise instance
- [x] Verified CA cert is loaded and used for TLS verification
- [x] Verified invalid CA cert path fails with appropriate error
- [x] All existing tests pass
- [x] Clippy and fmt pass
- [x] Docs build without warnings