### PR TITLE
feat(cli): add cluster health verification commands

### DIFF
--- a/crates/redisctl/src/cli/enterprise.rs
+++ b/crates/redisctl/src/cli/enterprise.rs
@@ -419,6 +419,18 @@ pub enum EnterpriseClusterCommands {
     #[command(name = "check-status")]
     CheckStatus,
 
+    /// Combined cluster health check (status, balance, rack-awareness)
+    #[command(name = "health")]
+    Health,
+
+    /// Verify shard distribution balance across nodes
+    #[command(name = "verify-balance")]
+    VerifyBalance,
+
+    /// Verify rack-aware placement of master/replica pairs
+    #[command(name = "verify-rack-awareness")]
+    VerifyRackAwareness,
+
     /// Get cluster certificates
     #[command(name = "get-certificates")]
     GetCertificates,

--- a/crates/redisctl/src/commands/enterprise/cluster.rs
+++ b/crates/redisctl/src/commands/enterprise/cluster.rs
@@ -173,6 +173,15 @@ pub async fn handle_cluster_command(
         EnterpriseClusterCommands::CheckStatus => {
             cluster_impl::check_cluster_status(conn_mgr, profile_name, output_format, query).await
         }
+        EnterpriseClusterCommands::Health => {
+            cluster_impl::cluster_health(conn_mgr, profile_name, output_format, query).await
+        }
+        EnterpriseClusterCommands::VerifyBalance => {
+            cluster_impl::verify_balance(conn_mgr, profile_name, output_format, query).await
+        }
+        EnterpriseClusterCommands::VerifyRackAwareness => {
+            cluster_impl::verify_rack_awareness(conn_mgr, profile_name, output_format, query).await
+        }
 
         // Certificates & Security
         EnterpriseClusterCommands::GetCertificates => {


### PR DESCRIPTION
## Summary

Closes #626

- Add `cluster verify-balance` command that checks shard distribution across nodes, flagging nodes that deviate >25% from mean
- Add `cluster verify-rack-awareness` command that verifies master/replica pairs are on different racks (skips if rack-awareness not enabled)
- Add `cluster health` command that combines cluster status, memory usage, balance, and rack-awareness into a unified PASS/WARN/FAIL report

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy -p redisctl --all-features -- -D warnings` passes
- [x] `cargo test --lib -p redisctl --all-features` passes (60 tests)
- [ ] Manual testing against a Redis Enterprise cluster with `verify-balance`, `verify-rack-awareness`, and `health` commands
- [ ] Verify JSON output matches documented shapes
- [ ] Verify `--output json` and `--query` flags work with new commands