### PR TITLE
chore: add package metadata to redisctl-core

### DIFF
--- a/crates/redisctl-core/Cargo.toml
+++ b/crates/redisctl-core/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
 description = "Core library for Redis CLI tools - config, workflows, and shared logic"
 
 [dependencies]


### PR DESCRIPTION
## Summary

- Inherit `repository` and `homepage` from workspace in redisctl-core Cargo.toml
- Fixes the `manifest has no documentation, homepage or repository` warning on crates.io publish

Non-blocking, just cleans up the publish output for future releases.