### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1559,7 +1559,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2606,7 +2606,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -2644,7 +2644,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -2800,8 +2800,8 @@ dependencies = [
 
 [[package]]
 name = "redis-enterprise"
-version = "0.8.4"
-source = "git+https://github.com/redis-developer/redis-enterprise-rs?branch=main#2f7c4b6c213b945a7f0a5959b79769b8227df939"
+version = "0.8.5"
+source = "git+https://github.com/redis-developer/redis-enterprise-rs?branch=main#23009fb66e596a93c871e3fc5ca6cbff95a0a51c"
 dependencies = [
  "anyhow",
  "async-stream",


### PR DESCRIPTION



## 🤖 New release

* `redisctl-core`: 0.1.0
* `redisctl`: 0.7.7 -> 0.8.0
* `redisctl-mcp`: 0.2.0 -> 0.3.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `redisctl-core`

<blockquote>

## [0.1.0](https://github.com/redis-developer/redisctl/releases/tag/redisctl-core-v0.1.0) - 2026-02-25

### Added

- *(cli)* cargo-style diagnostic error formatting ([#671](https://github.com/redis-developer/redisctl/pull/671))
- *(cli)* infer platform from profile — make cloud/enterprise prefix optional ([#668](https://github.com/redis-developer/redisctl/pull/668))
- *(mcp)* add Cloud database flush operation ([#633](https://github.com/redis-developer/redisctl/pull/633))
- *(mcp)* add Enterprise database write operations ([#632](https://github.com/redis-developer/redisctl/pull/632))
- [**breaking**] implement Layer 2 architecture in redisctl-core ([#630](https://github.com/redis-developer/redisctl/pull/630))

### Other

- consolidate workspace dependencies ([#640](https://github.com/redis-developer/redisctl/pull/640))
</blockquote>

## `redisctl`

<blockquote>

## [0.8.0](https://github.com/redis-developer/redisctl/compare/redisctl-v0.7.7...redisctl-v0.8.0) - 2026-02-25

### Added

- *(cli)* support name@version syntax for --module flag ([#675](https://github.com/redis-developer/redisctl/pull/675))
- *(cli)* group `profile list` output by deployment type ([#674](https://github.com/redis-developer/redisctl/pull/674))
- *(cli)* cargo-style diagnostic error formatting ([#671](https://github.com/redis-developer/redisctl/pull/671))
- *(cli)* infer platform from profile — make cloud/enterprise prefix optional ([#668](https://github.com/redis-developer/redisctl/pull/668))
- *(mcp)* add Enterprise license, cluster, and certificate management tools ([#636](https://github.com/redis-developer/redisctl/pull/636))
- [**breaking**] implement Layer 2 architecture in redisctl-core ([#630](https://github.com/redis-developer/redisctl/pull/630))
- add 'db open' command to spawn redis-cli with profile credentials ([#627](https://github.com/redis-developer/redisctl/pull/627))
- add custom CA certificate support for Kubernetes deployments ([#624](https://github.com/redis-developer/redisctl/pull/624))
- [**breaking**] rewrite redisctl-mcp using tower-mcp framework ([#597](https://github.com/redis-developer/redisctl/pull/597))
- update to redis-enterprise 0.8 ([#600](https://github.com/redis-developer/redisctl/pull/600))
- update to redis-cloud 0.9 ([#599](https://github.com/redis-developer/redisctl/pull/599))
- add one-shot cost-report export command ([#595](https://github.com/redis-developer/redisctl/pull/595))

### Fixed

- handle rate limits (429) and processing-completed state in task polling ([#587](https://github.com/redis-developer/redisctl/pull/587))

### Other

- update examples for prefix-free CLI commands ([#673](https://github.com/redis-developer/redisctl/pull/673))
- document Docker as zero-install MCP option ([#647](https://github.com/redis-developer/redisctl/pull/647)) ([#659](https://github.com/redis-developer/redisctl/pull/659))
- consolidate workspace dependencies ([#640](https://github.com/redis-developer/redisctl/pull/640))
- [**breaking**] extract redis-cloud and redis-enterprise to standalone repos ([#596](https://github.com/redis-developer/redisctl/pull/596))
</blockquote>

## `redisctl-mcp`

<blockquote>

## [0.3.0](https://github.com/redis-developer/redisctl/compare/redisctl-mcp-v0.2.0...redisctl-mcp-v0.3.0) - 2026-02-25

### Added

- *(mcp)* auto-detect toolsets from config profiles ([#667](https://github.com/redis-developer/redisctl/pull/667))
- *(mcp)* modular router with feature flags and runtime toolset selection ([#656](https://github.com/redis-developer/redisctl/pull/656))
- *(mcp)* default to read-only mode ([#655](https://github.com/redis-developer/redisctl/pull/655))
- *(mcp)* add multi-profile support for Cloud tools ([#654](https://github.com/redis-developer/redisctl/pull/654))
- *(mcp)* add multi-profile support for Enterprise tools ([#651](https://github.com/redis-developer/redisctl/pull/651)) ([#652](https://github.com/redis-developer/redisctl/pull/652))
- *(mcp)* add create_subscription tool for Cloud ([#643](https://github.com/redis-developer/redisctl/pull/643))
- *(mcp)* add Enterprise license, cluster, and certificate management tools ([#636](https://github.com/redis-developer/redisctl/pull/636))
- *(mcp)* add Enterprise Redis ACL tools ([#635](https://github.com/redis-developer/redisctl/pull/635))
- *(mcp)* add Cloud certificate and Enterprise roles tools ([#634](https://github.com/redis-developer/redisctl/pull/634))
- *(mcp)* add Cloud database flush operation ([#633](https://github.com/redis-developer/redisctl/pull/633))
- *(mcp)* add Enterprise database write operations ([#632](https://github.com/redis-developer/redisctl/pull/632))
- [**breaking**] implement Layer 2 architecture in redisctl-core ([#630](https://github.com/redis-developer/redisctl/pull/630))
- add custom CA certificate support for Kubernetes deployments ([#624](https://github.com/redis-developer/redisctl/pull/624))
- *(mcp)* upgrade tower-mcp to 0.3.4 ([#622](https://github.com/redis-developer/redisctl/pull/622))
- add filtering support and new Redis diagnostic tools ([#621](https://github.com/redis-developer/redisctl/pull/621))
- add individual getter tools for Cloud and Enterprise resources ([#620](https://github.com/redis-developer/redisctl/pull/620))
- add MCP resources and prompts to redisctl-mcp ([#619](https://github.com/redis-developer/redisctl/pull/619))
- *(mcp)* add read-only tool filter using CapabilityFilter ([#618](https://github.com/redis-developer/redisctl/pull/618))
- *(mcp)* add historical stats, Cloud logs, debug info, and modules tools ([#617](https://github.com/redis-developer/redisctl/pull/617))
- *(mcp)* add Enterprise logs and aggregate stats tools ([#616](https://github.com/redis-developer/redisctl/pull/616))
- *(mcp)* add Enterprise license tools ([#615](https://github.com/redis-developer/redisctl/pull/615))
- *(mcp)* add mock testing support for cloud and enterprise tools ([#611](https://github.com/redis-developer/redisctl/pull/611))
- *(mcp)* add profile management tools ([#609](https://github.com/redis-developer/redisctl/pull/609))

### Fixed

- pre-release cleanup — cfg-gate warnings and stale doc versions ([#676](https://github.com/redis-developer/redisctl/pull/676))
- *(mcp)* wrap array results in JSON objects for structuredContent compliance ([#653](https://github.com/redis-developer/redisctl/pull/653))
- *(mcp)* normalize 'default' profile to use configured default ([#608](https://github.com/redis-developer/redisctl/pull/608))

### Other

- *(mcp)* bump tower-mcp to 0.5.0 ([#658](https://github.com/redis-developer/redisctl/pull/658))
- consolidate workspace dependencies ([#640](https://github.com/redis-developer/redisctl/pull/640))
- upgrade tower-mcp to 0.2.3 and use from_serialize() ([#607](https://github.com/redis-developer/redisctl/pull/607))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).