### PR TITLE
feat(cli): improve profile help and discoverability

### DIFF
--- a/crates/redisctl/src/connection.rs
+++ b/crates/redisctl/src/connection.rs
@@ -129,6 +129,12 @@ impl ConnectionManager {
                         }
                         .to_string(),
                         expected_type: "cloud".to_string(),
+                        available_profiles: self
+                            .config
+                            .get_profiles_of_type(DeploymentType::Cloud)
+                            .into_iter()
+                            .map(String::from)
+                            .collect(),
                     });
                 }
 
@@ -275,6 +281,12 @@ impl ConnectionManager {
                         }
                         .to_string(),
                         expected_type: "enterprise".to_string(),
+                        available_profiles: self
+                            .config
+                            .get_profiles_of_type(DeploymentType::Enterprise)
+                            .into_iter()
+                            .map(String::from)
+                            .collect(),
                     });
                 }
 


### PR DESCRIPTION
## Summary

Closes #663

- Add a **PROFILE TYPES** section to `redisctl --help` explaining the three profile types (cloud, enterprise, database), what each unlocks, and how to create them
- Add **PROFILE REQUIREMENT** footer to `redisctl cloud --help`, `redisctl enterprise --help`, and `redisctl db --help` showing which profile type is needed with a setup command
- Add **CHOOSING A PROFILE TYPE** guide to `redisctl profile set --help` before the existing examples
- Enrich `ProfileTypeMismatch` error with available profiles of the correct type so users see actionable suggestions instead of generic advice

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib --all-features` (77 tests pass)
- [ ] Manual: `redisctl --help` shows PROFILE TYPES section
- [ ] Manual: `redisctl cloud --help` shows PROFILE REQUIREMENT footer
- [ ] Manual: `redisctl enterprise --help` shows PROFILE REQUIREMENT footer
- [ ] Manual: `redisctl db --help` shows PROFILE REQUIREMENT footer
- [ ] Manual: `redisctl profile set --help` shows CHOOSING A PROFILE TYPE section