### PR TITLE
feat(mcp): add Cloud database flush operation

### DIFF
--- a/crates/redisctl-mcp/src/lib.rs
+++ b/crates/redisctl-mcp/src/lib.rs
@@ -200,6 +200,7 @@ mod tests {
         let _ = tools::cloud::backup_database(state.clone());
         let _ = tools::cloud::import_database(state.clone());
         let _ = tools::cloud::delete_subscription(state.clone());
+        let _ = tools::cloud::flush_database(state.clone());
     }
 
     #[test]

--- a/crates/redisctl-mcp/src/main.rs
+++ b/crates/redisctl-mcp/src/main.rs
@@ -191,6 +191,7 @@ Redis Enterprise clusters and databases, and direct Redis database operations.
 - backup_database: Trigger a manual backup
 - import_database: Import data into a database
 - delete_subscription: Delete a subscription (all databases must be deleted first)
+- flush_database: Flush all data from a database
 
 ### Redis Enterprise - Cluster
 - get_cluster: Get cluster information
@@ -336,6 +337,7 @@ In HTTP mode with OAuth, credentials can be passed via JWT claims.
         .tool(tools::cloud::backup_database(state.clone()))
         .tool(tools::cloud::import_database(state.clone()))
         .tool(tools::cloud::delete_subscription(state.clone()))
+        .tool(tools::cloud::flush_database(state.clone()))
         // Enterprise - Cluster
         .tool(tools::enterprise::get_cluster(state.clone()))
         .tool(tools::enterprise::get_cluster_stats(state.clone()))


### PR DESCRIPTION
## Summary

- Add `flush_database_and_wait` workflow to redisctl-core for Cloud
- Add `flush_database` MCP tool

## New MCP Tool

| Tool | Description |
|------|-------------|
| `flush_database` | Flush all data from a Redis Cloud database (async with polling) |

The tool:
- Requires `--allow-writes` flag
- Uses Layer 2 workflow with task polling

## Test plan

- [x] All existing tests pass
- [x] Tool registered in router and tested in `test_cloud_tools_build`

## Related

- Continues #631 (CLI/MCP parity)