### PR TITLE
fix(mcp): wrap array results in JSON objects for structuredContent compliance

### DIFF
--- a/crates/redisctl-mcp/src/tools/cloud.rs
+++ b/crates/redisctl-mcp/src/tools/cloud.rs
@@ -17,6 +17,7 @@ use tower_mcp::extract::{Json, State};
 use tower_mcp::{CallToolResult, Error as McpError, Tool, ToolBuilder, ToolError};
 
 use crate::state::AppState;
+use crate::tools::wrap_list;
 
 /// Input for listing subscriptions
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -370,7 +371,7 @@ pub fn list_tasks(state: Arc<AppState>) -> Tool {
                     .await
                     .map_err(|e| ToolError::new(format!("Failed to list tasks: {}", e)))?;
 
-                CallToolResult::from_serialize(&tasks)
+                wrap_list("tasks", &tasks)
             },
         )
         .build()

--- a/crates/redisctl-mcp/src/tools/enterprise.rs
+++ b/crates/redisctl-mcp/src/tools/enterprise.rs
@@ -26,6 +26,7 @@ use tower_mcp::extract::{Json, State};
 use tower_mcp::{CallToolResult, Error as McpError, Tool, ToolBuilder, ToolError};
 
 use crate::state::AppState;
+use crate::tools::wrap_list;
 
 /// Input for getting cluster info (no required parameters)
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -194,7 +195,7 @@ pub fn list_logs(state: Arc<AppState>) -> Tool {
                     .await
                     .map_err(|e| ToolError::new(format!("Failed to list logs: {}", e)))?;
 
-                CallToolResult::from_serialize(&logs)
+                wrap_list("logs", &logs)
             },
         )
         .build()
@@ -260,7 +261,7 @@ pub fn list_databases(state: Arc<AppState>) -> Tool {
                     })
                     .collect();
 
-                CallToolResult::from_serialize(&filtered)
+                wrap_list("databases", &filtered)
             },
         )
         .build()
@@ -323,21 +324,7 @@ pub fn list_nodes(state: Arc<AppState>) -> Tool {
                     .await
                     .map_err(|e| ToolError::new(format!("Failed to list nodes: {}", e)))?;
 
-                let output = nodes
-                    .iter()
-                    .map(|node| {
-                        format!(
-                            "- Node {} ({}): {}",
-                            node.uid,
-                            node.addr.as_deref().unwrap_or("unknown"),
-                            node.status
-                        )
-                    })
-                    .collect::<Vec<_>>()
-                    .join("\n");
-
-                let summary = format!("Found {} node(s)\n\n{}", nodes.len(), output);
-                Ok(CallToolResult::text(summary))
+                wrap_list("nodes", &nodes)
             },
         )
         .build()
@@ -410,21 +397,7 @@ pub fn list_users(state: Arc<AppState>) -> Tool {
                     .await
                     .map_err(|e| ToolError::new(format!("Failed to list users: {}", e)))?;
 
-                let output = users
-                    .iter()
-                    .map(|user| {
-                        format!(
-                            "- {} (UID: {}): {}",
-                            user.name.as_deref().unwrap_or("(unnamed)"),
-                            user.uid,
-                            user.email
-                        )
-                    })
-                    .collect::<Vec<_>>()
-                    .join("\n");
-
-                let summary = format!("Found {} user(s)\n\n{}", users.len(), output);
-                Ok(CallToolResult::text(summary))
+                wrap_list("users", &users)
             },
         )
         .build()
@@ -493,7 +466,7 @@ pub fn list_alerts(state: Arc<AppState>) -> Tool {
                     .await
                     .map_err(|e| ToolError::new(format!("Failed to list alerts: {}", e)))?;
 
-                CallToolResult::from_serialize(&alerts)
+                wrap_list("alerts", &alerts)
             },
         )
         .build()
@@ -527,7 +500,7 @@ pub fn list_database_alerts(state: Arc<AppState>) -> Tool {
                     .await
                     .map_err(|e| ToolError::new(format!("Failed to list database alerts: {}", e)))?;
 
-                CallToolResult::from_serialize(&alerts)
+                wrap_list("alerts", &alerts)
             },
         )
         .build()
@@ -893,7 +866,7 @@ pub fn list_shards(state: Arc<AppState>) -> Tool {
                         .map_err(|e| ToolError::new(format!("Failed to list shards: {}", e)))?
                 };
 
-                CallToolResult::from_serialize(&shards)
+                wrap_list("shards", &shards)
             },
         )
         .build()
@@ -968,7 +941,7 @@ pub fn get_database_endpoints(state: Arc<AppState>) -> Tool {
                     .await
                     .map_err(|e| ToolError::new(format!("Failed to get endpoints: {}", e)))?;
 
-                CallToolResult::from_serialize(&endpoints)
+                wrap_list("endpoints", &endpoints)
             },
         )
         .build()
@@ -1007,7 +980,7 @@ pub fn list_debug_info_tasks(state: Arc<AppState>) -> Tool {
                     .await
                     .map_err(|e| ToolError::new(format!("Failed to list debug info tasks: {}", e)))?;
 
-                CallToolResult::from_serialize(&tasks)
+                wrap_list("tasks", &tasks)
             },
         )
         .build()
@@ -1083,7 +1056,7 @@ pub fn list_modules(state: Arc<AppState>) -> Tool {
                     .await
                     .map_err(|e| ToolError::new(format!("Failed to list modules: {}", e)))?;
 
-                CallToolResult::from_serialize(&modules)
+                wrap_list("modules", &modules)
             },
         )
         .build()
@@ -1496,7 +1469,7 @@ pub fn list_roles(state: Arc<AppState>) -> Tool {
                     .await
                     .map_err(|e| ToolError::new(format!("Failed to list roles: {}", e)))?;
 
-                CallToolResult::from_serialize(&roles)
+                wrap_list("roles", &roles)
             },
         )
         .build()
@@ -1569,7 +1542,7 @@ pub fn list_redis_acls(state: Arc<AppState>) -> Tool {
                     .await
                     .map_err(|e| ToolError::new(format!("Failed to list ACLs: {}", e)))?;
 
-                CallToolResult::from_serialize(&acls)
+                wrap_list("acls", &acls)
             },
         )
         .build()

--- a/crates/redisctl-mcp/src/tools/mod.rs
+++ b/crates/redisctl-mcp/src/tools/mod.rs
@@ -1,6 +1,18 @@
 //! MCP tools for Redis Cloud, Enterprise, and direct database operations
 
+use serde::Serialize;
+use tower_mcp::{CallToolResult, Error as McpError};
+
 pub mod cloud;
 pub mod enterprise;
 pub mod profile;
 pub mod redis;
+
+/// Wrap a list of items in a JSON object with a domain-specific key and count field.
+///
+/// The MCP protocol requires `structuredContent` to be a JSON object, not an array.
+/// This helper wraps `Vec<T>` results so they serialize as `{ key: [...], "count": N }`
+/// instead of a bare `[...]`.
+pub fn wrap_list<T: Serialize>(key: &str, items: &[T]) -> Result<CallToolResult, McpError> {
+    CallToolResult::from_serialize(&serde_json::json!({ key: items, "count": items.len() }))
+}

--- a/crates/redisctl-mcp/tests/cloud_tools.rs
+++ b/crates/redisctl-mcp/tests/cloud_tools.rs
@@ -233,7 +233,8 @@ async fn test_list_tasks() {
 
     let result = call_tool_json(&tool, json!({})).await;
 
-    let tasks = result.as_array().unwrap();
+    assert_eq!(result["count"], 2);
+    let tasks = result["tasks"].as_array().unwrap();
     assert_eq!(tasks.len(), 2);
     assert_eq!(tasks[0]["taskId"], "task-001");
     assert_eq!(tasks[0]["status"], "processing-completed");

--- a/crates/redisctl-mcp/tests/enterprise_tools.rs
+++ b/crates/redisctl-mcp/tests/enterprise_tools.rs
@@ -178,8 +178,8 @@ async fn test_list_logs() {
 
     let result = call_tool_json(&tool, json!({})).await;
 
-    assert!(result.is_array());
-    let logs = result.as_array().unwrap();
+    assert_eq!(result["count"], 3);
+    let logs = result["logs"].as_array().unwrap();
     assert_eq!(logs.len(), 3);
     assert_eq!(logs[0]["type"], "bdb_created");
     assert_eq!(logs[1]["type"], "node_joined");
@@ -215,8 +215,8 @@ async fn test_list_logs_with_params() {
     )
     .await;
 
-    assert!(result.is_array());
-    let logs = result.as_array().unwrap();
+    assert_eq!(result["count"], 1);
+    let logs = result["logs"].as_array().unwrap();
     assert_eq!(logs.len(), 1);
 }
 
@@ -244,7 +244,7 @@ async fn test_list_enterprise_databases() {
 
     let result = call_tool_json(&tool, json!({})).await;
 
-    let databases = result.as_array().expect("expected array");
+    let databases = result["databases"].as_array().expect("expected array");
     assert_eq!(databases.len(), 2);
     assert!(databases.iter().any(|db| db["name"] == "cache-primary"));
     assert!(databases.iter().any(|db| db["name"] == "sessions"));
@@ -266,7 +266,7 @@ async fn test_list_enterprise_databases_with_filter() {
 
     let result = call_tool_json(&tool, json!({"name_filter": "cache"})).await;
 
-    let databases = result.as_array().expect("expected array");
+    let databases = result["databases"].as_array().expect("expected array");
     assert_eq!(databases.len(), 2);
     assert!(databases.iter().any(|db| db["name"] == "cache-primary"));
     assert!(databases.iter().any(|db| db["name"] == "cache-replica"));
@@ -312,12 +312,14 @@ async fn test_list_nodes() {
     let state = Arc::new(AppState::with_enterprise_client(client));
     let tool = enterprise::list_nodes(state);
 
-    let result = call_tool_text(&tool, json!({})).await;
+    let result = call_tool_json(&tool, json!({})).await;
 
-    assert!(result.contains("10.0.0.1"));
-    assert!(result.contains("10.0.0.2"));
-    assert!(result.contains("10.0.0.3"));
-    assert!(result.contains("3 node(s)"));
+    assert_eq!(result["count"], 3);
+    let nodes = result["nodes"].as_array().unwrap();
+    assert_eq!(nodes.len(), 3);
+    assert_eq!(nodes[0]["addr"], "10.0.0.1");
+    assert_eq!(nodes[1]["addr"], "10.0.0.2");
+    assert_eq!(nodes[2]["addr"], "10.0.0.3");
 }
 
 #[tokio::test]
@@ -360,11 +362,13 @@ async fn test_list_enterprise_users() {
     let state = Arc::new(AppState::with_enterprise_client(client));
     let tool = enterprise::list_users(state);
 
-    let result = call_tool_text(&tool, json!({})).await;
+    let result = call_tool_json(&tool, json!({})).await;
 
-    assert!(result.contains("admin@example.com"));
-    assert!(result.contains("dev@example.com"));
-    assert!(result.contains("2 user(s)"));
+    assert_eq!(result["count"], 2);
+    let users = result["users"].as_array().unwrap();
+    assert_eq!(users.len(), 2);
+    assert_eq!(users[0]["email"], "admin@example.com");
+    assert_eq!(users[1]["email"], "dev@example.com");
 }
 
 #[tokio::test]
@@ -414,8 +418,8 @@ async fn test_list_alerts() {
 
     let result = call_tool_json(&tool, json!({})).await;
 
-    assert!(result.is_array());
-    let alerts = result.as_array().unwrap();
+    assert_eq!(result["count"], 2);
+    let alerts = result["alerts"].as_array().unwrap();
     assert_eq!(alerts.len(), 2);
     assert_eq!(alerts[0]["name"], "high_memory_usage");
     assert_eq!(alerts[1]["name"], "node_cpu_critical");
@@ -705,7 +709,8 @@ async fn test_list_debug_info_tasks() {
 
     let result = call_tool_json(&tool, json!({})).await;
 
-    let tasks = result.as_array().unwrap();
+    assert_eq!(result["count"], 2);
+    let tasks = result["tasks"].as_array().unwrap();
     assert_eq!(tasks.len(), 2);
     assert_eq!(tasks[0]["task_id"], "debug-123");
     assert_eq!(tasks[0]["status"], "completed");
@@ -777,7 +782,8 @@ async fn test_list_modules() {
 
     let result = call_tool_json(&tool, json!({})).await;
 
-    let modules = result.as_array().unwrap();
+    assert_eq!(result["count"], 2);
+    let modules = result["modules"].as_array().unwrap();
     assert_eq!(modules.len(), 2);
     assert_eq!(modules[0]["uid"], "redisjson-2.6.0");
     assert_eq!(modules[0]["module_name"], "ReJSON");


### PR DESCRIPTION
## Summary

- The MCP protocol requires `structuredContent` to be a JSON object, not an array. Tools returning `Vec<T>` via `CallToolResult::from_serialize` were serializing to bare `[{...}]` arrays, causing `"expected record, received array"` errors in MCP clients.
- Adds a `wrap_list` helper in `tools/mod.rs` that wraps array results as `{ key: [...], "count": N }` and applies it to 13 list-returning tools across `enterprise.rs` (12) and `cloud.rs` (1).
- Converts `list_nodes` and `list_users` from text-only format to structured JSON via `wrap_list` for consistency.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib --all-features` (73 tests pass)
- [x] `cargo test --test '*' --all-features` (416 non-ignored tests pass)
- [ ] Manual test via MCP tools against Docker clusters:
  - `list_enterprise_databases` with profile param
  - `list_nodes`, `list_alerts`, `list_modules` with profile param
  - `list_tasks` for cloud
  - Verify single-object tools still work (`get_cluster`, `get_license`)