### PR TITLE
fix: pre-release cleanup

### DIFF
--- a/crates/redisctl-mcp/src/main.rs
+++ b/crates/redisctl-mcp/src/main.rs
@@ -8,7 +8,9 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use clap::{Parser, ValueEnum};
-use redisctl_core::{Config, DeploymentType};
+use redisctl_core::Config;
+#[cfg(any(feature = "cloud", feature = "enterprise", feature = "database"))]
+use redisctl_core::DeploymentType;
 use tower_mcp::{CapabilityFilter, DenialBehavior, McpRouter, Tool, transport::StdioTransport};
 use tracing::info;
 use tracing_subscriber::{EnvFilter, fmt, prelude::*};
@@ -138,29 +140,28 @@ fn toolsets_from_config(config: &Config) -> Option<HashSet<Toolset>> {
         return None;
     }
 
-    let has_cloud = !config
-        .get_profiles_of_type(DeploymentType::Cloud)
-        .is_empty();
-    let has_enterprise = !config
-        .get_profiles_of_type(DeploymentType::Enterprise)
-        .is_empty();
-    let has_database = !config
-        .get_profiles_of_type(DeploymentType::Database)
-        .is_empty();
-
     let mut set = HashSet::new();
     set.insert(Toolset::App); // always include profile management
 
     #[cfg(feature = "cloud")]
-    if has_cloud {
+    if !config
+        .get_profiles_of_type(DeploymentType::Cloud)
+        .is_empty()
+    {
         set.insert(Toolset::Cloud);
     }
     #[cfg(feature = "enterprise")]
-    if has_enterprise {
+    if !config
+        .get_profiles_of_type(DeploymentType::Enterprise)
+        .is_empty()
+    {
         set.insert(Toolset::Enterprise);
     }
     #[cfg(feature = "database")]
-    if has_database {
+    if !config
+        .get_profiles_of_type(DeploymentType::Database)
+        .is_empty()
+    {
         set.insert(Toolset::Database);
     }
 

--- a/docs/docs/getting-started/docker.md
+++ b/docs/docs/getting-started/docker.md
@@ -188,12 +188,12 @@ docker run -i --rm \
 | Tag | Description |
 |-----|-------------|
 | `latest` | Most recent release |
-| `0.7.3` | Specific version |
+| `0.7.7` | Specific version |
 | `0.7` | Latest patch in minor version |
 
 ```bash
 # Pin to specific version
-docker run ghcr.io/redis-developer/redisctl:0.7.3 --version
+docker run ghcr.io/redis-developer/redisctl:0.7.7 --version
 ```
 
 ## CI/CD Example

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -91,7 +91,7 @@ redisctl --version
 Expected output:
 
 ```
-redisctl 0.7.3
+redisctl 0.7.7
 ```
 
 ## Shell Completions


### PR DESCRIPTION
## Summary

- Gate `DeploymentType` import and toolset-detection variables behind `#[cfg]` feature flags so `cargo check -p redisctl-mcp --no-default-features` compiles with zero warnings
- Update stale version examples (`0.7.3` -> `0.7.7`) in installation and Docker docs

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo check -p redisctl-mcp --no-default-features` zero warnings
- [x] `cargo test --lib --all-features` 77/77 passed
- [x] `cargo test --doc --all-features` passed
- [x] `cargo doc --no-deps --all-features` clean