### PR TITLE
chore: upgrade reqwest to 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ version = "0.3.1"
 version = "0.6.2"
 edition = "2024"
 rust-version = "1.89"
-authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]
+authors = ["Josh Rotenberg <josh.rotenberg@redis.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/redis-developer/redisctl"
 homepage = "https://github.com/redis-developer/redisctl"
@@ -63,7 +63,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 async-trait = "0.1"
 
 # HTTP and APIs
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "multipart"] }
+reqwest = { version = "0.13", default-features = false, features = ["json", "rustls", "multipart"] }
 url = "2.5"
 base64 = "0.22"
 urlencoding = "2.1"


### PR DESCRIPTION
## Summary

- Bump reqwest from 0.12 to 0.13 to align with redis-cloud and redis-enterprise
- Update `rustls-tls` feature to `rustls` (renamed in 0.13)
- Update author email to josh.rotenberg@redis.com

This eliminates duplicate reqwest versions being compiled.

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`

Closes #641