### PR TITLE
docs: document Docker as zero-install MCP option

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,9 +460,27 @@ Configure your AI assistant (Claude Desktop, Cursor, etc.) to use it:
 }
 ```
 
-**For development:** Copy `.mcp.json.example` to `.mcp.json`, update the profile name, and restart your IDE.
+**Zero-install with Docker** -- no local install needed:
 
-See the [MCP Documentation](https://redis-field-engineering.github.io/redisctl-docs/mcp/) for full setup instructions.
+```json
+{
+  "mcpServers": {
+    "redisctl": {
+      "command": "docker",
+      "args": [
+        "run", "-i", "--rm",
+        "-e", "REDIS_ENTERPRISE_URL=https://cluster:9443",
+        "-e", "REDIS_ENTERPRISE_USER=admin@redis.local",
+        "-e", "REDIS_ENTERPRISE_PASSWORD",
+        "ghcr.io/redis-developer/redisctl",
+        "redisctl-mcp"
+      ]
+    }
+  }
+}
+```
+
+See the [MCP Documentation](https://redis-field-engineering.github.io/redisctl-docs/mcp/) for full setup instructions including [Docker options](https://redis-field-engineering.github.io/redisctl-docs/getting-started/docker/#mcp-server-zero-install).
 
 ---
 

--- a/docs/docs/mcp/getting-started.md
+++ b/docs/docs/mcp/getting-started.md
@@ -12,13 +12,33 @@ brew install redis-developer/homebrew-tap/redisctl
 
 ### Linux/Windows
 
-Download from [GitHub Releases](https://github.com/redis-developer/redisctl/releases) or use Docker:
-
-```bash
-docker pull ghcr.io/redis-developer/redisctl
-```
+Download from [GitHub Releases](https://github.com/redis-developer/redisctl/releases).
 
 See the [Installation Guide](../getting-started/installation.md) for all options.
+
+### Docker (Zero-Install)
+
+No local install required. Pass credentials via environment variables and point your AI assistant at the Docker image:
+
+```json
+{
+  "mcpServers": {
+    "redisctl": {
+      "command": "docker",
+      "args": [
+        "run", "-i", "--rm",
+        "-e", "REDIS_ENTERPRISE_URL=https://cluster:9443",
+        "-e", "REDIS_ENTERPRISE_USER=admin@redis.local",
+        "-e", "REDIS_ENTERPRISE_PASSWORD",
+        "ghcr.io/redis-developer/redisctl",
+        "redisctl-mcp"
+      ]
+    }
+  }
+}
+```
+
+See [Docker Usage](../getting-started/docker.md#mcp-server-zero-install) for more options including mounted configs and local cluster access.
 
 ## Setting Up Credentials
 


### PR DESCRIPTION
## Summary

- Expand `docs/docs/getting-started/docker.md` MCP section with three `.mcp.json` snippets: env vars, mounted config, and `--network host` for local clusters
- Add Docker zero-install example to README MCP section
- Add Docker zero-install section to `docs/docs/mcp/getting-started.md` Installation

Closes #647

## Test plan

- [ ] Verify Docker MCP docs render correctly in mkdocs
- [ ] Verify `.mcp.json` snippets are copy-pasteable and work with Claude Desktop / Claude Code