### PR TITLE
feat(mcp): surface credential issues clearly in tool error responses

### DIFF
--- a/crates/redisctl-mcp/src/tools/cloud.rs
+++ b/crates/redisctl-mcp/src/tools/cloud.rs
@@ -39,7 +39,7 @@ pub fn list_subscriptions(state: Arc<AppState>) -> Tool {
                 let client = state
                     .cloud_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| ToolError::new(format!("Failed to get Cloud client: {}", e)))?;
+                    .map_err(|e| super::credential_error("cloud", e))?;
 
                 let handler = SubscriptionHandler::new(client);
                 let account_subs = handler
@@ -75,7 +75,7 @@ pub fn get_subscription(state: Arc<AppState>) -> Tool {
                 let client = state
                     .cloud_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| ToolError::new(format!("Failed to get Cloud client: {}", e)))?;
+                    .map_err(|e| super::credential_error("cloud", e))?;
 
                 let handler = SubscriptionHandler::new(client);
                 let subscription = handler
@@ -113,7 +113,7 @@ pub fn list_databases(state: Arc<AppState>) -> Tool {
                 let client = state
                     .cloud_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| ToolError::new(format!("Failed to get Cloud client: {}", e)))?;
+                    .map_err(|e| super::credential_error("cloud", e))?;
 
                 let handler = DatabaseHandler::new(client);
                 let databases = handler
@@ -151,7 +151,7 @@ pub fn get_database(state: Arc<AppState>) -> Tool {
                 let client = state
                     .cloud_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| ToolError::new(format!("Failed to get Cloud client: {}", e)))?;
+                    .map_err(|e| super::credential_error("cloud", e))?;
 
                 let handler = DatabaseHandler::new(client);
                 let database = handler
@@ -189,7 +189,7 @@ pub fn get_account(state: Arc<AppState>) -> Tool {
                 let client = state
                     .cloud_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| ToolError::new(format!("Failed to get Cloud client: {}", e)))?;
+                    .map_err(|e| super::credential_error("cloud", e))?;
 
                 let handler = AccountHandler::new(client);
                 let account = handler
@@ -232,7 +232,7 @@ pub fn get_system_logs(state: Arc<AppState>) -> Tool {
                 let client = state
                     .cloud_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| ToolError::new(format!("Failed to get Cloud client: {}", e)))?;
+                    .map_err(|e| super::credential_error("cloud", e))?;
 
                 let handler = AccountHandler::new(client);
                 let logs = handler
@@ -275,7 +275,7 @@ pub fn get_session_logs(state: Arc<AppState>) -> Tool {
                 let client = state
                     .cloud_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| ToolError::new(format!("Failed to get Cloud client: {}", e)))?;
+                    .map_err(|e| super::credential_error("cloud", e))?;
 
                 let handler = AccountHandler::new(client);
                 let logs = handler
@@ -314,7 +314,7 @@ pub fn get_regions(state: Arc<AppState>) -> Tool {
                 let client = state
                     .cloud_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| ToolError::new(format!("Failed to get Cloud client: {}", e)))?;
+                    .map_err(|e| super::credential_error("cloud", e))?;
 
                 let handler = AccountHandler::new(client);
                 let regions = handler
@@ -350,7 +350,7 @@ pub fn get_modules(state: Arc<AppState>) -> Tool {
                 let client = state
                     .cloud_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| ToolError::new(format!("Failed to get Cloud client: {}", e)))?;
+                    .map_err(|e| super::credential_error("cloud", e))?;
 
                 let handler = AccountHandler::new(client);
                 let modules = handler
@@ -388,7 +388,7 @@ pub fn list_tasks(state: Arc<AppState>) -> Tool {
                 let client = state
                     .cloud_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| ToolError::new(format!("Failed to get Cloud client: {}", e)))?;
+                    .map_err(|e| super::credential_error("cloud", e))?;
 
                 let handler = TaskHandler::new(client);
                 let tasks = handler
@@ -424,7 +424,7 @@ pub fn get_task(state: Arc<AppState>) -> Tool {
                 let client = state
                     .cloud_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| ToolError::new(format!("Failed to get Cloud client: {}", e)))?;
+                    .map_err(|e| super::credential_error("cloud", e))?;
 
                 let handler = TaskHandler::new(client);
                 let task = handler
@@ -464,7 +464,7 @@ pub fn list_account_users(state: Arc<AppState>) -> Tool {
                 let client = state
                     .cloud_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| ToolError::new(format!("Failed to get Cloud client: {}", e)))?;
+                    .map_err(|e| super::credential_error("cloud", e))?;
 
                 let handler = UserHandler::new(client);
                 let users = handler
@@ -498,9 +498,10 @@ pub fn get_account_user(state: Arc<AppState>) -> Tool {
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetAccountUserInput>| async move {
-                let client = state.cloud_client_for_profile(input.profile.as_deref()).await.map_err(|e| {
-                    ToolError::new(format!("Failed to get Cloud client: {}", e))
-                })?;
+                let client = state
+                    .cloud_client_for_profile(input.profile.as_deref())
+                    .await
+                    .map_err(|e| super::credential_error("cloud", e))?;
 
                 let handler = UserHandler::new(client);
                 let user = handler
@@ -538,7 +539,7 @@ pub fn list_acl_users(state: Arc<AppState>) -> Tool {
                 let client = state
                     .cloud_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| ToolError::new(format!("Failed to get Cloud client: {}", e)))?;
+                    .map_err(|e| super::credential_error("cloud", e))?;
 
                 let handler = AclHandler::new(client);
                 let users = handler
@@ -574,7 +575,7 @@ pub fn get_acl_user(state: Arc<AppState>) -> Tool {
                 let client = state
                     .cloud_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| ToolError::new(format!("Failed to get Cloud client: {}", e)))?;
+                    .map_err(|e| super::credential_error("cloud", e))?;
 
                 let handler = AclHandler::new(client);
                 let user = handler
@@ -608,7 +609,7 @@ pub fn list_acl_roles(state: Arc<AppState>) -> Tool {
                 let client = state
                     .cloud_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| ToolError::new(format!("Failed to get Cloud client: {}", e)))?;
+                    .map_err(|e| super::credential_error("cloud", e))?;
 
                 let handler = AclHandler::new(client);
                 let roles = handler
@@ -642,7 +643,7 @@ pub fn list_redis_rules(state: Arc<AppState>) -> Tool {
                 let client = state
                     .cloud_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| ToolError::new(format!("Failed to get Cloud client: {}", e)))?;
+                    .map_err(|e| super::credential_error("cloud", e))?;
 
                 let handler = AclHandler::new(client);
                 let rules = handler
@@ -687,7 +688,7 @@ pub fn get_backup_status(state: Arc<AppState>) -> Tool {
                 let client = state
                     .cloud_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| ToolError::new(format!("Failed to get Cloud client: {}", e)))?;
+                    .map_err(|e| super::credential_error("cloud", e))?;
 
                 let handler = DatabaseHandler::new(client);
                 let status = handler
@@ -734,7 +735,7 @@ pub fn get_slow_log(state: Arc<AppState>) -> Tool {
                 let client = state
                     .cloud_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| ToolError::new(format!("Failed to get Cloud client: {}", e)))?;
+                    .map_err(|e| super::credential_error("cloud", e))?;
 
                 let handler = DatabaseHandler::new(client);
                 let log = handler
@@ -772,7 +773,7 @@ pub fn get_tags(state: Arc<AppState>) -> Tool {
                 let client = state
                     .cloud_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| ToolError::new(format!("Failed to get Cloud client: {}", e)))?;
+                    .map_err(|e| super::credential_error("cloud", e))?;
 
                 let handler = DatabaseHandler::new(client);
                 let tags = handler
@@ -813,7 +814,7 @@ pub fn get_database_certificate(state: Arc<AppState>) -> Tool {
                 let client = state
                     .cloud_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| ToolError::new(format!("Failed to get Cloud client: {}", e)))?;
+                    .map_err(|e| super::credential_error("cloud", e))?;
 
                 let handler = DatabaseHandler::new(client);
                 let cert = handler
@@ -896,7 +897,7 @@ pub fn create_database(state: Arc<AppState>) -> Tool {
                 let client = state
                     .cloud_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| ToolError::new(format!("Failed to get Cloud client: {}", e)))?;
+                    .map_err(|e| super::credential_error("cloud", e))?;
 
                 // Build the request using Layer 1's TypedBuilder
                 let request = match (input.protocol.as_str(), input.data_persistence.as_ref()) {
@@ -1000,7 +1001,7 @@ pub fn update_database(state: Arc<AppState>) -> Tool {
                 let client = state
                     .cloud_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| ToolError::new(format!("Failed to get Cloud client: {}", e)))?;
+                    .map_err(|e| super::credential_error("cloud", e))?;
 
                 // Build the update request
                 let mut request = DatabaseUpdateRequest::builder().build();
@@ -1080,7 +1081,7 @@ pub fn delete_database(state: Arc<AppState>) -> Tool {
                 let client = state
                     .cloud_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| ToolError::new(format!("Failed to get Cloud client: {}", e)))?;
+                    .map_err(|e| super::credential_error("cloud", e))?;
 
                 // Use Layer 2 workflow
                 delete_database_and_wait(
@@ -1146,7 +1147,7 @@ pub fn backup_database(state: Arc<AppState>) -> Tool {
                 let client = state
                     .cloud_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| ToolError::new(format!("Failed to get Cloud client: {}", e)))?;
+                    .map_err(|e| super::credential_error("cloud", e))?;
 
                 // Use Layer 2 workflow
                 backup_database_and_wait(
@@ -1220,7 +1221,7 @@ pub fn import_database(state: Arc<AppState>) -> Tool {
                 let client = state
                     .cloud_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| ToolError::new(format!("Failed to get Cloud client: {}", e)))?;
+                    .map_err(|e| super::credential_error("cloud", e))?;
 
                 // Build the import request
                 let request = DatabaseImportRequest::builder()
@@ -1288,7 +1289,7 @@ pub fn delete_subscription(state: Arc<AppState>) -> Tool {
                 let client = state
                     .cloud_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| ToolError::new(format!("Failed to get Cloud client: {}", e)))?;
+                    .map_err(|e| super::credential_error("cloud", e))?;
 
                 // Use Layer 2 workflow
                 delete_subscription_and_wait(
@@ -1353,7 +1354,7 @@ pub fn flush_database(state: Arc<AppState>) -> Tool {
                 let client = state
                     .cloud_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| ToolError::new(format!("Failed to get Cloud client: {}", e)))?;
+                    .map_err(|e| super::credential_error("cloud", e))?;
 
                 // Use Layer 2 workflow
                 flush_database_and_wait(
@@ -1446,7 +1447,7 @@ pub fn create_subscription(state: Arc<AppState>) -> Tool {
                 let client = state
                     .cloud_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| ToolError::new(format!("Failed to get Cloud client: {}", e)))?;
+                    .map_err(|e| super::credential_error("cloud", e))?;
 
                 // Build the subscription request
                 let request = SubscriptionCreateRequest::builder()

--- a/crates/redisctl-mcp/src/tools/enterprise.rs
+++ b/crates/redisctl-mcp/src/tools/enterprise.rs
@@ -50,9 +50,7 @@ pub fn get_cluster(state: Arc<AppState>) -> Tool {
                 let client = state
                     .enterprise_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| {
-                        ToolError::new(format!("Failed to get Enterprise client: {}", e))
-                    })?;
+                    .map_err(|e| super::credential_error("enterprise", e))?;
 
                 let handler = ClusterHandler::new(client);
                 let cluster = handler
@@ -93,9 +91,7 @@ pub fn get_license(state: Arc<AppState>) -> Tool {
                 let client = state
                     .enterprise_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| {
-                        ToolError::new(format!("Failed to get Enterprise client: {}", e))
-                    })?;
+                    .map_err(|e| super::credential_error("enterprise", e))?;
 
                 let handler = LicenseHandler::new(client);
                 let license = handler
@@ -132,7 +128,7 @@ pub fn get_license_usage(state: Arc<AppState>) -> Tool {
                 let client = state
                     .enterprise_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| ToolError::new(format!("Failed to get Enterprise client: {}", e)))?;
+                    .map_err(|e| super::credential_error("enterprise", e))?;
 
                 let handler = LicenseHandler::new(client);
                 let usage = handler
@@ -189,9 +185,7 @@ pub fn list_logs(state: Arc<AppState>) -> Tool {
                 let client = state
                     .enterprise_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| {
-                        ToolError::new(format!("Failed to get Enterprise client: {}", e))
-                    })?;
+                    .map_err(|e| super::credential_error("enterprise", e))?;
 
                 let query = if input.start_time.is_some()
                     || input.end_time.is_some()
@@ -255,9 +249,7 @@ pub fn list_databases(state: Arc<AppState>) -> Tool {
                 let client = state
                     .enterprise_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| {
-                        ToolError::new(format!("Failed to get Enterprise client: {}", e))
-                    })?;
+                    .map_err(|e| super::credential_error("enterprise", e))?;
 
                 let handler = DatabaseHandler::new(client);
                 let databases = handler
@@ -315,9 +307,7 @@ pub fn get_database(state: Arc<AppState>) -> Tool {
                 let client = state
                     .enterprise_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| {
-                        ToolError::new(format!("Failed to get Enterprise client: {}", e))
-                    })?;
+                    .map_err(|e| super::credential_error("enterprise", e))?;
 
                 let handler = DatabaseHandler::new(client);
                 let database = handler
@@ -351,9 +341,7 @@ pub fn list_nodes(state: Arc<AppState>) -> Tool {
                 let client = state
                     .enterprise_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| {
-                        ToolError::new(format!("Failed to get Enterprise client: {}", e))
-                    })?;
+                    .map_err(|e| super::credential_error("enterprise", e))?;
 
                 let handler = NodeHandler::new(client);
                 let nodes = handler
@@ -395,9 +383,7 @@ pub fn get_node(state: Arc<AppState>) -> Tool {
                 let client = state
                     .enterprise_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| {
-                        ToolError::new(format!("Failed to get Enterprise client: {}", e))
-                    })?;
+                    .map_err(|e| super::credential_error("enterprise", e))?;
 
                 let handler = NodeHandler::new(client);
                 let node = handler
@@ -435,9 +421,7 @@ pub fn list_users(state: Arc<AppState>) -> Tool {
                 let client = state
                     .enterprise_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| {
-                        ToolError::new(format!("Failed to get Enterprise client: {}", e))
-                    })?;
+                    .map_err(|e| super::credential_error("enterprise", e))?;
 
                 let handler = UserHandler::new(client);
                 let users = handler
@@ -475,9 +459,7 @@ pub fn get_user(state: Arc<AppState>) -> Tool {
                 let client = state
                     .enterprise_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| {
-                        ToolError::new(format!("Failed to get Enterprise client: {}", e))
-                    })?;
+                    .map_err(|e| super::credential_error("enterprise", e))?;
 
                 let handler = UserHandler::new(client);
                 let user = handler
@@ -515,9 +497,7 @@ pub fn list_alerts(state: Arc<AppState>) -> Tool {
                 let client = state
                     .enterprise_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| {
-                        ToolError::new(format!("Failed to get Enterprise client: {}", e))
-                    })?;
+                    .map_err(|e| super::credential_error("enterprise", e))?;
 
                 let handler = AlertHandler::new(client);
                 let alerts = handler
@@ -553,7 +533,7 @@ pub fn list_database_alerts(state: Arc<AppState>) -> Tool {
                 let client = state
                     .enterprise_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| ToolError::new(format!("Failed to get Enterprise client: {}", e)))?;
+                    .map_err(|e| super::credential_error("enterprise", e))?;
 
                 let handler = AlertHandler::new(client);
                 let alerts = handler
@@ -603,7 +583,7 @@ pub fn get_cluster_stats(state: Arc<AppState>) -> Tool {
                 let client = state
                     .enterprise_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| ToolError::new(format!("Failed to get Enterprise client: {}", e)))?;
+                    .map_err(|e| super::credential_error("enterprise", e))?;
 
                 let handler = StatsHandler::new(client);
 
@@ -666,7 +646,7 @@ pub fn get_database_stats(state: Arc<AppState>) -> Tool {
                 let client = state
                     .enterprise_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| ToolError::new(format!("Failed to get Enterprise client: {}", e)))?;
+                    .map_err(|e| super::credential_error("enterprise", e))?;
 
                 let handler = StatsHandler::new(client);
 
@@ -728,9 +708,7 @@ pub fn get_node_stats(state: Arc<AppState>) -> Tool {
                 let client = state
                     .enterprise_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| {
-                        ToolError::new(format!("Failed to get Enterprise client: {}", e))
-                    })?;
+                    .map_err(|e| super::credential_error("enterprise", e))?;
 
                 let handler = StatsHandler::new(client);
 
@@ -784,7 +762,7 @@ pub fn get_all_nodes_stats(state: Arc<AppState>) -> Tool {
                 let client = state
                     .enterprise_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| ToolError::new(format!("Failed to get Enterprise client: {}", e)))?;
+                    .map_err(|e| super::credential_error("enterprise", e))?;
 
                 let handler = StatsHandler::new(client);
                 let stats = handler
@@ -822,7 +800,7 @@ pub fn get_all_databases_stats(state: Arc<AppState>) -> Tool {
                 let client = state
                     .enterprise_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| ToolError::new(format!("Failed to get Enterprise client: {}", e)))?;
+                    .map_err(|e| super::credential_error("enterprise", e))?;
 
                 let handler = StatsHandler::new(client);
                 let stats = handler.databases_last().await.map_err(|e| {
@@ -857,9 +835,7 @@ pub fn get_shard_stats(state: Arc<AppState>) -> Tool {
                 let client = state
                     .enterprise_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| {
-                        ToolError::new(format!("Failed to get Enterprise client: {}", e))
-                    })?;
+                    .map_err(|e| super::credential_error("enterprise", e))?;
 
                 let handler = StatsHandler::new(client);
                 let stats = handler
@@ -896,7 +872,7 @@ pub fn get_all_shards_stats(state: Arc<AppState>) -> Tool {
                 let client = state
                     .enterprise_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| ToolError::new(format!("Failed to get Enterprise client: {}", e)))?;
+                    .map_err(|e| super::credential_error("enterprise", e))?;
 
                 let handler = StatsHandler::new(client);
                 let stats = handler
@@ -939,9 +915,7 @@ pub fn list_shards(state: Arc<AppState>) -> Tool {
                 let client = state
                     .enterprise_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| {
-                        ToolError::new(format!("Failed to get Enterprise client: {}", e))
-                    })?;
+                    .map_err(|e| super::credential_error("enterprise", e))?;
 
                 let handler = ShardHandler::new(client);
                 let shards = if let Some(db_uid) = input.database_uid {
@@ -987,9 +961,7 @@ pub fn get_shard(state: Arc<AppState>) -> Tool {
                 let client = state
                     .enterprise_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| {
-                        ToolError::new(format!("Failed to get Enterprise client: {}", e))
-                    })?;
+                    .map_err(|e| super::credential_error("enterprise", e))?;
 
                 let handler = ShardHandler::new(client);
                 let shard = handler
@@ -1031,7 +1003,7 @@ pub fn get_database_endpoints(state: Arc<AppState>) -> Tool {
                 let client = state
                     .enterprise_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| ToolError::new(format!("Failed to get Enterprise client: {}", e)))?;
+                    .map_err(|e| super::credential_error("enterprise", e))?;
 
                 let handler = DatabaseHandler::new(client);
                 let endpoints = handler
@@ -1073,7 +1045,7 @@ pub fn list_debug_info_tasks(state: Arc<AppState>) -> Tool {
                 let client = state
                     .enterprise_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| ToolError::new(format!("Failed to get Enterprise client: {}", e)))?;
+                    .map_err(|e| super::credential_error("enterprise", e))?;
 
                 let handler = DebugInfoHandler::new(client);
                 let tasks = handler
@@ -1113,7 +1085,7 @@ pub fn get_debug_info_status(state: Arc<AppState>) -> Tool {
                 let client = state
                     .enterprise_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| ToolError::new(format!("Failed to get Enterprise client: {}", e)))?;
+                    .map_err(|e| super::credential_error("enterprise", e))?;
 
                 let handler = DebugInfoHandler::new(client);
                 let status = handler
@@ -1155,9 +1127,7 @@ pub fn list_modules(state: Arc<AppState>) -> Tool {
                 let client = state
                     .enterprise_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| {
-                        ToolError::new(format!("Failed to get Enterprise client: {}", e))
-                    })?;
+                    .map_err(|e| super::credential_error("enterprise", e))?;
 
                 let handler = ModuleHandler::new(client);
                 let modules = handler
@@ -1196,9 +1166,7 @@ pub fn get_module(state: Arc<AppState>) -> Tool {
                 let client = state
                     .enterprise_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| {
-                        ToolError::new(format!("Failed to get Enterprise client: {}", e))
-                    })?;
+                    .map_err(|e| super::credential_error("enterprise", e))?;
 
                 let handler = ModuleHandler::new(client);
                 let module = handler
@@ -1254,7 +1222,7 @@ pub fn backup_enterprise_database(state: Arc<AppState>) -> Tool {
                 let client = state
                     .enterprise_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| ToolError::new(format!("Failed to get Enterprise client: {}", e)))?;
+                    .map_err(|e| super::credential_error("enterprise", e))?;
 
                 // Use Layer 2 workflow
                 backup_database_and_wait(
@@ -1315,7 +1283,7 @@ pub fn import_enterprise_database(state: Arc<AppState>) -> Tool {
                 let client = state
                     .enterprise_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| ToolError::new(format!("Failed to get Enterprise client: {}", e)))?;
+                    .map_err(|e| super::credential_error("enterprise", e))?;
 
                 // Use Layer 2 workflow
                 import_database_and_wait(
@@ -1386,9 +1354,7 @@ pub fn create_enterprise_database(state: Arc<AppState>) -> Tool {
                 let client = state
                     .enterprise_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| {
-                        ToolError::new(format!("Failed to get Enterprise client: {}", e))
-                    })?;
+                    .map_err(|e| super::credential_error("enterprise", e))?;
 
                 // Build the request using struct construction (all Option fields have defaults)
                 let request = CreateDatabaseRequest {
@@ -1453,9 +1419,7 @@ pub fn update_enterprise_database(state: Arc<AppState>) -> Tool {
                 let client = state
                     .enterprise_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| {
-                        ToolError::new(format!("Failed to get Enterprise client: {}", e))
-                    })?;
+                    .map_err(|e| super::credential_error("enterprise", e))?;
 
                 let handler = DatabaseHandler::new(client);
                 let database = handler
@@ -1501,9 +1465,7 @@ pub fn delete_enterprise_database(state: Arc<AppState>) -> Tool {
                 let client = state
                     .enterprise_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| {
-                        ToolError::new(format!("Failed to get Enterprise client: {}", e))
-                    })?;
+                    .map_err(|e| super::credential_error("enterprise", e))?;
 
                 let handler = DatabaseHandler::new(client);
                 handler
@@ -1555,9 +1517,7 @@ pub fn flush_enterprise_database(state: Arc<AppState>) -> Tool {
                 let client = state
                     .enterprise_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| {
-                        ToolError::new(format!("Failed to get Enterprise client: {}", e))
-                    })?;
+                    .map_err(|e| super::credential_error("enterprise", e))?;
 
                 // Use Layer 2 workflow
                 flush_database_and_wait(
@@ -1605,9 +1565,7 @@ pub fn list_roles(state: Arc<AppState>) -> Tool {
                 let client = state
                     .enterprise_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| {
-                        ToolError::new(format!("Failed to get Enterprise client: {}", e))
-                    })?;
+                    .map_err(|e| super::credential_error("enterprise", e))?;
 
                 let handler = RolesHandler::new(client);
                 let roles = handler
@@ -1646,9 +1604,7 @@ pub fn get_role(state: Arc<AppState>) -> Tool {
                 let client = state
                     .enterprise_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| {
-                        ToolError::new(format!("Failed to get Enterprise client: {}", e))
-                    })?;
+                    .map_err(|e| super::credential_error("enterprise", e))?;
 
                 let handler = RolesHandler::new(client);
                 let role = handler
@@ -1689,9 +1645,7 @@ pub fn list_redis_acls(state: Arc<AppState>) -> Tool {
                 let client = state
                     .enterprise_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| {
-                        ToolError::new(format!("Failed to get Enterprise client: {}", e))
-                    })?;
+                    .map_err(|e| super::credential_error("enterprise", e))?;
 
                 let handler = RedisAclHandler::new(client);
                 let acls = handler
@@ -1730,9 +1684,7 @@ pub fn get_redis_acl(state: Arc<AppState>) -> Tool {
                 let client = state
                     .enterprise_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| {
-                        ToolError::new(format!("Failed to get Enterprise client: {}", e))
-                    })?;
+                    .map_err(|e| super::credential_error("enterprise", e))?;
 
                 let handler = RedisAclHandler::new(client);
                 let acl = handler
@@ -1780,9 +1732,7 @@ pub fn update_license(state: Arc<AppState>) -> Tool {
                 let client = state
                     .enterprise_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| {
-                        ToolError::new(format!("Failed to get Enterprise client: {}", e))
-                    })?;
+                    .map_err(|e| super::credential_error("enterprise", e))?;
 
                 let handler = LicenseHandler::new(client);
                 let request = LicenseUpdateRequest {
@@ -1826,7 +1776,7 @@ pub fn validate_license(state: Arc<AppState>) -> Tool {
                 let client = state
                     .enterprise_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| ToolError::new(format!("Failed to get Enterprise client: {}", e)))?;
+                    .map_err(|e| super::credential_error("enterprise", e))?;
 
                 let handler = LicenseHandler::new(client);
                 let license = handler
@@ -1875,9 +1825,7 @@ pub fn update_cluster(state: Arc<AppState>) -> Tool {
                 let client = state
                     .enterprise_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| {
-                        ToolError::new(format!("Failed to get Enterprise client: {}", e))
-                    })?;
+                    .map_err(|e| super::credential_error("enterprise", e))?;
 
                 let handler = ClusterHandler::new(client);
                 let result = handler
@@ -1915,7 +1863,7 @@ pub fn get_cluster_policy(state: Arc<AppState>) -> Tool {
                 let client = state
                     .enterprise_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| ToolError::new(format!("Failed to get Enterprise client: {}", e)))?;
+                    .map_err(|e| super::credential_error("enterprise", e))?;
 
                 let handler = ClusterHandler::new(client);
                 let policy = handler
@@ -1963,7 +1911,7 @@ pub fn update_cluster_policy(state: Arc<AppState>) -> Tool {
                 let client = state
                     .enterprise_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| ToolError::new(format!("Failed to get Enterprise client: {}", e)))?;
+                    .map_err(|e| super::credential_error("enterprise", e))?;
 
                 let handler = ClusterHandler::new(client);
                 let result = handler
@@ -2011,7 +1959,7 @@ pub fn enable_maintenance_mode(state: Arc<AppState>) -> Tool {
                 let client = state
                     .enterprise_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| ToolError::new(format!("Failed to get Enterprise client: {}", e)))?;
+                    .map_err(|e| super::credential_error("enterprise", e))?;
 
                 let handler = ClusterHandler::new(client);
                 // Enable maintenance mode by setting block_cluster_changes to true
@@ -2061,7 +2009,7 @@ pub fn disable_maintenance_mode(state: Arc<AppState>) -> Tool {
                 let client = state
                     .enterprise_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| ToolError::new(format!("Failed to get Enterprise client: {}", e)))?;
+                    .map_err(|e| super::credential_error("enterprise", e))?;
 
                 let handler = ClusterHandler::new(client);
                 // Disable maintenance mode by setting block_cluster_changes to false
@@ -2109,7 +2057,7 @@ pub fn get_cluster_certificates(state: Arc<AppState>) -> Tool {
                 let client = state
                     .enterprise_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| ToolError::new(format!("Failed to get Enterprise client: {}", e)))?;
+                    .map_err(|e| super::credential_error("enterprise", e))?;
 
                 let handler = ClusterHandler::new(client);
                 let certificates = handler
@@ -2153,9 +2101,7 @@ pub fn rotate_cluster_certificates(state: Arc<AppState>) -> Tool {
                 let client = state
                     .enterprise_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| {
-                        ToolError::new(format!("Failed to get Enterprise client: {}", e))
-                    })?;
+                    .map_err(|e| super::credential_error("enterprise", e))?;
 
                 let handler = ClusterHandler::new(client);
                 let result = handler
@@ -2208,9 +2154,7 @@ pub fn update_cluster_certificates(state: Arc<AppState>) -> Tool {
                 let client = state
                     .enterprise_client_for_profile(input.profile.as_deref())
                     .await
-                    .map_err(|e| {
-                        ToolError::new(format!("Failed to get Enterprise client: {}", e))
-                    })?;
+                    .map_err(|e| super::credential_error("enterprise", e))?;
 
                 let handler = ClusterHandler::new(client);
                 let body = serde_json::json!({

--- a/crates/redisctl-mcp/src/tools/mod.rs
+++ b/crates/redisctl-mcp/src/tools/mod.rs
@@ -3,7 +3,7 @@
 #[cfg(any(feature = "cloud", feature = "enterprise"))]
 use serde::Serialize;
 #[cfg(any(feature = "cloud", feature = "enterprise"))]
-use tower_mcp::{CallToolResult, Error as McpError};
+use tower_mcp::{CallToolResult, Error as McpError, ToolError};
 
 #[cfg(feature = "cloud")]
 pub mod cloud;
@@ -21,4 +21,74 @@ pub mod redis;
 #[cfg(any(feature = "cloud", feature = "enterprise"))]
 pub fn wrap_list<T: Serialize>(key: &str, items: &[T]) -> Result<CallToolResult, McpError> {
     CallToolResult::from_serialize(&serde_json::json!({ key: items, "count": items.len() }))
+}
+
+/// Format a client creation error with structured remediation guidance for LLMs.
+///
+/// Inspects the error chain to identify common credential issues and provides
+/// actionable MCP tool calls the LLM can use to diagnose and fix the problem.
+#[cfg(any(feature = "cloud", feature = "enterprise"))]
+pub fn credential_error(platform: &str, err: anyhow::Error) -> ToolError {
+    let msg = format!("{:#}", err);
+    let err_lower = msg.to_lowercase();
+
+    let mut output = String::new();
+
+    if err_lower.contains("no redisctl config available") {
+        output.push_str("No profiles configured.\n\n");
+        output.push_str("Suggested actions:\n");
+        output.push_str(&format!(
+            "- Call profile_create with profile_type='{}' to create a profile\n",
+            platform
+        ));
+        output.push_str("- Call profile_path to check the config file location\n");
+    } else if err_lower.contains("failed to resolve") && err_lower.contains("profile") {
+        output.push_str(&format!("No {} profile available.\n\n", platform));
+        output.push_str("Suggested actions:\n");
+        output.push_str("- Call profile_list to see available profiles\n");
+        output.push_str(&format!(
+            "- Call profile_create with profile_type='{}' to create one\n",
+            platform
+        ));
+        output.push_str("- Pass the 'profile' parameter to specify an existing profile by name\n");
+    } else if err_lower.contains("not found") {
+        output.push_str("The specified profile does not exist.\n\n");
+        output.push_str("Suggested actions:\n");
+        output.push_str("- Call profile_list to see available profiles\n");
+        output.push_str(&format!(
+            "- Call profile_create with profile_type='{}' to create a new profile\n",
+            platform
+        ));
+    } else if err_lower.contains("no cloud credentials")
+        || err_lower.contains("no enterprise credentials")
+    {
+        output.push_str(&format!(
+            "The resolved profile does not have {} credentials.\n\n",
+            platform
+        ));
+        output.push_str("Suggested actions:\n");
+        output.push_str("- Call profile_list to find profiles of the correct type\n");
+        output.push_str("- Pass the 'profile' parameter with a profile name of the correct type\n");
+        output.push_str(&format!(
+            "- Call profile_create with profile_type='{}' to create one\n",
+            platform
+        ));
+    } else if err_lower.contains("credential") {
+        output.push_str(
+            "Credential resolution failed (keyring or environment variable lookup may have failed).\n\n",
+        );
+        output.push_str("Suggested actions:\n");
+        output.push_str("- Call profile_show to inspect credential sources\n");
+        output.push_str("- Call profile_validate with connect=true to diagnose issues\n");
+    } else {
+        output.push_str(&format!("Failed to initialize {} client.\n\n", platform));
+        output.push_str("Suggested actions:\n");
+        output.push_str("- Call profile_list to check configured profiles\n");
+        output.push_str("- Call profile_validate with connect=true to test connectivity\n");
+        output.push_str("- Call profile_show <name> to inspect a specific profile\n");
+    }
+
+    output.push_str(&format!("\nError details: {}", msg));
+
+    ToolError::new(output)
 }


### PR DESCRIPTION
## Summary

Closes #695

- Adds `credential_error` helper that inspects the anyhow error chain from client creation and produces structured, LLM-readable error messages with actionable MCP tool call suggestions
- Differentiates between: no config, no profile of type, profile not found, wrong credential type, credential resolution failure, and generic client init failures
- Each error category includes specific suggested actions (e.g., "Call profile_create with profile_type='cloud'")
- Applied to all 28 cloud and 18 enterprise client creation error sites
- Error details preserved in every message for debugging

### Before
```
Failed to get Cloud client: Failed to resolve cloud profile
```

### After
```
No cloud profile available.

Suggested actions:
- Call profile_list to see available profiles
- Call profile_create with profile_type='cloud' to create one
- Pass the 'profile' parameter to specify an existing profile by name

Error details: Failed to resolve cloud profile
```

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo check -p redisctl-mcp --no-default-features` passes
- [x] `cargo test -p redisctl-mcp --lib --all-features` passes (17 tests)