### PR TITLE
docs(mcp): add Cloud and Enterprise quickstart walkthroughs

### DIFF
--- a/docs/docs/mcp/cloud-quickstart.md
+++ b/docs/docs/mcp/cloud-quickstart.md
@@ -1,0 +1,175 @@
+# Cloud Quickstart
+
+Get up and running with MCP for Redis Cloud in 5 minutes.
+
+## Prerequisites
+
+- Redis Cloud account with API access enabled
+- API key and secret key from [Redis Cloud Console](https://cloud.redis.io/) → Account → API Keys
+- redisctl installed ([Installation Guide](../getting-started/installation.md))
+
+## Step 1: Create a Profile
+
+```bash
+redisctl profile set my-cloud \
+  --type cloud \
+  --api-key YOUR_API_KEY \
+  --api-secret YOUR_SECRET_KEY
+```
+
+Verify it works:
+
+```bash
+redisctl -p my-cloud cloud subscription list
+```
+
+## Step 2: Configure Your AI Assistant
+
+Add to your MCP configuration (read-only by default for safe exploration):
+
+=== "Claude Desktop"
+
+    **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+
+    ```json
+    {
+      "mcpServers": {
+        "redisctl": {
+          "command": "redisctl-mcp",
+          "args": ["--profile", "my-cloud"]
+        }
+      }
+    }
+    ```
+
+=== "Claude Code"
+
+    Add to `.mcp.json` in your project:
+
+    ```json
+    {
+      "mcpServers": {
+        "redisctl": {
+          "command": "redisctl-mcp",
+          "args": ["--profile", "my-cloud"]
+        }
+      }
+    }
+    ```
+
+=== "Cursor"
+
+    **macOS**: `~/.cursor/mcp.json`
+
+    ```json
+    {
+      "mcpServers": {
+        "redisctl": {
+          "command": "redisctl-mcp",
+          "args": ["--profile", "my-cloud"]
+        }
+      }
+    }
+    ```
+
+Restart your AI assistant to load the new configuration.
+
+## Step 3: Try These Prompts
+
+Start a conversation with your AI assistant and try these examples:
+
+### Explore Your Infrastructure
+
+| Prompt | What it does |
+|--------|--------------|
+| "List my Redis Cloud subscriptions" | Shows all your subscriptions with IDs and names |
+| "Show databases in subscription 12345" | Lists databases in a specific subscription |
+| "What's my current account info?" | Displays account details and limits |
+
+### Database Information
+
+| Prompt | What it does |
+|--------|--------------|
+| "Show me database 67890 details" | Full database configuration |
+| "What modules are enabled on my databases?" | Lists databases with their modules |
+| "Which databases have persistence enabled?" | Filters by configuration |
+
+### Monitoring
+
+| Prompt | What it does |
+|--------|--------------|
+| "Are there any active tasks?" | Shows pending async operations |
+| "What's the status of task abc-123?" | Checks a specific task |
+| "Show me my cost report for this month" | Displays billing information |
+
+## Optional: Enable Write Operations
+
+By default, the MCP server runs in **read-only mode** - you can explore freely without risk of modifying anything. When you're ready for write operations, update your config:
+
+```json
+{
+  "mcpServers": {
+    "redisctl": {
+      "command": "redisctl-mcp",
+      "args": ["--profile", "my-cloud", "--read-only=false"]
+    }
+  }
+}
+```
+
+Write prompts to try:
+
+| Prompt | What it does |
+|--------|--------------|
+| "Create a 1GB database called cache-prod in subscription 12345" | Creates a new database |
+| "Backup database 67890" | Triggers an on-demand backup |
+
+## Example Conversation
+
+> **You**: What subscriptions do I have?
+>
+> **AI**: You have 2 subscriptions:
+>
+> | ID | Name | Cloud | Region | Databases |
+> |----|------|-------|--------|-----------|
+> | 12345 | Production | AWS | us-east-1 | 3 |
+> | 12346 | Staging | GCP | us-central1 | 1 |
+
+> **You**: Show me the databases in Production
+>
+> **AI**: Production (subscription 12345) has 3 databases:
+>
+> | ID | Name | Memory | Status |
+> |----|------|--------|--------|
+> | 101 | users-cache | 2 GB | active |
+> | 102 | sessions | 512 MB | active |
+> | 103 | analytics | 4 GB | active |
+
+> **You**: What's the total memory I'm using?
+>
+> **AI**: Across your 2 subscriptions, you're using **6.5 GB** of memory:
+> - Production: 6.5 GB (3 databases)
+> - Staging: 256 MB (1 database)
+
+## Troubleshooting
+
+### "No subscriptions found"
+
+- Verify your API key has the correct permissions
+- Check that the account has subscriptions created
+
+### "Authentication failed"
+
+- Ensure API key and secret are correct
+- Verify API access is enabled in Cloud Console
+
+### Tools not appearing
+
+- Restart your AI assistant after config changes
+- Check that `redisctl-mcp` is in your PATH
+
+## Next Steps
+
+- [Tools Reference](tools-reference.md) - Complete list of Cloud tools
+- [Advanced Usage](advanced-usage.md) - Complex queries with JMESPath
+- [Enterprise Quickstart](enterprise-quickstart.md) - If you also use Redis Enterprise

--- a/docs/docs/mcp/enterprise-quickstart.md
+++ b/docs/docs/mcp/enterprise-quickstart.md
@@ -1,0 +1,252 @@
+# Enterprise Quickstart
+
+Get up and running with MCP for Redis Enterprise in 5 minutes.
+
+## Prerequisites
+
+- Redis Enterprise cluster with REST API access (port 9443)
+- Admin credentials for your cluster(s)
+- redisctl installed ([Installation Guide](../getting-started/installation.md))
+
+## Step 1: Create a Profile
+
+```bash
+redisctl profile set my-cluster \
+  --type enterprise \
+  --url https://your-cluster:9443 \
+  --username admin@redis.local \
+  --password YOUR_PASSWORD \
+  --insecure  # if using self-signed certificates
+```
+
+Verify it works:
+
+```bash
+redisctl -p my-cluster enterprise cluster get
+```
+
+### Multiple Clusters
+
+A key advantage of redisctl is **multi-cluster management**. Add profiles for each cluster:
+
+```bash
+# Production cluster
+redisctl profile set prod-cluster \
+  --type enterprise \
+  --url https://prod.example.com:9443 \
+  --username admin \
+  --password PROD_PASSWORD
+
+# Staging cluster
+redisctl profile set staging-cluster \
+  --type enterprise \
+  --url https://staging.example.com:9443 \
+  --username admin \
+  --password STAGING_PASSWORD
+
+# Development cluster
+redisctl profile set dev-cluster \
+  --type enterprise \
+  --url https://dev.example.com:9443 \
+  --username admin \
+  --password DEV_PASSWORD \
+  --insecure
+```
+
+## Step 2: Configure Your AI Assistant
+
+Add to your MCP configuration (read-only by default - explore safely without modifying anything):
+
+=== "Claude Desktop"
+
+    **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+
+    ```json
+    {
+      "mcpServers": {
+        "redisctl": {
+          "command": "redisctl-mcp",
+          "args": ["--profile", "my-cluster"]
+        }
+      }
+    }
+    ```
+
+=== "Claude Code"
+
+    Add to `.mcp.json` in your project:
+
+    ```json
+    {
+      "mcpServers": {
+        "redisctl": {
+          "command": "redisctl-mcp",
+          "args": ["--profile", "my-cluster"]
+        }
+      }
+    }
+    ```
+
+=== "Cursor"
+
+    **macOS**: `~/.cursor/mcp.json`
+
+    ```json
+    {
+      "mcpServers": {
+        "redisctl": {
+          "command": "redisctl-mcp",
+          "args": ["--profile", "my-cluster"]
+        }
+      }
+    }
+    ```
+
+Restart your AI assistant to load the new configuration.
+
+## Step 3: Try These Prompts
+
+Start a conversation with your AI assistant and try these examples:
+
+### Cluster Overview
+
+| Prompt | What it does |
+|--------|--------------|
+| "Show me the cluster info" | Cluster name, version, node count |
+| "List all nodes in the cluster" | Node IDs, addresses, status |
+| "What's the cluster health?" | Overall status and any issues |
+
+### Database Management
+
+| Prompt | What it does |
+|--------|--------------|
+| "List all databases" | All databases with memory and status |
+| "Show database 1 details" | Full configuration for a database |
+| "Which databases have persistence enabled?" | Filter by configuration |
+| "What modules are loaded?" | List available modules |
+
+### License Management
+
+| Prompt | What it does |
+|--------|--------------|
+| "Check the license status" | Expiration, type, features |
+| "Show license usage" | Shards and RAM used vs limits |
+| "Is the license expiring soon?" | Quick expiration check |
+
+### Monitoring
+
+| Prompt | What it does |
+|--------|--------------|
+| "Are there any alerts?" | Active cluster alerts |
+| "Show cluster statistics" | CPU, memory, throughput |
+| "Get stats for database 1" | Per-database metrics |
+
+### Multi-Cluster Operations
+
+| Prompt | What it does |
+|--------|--------------|
+| "List my profiles" | Shows all configured clusters |
+| "Switch to prod-cluster" | Changes default Enterprise profile |
+| "Show cluster info for staging-cluster" | Query a specific cluster |
+
+## Optional: Enable Write Operations
+
+By default, the MCP server runs in **read-only mode** - you can explore your clusters freely without risk of modifying anything. When you're ready for write operations, update your config:
+
+```json
+{
+  "mcpServers": {
+    "redisctl": {
+      "command": "redisctl-mcp",
+      "args": ["--profile", "my-cluster", "--read-only=false"]
+    }
+  }
+}
+```
+
+Write prompts to try:
+
+| Prompt | What it does |
+|--------|--------------|
+| "Create a 2GB database called cache-db" | Creates a new database |
+| "Enable maintenance mode" | Prepares cluster for upgrades |
+| "Update the cluster license with: LICENSE_STRING" | Applies a new license |
+
+## Example Conversation
+
+> **You**: What profiles do I have configured?
+>
+> **AI**: You have 3 Enterprise profiles:
+>
+> | Name | URL | Default |
+> |------|-----|---------|
+> | prod-cluster | https://prod:9443 | Yes |
+> | staging-cluster | https://staging:9443 | No |
+> | dev-cluster | https://dev:9443 | No |
+
+> **You**: Check the license on all my clusters
+>
+> **AI**: I'll check each cluster:
+>
+> **prod-cluster**: Enterprise license, expires March 15, 2027 (407 days remaining)
+> - Shards: 24/100 used
+> - Status: OK
+>
+> **staging-cluster**: Trial license, expires February 28, 2026 (23 days remaining)
+> - Shards: 4/4 used
+> - Status: WARNING - Expiring soon, at shard limit
+>
+> **dev-cluster**: Trial license, expires February 20, 2026 (15 days remaining)
+> - Shards: 2/4 used
+> - Status: WARNING - Expiring soon
+
+> **You**: What's my total memory allocation across all clusters?
+>
+> **AI**: Total memory across 3 clusters: **52 GB**
+>
+> | Cluster | Databases | Memory |
+> |---------|-----------|--------|
+> | prod-cluster | 8 | 40 GB |
+> | staging-cluster | 3 | 8 GB |
+> | dev-cluster | 2 | 4 GB |
+
+## Multi-Cluster Workflow
+
+The MCP server can query across multiple clusters by switching profiles:
+
+1. **List profiles** - AI discovers your configured clusters
+2. **Set default** - AI switches to a cluster using `profile_set_default_enterprise`
+3. **Query** - AI runs tools against the current default
+4. **Repeat** - AI switches and queries other clusters
+5. **Aggregate** - AI combines results into a unified view
+
+This enables powerful cross-cluster operations that aren't possible with the native Redis Enterprise UI.
+
+## Troubleshooting
+
+### "Connection refused"
+
+- Verify the cluster URL and port (default: 9443)
+- Check firewall rules allow access
+- Ensure the REST API is enabled
+
+### "Authentication failed"
+
+- Verify username and password
+- Check the user has appropriate permissions
+
+### "Certificate error"
+
+- Add `--insecure` for self-signed certificates
+- Or configure a CA certificate with `--ca-cert`
+
+### Tools not appearing
+
+- Restart your AI assistant after config changes
+- Check that `redisctl-mcp` is in your PATH
+
+## Next Steps
+
+- [Tools Reference](tools-reference.md) - Complete list of Enterprise tools
+- [Advanced Usage](advanced-usage.md) - Complex queries with JMESPath
+- [Cloud Quickstart](cloud-quickstart.md) - If you also use Redis Cloud

--- a/docs/docs/mcp/getting-started.md
+++ b/docs/docs/mcp/getting-started.md
@@ -354,6 +354,13 @@ The MCP server uses:
 
 For MCP protocol details, see the [MCP Specification](https://spec.modelcontextprotocol.io/).
 
+## Quick Walkthroughs
+
+Want a faster path to try things out? Check out our quickstart guides:
+
+- **[Cloud Quickstart](cloud-quickstart.md)** - Redis Cloud setup with example prompts
+- **[Enterprise Quickstart](enterprise-quickstart.md)** - Redis Enterprise setup with multi-cluster examples
+
 ## Next Steps
 
 - [Tools Reference](tools-reference.md) - Complete list of available tools

--- a/docs/docs/mcp/index.md
+++ b/docs/docs/mcp/index.md
@@ -69,6 +69,10 @@ Once configured, interact naturally with your Redis infrastructure:
 
 ## Getting Started
 
-Ready to set up MCP? Head to the [Getting Started](getting-started.md) guide.
+Ready to set up MCP? Choose your path:
+
+- **[Getting Started](getting-started.md)** - Full installation and configuration guide
+- **[Cloud Quickstart](cloud-quickstart.md)** - Redis Cloud users: get running in 5 minutes
+- **[Enterprise Quickstart](enterprise-quickstart.md)** - Redis Enterprise users: includes multi-cluster setup
 
 Want to see what's possible? Check out [Advanced Usage](advanced-usage.md) for JMESPath integration and complex analytics pipelines.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -166,6 +166,8 @@ nav:
   - MCP:
       - mcp/index.md
       - Getting Started: mcp/getting-started.md
+      - Cloud Quickstart: mcp/cloud-quickstart.md
+      - Enterprise Quickstart: mcp/enterprise-quickstart.md
       - Tools Reference: mcp/tools-reference.md
       - Advanced Usage: mcp/advanced-usage.md
       - Workflows: mcp/workflows.md


### PR DESCRIPTION
## Summary

Add dedicated quickstart guides for Cloud and Enterprise users to get up and running with MCP quickly.

## Changes

- **cloud-quickstart.md** - 5-minute guide for Redis Cloud users
  - Profile setup with API keys
  - Example prompts for subscriptions, databases, monitoring
  - Sample conversation showing the experience

- **enterprise-quickstart.md** - Guide for Redis Enterprise users
  - Single and multi-cluster profile setup
  - Example prompts for cluster, databases, license management
  - Multi-cluster workflow explanation
  - Sample conversation with cross-cluster queries

- Updated nav and cross-links from index and getting-started pages

## Design Decisions

- **Read-only by default** - All examples use read-only mode, with writes as an optional section
- **Prompt tables** - Easy-to-scan format for trying things out
- **Example conversations** - Shows what the experience actually looks like

Closes #645