### PR TITLE
chore(mcp): bump tower-mcp to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4164,9 +4164,9 @@ checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-mcp"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1718138ce0bd4ff2bdfdce0dc085ab165d54324f1e0aa0268b10eb36b7e63e6e"
+checksum = "a65dc3cd2b853a0aa855ebd2d8d353a21c8351573758339d4ba4e323622977a0"
 dependencies = [
  "async-trait",
  "axum",

--- a/crates/redisctl-mcp/Cargo.toml
+++ b/crates/redisctl-mcp/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 # MCP framework
-tower-mcp = { version = "0.4.0", features = ["http", "oauth"] }
+tower-mcp = { version = "0.5.0", features = ["http", "oauth"] }
 schemars = "1.2"
 
 # Internal crates

--- a/crates/redisctl-mcp/src/tools/cloud.rs
+++ b/crates/redisctl-mcp/src/tools/cloud.rs
@@ -51,7 +51,6 @@ pub fn list_subscriptions(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for getting a specific subscription
@@ -88,7 +87,6 @@ pub fn get_subscription(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for listing databases
@@ -127,7 +125,6 @@ pub fn list_databases(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for getting a specific database
@@ -166,7 +163,6 @@ pub fn get_database(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 // ============================================================================
@@ -205,7 +201,6 @@ pub fn get_account(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for getting account system logs
@@ -249,7 +244,6 @@ pub fn get_system_logs(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for getting account session logs
@@ -293,7 +287,6 @@ pub fn get_session_logs(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for getting supported regions
@@ -333,7 +326,6 @@ pub fn get_regions(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for getting database modules
@@ -370,7 +362,6 @@ pub fn get_modules(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 // ============================================================================
@@ -409,7 +400,6 @@ pub fn list_tasks(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for getting a specific task
@@ -446,7 +436,6 @@ pub fn get_task(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 // ============================================================================
@@ -487,7 +476,6 @@ pub fn list_account_users(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for getting a specific account user
@@ -524,7 +512,6 @@ pub fn get_account_user(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 // ============================================================================
@@ -563,7 +550,6 @@ pub fn list_acl_users(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for getting a specific ACL user
@@ -600,7 +586,6 @@ pub fn get_acl_user(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for listing ACL roles
@@ -635,7 +620,6 @@ pub fn list_acl_roles(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for listing Redis rules
@@ -670,7 +654,6 @@ pub fn list_redis_rules(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 // ============================================================================
@@ -720,7 +703,6 @@ pub fn get_backup_status(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for getting slow log
@@ -764,7 +746,6 @@ pub fn get_slow_log(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for getting database tags
@@ -803,7 +784,6 @@ pub fn get_tags(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for getting database certificate
@@ -845,7 +825,6 @@ pub fn get_database_certificate(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 // ============================================================================
@@ -962,7 +941,6 @@ pub fn create_database(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 // ============================================================================
@@ -1060,7 +1038,6 @@ pub fn update_database(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 // ============================================================================
@@ -1124,7 +1101,6 @@ pub fn delete_database(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 // ============================================================================
@@ -1192,7 +1168,6 @@ pub fn backup_database(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 // ============================================================================
@@ -1273,7 +1248,6 @@ pub fn import_database(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 // ============================================================================
@@ -1333,7 +1307,6 @@ pub fn delete_subscription(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 // ============================================================================
@@ -1401,7 +1374,6 @@ pub fn flush_database(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 // ============================================================================
@@ -1523,7 +1495,6 @@ pub fn create_subscription(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Instructions text describing all Cloud tools

--- a/crates/redisctl-mcp/src/tools/enterprise.rs
+++ b/crates/redisctl-mcp/src/tools/enterprise.rs
@@ -64,7 +64,6 @@ pub fn get_cluster(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 // ============================================================================
@@ -108,7 +107,6 @@ pub fn get_license(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for getting license usage
@@ -146,7 +144,6 @@ pub fn get_license_usage(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 // ============================================================================
@@ -223,7 +220,6 @@ pub fn list_logs(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 // ============================================================================
@@ -295,7 +291,6 @@ pub fn list_databases(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for getting a specific database
@@ -334,7 +329,6 @@ pub fn get_database(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for listing nodes
@@ -371,7 +365,6 @@ pub fn list_nodes(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 // ============================================================================
@@ -416,7 +409,6 @@ pub fn get_node(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 // ============================================================================
@@ -457,7 +449,6 @@ pub fn list_users(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for getting a specific user
@@ -498,7 +489,6 @@ pub fn get_user(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 // ============================================================================
@@ -539,7 +529,6 @@ pub fn list_alerts(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for listing database alerts
@@ -576,7 +565,6 @@ pub fn list_database_alerts(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 // ============================================================================
@@ -642,7 +630,6 @@ pub fn get_cluster_stats(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for getting database stats
@@ -705,7 +692,6 @@ pub fn get_database_stats(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for getting node stats
@@ -773,7 +759,6 @@ pub fn get_node_stats(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for getting all nodes stats
@@ -811,7 +796,6 @@ pub fn get_all_nodes_stats(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for getting all databases stats
@@ -849,7 +833,6 @@ pub fn get_all_databases_stats(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for getting shard stats
@@ -888,7 +871,6 @@ pub fn get_shard_stats(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for getting all shards stats
@@ -926,7 +908,6 @@ pub fn get_all_shards_stats(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 // ============================================================================
@@ -979,7 +960,6 @@ pub fn list_shards(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for getting a specific shard
@@ -1021,7 +1001,6 @@ pub fn get_shard(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 // ============================================================================
@@ -1064,7 +1043,6 @@ pub fn get_database_endpoints(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 // ============================================================================
@@ -1107,7 +1085,6 @@ pub fn list_debug_info_tasks(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for getting debug info task status
@@ -1148,7 +1125,6 @@ pub fn get_debug_info_status(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 // ============================================================================
@@ -1193,7 +1169,6 @@ pub fn list_modules(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for getting a specific module
@@ -1235,7 +1210,6 @@ pub fn get_module(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 // ============================================================================
@@ -1299,7 +1273,6 @@ pub fn backup_enterprise_database(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for importing data into an Enterprise database
@@ -1364,7 +1337,6 @@ pub fn import_enterprise_database(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for creating an Enterprise database
@@ -1446,7 +1418,6 @@ pub fn create_enterprise_database(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for updating an Enterprise database
@@ -1496,7 +1467,6 @@ pub fn update_enterprise_database(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for deleting an Enterprise database
@@ -1548,7 +1518,6 @@ pub fn delete_enterprise_database(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for flushing an Enterprise database
@@ -1607,7 +1576,6 @@ pub fn flush_enterprise_database(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 // ============================================================================
@@ -1651,7 +1619,6 @@ pub fn list_roles(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for getting a specific role
@@ -1693,7 +1660,6 @@ pub fn get_role(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 // ============================================================================
@@ -1737,7 +1703,6 @@ pub fn list_redis_acls(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for getting a specific Redis ACL
@@ -1779,7 +1744,6 @@ pub fn get_redis_acl(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 // ============================================================================
@@ -1833,7 +1797,6 @@ pub fn update_license(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for validating license
@@ -1875,7 +1838,6 @@ pub fn validate_license(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 // ============================================================================
@@ -1927,7 +1889,6 @@ pub fn update_cluster(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for getting cluster policy (no required parameters)
@@ -1966,7 +1927,6 @@ pub fn get_cluster_policy(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for updating cluster policy
@@ -2015,7 +1975,6 @@ pub fn update_cluster_policy(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 // ============================================================================
@@ -2070,7 +2029,6 @@ pub fn enable_maintenance_mode(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for disabling maintenance mode (no required parameters)
@@ -2121,7 +2079,6 @@ pub fn disable_maintenance_mode(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 // ============================================================================
@@ -2164,7 +2121,6 @@ pub fn get_cluster_certificates(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for rotating cluster certificates (no required parameters)
@@ -2214,7 +2170,6 @@ pub fn rotate_cluster_certificates(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for updating cluster certificates
@@ -2276,7 +2231,6 @@ pub fn update_cluster_certificates(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Instructions text describing all Enterprise tools

--- a/crates/redisctl-mcp/src/tools/profile.rs
+++ b/crates/redisctl-mcp/src/tools/profile.rs
@@ -84,7 +84,6 @@ pub fn list_profiles(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for showing a specific profile
@@ -257,7 +256,6 @@ pub fn show_profile(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for getting config path (no required parameters)
@@ -284,7 +282,6 @@ pub fn config_path(_state: Arc<AppState>) -> Tool {
             Ok(CallToolResult::text(output))
         })
         .build()
-        .expect("valid tool")
 }
 
 /// Input for validating config (no required parameters)
@@ -398,7 +395,6 @@ pub fn validate_config(_state: Arc<AppState>) -> Tool {
             Ok(CallToolResult::text(output))
         })
         .build()
-        .expect("valid tool")
 }
 
 // ============================================================================
@@ -453,7 +449,6 @@ pub fn set_default_cloud(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for setting default enterprise profile
@@ -504,7 +499,6 @@ pub fn set_default_enterprise(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for deleting a profile
@@ -551,7 +545,6 @@ pub fn delete_profile(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Instructions text describing all App-level tools, resources, and prompts

--- a/crates/redisctl-mcp/src/tools/redis.rs
+++ b/crates/redisctl-mcp/src/tools/redis.rs
@@ -51,7 +51,6 @@ pub fn ping(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for info command
@@ -101,7 +100,6 @@ pub fn info(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for keys command
@@ -192,7 +190,6 @@ pub fn keys(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 // ============================================================================
@@ -247,7 +244,6 @@ pub fn get(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for TYPE command
@@ -292,7 +288,6 @@ pub fn key_type(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for TTL command
@@ -343,7 +338,6 @@ pub fn ttl(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for EXISTS command
@@ -396,7 +390,6 @@ pub fn exists(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for DBSIZE command
@@ -441,7 +434,6 @@ pub fn dbsize(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for MEMORY USAGE command
@@ -493,7 +485,6 @@ pub fn memory_usage(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 // ============================================================================
@@ -560,7 +551,6 @@ pub fn hgetall(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 // ============================================================================
@@ -640,7 +630,6 @@ pub fn lrange(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 // ============================================================================
@@ -701,7 +690,6 @@ pub fn smembers(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 // ============================================================================
@@ -812,7 +800,6 @@ pub fn zrange(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 // ============================================================================
@@ -859,7 +846,6 @@ pub fn cluster_info(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Input for CLIENT LIST command
@@ -906,7 +892,6 @@ pub fn client_list(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 // ============================================================================
@@ -1011,7 +996,6 @@ pub fn scan(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 // ============================================================================
@@ -1071,7 +1055,6 @@ pub fn object_encoding(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 // ============================================================================
@@ -1153,7 +1136,6 @@ pub fn slowlog(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 fn format_value(v: &redis::Value) -> String {


### PR DESCRIPTION
## Summary

- Bump `tower-mcp` dependency from 0.4.0 to 0.5.0
- Remove `.expect("valid tool")` from all 100 `ToolBuilder::build()` call sites since `build()` is now infallible (returns `Tool` directly instead of `Result<Tool>`)

## Test plan

- [x] `cargo clippy -p redisctl-mcp --all-features -- -D warnings` passes
- [x] `cargo check -p redisctl-mcp --no-default-features` passes
- [x] `cargo test -p redisctl-mcp --lib --all-features` passes (17/17)