### PR TITLE
feat(mcp): add 14 Redis read tools for streams, pub/sub, diagnostics, ACL, modules

### DIFF
--- a/crates/redisctl-mcp/src/tools/redis/server.rs
+++ b/crates/redisctl-mcp/src/tools/redis/server.rs
@@ -1,4 +1,5 @@
-//! Server-level Redis tools (ping, info, dbsize, client_list, cluster_info, slowlog)
+//! Server-level Redis tools (ping, info, dbsize, client_list, cluster_info, slowlog,
+//! config_get, memory_stats, latency_history, acl_list, acl_whoami, module_list)
 
 use std::sync::Arc;
 
@@ -17,6 +18,12 @@ pub(super) const INSTRUCTIONS: &str = "\
 - redis_client_list: Get connected clients\n\
 - redis_cluster_info: Get cluster info (if clustered)\n\
 - redis_slowlog: Get slow query log entries\n\
+- redis_config_get: Get configuration parameter values\n\
+- redis_memory_stats: Get detailed memory allocator statistics\n\
+- redis_latency_history: Get latency history for an event\n\
+- redis_acl_list: List ACL rules\n\
+- redis_acl_whoami: Get current authenticated username\n\
+- redis_module_list: List loaded modules\n\
 ";
 
 /// Build a sub-router containing all server-level Redis tools
@@ -28,6 +35,12 @@ pub fn router(state: Arc<AppState>) -> McpRouter {
         .tool(client_list(state.clone()))
         .tool(cluster_info(state.clone()))
         .tool(slowlog(state.clone()))
+        .tool(config_get(state.clone()))
+        .tool(memory_stats(state.clone()))
+        .tool(latency_history(state.clone()))
+        .tool(acl_list(state.clone()))
+        .tool(acl_whoami(state.clone()))
+        .tool(module_list(state.clone()))
 }
 
 /// Input for ping command
@@ -327,6 +340,332 @@ pub fn slowlog(state: Arc<AppState>) -> Tool {
                 }
 
                 Ok(CallToolResult::text(output))
+            },
+        )
+        .build()
+}
+
+/// Input for CONFIG GET command
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ConfigGetInput {
+    /// Optional Redis URL (uses configured URL if not provided)
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Configuration parameter pattern (e.g. "maxmemory", "save", "*")
+    pub parameter: String,
+}
+
+/// Build the config_get tool
+pub fn config_get(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("redis_config_get")
+        .description(
+            "Get Redis configuration parameter values using CONFIG GET. \
+             Supports glob-style patterns (e.g. \"maxmemory\", \"*memory*\", \"*\").",
+        )
+        .read_only()
+        .idempotent()
+        .extractor_handler_typed::<_, _, _, ConfigGetInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<ConfigGetInput>| async move {
+                let url = input
+                    .url
+                    .or_else(|| state.database_url.clone())
+                    .ok_or_else(|| ToolError::new("No Redis URL provided or configured"))?;
+
+                let client = redis::Client::open(url.as_str())
+                    .map_err(|e| ToolError::new(format!("Invalid URL: {}", e)))?;
+
+                let mut conn = client
+                    .get_multiplexed_async_connection()
+                    .await
+                    .map_err(|e| ToolError::new(format!("Connection failed: {}", e)))?;
+
+                let result: Vec<(String, String)> = redis::cmd("CONFIG")
+                    .arg("GET")
+                    .arg(&input.parameter)
+                    .query_async(&mut conn)
+                    .await
+                    .map_err(|e| ToolError::new(format!("CONFIG GET failed: {}", e)))?;
+
+                if result.is_empty() {
+                    return Ok(CallToolResult::text(format!(
+                        "No configuration parameters matching '{}'",
+                        input.parameter
+                    )));
+                }
+
+                let output = result
+                    .iter()
+                    .map(|(k, v)| format!("{}: {}", k, v))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+
+                Ok(CallToolResult::text(format!(
+                    "Configuration ({} parameter(s)):\n{}",
+                    result.len(),
+                    output
+                )))
+            },
+        )
+        .build()
+}
+
+/// Input for MEMORY STATS command
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct MemoryStatsInput {
+    /// Optional Redis URL (uses configured URL if not provided)
+    #[serde(default)]
+    pub url: Option<String>,
+}
+
+/// Build the memory_stats tool
+pub fn memory_stats(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("redis_memory_stats")
+        .description(
+            "Get detailed memory allocator statistics using MEMORY STATS. \
+             Shows memory usage breakdown by category.",
+        )
+        .read_only()
+        .idempotent()
+        .extractor_handler_typed::<_, _, _, MemoryStatsInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<MemoryStatsInput>| async move {
+                let url = input
+                    .url
+                    .or_else(|| state.database_url.clone())
+                    .ok_or_else(|| ToolError::new("No Redis URL provided or configured"))?;
+
+                let client = redis::Client::open(url.as_str())
+                    .map_err(|e| ToolError::new(format!("Invalid URL: {}", e)))?;
+
+                let mut conn = client
+                    .get_multiplexed_async_connection()
+                    .await
+                    .map_err(|e| ToolError::new(format!("Connection failed: {}", e)))?;
+
+                let result: redis::Value = redis::cmd("MEMORY")
+                    .arg("STATS")
+                    .query_async(&mut conn)
+                    .await
+                    .map_err(|e| ToolError::new(format!("MEMORY STATS failed: {}", e)))?;
+
+                Ok(CallToolResult::text(super::format_value(&result)))
+            },
+        )
+        .build()
+}
+
+/// Input for LATENCY HISTORY command
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct LatencyHistoryInput {
+    /// Optional Redis URL (uses configured URL if not provided)
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Latency event name (e.g. "command", "fast-command")
+    pub event: String,
+}
+
+/// Build the latency_history tool
+pub fn latency_history(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("redis_latency_history")
+        .description(
+            "Get latency history for a specific event using LATENCY HISTORY. \
+             Returns timestamp and latency pairs. Events include \"command\", \
+             \"fast-command\", etc. May return empty if latency monitoring is not enabled \
+             (CONFIG SET latency-monitor-threshold <ms>).",
+        )
+        .read_only()
+        .idempotent()
+        .extractor_handler_typed::<_, _, _, LatencyHistoryInput>(
+            state,
+            |State(state): State<Arc<AppState>>,
+             Json(input): Json<LatencyHistoryInput>| async move {
+                let url = input
+                    .url
+                    .or_else(|| state.database_url.clone())
+                    .ok_or_else(|| ToolError::new("No Redis URL provided or configured"))?;
+
+                let client = redis::Client::open(url.as_str())
+                    .map_err(|e| ToolError::new(format!("Invalid URL: {}", e)))?;
+
+                let mut conn = client
+                    .get_multiplexed_async_connection()
+                    .await
+                    .map_err(|e| ToolError::new(format!("Connection failed: {}", e)))?;
+
+                let result: Vec<Vec<redis::Value>> = redis::cmd("LATENCY")
+                    .arg("HISTORY")
+                    .arg(&input.event)
+                    .query_async(&mut conn)
+                    .await
+                    .map_err(|e| ToolError::new(format!("LATENCY HISTORY failed: {}", e)))?;
+
+                if result.is_empty() {
+                    return Ok(CallToolResult::text(format!(
+                        "No latency history for event '{}'. \
+                         Latency monitoring may not be enabled \
+                         (CONFIG SET latency-monitor-threshold <ms>).",
+                        input.event
+                    )));
+                }
+
+                let mut output = format!(
+                    "Latency history for '{}' ({} entries):\n\n",
+                    input.event,
+                    result.len()
+                );
+
+                for entry in &result {
+                    if entry.len() >= 2 {
+                        let timestamp = super::format_value(&entry[0]);
+                        let latency_ms = super::format_value(&entry[1]);
+                        output.push_str(&format!("  {} - {} ms\n", timestamp, latency_ms));
+                    }
+                }
+
+                Ok(CallToolResult::text(output))
+            },
+        )
+        .build()
+}
+
+/// Input for ACL LIST command
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct AclListInput {
+    /// Optional Redis URL (uses configured URL if not provided)
+    #[serde(default)]
+    pub url: Option<String>,
+}
+
+/// Build the acl_list tool
+pub fn acl_list(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("redis_acl_list")
+        .description("List all ACL rules configured on the Redis server using ACL LIST")
+        .read_only()
+        .idempotent()
+        .extractor_handler_typed::<_, _, _, AclListInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<AclListInput>| async move {
+                let url = input
+                    .url
+                    .or_else(|| state.database_url.clone())
+                    .ok_or_else(|| ToolError::new("No Redis URL provided or configured"))?;
+
+                let client = redis::Client::open(url.as_str())
+                    .map_err(|e| ToolError::new(format!("Invalid URL: {}", e)))?;
+
+                let mut conn = client
+                    .get_multiplexed_async_connection()
+                    .await
+                    .map_err(|e| ToolError::new(format!("Connection failed: {}", e)))?;
+
+                let rules: Vec<String> = redis::cmd("ACL")
+                    .arg("LIST")
+                    .query_async(&mut conn)
+                    .await
+                    .map_err(|e| ToolError::new(format!("ACL LIST failed: {}", e)))?;
+
+                if rules.is_empty() {
+                    return Ok(CallToolResult::text("No ACL rules configured"));
+                }
+
+                Ok(CallToolResult::text(format!(
+                    "ACL rules ({}):\n{}",
+                    rules.len(),
+                    rules.join("\n")
+                )))
+            },
+        )
+        .build()
+}
+
+/// Input for ACL WHOAMI command
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct AclWhoamiInput {
+    /// Optional Redis URL (uses configured URL if not provided)
+    #[serde(default)]
+    pub url: Option<String>,
+}
+
+/// Build the acl_whoami tool
+pub fn acl_whoami(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("redis_acl_whoami")
+        .description("Get the username of the current authenticated connection using ACL WHOAMI")
+        .read_only()
+        .idempotent()
+        .extractor_handler_typed::<_, _, _, AclWhoamiInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<AclWhoamiInput>| async move {
+                let url = input
+                    .url
+                    .or_else(|| state.database_url.clone())
+                    .ok_or_else(|| ToolError::new("No Redis URL provided or configured"))?;
+
+                let client = redis::Client::open(url.as_str())
+                    .map_err(|e| ToolError::new(format!("Invalid URL: {}", e)))?;
+
+                let mut conn = client
+                    .get_multiplexed_async_connection()
+                    .await
+                    .map_err(|e| ToolError::new(format!("Connection failed: {}", e)))?;
+
+                let username: String = redis::cmd("ACL")
+                    .arg("WHOAMI")
+                    .query_async(&mut conn)
+                    .await
+                    .map_err(|e| ToolError::new(format!("ACL WHOAMI failed: {}", e)))?;
+
+                Ok(CallToolResult::text(format!("Current user: {}", username)))
+            },
+        )
+        .build()
+}
+
+/// Input for MODULE LIST command
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ModuleListInput {
+    /// Optional Redis URL (uses configured URL if not provided)
+    #[serde(default)]
+    pub url: Option<String>,
+}
+
+/// Build the module_list tool
+pub fn module_list(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("redis_module_list")
+        .description("List loaded Redis modules with their names and versions using MODULE LIST")
+        .read_only()
+        .idempotent()
+        .extractor_handler_typed::<_, _, _, ModuleListInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<ModuleListInput>| async move {
+                let url = input
+                    .url
+                    .or_else(|| state.database_url.clone())
+                    .ok_or_else(|| ToolError::new("No Redis URL provided or configured"))?;
+
+                let client = redis::Client::open(url.as_str())
+                    .map_err(|e| ToolError::new(format!("Invalid URL: {}", e)))?;
+
+                let mut conn = client
+                    .get_multiplexed_async_connection()
+                    .await
+                    .map_err(|e| ToolError::new(format!("Connection failed: {}", e)))?;
+
+                let result: redis::Value = redis::cmd("MODULE")
+                    .arg("LIST")
+                    .query_async(&mut conn)
+                    .await
+                    .map_err(|e| ToolError::new(format!("MODULE LIST failed: {}", e)))?;
+
+                let formatted = super::format_value(&result);
+                if formatted == "[]" {
+                    return Ok(CallToolResult::text("No modules loaded"));
+                }
+
+                Ok(CallToolResult::text(format!(
+                    "Loaded modules:\n{}",
+                    formatted
+                )))
             },
         )
         .build()

--- a/crates/redisctl-mcp/src/tools/redis/structures.rs
+++ b/crates/redisctl-mcp/src/tools/redis/structures.rs
@@ -1,4 +1,5 @@
-//! Data structure Redis tools (hgetall, lrange, smembers, zrange)
+//! Data structure Redis tools (hgetall, lrange, smembers, zrange, xinfo_stream, xrange, xlen,
+//! pubsub_channels, pubsub_numsub)
 
 use std::sync::Arc;
 
@@ -15,6 +16,11 @@ pub(super) const INSTRUCTIONS: &str = "\
 - redis_lrange: Get list range\n\
 - redis_smembers: Get set members\n\
 - redis_zrange: Get sorted set range\n\
+- redis_xinfo_stream: Get stream metadata (length, groups, first/last entry)\n\
+- redis_xrange: Get stream entries in a range\n\
+- redis_xlen: Get stream length\n\
+- redis_pubsub_channels: List active pub/sub channels\n\
+- redis_pubsub_numsub: Get subscriber counts for channels\n\
 ";
 
 /// Build a sub-router containing all data structure Redis tools
@@ -24,6 +30,11 @@ pub fn router(state: Arc<AppState>) -> McpRouter {
         .tool(lrange(state.clone()))
         .tool(smembers(state.clone()))
         .tool(zrange(state.clone()))
+        .tool(xinfo_stream(state.clone()))
+        .tool(xrange(state.clone()))
+        .tool(xlen(state.clone()))
+        .tool(pubsub_channels(state.clone()))
+        .tool(pubsub_numsub(state.clone()))
 }
 
 /// Input for HGETALL command
@@ -320,6 +331,325 @@ pub fn zrange(state: Arc<AppState>) -> Tool {
                         output
                     )))
                 }
+            },
+        )
+        .build()
+}
+
+/// Input for XINFO STREAM command
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct XinfoStreamInput {
+    /// Optional Redis URL (uses configured URL if not provided)
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Stream key to inspect
+    pub key: String,
+}
+
+/// Build the xinfo_stream tool
+pub fn xinfo_stream(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("redis_xinfo_stream")
+        .description(
+            "Get stream metadata using XINFO STREAM, including length, consumer groups, \
+             first and last entry, and other stream details.",
+        )
+        .read_only()
+        .idempotent()
+        .extractor_handler_typed::<_, _, _, XinfoStreamInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<XinfoStreamInput>| async move {
+                let url = input
+                    .url
+                    .or_else(|| state.database_url.clone())
+                    .ok_or_else(|| ToolError::new("No Redis URL provided or configured"))?;
+
+                let client = redis::Client::open(url.as_str())
+                    .map_err(|e| ToolError::new(format!("Invalid URL: {}", e)))?;
+
+                let mut conn = client
+                    .get_multiplexed_async_connection()
+                    .await
+                    .map_err(|e| ToolError::new(format!("Connection failed: {}", e)))?;
+
+                let result: redis::Value = redis::cmd("XINFO")
+                    .arg("STREAM")
+                    .arg(&input.key)
+                    .query_async(&mut conn)
+                    .await
+                    .map_err(|e| ToolError::new(format!("XINFO STREAM failed: {}", e)))?;
+
+                Ok(CallToolResult::text(format!(
+                    "Stream '{}':\n{}",
+                    input.key,
+                    super::format_value(&result)
+                )))
+            },
+        )
+        .build()
+}
+
+/// Input for XRANGE command
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct XrangeInput {
+    /// Optional Redis URL (uses configured URL if not provided)
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Stream key
+    pub key: String,
+    /// Start ID (default: "-" for beginning)
+    #[serde(default = "default_xrange_start")]
+    pub start: String,
+    /// End ID (default: "+" for end)
+    #[serde(default = "default_xrange_end")]
+    pub end: String,
+    /// Maximum number of entries to return
+    #[serde(default)]
+    pub count: Option<usize>,
+}
+
+fn default_xrange_start() -> String {
+    "-".to_string()
+}
+
+fn default_xrange_end() -> String {
+    "+".to_string()
+}
+
+/// Build the xrange tool
+pub fn xrange(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("redis_xrange")
+        .description(
+            "Get stream entries in a range using XRANGE. Use start=\"-\" and end=\"+\" \
+             for all entries. Optionally limit with count.",
+        )
+        .read_only()
+        .idempotent()
+        .extractor_handler_typed::<_, _, _, XrangeInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<XrangeInput>| async move {
+                let url = input
+                    .url
+                    .or_else(|| state.database_url.clone())
+                    .ok_or_else(|| ToolError::new("No Redis URL provided or configured"))?;
+
+                let client = redis::Client::open(url.as_str())
+                    .map_err(|e| ToolError::new(format!("Invalid URL: {}", e)))?;
+
+                let mut conn = client
+                    .get_multiplexed_async_connection()
+                    .await
+                    .map_err(|e| ToolError::new(format!("Connection failed: {}", e)))?;
+
+                let mut cmd = redis::cmd("XRANGE");
+                cmd.arg(&input.key).arg(&input.start).arg(&input.end);
+
+                if let Some(count) = input.count {
+                    cmd.arg("COUNT").arg(count);
+                }
+
+                let result: redis::Value = cmd
+                    .query_async(&mut conn)
+                    .await
+                    .map_err(|e| ToolError::new(format!("XRANGE failed: {}", e)))?;
+
+                // Format stream entries
+                let formatted = match &result {
+                    redis::Value::Array(entries) if entries.is_empty() => {
+                        format!("(empty stream or key '{}' not found)", input.key)
+                    }
+                    redis::Value::Array(entries) => {
+                        let mut output =
+                            format!("Stream '{}' ({} entries):\n", input.key, entries.len());
+                        for entry in entries {
+                            output.push_str(&super::format_value(entry));
+                            output.push('\n');
+                        }
+                        output
+                    }
+                    _ => super::format_value(&result),
+                };
+
+                Ok(CallToolResult::text(formatted))
+            },
+        )
+        .build()
+}
+
+/// Input for XLEN command
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct XlenInput {
+    /// Optional Redis URL (uses configured URL if not provided)
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Stream key
+    pub key: String,
+}
+
+/// Build the xlen tool
+pub fn xlen(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("redis_xlen")
+        .description("Get the number of entries in a stream using XLEN")
+        .read_only()
+        .idempotent()
+        .extractor_handler_typed::<_, _, _, XlenInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<XlenInput>| async move {
+                let url = input
+                    .url
+                    .or_else(|| state.database_url.clone())
+                    .ok_or_else(|| ToolError::new("No Redis URL provided or configured"))?;
+
+                let client = redis::Client::open(url.as_str())
+                    .map_err(|e| ToolError::new(format!("Invalid URL: {}", e)))?;
+
+                let mut conn = client
+                    .get_multiplexed_async_connection()
+                    .await
+                    .map_err(|e| ToolError::new(format!("Connection failed: {}", e)))?;
+
+                let len: i64 = redis::cmd("XLEN")
+                    .arg(&input.key)
+                    .query_async(&mut conn)
+                    .await
+                    .map_err(|e| ToolError::new(format!("XLEN failed: {}", e)))?;
+
+                Ok(CallToolResult::text(format!(
+                    "Stream '{}': {} entries",
+                    input.key, len
+                )))
+            },
+        )
+        .build()
+}
+
+/// Input for PUBSUB CHANNELS command
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct PubsubChannelsInput {
+    /// Optional Redis URL (uses configured URL if not provided)
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Optional glob-style pattern to filter channels
+    #[serde(default)]
+    pub pattern: Option<String>,
+}
+
+/// Build the pubsub_channels tool
+pub fn pubsub_channels(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("redis_pubsub_channels")
+        .description(
+            "List active pub/sub channels using PUBSUB CHANNELS. \
+             Optionally filter with a glob-style pattern.",
+        )
+        .read_only()
+        .idempotent()
+        .extractor_handler_typed::<_, _, _, PubsubChannelsInput>(
+            state,
+            |State(state): State<Arc<AppState>>,
+             Json(input): Json<PubsubChannelsInput>| async move {
+                let url = input
+                    .url
+                    .or_else(|| state.database_url.clone())
+                    .ok_or_else(|| ToolError::new("No Redis URL provided or configured"))?;
+
+                let client = redis::Client::open(url.as_str())
+                    .map_err(|e| ToolError::new(format!("Invalid URL: {}", e)))?;
+
+                let mut conn = client
+                    .get_multiplexed_async_connection()
+                    .await
+                    .map_err(|e| ToolError::new(format!("Connection failed: {}", e)))?;
+
+                let mut cmd = redis::cmd("PUBSUB");
+                cmd.arg("CHANNELS");
+
+                if let Some(ref pattern) = input.pattern {
+                    cmd.arg(pattern);
+                }
+
+                let channels: Vec<String> = cmd
+                    .query_async(&mut conn)
+                    .await
+                    .map_err(|e| ToolError::new(format!("PUBSUB CHANNELS failed: {}", e)))?;
+
+                if channels.is_empty() {
+                    return Ok(CallToolResult::text("No active pub/sub channels"));
+                }
+
+                Ok(CallToolResult::text(format!(
+                    "Active channels ({}):\n{}",
+                    channels.len(),
+                    channels.join("\n")
+                )))
+            },
+        )
+        .build()
+}
+
+/// Input for PUBSUB NUMSUB command
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct PubsubNumsubInput {
+    /// Optional Redis URL (uses configured URL if not provided)
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Channel names to get subscriber counts for (omit for all)
+    #[serde(default)]
+    pub channels: Option<Vec<String>>,
+}
+
+/// Build the pubsub_numsub tool
+pub fn pubsub_numsub(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("redis_pubsub_numsub")
+        .description(
+            "Get subscriber counts for pub/sub channels using PUBSUB NUMSUB. \
+             Provide channel names to query specific channels.",
+        )
+        .read_only()
+        .idempotent()
+        .extractor_handler_typed::<_, _, _, PubsubNumsubInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<PubsubNumsubInput>| async move {
+                let url = input
+                    .url
+                    .or_else(|| state.database_url.clone())
+                    .ok_or_else(|| ToolError::new("No Redis URL provided or configured"))?;
+
+                let client = redis::Client::open(url.as_str())
+                    .map_err(|e| ToolError::new(format!("Invalid URL: {}", e)))?;
+
+                let mut conn = client
+                    .get_multiplexed_async_connection()
+                    .await
+                    .map_err(|e| ToolError::new(format!("Connection failed: {}", e)))?;
+
+                let mut cmd = redis::cmd("PUBSUB");
+                cmd.arg("NUMSUB");
+
+                if let Some(ref channels) = input.channels {
+                    for channel in channels {
+                        cmd.arg(channel);
+                    }
+                }
+
+                // PUBSUB NUMSUB returns alternating channel name + count
+                let result: Vec<redis::Value> = cmd
+                    .query_async(&mut conn)
+                    .await
+                    .map_err(|e| ToolError::new(format!("PUBSUB NUMSUB failed: {}", e)))?;
+
+                if result.is_empty() {
+                    return Ok(CallToolResult::text("No subscriber information available"));
+                }
+
+                let mut output = String::from("Channel subscriber counts:\n");
+                for pair in result.chunks(2) {
+                    if pair.len() == 2 {
+                        let channel = super::format_value(&pair[0]);
+                        let count = super::format_value(&pair[1]);
+                        output.push_str(&format!("  {}: {} subscribers\n", channel, count));
+                    }
+                }
+
+                Ok(CallToolResult::text(output))
             },
         )
         .build()


### PR DESCRIPTION
## Summary

- Adds 14 new read-only Redis MCP tools covering the remaining coverage gaps identified in #735
- Tools distributed across the 3 existing submodules from the recent split (#740)

## New Tools

**Server diagnostics (6 tools in `server.rs`):**
- `redis_config_get` -- CONFIG GET with glob pattern support
- `redis_memory_stats` -- MEMORY STATS (detailed allocator info)
- `redis_latency_history` -- LATENCY HISTORY event
- `redis_acl_list` -- ACL LIST (all rules)
- `redis_acl_whoami` -- ACL WHOAMI (current user)
- `redis_module_list` -- MODULE LIST (loaded modules + versions)

**Key analysis (3 tools in `keys.rs`):**
- `redis_object_freq` -- OBJECT FREQ (LFU access frequency)
- `redis_object_idletime` -- OBJECT IDLETIME (LRU idle seconds)
- `redis_object_help` -- OBJECT HELP (available subcommands)

**Streams + Pub/Sub (5 tools in `structures.rs`):**
- `redis_xinfo_stream` -- XINFO STREAM (stream metadata)
- `redis_xrange` -- XRANGE with start/end/count
- `redis_xlen` -- XLEN (stream length)
- `redis_pubsub_channels` -- PUBSUB CHANNELS with optional pattern
- `redis_pubsub_numsub` -- PUBSUB NUMSUB with channel list

All tools are `.read_only().idempotent()`. No changes to `mod.rs` needed.

## Scope

- Affected areas: `server.rs`, `keys.rs`, `structures.rs` in `crates/redisctl-mcp/src/tools/redis/`
- API surface changes: 14 new MCP tools (18 existing -> 32 total)
- Docs/tests: existing `test_redis_tools_build` validates all tools

## Checklist

- [x] Tests pass locally
- [x] cargo fmt, clippy (-D warnings) clean
- [x] `cargo check -p redisctl-mcp --no-default-features` passes

## Links

- Fixes #735
- Part of #708