### PR TITLE
chore: bump redis-enterprise to v0.8.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1559,7 +1559,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2606,7 +2606,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -2644,7 +2644,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -2800,8 +2800,8 @@ dependencies = [
 
 [[package]]
 name = "redis-enterprise"
-version = "0.8.3"
-source = "git+https://github.com/redis-developer/redis-enterprise-rs?branch=main#59cbe18041d55cb77863079e5c6aa41c7eded062"
+version = "0.8.4"
+source = "git+https://github.com/redis-developer/redis-enterprise-rs?branch=main#2f7c4b6c213b945a7f0a5959b79769b8227df939"
 dependencies = [
  "anyhow",
  "async-stream",


### PR DESCRIPTION
## Summary
- Updates `redis-enterprise` dependency from v0.8.3 to v0.8.4
- Picks up fix for module `platforms` deserialization (`HashMap` instead of `Vec`) from redis-developer/redis-enterprise-rs#33
- No code changes needed in this repo — module resolution only uses `module_name`, `semantic_version`, and `uid` fields

## Test plan
- [x] `cargo check` compiles cleanly
- [x] `cargo test` — all tests pass

Fixes #660