### PR TITLE
feat(cli): add profile current command for shell prompt integration

### DIFF
--- a/crates/redisctl/src/cli/mod.rs
+++ b/crates/redisctl/src/cli/mod.rs
@@ -322,6 +322,28 @@ pub enum ProfileCommands {
     /// Show the path to the configuration file
     Path,
 
+    /// Print the active profile name (for shell prompt integration)
+    #[command(visible_alias = "active")]
+    #[command(
+        after_help = "Prints the profile that would be used for the given deployment type.
+Useful for embedding in your shell prompt (PS1).
+
+EXAMPLES:
+    # Show active cloud profile
+    redisctl profile current --type cloud
+
+    # Show active enterprise profile
+    redisctl profile current --type enterprise
+
+    # Use in shell prompt (bash)
+    PS1='[\\$(redisctl profile current --type cloud 2>/dev/null)]\\$ '"
+    )]
+    Current {
+        /// Deployment type to show the active profile for
+        #[arg(long, value_enum)]
+        r#type: DeploymentType,
+    },
+
     /// Show details of a specific profile
     #[command(visible_alias = "sh", visible_alias = "get")]
     Show {

--- a/crates/redisctl/src/commands/profile.rs
+++ b/crates/redisctl/src/commands/profile.rs
@@ -24,6 +24,7 @@ pub async fn handle_profile_command(
     match profile_cmd {
         List => handle_list(conn_mgr, output_format).await,
         Path => handle_path(output_format).await,
+        Current { r#type } => handle_current(conn_mgr, r#type).await,
         Show { name } => handle_show(conn_mgr, name, output_format).await,
         Set {
             name,
@@ -288,6 +289,23 @@ async fn handle_path(output_format: OutputFormat) -> Result<(), RedisCtlError> {
             println!("{}", config_path.display());
         }
     }
+    Ok(())
+}
+
+async fn handle_current(
+    conn_mgr: &ConnectionManager,
+    deployment_type: &redisctl_core::DeploymentType,
+) -> Result<(), RedisCtlError> {
+    let resolved = match deployment_type {
+        redisctl_core::DeploymentType::Cloud => conn_mgr.config.resolve_cloud_profile(None)?,
+        redisctl_core::DeploymentType::Enterprise => {
+            conn_mgr.config.resolve_enterprise_profile(None)?
+        }
+        redisctl_core::DeploymentType::Database => {
+            conn_mgr.config.resolve_database_profile(None)?
+        }
+    };
+    println!("{}", resolved);
     Ok(())
 }
 

--- a/crates/redisctl/src/main.rs
+++ b/crates/redisctl/src/main.rs
@@ -539,6 +539,7 @@ fn format_command(command: &Commands) -> String {
             match cmd {
                 List => "profile list".to_string(),
                 Path => "profile path".to_string(),
+                Current { r#type } => format!("profile current --type {}", r#type),
                 Show { name } => format!("profile show {}", name),
                 Set { name, .. } => format!("profile set {} [credentials redacted]", name),
                 Remove { name } => format!("profile remove {}", name),


### PR DESCRIPTION
## Summary

Closes #693

Add `redisctl profile current --type <cloud|enterprise|database>` (alias: `profile active`) that prints the resolved active profile name for a given deployment type. Uses the existing profile resolution logic (explicit > default > first).

Intended for shell prompt integration:
```bash
PS1='[$(redisctl profile current --type cloud 2>/dev/null)]\$ '
```

Note: verbose output (`-v`) already shows the resolved profile via tracing (`info!("Using Redis Cloud profile: ...")` in connection.rs), so no additional changes needed there.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib --all-features` (77 tests pass)
- [ ] Manual: `redisctl profile current --type cloud` prints cloud profile name
- [ ] Manual: `redisctl profile current --type enterprise` prints enterprise profile name
- [ ] Manual: `redisctl profile current --type database` prints database profile name
- [ ] Manual: `redisctl profile active --type cloud` alias works
- [ ] Manual: error when no profiles of requested type exist