### PR TITLE
feat(mcp): add Enterprise database write operations

### DIFF
--- a/crates/redisctl-core/src/enterprise/mod.rs
+++ b/crates/redisctl-core/src/enterprise/mod.rs
@@ -36,6 +36,6 @@ pub mod workflows;
 // Re-export key types for convenience
 pub use progress::{EnterpriseProgressCallback, EnterpriseProgressEvent, poll_action};
 pub use workflows::{
-    DEFAULT_INTERVAL, DEFAULT_TIMEOUT, backup_database_and_wait, import_database_and_wait,
-    upgrade_database_and_wait, upgrade_module_and_wait,
+    DEFAULT_INTERVAL, DEFAULT_TIMEOUT, backup_database_and_wait, flush_database_and_wait,
+    import_database_and_wait, upgrade_database_and_wait, upgrade_module_and_wait,
 };

--- a/crates/redisctl-core/src/enterprise/workflows.rs
+++ b/crates/redisctl-core/src/enterprise/workflows.rs
@@ -181,3 +181,35 @@ pub async fn import_database_and_wait(
 
     Ok(())
 }
+
+/// Flush all data from an Enterprise database and wait for completion
+///
+/// WARNING: This permanently deletes all data in the database!
+///
+/// # Arguments
+///
+/// * `client` - The Enterprise API client
+/// * `bdb_uid` - The database UID to flush
+/// * `timeout` - Maximum time to wait for completion
+/// * `on_progress` - Optional callback for progress updates
+pub async fn flush_database_and_wait(
+    client: &EnterpriseClient,
+    bdb_uid: u32,
+    timeout: Duration,
+    on_progress: Option<EnterpriseProgressCallback>,
+) -> Result<()> {
+    // Trigger flush
+    let response = client.databases().flush(bdb_uid).await?;
+
+    // Poll until completion
+    poll_action(
+        client,
+        &response.action_uid,
+        timeout,
+        DEFAULT_INTERVAL,
+        on_progress,
+    )
+    .await?;
+
+    Ok(())
+}

--- a/crates/redisctl-mcp/src/lib.rs
+++ b/crates/redisctl-mcp/src/lib.rs
@@ -246,6 +246,10 @@ mod tests {
         // Write operations
         let _ = tools::enterprise::backup_enterprise_database(state.clone());
         let _ = tools::enterprise::import_enterprise_database(state.clone());
+        let _ = tools::enterprise::create_enterprise_database(state.clone());
+        let _ = tools::enterprise::update_enterprise_database(state.clone());
+        let _ = tools::enterprise::delete_enterprise_database(state.clone());
+        let _ = tools::enterprise::flush_enterprise_database(state.clone());
     }
 
     #[test]

--- a/crates/redisctl-mcp/src/main.rs
+++ b/crates/redisctl-mcp/src/main.rs
@@ -241,6 +241,10 @@ Redis Enterprise clusters and databases, and direct Redis database operations.
 ### Redis Enterprise - Write Operations (require --read-only=false)
 - backup_enterprise_database: Trigger a database backup and wait for completion
 - import_enterprise_database: Import data into a database and wait for completion
+- create_enterprise_database: Create a new database
+- update_enterprise_database: Update database configuration
+- delete_enterprise_database: Delete a database
+- flush_enterprise_database: Flush all data from a database
 
 ### Redis Database - Connection
 - redis_ping: Test connectivity
@@ -370,6 +374,10 @@ In HTTP mode with OAuth, credentials can be passed via JWT claims.
         // Enterprise - Write Operations (require --read-only=false)
         .tool(tools::enterprise::backup_enterprise_database(state.clone()))
         .tool(tools::enterprise::import_enterprise_database(state.clone()))
+        .tool(tools::enterprise::create_enterprise_database(state.clone()))
+        .tool(tools::enterprise::update_enterprise_database(state.clone()))
+        .tool(tools::enterprise::delete_enterprise_database(state.clone()))
+        .tool(tools::enterprise::flush_enterprise_database(state.clone()))
         // Redis - Connection
         .tool(tools::redis::ping(state.clone()))
         .tool(tools::redis::info(state.clone()))


### PR DESCRIPTION
## Summary

- Add MCP tools for Enterprise database management (create, update, delete, flush)
- Add `flush_database_and_wait` workflow to redisctl-core

## New MCP Tools

| Tool | Description |
|------|-------------|
| `create_enterprise_database` | Create a new database with configurable options |
| `update_enterprise_database` | Update database configuration via JSON |
| `delete_enterprise_database` | Delete a database |
| `flush_enterprise_database` | Flush all data from a database (async with polling) |

All write tools:
- Require `--allow-writes` flag (disabled by default)
- Use Layer 2 workflows where async operations are involved

## Test plan

- [x] All existing tests pass
- [x] New tools are registered in router
- [x] Tools build successfully (tested in `test_enterprise_tools_build`)

## Related

- Partial progress on #631 (CLI/MCP parity)
- Closes the Enterprise database operations portion of #629