### PR TITLE
feat(cli): add interactive profile init wizard

### DIFF
--- a/crates/redisctl/src/cli/mod.rs
+++ b/crates/redisctl/src/cli/mod.rs
@@ -494,6 +494,13 @@ EXAMPLES:
         #[arg(long, short = 'c')]
         connect: bool,
     },
+
+    /// Interactive wizard to create a new profile
+    #[command(visible_alias = "setup")]
+    #[command(after_help = "Walks you through creating a profile step by step.
+Prompts for the profile type, name, and required credentials.
+Optionally tests connectivity before saving.")]
+    Init,
 }
 
 /// Files.com API key management commands

--- a/crates/redisctl/src/main.rs
+++ b/crates/redisctl/src/main.rs
@@ -552,6 +552,7 @@ fn format_command(command: &Commands) -> String {
                         "profile validate".to_string()
                     }
                 }
+                Init => "profile init".to_string(),
             }
         }
         Commands::Api {


### PR DESCRIPTION
## Summary

Closes #690

- Add `redisctl profile init` (alias: `profile setup`) interactive wizard
- Walks through: profile type selection, name, type-specific credentials
- Optionally tests connectivity before saving (reuses existing `test_*_connectivity` functions)
- Auto-sets as default if it's the first profile of that type
- Uses `dialoguer` (already a dependency) for `Select`, `Input`, `Confirm` prompts
- Uses `rpassword` (already a dependency) for secure password/secret entry

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib --all-features` (77 tests pass)
- [ ] Manual: `redisctl profile init` walks through cloud profile creation
- [ ] Manual: `redisctl profile init` walks through enterprise profile creation
- [ ] Manual: `redisctl profile init` walks through database profile creation
- [ ] Manual: `redisctl profile setup` alias works
- [ ] Manual: connectivity test pass/fail paths work correctly
- [ ] Manual: overwrite prompt appears for existing profile names