### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2826,7 +2826,7 @@ dependencies = [
 
 [[package]]
 name = "redisctl"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2878,7 +2878,7 @@ dependencies = [
 
 [[package]]
 name = "redisctl-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "directories",
@@ -2899,7 +2899,7 @@ dependencies = [
 
 [[package]]
 name = "redisctl-mcp"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/redisctl-core/CHANGELOG.md
+++ b/crates/redisctl-core/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/redis-developer/redisctl/compare/redisctl-core-v0.1.0...redisctl-core-v0.2.0) - 2026-02-28
+
+### Added
+
+- *(cli)* add profile tags for organizing many profiles ([#692](https://github.com/redis-developer/redisctl/pull/692)) ([#705](https://github.com/redis-developer/redisctl/pull/705))
+
+### Other
+
+- add edge case tests for profile config loading ([#696](https://github.com/redis-developer/redisctl/pull/696)) ([#699](https://github.com/redis-developer/redisctl/pull/699))
+- add repository and homepage metadata to redisctl-core ([#685](https://github.com/redis-developer/redisctl/pull/685))
+
 ## [0.1.0](https://github.com/redis-developer/redisctl/releases/tag/redisctl-core-v0.1.0) - 2026-02-25
 
 ### Added

--- a/crates/redisctl-core/Cargo.toml
+++ b/crates/redisctl-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redisctl-core"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/redisctl-mcp/CHANGELOG.md
+++ b/crates/redisctl-mcp/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/redis-developer/redisctl/compare/redisctl-mcp-v0.3.0...redisctl-mcp-v0.4.0) - 2026-02-28
+
+### Added
+
+- *(mcp)* migrate to tower-mcp 0.7.0 ([#748](https://github.com/redis-developer/redisctl/pull/748))
+- *(mcp)* add safety annotations, normalize instructions, add verification tests ([#610](https://github.com/redis-developer/redisctl/pull/610)) ([#746](https://github.com/redis-developer/redisctl/pull/746))
+- *(mcp)* add 4 composed Redis diagnostic tools ([#737](https://github.com/redis-developer/redisctl/pull/737)) ([#744](https://github.com/redis-developer/redisctl/pull/744))
+- *(mcp)* add 18 write-gated Redis data management tools ([#743](https://github.com/redis-developer/redisctl/pull/743))
+- *(mcp)* add profile-based connection support for Redis database tools ([#742](https://github.com/redis-developer/redisctl/pull/742))
+- *(mcp)* add 14 Redis read tools for streams, pub/sub, diagnostics, ACL, modules ([#741](https://github.com/redis-developer/redisctl/pull/741))
+- *(mcp)* add 27 Fixed/Essentials tier MCP tools ([#734](https://github.com/redis-developer/redisctl/pull/734))
+- *(mcp)* add 5 cloud accounts (BYOC) MCP tools ([#733](https://github.com/redis-developer/redisctl/pull/733))
+- *(mcp)* add 51 cloud networking MCP tools for VPC, TGW, PSC, PrivateLink ([#732](https://github.com/redis-developer/redisctl/pull/732))
+- *(mcp)* add 19 cloud subscription and database MCP tools ([#731](https://github.com/redis-developer/redisctl/pull/731))
+- *(mcp)* add ACL write, cost report, and payment method cloud tools ([#730](https://github.com/redis-developer/redisctl/pull/730))
+- *(mcp)* add 18 enterprise tools for node actions, RBAC, CRDB, and LDAP ([#715](https://github.com/redis-developer/redisctl/pull/715))
+- *(cli)* add profile tags for organizing many profiles ([#692](https://github.com/redis-developer/redisctl/pull/692)) ([#705](https://github.com/redis-developer/redisctl/pull/705))
+- *(mcp)* surface credential issues clearly in tool error responses ([#695](https://github.com/redis-developer/redisctl/pull/695)) ([#704](https://github.com/redis-developer/redisctl/pull/704))
+- *(mcp)* add profile_create tool for creating profiles via MCP ([#646](https://github.com/redis-developer/redisctl/pull/646)) ([#703](https://github.com/redis-developer/redisctl/pull/703))
+- *(cli)* add --connect flag to profile validate for connectivity testing ([#688](https://github.com/redis-developer/redisctl/pull/688))
+
+### Other
+
+- *(mcp)* split redis.rs into server, keys, and structures submodules ([#740](https://github.com/redis-developer/redisctl/pull/740))
+- *(mcp)* split enterprise.rs and cloud.rs into domain submodules ([#717](https://github.com/redis-developer/redisctl/pull/717))
+
 ## [0.3.0](https://github.com/redis-developer/redisctl/compare/redisctl-mcp-v0.2.0...redisctl-mcp-v0.3.0) - 2026-02-25
 
 ### Added

--- a/crates/redisctl-mcp/Cargo.toml
+++ b/crates/redisctl-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redisctl-mcp"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
@@ -21,7 +21,7 @@ tower-mcp = { version = "0.7.0", features = ["http", "oauth"] }
 schemars = "1.2"
 
 # Internal crates
-redisctl-core = { version = "0.1.0", path = "../redisctl-core" }
+redisctl-core = { version = "0.2.0", path = "../redisctl-core" }
 
 # External API clients (optional, gated by features)
 redis-cloud = { workspace = true, optional = true }

--- a/crates/redisctl/CHANGELOG.md
+++ b/crates/redisctl/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1](https://github.com/redis-developer/redisctl/compare/redisctl-v0.8.0...redisctl-v0.8.1) - 2026-02-28
+
+### Added
+
+- *(cli)* add table output and brief summary for enterprise status ([#714](https://github.com/redis-developer/redisctl/pull/714))
+- *(cli)* add cluster health verification commands ([#626](https://github.com/redis-developer/redisctl/pull/626)) ([#713](https://github.com/redis-developer/redisctl/pull/713))
+- *(cli)* add profile tags for organizing many profiles ([#692](https://github.com/redis-developer/redisctl/pull/692)) ([#705](https://github.com/redis-developer/redisctl/pull/705))
+- *(cli)* preserve profile settings on credential update ([#694](https://github.com/redis-developer/redisctl/pull/694)) ([#702](https://github.com/redis-developer/redisctl/pull/702))
+- *(cli)* add profile current command for shell prompt integration ([#693](https://github.com/redis-developer/redisctl/pull/693)) ([#701](https://github.com/redis-developer/redisctl/pull/701))
+- *(cli)* add interactive profile init wizard ([#690](https://github.com/redis-developer/redisctl/pull/690)) ([#698](https://github.com/redis-developer/redisctl/pull/698))
+- *(cli)* improve profile help and discoverability ([#663](https://github.com/redis-developer/redisctl/pull/663)) ([#689](https://github.com/redis-developer/redisctl/pull/689))
+- *(cli)* add --connect flag to profile validate for connectivity testing ([#688](https://github.com/redis-developer/redisctl/pull/688))
+
+### Fixed
+
+- *(cli)* improve error messages for credential and connection failures ([#691](https://github.com/redis-developer/redisctl/pull/691)) ([#700](https://github.com/redis-developer/redisctl/pull/700))
+
 ## [0.8.0](https://github.com/redis-developer/redisctl/compare/redisctl-v0.7.7...redisctl-v0.8.0) - 2026-02-25
 
 ### Added

--- a/crates/redisctl/Cargo.toml
+++ b/crates/redisctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redisctl"
-version = "0.8.0"
+version = "0.8.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
@@ -18,7 +18,7 @@ path = "src/main.rs"
 
 
 [dependencies]
-redisctl-core = { version = "0.1.0", path = "../redisctl-core" }
+redisctl-core = { version = "0.2.0", path = "../redisctl-core" }
 redis-cloud = { workspace = true, features = ["tower-integration"] }
 redis-enterprise = { workspace = true, features = ["tower-integration"] }
 files-sdk = { workspace = true, optional = true }


### PR DESCRIPTION



## 🤖 New release

* `redisctl-core`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)
* `redisctl`: 0.8.0 -> 0.8.1 (✓ API compatible changes)
* `redisctl-mcp`: 0.3.0 -> 0.4.0 (⚠ API breaking changes)

### ⚠ `redisctl-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Profile.tags in /tmp/.tmpmCEVXh/redisctl/crates/redisctl-core/src/config/config.rs:55
  field Profile.tags in /tmp/.tmpmCEVXh/redisctl/crates/redisctl-core/src/config/config.rs:55
  field Profile.tags in /tmp/.tmpmCEVXh/redisctl/crates/redisctl-core/src/config/config.rs:55
```

### ⚠ `redisctl-mcp` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field TypeInput.profile in /tmp/.tmpmCEVXh/redisctl/crates/redisctl-mcp/src/tools/redis/keys.rs:177
  field MemoryUsageInput.profile in /tmp/.tmpmCEVXh/redisctl/crates/redisctl-mcp/src/tools/redis/keys.rs:318
  field ClientListInput.profile in /tmp/.tmpmCEVXh/redisctl/crates/redisctl-mcp/src/tools/redis/server.rs:172
  field KeysInput.profile in /tmp/.tmpmCEVXh/redisctl/crates/redisctl-mcp/src/tools/redis/keys.rs:41
  field SmembersInput.profile in /tmp/.tmpmCEVXh/redisctl/crates/redisctl-mcp/src/tools/redis/structures.rs:182
  field ObjectEncodingInput.profile in /tmp/.tmpmCEVXh/redisctl/crates/redisctl-mcp/src/tools/redis/keys.rs:465
  field SlowlogInput.profile in /tmp/.tmpmCEVXh/redisctl/crates/redisctl-mcp/src/tools/redis/server.rs:256
  field PingInput.profile in /tmp/.tmpmCEVXh/redisctl/crates/redisctl-mcp/src/tools/redis/server.rs:41
  field TtlInput.profile in /tmp/.tmpmCEVXh/redisctl/crates/redisctl-mcp/src/tools/redis/keys.rs:219
  field DbsizeInput.profile in /tmp/.tmpmCEVXh/redisctl/crates/redisctl-mcp/src/tools/redis/server.rs:130
  field LrangeInput.profile in /tmp/.tmpmCEVXh/redisctl/crates/redisctl-mcp/src/tools/redis/structures.rs:109
  field GetInput.profile in /tmp/.tmpmCEVXh/redisctl/crates/redisctl-mcp/src/tools/redis/keys.rs:129
  field ZrangeInput.profile in /tmp/.tmpmCEVXh/redisctl/crates/redisctl-mcp/src/tools/redis/structures.rs:236
  field ValidateConfigInput.connect in /tmp/.tmpmCEVXh/redisctl/crates/redisctl-mcp/src/tools/profile.rs:300
  field HgetallInput.profile in /tmp/.tmpmCEVXh/redisctl/crates/redisctl-mcp/src/tools/redis/structures.rs:49
  field InfoInput.profile in /tmp/.tmpmCEVXh/redisctl/crates/redisctl-mcp/src/tools/redis/server.rs:83
  field ExistsInput.profile in /tmp/.tmpmCEVXh/redisctl/crates/redisctl-mcp/src/tools/redis/keys.rs:268
  field ScanInput.profile in /tmp/.tmpmCEVXh/redisctl/crates/redisctl-mcp/src/tools/redis/keys.rs:367
  field ClusterInfoInput.profile in /tmp/.tmpmCEVXh/redisctl/crates/redisctl-mcp/src/tools/redis/server.rs:216

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_missing.ron

Failed in:
  function redisctl_mcp::tools::enterprise::instructions, previously in file /tmp/.tmpG1dekO/redisctl-mcp/src/tools/enterprise.rs:2237
  function redisctl_mcp::tools::profile::instructions, previously in file /tmp/.tmpG1dekO/redisctl-mcp/src/tools/profile.rs:551
  function redisctl_mcp::tools::redis::instructions, previously in file /tmp/.tmpG1dekO/redisctl-mcp/src/tools/redis.rs:1156
  function redisctl_mcp::tools::cloud::instructions, previously in file /tmp/.tmpG1dekO/redisctl-mcp/src/tools/cloud.rs:1501
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `redisctl-core`

<blockquote>

## [0.2.0](https://github.com/redis-developer/redisctl/compare/redisctl-core-v0.1.0...redisctl-core-v0.2.0) - 2026-02-28

### Added

- *(cli)* add profile tags for organizing many profiles ([#692](https://github.com/redis-developer/redisctl/pull/692)) ([#705](https://github.com/redis-developer/redisctl/pull/705))

### Other

- add edge case tests for profile config loading ([#696](https://github.com/redis-developer/redisctl/pull/696)) ([#699](https://github.com/redis-developer/redisctl/pull/699))
- add repository and homepage metadata to redisctl-core ([#685](https://github.com/redis-developer/redisctl/pull/685))
</blockquote>

## `redisctl`

<blockquote>

## [0.8.1](https://github.com/redis-developer/redisctl/compare/redisctl-v0.8.0...redisctl-v0.8.1) - 2026-02-28

### Added

- *(cli)* add table output and brief summary for enterprise status ([#714](https://github.com/redis-developer/redisctl/pull/714))
- *(cli)* add cluster health verification commands ([#626](https://github.com/redis-developer/redisctl/pull/626)) ([#713](https://github.com/redis-developer/redisctl/pull/713))
- *(cli)* add profile tags for organizing many profiles ([#692](https://github.com/redis-developer/redisctl/pull/692)) ([#705](https://github.com/redis-developer/redisctl/pull/705))
- *(cli)* preserve profile settings on credential update ([#694](https://github.com/redis-developer/redisctl/pull/694)) ([#702](https://github.com/redis-developer/redisctl/pull/702))
- *(cli)* add profile current command for shell prompt integration ([#693](https://github.com/redis-developer/redisctl/pull/693)) ([#701](https://github.com/redis-developer/redisctl/pull/701))
- *(cli)* add interactive profile init wizard ([#690](https://github.com/redis-developer/redisctl/pull/690)) ([#698](https://github.com/redis-developer/redisctl/pull/698))
- *(cli)* improve profile help and discoverability ([#663](https://github.com/redis-developer/redisctl/pull/663)) ([#689](https://github.com/redis-developer/redisctl/pull/689))
- *(cli)* add --connect flag to profile validate for connectivity testing ([#688](https://github.com/redis-developer/redisctl/pull/688))

### Fixed

- *(cli)* improve error messages for credential and connection failures ([#691](https://github.com/redis-developer/redisctl/pull/691)) ([#700](https://github.com/redis-developer/redisctl/pull/700))
</blockquote>

## `redisctl-mcp`

<blockquote>

## [0.4.0](https://github.com/redis-developer/redisctl/compare/redisctl-mcp-v0.3.0...redisctl-mcp-v0.4.0) - 2026-02-28

### Added

- *(mcp)* migrate to tower-mcp 0.7.0 ([#748](https://github.com/redis-developer/redisctl/pull/748))
- *(mcp)* add safety annotations, normalize instructions, add verification tests ([#610](https://github.com/redis-developer/redisctl/pull/610)) ([#746](https://github.com/redis-developer/redisctl/pull/746))
- *(mcp)* add 4 composed Redis diagnostic tools ([#737](https://github.com/redis-developer/redisctl/pull/737)) ([#744](https://github.com/redis-developer/redisctl/pull/744))
- *(mcp)* add 18 write-gated Redis data management tools ([#743](https://github.com/redis-developer/redisctl/pull/743))
- *(mcp)* add profile-based connection support for Redis database tools ([#742](https://github.com/redis-developer/redisctl/pull/742))
- *(mcp)* add 14 Redis read tools for streams, pub/sub, diagnostics, ACL, modules ([#741](https://github.com/redis-developer/redisctl/pull/741))
- *(mcp)* add 27 Fixed/Essentials tier MCP tools ([#734](https://github.com/redis-developer/redisctl/pull/734))
- *(mcp)* add 5 cloud accounts (BYOC) MCP tools ([#733](https://github.com/redis-developer/redisctl/pull/733))
- *(mcp)* add 51 cloud networking MCP tools for VPC, TGW, PSC, PrivateLink ([#732](https://github.com/redis-developer/redisctl/pull/732))
- *(mcp)* add 19 cloud subscription and database MCP tools ([#731](https://github.com/redis-developer/redisctl/pull/731))
- *(mcp)* add ACL write, cost report, and payment method cloud tools ([#730](https://github.com/redis-developer/redisctl/pull/730))
- *(mcp)* add 18 enterprise tools for node actions, RBAC, CRDB, and LDAP ([#715](https://github.com/redis-developer/redisctl/pull/715))
- *(cli)* add profile tags for organizing many profiles ([#692](https://github.com/redis-developer/redisctl/pull/692)) ([#705](https://github.com/redis-developer/redisctl/pull/705))
- *(mcp)* surface credential issues clearly in tool error responses ([#695](https://github.com/redis-developer/redisctl/pull/695)) ([#704](https://github.com/redis-developer/redisctl/pull/704))
- *(mcp)* add profile_create tool for creating profiles via MCP ([#646](https://github.com/redis-developer/redisctl/pull/646)) ([#703](https://github.com/redis-developer/redisctl/pull/703))
- *(cli)* add --connect flag to profile validate for connectivity testing ([#688](https://github.com/redis-developer/redisctl/pull/688))

### Other

- *(mcp)* split redis.rs into server, keys, and structures submodules ([#740](https://github.com/redis-developer/redisctl/pull/740))
- *(mcp)* split enterprise.rs and cloud.rs into domain submodules ([#717](https://github.com/redis-developer/redisctl/pull/717))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).