### PR TITLE
feat(mcp): add Cloud certificate and Enterprise roles tools

### DIFF
--- a/crates/redisctl-mcp/src/lib.rs
+++ b/crates/redisctl-mcp/src/lib.rs
@@ -201,6 +201,7 @@ mod tests {
         let _ = tools::cloud::import_database(state.clone());
         let _ = tools::cloud::delete_subscription(state.clone());
         let _ = tools::cloud::flush_database(state.clone());
+        let _ = tools::cloud::get_database_certificate(state.clone());
     }
 
     #[test]
@@ -244,6 +245,9 @@ mod tests {
         // Modules
         let _ = tools::enterprise::list_modules(state.clone());
         let _ = tools::enterprise::get_module(state.clone());
+        // Roles
+        let _ = tools::enterprise::list_roles(state.clone());
+        let _ = tools::enterprise::get_role(state.clone());
         // Write operations
         let _ = tools::enterprise::backup_enterprise_database(state.clone());
         let _ = tools::enterprise::import_enterprise_database(state.clone());

--- a/crates/redisctl-mcp/src/main.rs
+++ b/crates/redisctl-mcp/src/main.rs
@@ -164,6 +164,7 @@ Redis Enterprise clusters and databases, and direct Redis database operations.
 - get_backup_status: Get database backup status
 - get_slow_log: Get slow query log
 - get_database_tags: Get tags for a database
+- get_database_certificate: Get TLS/SSL certificate for a database
 
 ### Redis Cloud - Account & Configuration
 - get_account: Get current account information
@@ -238,6 +239,10 @@ Redis Enterprise clusters and databases, and direct Redis database operations.
 ### Redis Enterprise - Modules
 - list_modules: List installed Redis modules (RedisJSON, RediSearch, etc.)
 - get_module: Get details about a specific module
+
+### Redis Enterprise - Roles
+- list_enterprise_roles: List all roles in the cluster
+- get_enterprise_role: Get role details and permissions
 
 ### Redis Enterprise - Write Operations (require --read-only=false)
 - backup_enterprise_database: Trigger a database backup and wait for completion
@@ -314,6 +319,7 @@ In HTTP mode with OAuth, credentials can be passed via JWT claims.
         .tool(tools::cloud::get_backup_status(state.clone()))
         .tool(tools::cloud::get_slow_log(state.clone()))
         .tool(tools::cloud::get_tags(state.clone()))
+        .tool(tools::cloud::get_database_certificate(state.clone()))
         // Cloud - Account & Configuration
         .tool(tools::cloud::get_account(state.clone()))
         .tool(tools::cloud::get_regions(state.clone()))
@@ -373,6 +379,9 @@ In HTTP mode with OAuth, credentials can be passed via JWT claims.
         // Enterprise - Modules
         .tool(tools::enterprise::list_modules(state.clone()))
         .tool(tools::enterprise::get_module(state.clone()))
+        // Enterprise - Roles
+        .tool(tools::enterprise::list_roles(state.clone()))
+        .tool(tools::enterprise::get_role(state.clone()))
         // Enterprise - Write Operations (require --read-only=false)
         .tool(tools::enterprise::backup_enterprise_database(state.clone()))
         .tool(tools::enterprise::import_enterprise_database(state.clone()))


### PR DESCRIPTION
## Summary

- Add `get_database_certificate` tool for Cloud TLS certificates
- Add `list_enterprise_roles` and `get_enterprise_role` tools

## New MCP Tools

| Tool | Platform | Description |
|------|----------|-------------|
| `get_database_certificate` | Cloud | Get TLS/SSL certificate for database connections |
| `list_enterprise_roles` | Enterprise | List all roles with permissions |
| `get_enterprise_role` | Enterprise | Get specific role details |

All tools are read-only.

## Test plan

- [x] All existing tests pass
- [x] New tools registered and tested

## Related

- Continues #631 (CLI/MCP parity)