### PR TITLE
feat(docker): add redisctl-mcp binary to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ WORKDIR /app
 # Copy all source files
 COPY . .
 
-# Build static binary with musl
-RUN cargo build --release --bin redisctl
+# Build static binaries with musl
+RUN cargo build --release --bin redisctl --bin redisctl-mcp
 
 # Final minimal image
 FROM alpine:3.19
@@ -19,8 +19,9 @@ FROM alpine:3.19
 # Install runtime dependencies
 RUN apk add --no-cache ca-certificates
 
-# Copy binary from builder
+# Copy binaries from builder
 COPY --from=builder /app/target/release/redisctl /usr/local/bin/redisctl
+COPY --from=builder /app/target/release/redisctl-mcp /usr/local/bin/redisctl-mcp
 
 # Create non-root user
 RUN adduser -D -u 1001 redisctl

--- a/docs/docs/getting-started/docker.md
+++ b/docs/docs/getting-started/docker.md
@@ -84,6 +84,46 @@ docker run --rm \
   enterprise support-package cluster --output-dir /output
 ```
 
+## MCP Server
+
+The Docker image also includes `redisctl-mcp` for AI assistant integration:
+
+```bash
+# Run MCP server with environment credentials
+docker run -i --rm \
+  -e REDIS_ENTERPRISE_URL \
+  -e REDIS_ENTERPRISE_USER \
+  -e REDIS_ENTERPRISE_PASSWORD \
+  ghcr.io/redis-developer/redisctl \
+  redisctl-mcp --read-only=false
+
+# Or mount config for profile-based auth
+docker run -i --rm \
+  -v ~/.config/redisctl:/root/.config/redisctl:ro \
+  ghcr.io/redis-developer/redisctl \
+  redisctl-mcp --profile my-profile
+```
+
+For IDE configuration (note the `-i` flag for stdin):
+
+```json
+{
+  "mcpServers": {
+    "redisctl": {
+      "command": "docker",
+      "args": [
+        "run", "-i", "--rm",
+        "-v", "~/.config/redisctl:/root/.config/redisctl:ro",
+        "ghcr.io/redis-developer/redisctl",
+        "redisctl-mcp", "--profile", "my-profile"
+      ]
+    }
+  }
+}
+```
+
+**Note:** Native installation is recommended for MCP usage since Docker adds latency to each tool call.
+
 ## Image Tags
 
 | Tag | Description |


### PR DESCRIPTION
## Summary

- Build both `redisctl` and `redisctl-mcp` binaries in the Docker image
- Keep `redisctl` as the default entrypoint
- Add documentation for running MCP server from Docker

## Usage

```bash
# CLI (default, unchanged)
docker run ghcr.io/redis-developer/redisctl cloud db list

# MCP server
docker run -i ghcr.io/redis-developer/redisctl redisctl-mcp --profile myprofile
```

## Test plan

- [ ] Build Docker image locally: `docker build -t redisctl-test .`
- [ ] Verify redisctl works: `docker run redisctl-test --version`
- [ ] Verify redisctl-mcp works: `docker run redisctl-test redisctl-mcp --help`

Closes #637