### PR TITLE
feat(cli): add profile tags for organizing many profiles

### DIFF
--- a/crates/redisctl-core/src/config/config.rs
+++ b/crates/redisctl-core/src/config/config.rs
@@ -50,6 +50,9 @@ pub struct Profile {
     /// Resilience configuration for this profile
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resilience: Option<super::ResilienceConfig>,
+    /// Tags for organizing profiles
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
 }
 
 /// Supported deployment types
@@ -686,6 +689,7 @@ mod tests {
             },
             files_api_key: None,
             resilience: None,
+            tags: vec![],
         };
 
         config.set_profile("test".to_string(), cloud_profile);
@@ -709,6 +713,7 @@ mod tests {
             },
             files_api_key: None,
             resilience: None,
+            tags: vec![],
         };
 
         let (key, secret, url) = cloud_profile.cloud_credentials().unwrap();
@@ -845,6 +850,7 @@ api_url = "${REDIS_TEST_URL:-https://api.redislabs.com/v1}"
             },
             files_api_key: None,
             resilience: None,
+            tags: vec![],
         };
         config.set_profile("ent1".to_string(), enterprise_profile);
 
@@ -876,6 +882,7 @@ api_url = "${REDIS_TEST_URL:-https://api.redislabs.com/v1}"
             },
             files_api_key: None,
             resilience: None,
+            tags: vec![],
         };
         config.set_profile("cloud1".to_string(), cloud_profile);
 
@@ -907,6 +914,7 @@ api_url = "${REDIS_TEST_URL:-https://api.redislabs.com/v1}"
             },
             files_api_key: None,
             resilience: None,
+            tags: vec![],
         };
         config.set_profile("cloud1".to_string(), cloud_profile.clone());
         config.set_profile("cloud2".to_string(), cloud_profile);
@@ -923,6 +931,7 @@ api_url = "${REDIS_TEST_URL:-https://api.redislabs.com/v1}"
             },
             files_api_key: None,
             resilience: None,
+            tags: vec![],
         };
         config.set_profile("ent1".to_string(), enterprise_profile.clone());
         config.set_profile("ent2".to_string(), enterprise_profile);
@@ -963,6 +972,7 @@ api_url = "${REDIS_TEST_URL:-https://api.redislabs.com/v1}"
             },
             files_api_key: None,
             resilience: None,
+            tags: vec![],
         };
         config.set_profile("cloud1".to_string(), cloud_profile);
 
@@ -988,6 +998,7 @@ api_url = "${REDIS_TEST_URL:-https://api.redislabs.com/v1}"
             },
             files_api_key: None,
             resilience: None,
+            tags: vec![],
         };
 
         config.set_profile("myredis".to_string(), db_profile);
@@ -1029,6 +1040,7 @@ api_url = "${REDIS_TEST_URL:-https://api.redislabs.com/v1}"
             },
             files_api_key: None,
             resilience: None,
+            tags: vec![],
         };
         config.set_profile("db1".to_string(), db_profile);
 
@@ -1077,6 +1089,7 @@ port = 12345
             },
             files_api_key: None,
             resilience: None,
+            tags: vec![],
         }
     }
 
@@ -1092,6 +1105,7 @@ port = 12345
             },
             files_api_key: None,
             resilience: None,
+            tags: vec![],
         }
     }
 
@@ -1185,6 +1199,7 @@ port = 12345
                 },
                 files_api_key: None,
                 resilience: None,
+                tags: vec![],
             },
         );
 

--- a/crates/redisctl-mcp/src/main.rs
+++ b/crates/redisctl-mcp/src/main.rs
@@ -391,6 +391,7 @@ mod tests {
             },
             files_api_key: None,
             resilience: None,
+            tags: vec![],
         }
     }
 
@@ -406,6 +407,7 @@ mod tests {
             },
             files_api_key: None,
             resilience: None,
+            tags: vec![],
         }
     }
 
@@ -422,6 +424,7 @@ mod tests {
             },
             files_api_key: None,
             resilience: None,
+            tags: vec![],
         }
     }
 

--- a/crates/redisctl-mcp/src/tools/profile.rs
+++ b/crates/redisctl-mcp/src/tools/profile.rs
@@ -24,6 +24,8 @@ struct ProfileSummary {
     name: String,
     deployment_type: String,
     is_default: bool,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    tags: Vec<String>,
 }
 
 /// Build the profile_list tool
@@ -60,6 +62,7 @@ pub fn list_profiles(state: Arc<AppState>) -> Tool {
                             name: (*name).clone(),
                             deployment_type: deployment_type.to_string(),
                             is_default,
+                            tags: profile.tags.clone(),
                         }
                     })
                     .collect();
@@ -74,9 +77,14 @@ pub fn list_profiles(state: Arc<AppState>) -> Tool {
                 let mut output = format!("Found {} profile(s):\n\n", profiles.len());
                 for p in &profiles {
                     let default_marker = if p.is_default { " (default)" } else { "" };
+                    let tag_suffix = if p.tags.is_empty() {
+                        String::new()
+                    } else {
+                        format!(" [{}]", p.tags.join(", "))
+                    };
                     output.push_str(&format!(
-                        "- {}: {}{}\n",
-                        p.name, p.deployment_type, default_marker
+                        "- {}: {}{}{}\n",
+                        p.name, p.deployment_type, default_marker, tag_suffix
                     ));
                 }
 
@@ -99,6 +107,8 @@ struct MaskedProfileDetails {
     name: String,
     deployment_type: String,
     is_default: bool,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    tags: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     cloud: Option<MaskedCloudCredentials>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -247,6 +257,7 @@ pub fn show_profile(state: Arc<AppState>) -> Tool {
                     name: input.name,
                     deployment_type: deployment_type.to_string(),
                     is_default,
+                    tags: profile.tags.clone(),
                     cloud,
                     enterprise,
                     database,
@@ -865,6 +876,7 @@ pub fn create_profile(state: Arc<AppState>) -> Tool {
                     credentials,
                     files_api_key: None,
                     resilience: None,
+                    tags: vec![],
                 };
 
                 // Check if this is the first profile of its type

--- a/crates/redisctl/src/cli/mod.rs
+++ b/crates/redisctl/src/cli/mod.rs
@@ -317,7 +317,11 @@ impl std::fmt::Display for HttpMethod {
 pub enum ProfileCommands {
     /// List all configured profiles
     #[command(visible_alias = "ls", visible_alias = "l")]
-    List,
+    List {
+        /// Filter profiles by tag (repeatable, matches any)
+        #[arg(long = "tag", action = clap::ArgAction::Append)]
+        tags: Vec<String>,
+    },
 
     /// Show the path to the configuration file
     Path,
@@ -395,6 +399,11 @@ EXAMPLES:
         --host localhost \\
         --port 6379 \\
         --no-tls
+
+    # Tag a profile for organization
+    redisctl profile set prod-cloud --type cloud \\
+        --api-key KEY --api-secret SECRET \\
+        --tag prod --tag us-east
 ")]
     Set {
         /// Profile name
@@ -456,6 +465,10 @@ EXAMPLES:
         #[cfg(feature = "secure-storage")]
         #[arg(long)]
         use_keyring: bool,
+
+        /// Tags for organizing profiles (repeatable)
+        #[arg(long = "tag", action = clap::ArgAction::Append)]
+        tags: Vec<String>,
     },
 
     /// Remove a profile

--- a/crates/redisctl/src/main.rs
+++ b/crates/redisctl/src/main.rs
@@ -537,7 +537,7 @@ fn format_command(command: &Commands) -> String {
         Commands::Profile(cmd) => {
             use cli::ProfileCommands::*;
             match cmd {
-                List => "profile list".to_string(),
+                List { .. } => "profile list".to_string(),
                 Path => "profile path".to_string(),
                 Current { r#type } => format!("profile current --type {}", r#type),
                 Show { name } => format!("profile show {}", name),


### PR DESCRIPTION
## Summary

- Add optional `tags` field to profiles for categorizing deployments (dev/staging/prod, regions, etc.)
- Add `--tag` flag to `profile set` (repeatable, e.g. `--tag prod --tag us-east`); tags are preserved on update when not specified
- Add `--tag` filter to `profile list` (matches any provided tag)
- Display tags inline in `profile list` (dimmed `[tag1, tag2]`) and as a `Tags:` line in `profile show`
- Expose tags in MCP profile tools (`profile_list` and `profile_show`)
- Fully backward compatible: TOML without `tags` deserializes to empty vec; empty tags are not serialized

Closes #692

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib --all-features` (77 tests pass)
- [x] `cargo test --test '*' --all-features` (all integration tests pass)
- [x] New tests: backward compat (TOML without tags), round-trip (save/reload with tags), empty tags not serialized
- [ ] Manual: `redisctl profile set test --type cloud --api-key k --api-secret s --tag prod --tag eu`
- [ ] Manual: `redisctl profile list` / `redisctl profile list --tag prod` / `redisctl profile show test`