### PR TITLE
feat(mcp): default to read-only mode

### DIFF
--- a/crates/redisctl-mcp/src/main.rs
+++ b/crates/redisctl-mcp/src/main.rs
@@ -42,8 +42,8 @@ struct Args {
     #[arg(short, long, env = "REDISCTL_PROFILE")]
     profile: Vec<String>,
 
-    /// Read-only mode (disables write operations)
-    #[arg(long, default_value = "false")]
+    /// Read-only mode (enabled by default; use --read-only=false to allow writes)
+    #[arg(long, default_value = "true")]
     read_only: bool,
 
     /// Redis database URL for direct connections


### PR DESCRIPTION
## Summary
- Default `--read-only` to `true` so write operations (create, update, delete, flush, backup, import) are disabled unless explicitly opted into with `--read-only=false`
- Safer default for MCP server usage, preventing accidental mutations

## Test plan
- [x] Verified only read-only tools are exposed when starting the MCP server with default flags
- [ ] Verify `--read-only=false` still enables write tools