### PR TITLE
feat(mcp): add create_subscription tool to complete write operations

### DIFF
--- a/crates/redisctl-mcp/src/main.rs
+++ b/crates/redisctl-mcp/src/main.rs
@@ -358,6 +358,7 @@ In HTTP mode with OAuth, credentials can be passed via JWT claims.
         .tool(tools::cloud::import_database(state.clone()))
         .tool(tools::cloud::delete_subscription(state.clone()))
         .tool(tools::cloud::flush_database(state.clone()))
+        .tool(tools::cloud::create_subscription(state.clone()))
         // Enterprise - Cluster
         .tool(tools::enterprise::get_cluster(state.clone()))
         .tool(tools::enterprise::get_cluster_stats(state.clone()))


### PR DESCRIPTION
## Summary

Adds the final missing write operation from #629: `create_subscription` for Redis Cloud.

## Implemented Tools

### Enterprise Write Operations (were already implemented)
- `create_enterprise_database` - Create a new database
- `update_enterprise_database` - Update database configuration
- `delete_enterprise_database` - Delete a database
- `flush_enterprise_database` - Flush all data

### Cloud Write Operations (were already implemented + new)
- `create_database` - Create a new database
- `update_database` - Update database configuration
- `delete_database` - Delete a database
- `backup_database` - Trigger backup
- `import_database` - Import data
- `delete_subscription` - Delete subscription
- `flush_database` - Flush all data
- **`create_subscription`** - **NEW** - Create Pro subscription with initial database

## create_subscription Tool

Provides a simplified interface for creating subscriptions:

```json
{
  "name": "my-subscription",
  "cloud_provider": "AWS",
  "region": "us-east-1", 
  "database_name": "my-db",
  "memory_limit_in_gb": 1.0,
  "protocol": "redis",
  "replication": true
}
```

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`

Closes #629