### PR TITLE
feat(cli): add --connect flag to profile validate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1559,7 +1559,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2606,7 +2606,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -2644,7 +2644,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -2800,8 +2800,8 @@ dependencies = [
 
 [[package]]
 name = "redis-enterprise"
-version = "0.8.4"
-source = "git+https://github.com/redis-developer/redis-enterprise-rs?branch=main#2f7c4b6c213b945a7f0a5959b79769b8227df939"
+version = "0.8.5"
+source = "git+https://github.com/redis-developer/redis-enterprise-rs?branch=main#23009fb66e596a93c871e3fc5ca6cbff95a0a51c"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2917,6 +2917,7 @@ dependencies = [
  "tower-mcp",
  "tracing",
  "tracing-subscriber",
+ "urlencoding",
  "wiremock",
 ]
 

--- a/crates/redisctl-mcp/Cargo.toml
+++ b/crates/redisctl-mcp/Cargo.toml
@@ -29,6 +29,7 @@ redis-enterprise = { workspace = true, optional = true }
 
 # Redis client for direct database connections (optional, gated by features)
 redis = { workspace = true, optional = true }
+urlencoding = { workspace = true, optional = true }
 
 # Core dependencies
 anyhow = { workspace = true }
@@ -51,7 +52,7 @@ default = ["http", "cloud", "enterprise", "database"]
 http = []
 cloud = ["dep:redis-cloud"]
 enterprise = ["dep:redis-enterprise"]
-database = ["dep:redis"]
+database = ["dep:redis", "dep:urlencoding"]
 test-support = []
 
 [dev-dependencies]

--- a/crates/redisctl/Cargo.toml
+++ b/crates/redisctl/Cargo.toml
@@ -63,6 +63,7 @@ tower-resilience = { version = "0.1", features = ["circuitbreaker", "retry", "ra
 regex = "1.12.2"
 zip = "6.0.0"
 which = "7"
+redis = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 pager = "0.16"

--- a/crates/redisctl/src/cli/mod.rs
+++ b/crates/redisctl/src/cli/mod.rs
@@ -427,6 +427,12 @@ pub enum ProfileCommands {
     # Validate all profiles and configuration
     redisctl profile validate
 
+    # Validate and test connectivity to all profiles
+    redisctl profile validate --connect
+
+    # Machine-readable validation output
+    redisctl profile validate --connect -o json
+
     # Example output:
     # Configuration file: /Users/user/.config/redisctl/config.toml
     # ✓ Configuration file exists and is readable
@@ -440,7 +446,11 @@ pub enum ProfileCommands {
     #
     # ✓ Configuration is valid
 ")]
-    Validate,
+    Validate {
+        /// Test actual API/database connectivity for each profile
+        #[arg(long, short = 'c')]
+        connect: bool,
+    },
 }
 
 /// Files.com API key management commands

--- a/crates/redisctl/src/main.rs
+++ b/crates/redisctl/src/main.rs
@@ -545,7 +545,13 @@ fn format_command(command: &Commands) -> String {
                 DefaultEnterprise { name } => format!("profile default-enterprise {}", name),
                 DefaultCloud { name } => format!("profile default-cloud {}", name),
                 DefaultDatabase { name } => format!("profile default-database {}", name),
-                Validate => "profile validate".to_string(),
+                Validate { connect } => {
+                    if *connect {
+                        "profile validate --connect".to_string()
+                    } else {
+                        "profile validate".to_string()
+                    }
+                }
             }
         }
         Commands::Api {


### PR DESCRIPTION
## Summary

- Add `--connect` / `-c` flag to `profile validate` that tests actual API/database connectivity per profile after structural checks pass
- Cloud profiles test via `SubscriptionHandler::get_all_subscriptions()`, Enterprise via `ClusterHandler::info()`, Database via Redis `PING`
- Each connectivity test uses a 10s timeout with error classification (auth failed, connection refused, timeout, TLS error)
- Add structured JSON/YAML output support (`-o json` / `-o yaml`) for scripting
- Enhance structural checks: warn on HTTP Enterprise URLs, non-standard Cloud API URLs, missing `ca_cert` files
- Add `connect` parameter to MCP `profile_validate` tool with the same behavior

## Test plan

- [x] `redisctl profile validate` -- structural checks only (existing behavior preserved)
- [x] `redisctl profile validate --connect` -- structural + connectivity testing
- [x] `redisctl profile validate --connect -o json` -- machine-readable output
- [x] `redisctl profile validate -o yaml` -- YAML output
- [ ] Test with bad credentials (expect auth failure classification)
- [x] Test with unreachable host (expect connection refused / timeout)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --lib --all-features` passes (77 tests)
- [x] `cargo check -p redisctl-mcp --no-default-features` passes
- [x] `cargo check -p redisctl-mcp --features cloud/enterprise/database` all pass