### PR TITLE
fix: add version specifiers to git deps for crates.io publish

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,9 +99,9 @@ pretty_assertions = "1.4"
 # Redis client
 redis = { version = "0.27", features = ["tokio-comp", "tokio-rustls-comp", "connection-manager"] }
 
-# External crates (using git for CI, override with path locally if needed)
-redis-cloud = { git = "https://github.com/redis-developer/redis-cloud-rs", branch = "main" }
-redis-enterprise = { git = "https://github.com/redis-developer/redis-enterprise-rs", branch = "main" }
+# External crates (git for dev, version required for crates.io publish)
+redis-cloud = { version = "0.9.5", git = "https://github.com/redis-developer/redis-cloud-rs", branch = "main" }
+redis-enterprise = { version = "0.8.5", git = "https://github.com/redis-developer/redis-enterprise-rs", branch = "main" }
 
 # Windows CI workaround - ensure these are available in workspace
 shellexpand = "3.1"


### PR DESCRIPTION
## Summary

- Add `version` field to `redis-cloud` and `redis-enterprise` workspace git dependencies
- Required because crates.io strips `git` source and needs a version to resolve from the registry
- This was the cause of the release failure: `dependency redis-cloud does not specify a version`

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo package -p redisctl-core` builds and verifies against crates.io versions
- [x] Packaged crate correctly resolves `redis-cloud = "0.9.5"` and `redis-enterprise = "0.8.5"` from crates.io

Once merged, re-trigger the release workflow to publish the pending 0.8.0 / 0.3.0 / 0.1.0 releases.