### PR TITLE
feat(mcp): add profile-based connection support for Redis database tools

### DIFF
--- a/crates/redisctl-mcp/src/tools/redis/keys.rs
+++ b/crates/redisctl-mcp/src/tools/redis/keys.rs
@@ -44,9 +44,12 @@ pub fn router(state: Arc<AppState>) -> McpRouter {
 /// Input for keys command
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct KeysInput {
-    /// Optional Redis URL (uses configured URL if not provided)
+    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
     #[serde(default)]
     pub url: Option<String>,
+    /// Optional profile name to resolve connection from (uses default profile if not set)
+    #[serde(default)]
+    pub profile: Option<String>,
     /// Key pattern to match (default: "*")
     #[serde(default = "default_pattern")]
     pub pattern: String,
@@ -75,10 +78,7 @@ pub fn keys(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, KeysInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<KeysInput>| async move {
-                let url = input
-                    .url
-                    .or_else(|| state.database_url.clone())
-                    .ok_or_else(|| ToolError::new("No Redis URL provided or configured"))?;
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
 
                 let client = redis::Client::open(url.as_str())
                     .map_err(|e| ToolError::new(format!("Invalid URL: {}", e)))?;
@@ -134,9 +134,12 @@ pub fn keys(state: Arc<AppState>) -> Tool {
 /// Input for GET command
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct GetInput {
-    /// Optional Redis URL (uses configured URL if not provided)
+    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
     #[serde(default)]
     pub url: Option<String>,
+    /// Optional profile name to resolve connection from (uses default profile if not set)
+    #[serde(default)]
+    pub profile: Option<String>,
     /// Key to get
     pub key: String,
 }
@@ -150,10 +153,7 @@ pub fn get(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, GetInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetInput>| async move {
-                let url = input
-                    .url
-                    .or_else(|| state.database_url.clone())
-                    .ok_or_else(|| ToolError::new("No Redis URL provided or configured"))?;
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
 
                 let client = redis::Client::open(url.as_str())
                     .map_err(|e| ToolError::new(format!("Invalid URL: {}", e)))?;
@@ -184,9 +184,12 @@ pub fn get(state: Arc<AppState>) -> Tool {
 /// Input for TYPE command
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct TypeInput {
-    /// Optional Redis URL (uses configured URL if not provided)
+    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
     #[serde(default)]
     pub url: Option<String>,
+    /// Optional profile name to resolve connection from (uses default profile if not set)
+    #[serde(default)]
+    pub profile: Option<String>,
     /// Key to check type
     pub key: String,
 }
@@ -200,10 +203,7 @@ pub fn key_type(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, TypeInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<TypeInput>| async move {
-                let url = input
-                    .url
-                    .or_else(|| state.database_url.clone())
-                    .ok_or_else(|| ToolError::new("No Redis URL provided or configured"))?;
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
 
                 let client = redis::Client::open(url.as_str())
                     .map_err(|e| ToolError::new(format!("Invalid URL: {}", e)))?;
@@ -228,9 +228,12 @@ pub fn key_type(state: Arc<AppState>) -> Tool {
 /// Input for TTL command
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct TtlInput {
-    /// Optional Redis URL (uses configured URL if not provided)
+    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
     #[serde(default)]
     pub url: Option<String>,
+    /// Optional profile name to resolve connection from (uses default profile if not set)
+    #[serde(default)]
+    pub profile: Option<String>,
     /// Key to check TTL
     pub key: String,
 }
@@ -244,10 +247,7 @@ pub fn ttl(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, TtlInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<TtlInput>| async move {
-                let url = input
-                    .url
-                    .or_else(|| state.database_url.clone())
-                    .ok_or_else(|| ToolError::new("No Redis URL provided or configured"))?;
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
 
                 let client = redis::Client::open(url.as_str())
                     .map_err(|e| ToolError::new(format!("Invalid URL: {}", e)))?;
@@ -278,9 +278,12 @@ pub fn ttl(state: Arc<AppState>) -> Tool {
 /// Input for EXISTS command
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ExistsInput {
-    /// Optional Redis URL (uses configured URL if not provided)
+    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
     #[serde(default)]
     pub url: Option<String>,
+    /// Optional profile name to resolve connection from (uses default profile if not set)
+    #[serde(default)]
+    pub profile: Option<String>,
     /// Keys to check existence
     pub keys: Vec<String>,
 }
@@ -294,10 +297,7 @@ pub fn exists(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, ExistsInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ExistsInput>| async move {
-                let url = input
-                    .url
-                    .or_else(|| state.database_url.clone())
-                    .ok_or_else(|| ToolError::new("No Redis URL provided or configured"))?;
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
 
                 let client = redis::Client::open(url.as_str())
                     .map_err(|e| ToolError::new(format!("Invalid URL: {}", e)))?;
@@ -330,9 +330,12 @@ pub fn exists(state: Arc<AppState>) -> Tool {
 /// Input for MEMORY USAGE command
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct MemoryUsageInput {
-    /// Optional Redis URL (uses configured URL if not provided)
+    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
     #[serde(default)]
     pub url: Option<String>,
+    /// Optional profile name to resolve connection from (uses default profile if not set)
+    #[serde(default)]
+    pub profile: Option<String>,
     /// Key to check memory usage
     pub key: String,
 }
@@ -346,10 +349,7 @@ pub fn memory_usage(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, MemoryUsageInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<MemoryUsageInput>| async move {
-                let url = input
-                    .url
-                    .or_else(|| state.database_url.clone())
-                    .ok_or_else(|| ToolError::new("No Redis URL provided or configured"))?;
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
 
                 let client = redis::Client::open(url.as_str())
                     .map_err(|e| ToolError::new(format!("Invalid URL: {}", e)))?;
@@ -381,9 +381,12 @@ pub fn memory_usage(state: Arc<AppState>) -> Tool {
 /// Input for SCAN with type filter
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ScanInput {
-    /// Optional Redis URL (uses configured URL if not provided)
+    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
     #[serde(default)]
     pub url: Option<String>,
+    /// Optional profile name to resolve connection from (uses default profile if not set)
+    #[serde(default)]
+    pub profile: Option<String>,
     /// Key pattern to match (default: "*")
     #[serde(default = "default_pattern")]
     pub pattern: String,
@@ -407,10 +410,7 @@ pub fn scan(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, ScanInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ScanInput>| async move {
-                let url = input
-                    .url
-                    .or_else(|| state.database_url.clone())
-                    .ok_or_else(|| ToolError::new("No Redis URL provided or configured"))?;
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
 
                 let client = redis::Client::open(url.as_str())
                     .map_err(|e| ToolError::new(format!("Invalid URL: {}", e)))?;
@@ -481,9 +481,12 @@ pub fn scan(state: Arc<AppState>) -> Tool {
 /// Input for OBJECT ENCODING command
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ObjectEncodingInput {
-    /// Optional Redis URL (uses configured URL if not provided)
+    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
     #[serde(default)]
     pub url: Option<String>,
+    /// Optional profile name to resolve connection from (uses default profile if not set)
+    #[serde(default)]
+    pub profile: Option<String>,
     /// Key to check encoding
     pub key: String,
 }
@@ -501,10 +504,7 @@ pub fn object_encoding(state: Arc<AppState>) -> Tool {
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<ObjectEncodingInput>| async move {
-                let url = input
-                    .url
-                    .or_else(|| state.database_url.clone())
-                    .ok_or_else(|| ToolError::new("No Redis URL provided or configured"))?;
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
 
                 let client = redis::Client::open(url.as_str())
                     .map_err(|e| ToolError::new(format!("Invalid URL: {}", e)))?;
@@ -536,9 +536,12 @@ pub fn object_encoding(state: Arc<AppState>) -> Tool {
 /// Input for OBJECT FREQ command
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ObjectFreqInput {
-    /// Optional Redis URL (uses configured URL if not provided)
+    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
     #[serde(default)]
     pub url: Option<String>,
+    /// Optional profile name to resolve connection from (uses default profile if not set)
+    #[serde(default)]
+    pub profile: Option<String>,
     /// Key to get LFU access frequency for
     pub key: String,
 }
@@ -555,10 +558,7 @@ pub fn object_freq(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, ObjectFreqInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ObjectFreqInput>| async move {
-                let url = input
-                    .url
-                    .or_else(|| state.database_url.clone())
-                    .ok_or_else(|| ToolError::new("No Redis URL provided or configured"))?;
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
 
                 let client = redis::Client::open(url.as_str())
                     .map_err(|e| ToolError::new(format!("Invalid URL: {}", e)))?;
@@ -587,9 +587,12 @@ pub fn object_freq(state: Arc<AppState>) -> Tool {
 /// Input for OBJECT IDLETIME command
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ObjectIdletimeInput {
-    /// Optional Redis URL (uses configured URL if not provided)
+    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
     #[serde(default)]
     pub url: Option<String>,
+    /// Optional profile name to resolve connection from (uses default profile if not set)
+    #[serde(default)]
+    pub profile: Option<String>,
     /// Key to get idle time for
     pub key: String,
 }
@@ -607,10 +610,7 @@ pub fn object_idletime(state: Arc<AppState>) -> Tool {
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<ObjectIdletimeInput>| async move {
-                let url = input
-                    .url
-                    .or_else(|| state.database_url.clone())
-                    .ok_or_else(|| ToolError::new("No Redis URL provided or configured"))?;
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
 
                 let client = redis::Client::open(url.as_str())
                     .map_err(|e| ToolError::new(format!("Invalid URL: {}", e)))?;
@@ -639,9 +639,12 @@ pub fn object_idletime(state: Arc<AppState>) -> Tool {
 /// Input for OBJECT HELP command
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ObjectHelpInput {
-    /// Optional Redis URL (uses configured URL if not provided)
+    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
     #[serde(default)]
     pub url: Option<String>,
+    /// Optional profile name to resolve connection from (uses default profile if not set)
+    #[serde(default)]
+    pub profile: Option<String>,
 }
 
 /// Build the object_help tool
@@ -653,10 +656,7 @@ pub fn object_help(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, ObjectHelpInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ObjectHelpInput>| async move {
-                let url = input
-                    .url
-                    .or_else(|| state.database_url.clone())
-                    .ok_or_else(|| ToolError::new("No Redis URL provided or configured"))?;
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
 
                 let client = redis::Client::open(url.as_str())
                     .map_err(|e| ToolError::new(format!("Invalid URL: {}", e)))?;

--- a/crates/redisctl-mcp/src/tools/redis/structures.rs
+++ b/crates/redisctl-mcp/src/tools/redis/structures.rs
@@ -40,9 +40,12 @@ pub fn router(state: Arc<AppState>) -> McpRouter {
 /// Input for HGETALL command
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct HgetallInput {
-    /// Optional Redis URL (uses configured URL if not provided)
+    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
     #[serde(default)]
     pub url: Option<String>,
+    /// Optional profile name to resolve connection from (uses default profile if not set)
+    #[serde(default)]
+    pub profile: Option<String>,
     /// Hash key to get
     pub key: String,
 }
@@ -56,10 +59,7 @@ pub fn hgetall(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, HgetallInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<HgetallInput>| async move {
-                let url = input
-                    .url
-                    .or_else(|| state.database_url.clone())
-                    .ok_or_else(|| ToolError::new("No Redis URL provided or configured"))?;
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
 
                 let client = redis::Client::open(url.as_str())
                     .map_err(|e| ToolError::new(format!("Invalid URL: {}", e)))?;
@@ -102,9 +102,12 @@ pub fn hgetall(state: Arc<AppState>) -> Tool {
 /// Input for LRANGE command
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct LrangeInput {
-    /// Optional Redis URL (uses configured URL if not provided)
+    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
     #[serde(default)]
     pub url: Option<String>,
+    /// Optional profile name to resolve connection from (uses default profile if not set)
+    #[serde(default)]
+    pub profile: Option<String>,
     /// List key
     pub key: String,
     /// Start index (0-based)
@@ -128,10 +131,7 @@ pub fn lrange(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, LrangeInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<LrangeInput>| async move {
-                let url = input
-                    .url
-                    .or_else(|| state.database_url.clone())
-                    .ok_or_else(|| ToolError::new("No Redis URL provided or configured"))?;
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
 
                 let client = redis::Client::open(url.as_str())
                     .map_err(|e| ToolError::new(format!("Invalid URL: {}", e)))?;
@@ -177,9 +177,12 @@ pub fn lrange(state: Arc<AppState>) -> Tool {
 /// Input for SMEMBERS command
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct SmembersInput {
-    /// Optional Redis URL (uses configured URL if not provided)
+    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
     #[serde(default)]
     pub url: Option<String>,
+    /// Optional profile name to resolve connection from (uses default profile if not set)
+    #[serde(default)]
+    pub profile: Option<String>,
     /// Set key
     pub key: String,
 }
@@ -193,10 +196,7 @@ pub fn smembers(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, SmembersInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<SmembersInput>| async move {
-                let url = input
-                    .url
-                    .or_else(|| state.database_url.clone())
-                    .ok_or_else(|| ToolError::new("No Redis URL provided or configured"))?;
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
 
                 let client = redis::Client::open(url.as_str())
                     .map_err(|e| ToolError::new(format!("Invalid URL: {}", e)))?;
@@ -233,9 +233,12 @@ pub fn smembers(state: Arc<AppState>) -> Tool {
 /// Input for ZRANGE command
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ZrangeInput {
-    /// Optional Redis URL (uses configured URL if not provided)
+    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
     #[serde(default)]
     pub url: Option<String>,
+    /// Optional profile name to resolve connection from (uses default profile if not set)
+    #[serde(default)]
+    pub profile: Option<String>,
     /// Sorted set key
     pub key: String,
     /// Start index (0-based)
@@ -258,10 +261,7 @@ pub fn zrange(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, ZrangeInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ZrangeInput>| async move {
-                let url = input
-                    .url
-                    .or_else(|| state.database_url.clone())
-                    .ok_or_else(|| ToolError::new("No Redis URL provided or configured"))?;
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
 
                 let client = redis::Client::open(url.as_str())
                     .map_err(|e| ToolError::new(format!("Invalid URL: {}", e)))?;
@@ -339,9 +339,12 @@ pub fn zrange(state: Arc<AppState>) -> Tool {
 /// Input for XINFO STREAM command
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct XinfoStreamInput {
-    /// Optional Redis URL (uses configured URL if not provided)
+    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
     #[serde(default)]
     pub url: Option<String>,
+    /// Optional profile name to resolve connection from (uses default profile if not set)
+    #[serde(default)]
+    pub profile: Option<String>,
     /// Stream key to inspect
     pub key: String,
 }
@@ -358,10 +361,7 @@ pub fn xinfo_stream(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, XinfoStreamInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<XinfoStreamInput>| async move {
-                let url = input
-                    .url
-                    .or_else(|| state.database_url.clone())
-                    .ok_or_else(|| ToolError::new("No Redis URL provided or configured"))?;
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
 
                 let client = redis::Client::open(url.as_str())
                     .map_err(|e| ToolError::new(format!("Invalid URL: {}", e)))?;
@@ -391,9 +391,12 @@ pub fn xinfo_stream(state: Arc<AppState>) -> Tool {
 /// Input for XRANGE command
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct XrangeInput {
-    /// Optional Redis URL (uses configured URL if not provided)
+    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
     #[serde(default)]
     pub url: Option<String>,
+    /// Optional profile name to resolve connection from (uses default profile if not set)
+    #[serde(default)]
+    pub profile: Option<String>,
     /// Stream key
     pub key: String,
     /// Start ID (default: "-" for beginning)
@@ -427,10 +430,7 @@ pub fn xrange(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, XrangeInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<XrangeInput>| async move {
-                let url = input
-                    .url
-                    .or_else(|| state.database_url.clone())
-                    .ok_or_else(|| ToolError::new("No Redis URL provided or configured"))?;
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
 
                 let client = redis::Client::open(url.as_str())
                     .map_err(|e| ToolError::new(format!("Invalid URL: {}", e)))?;
@@ -478,9 +478,12 @@ pub fn xrange(state: Arc<AppState>) -> Tool {
 /// Input for XLEN command
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct XlenInput {
-    /// Optional Redis URL (uses configured URL if not provided)
+    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
     #[serde(default)]
     pub url: Option<String>,
+    /// Optional profile name to resolve connection from (uses default profile if not set)
+    #[serde(default)]
+    pub profile: Option<String>,
     /// Stream key
     pub key: String,
 }
@@ -494,10 +497,7 @@ pub fn xlen(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, XlenInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<XlenInput>| async move {
-                let url = input
-                    .url
-                    .or_else(|| state.database_url.clone())
-                    .ok_or_else(|| ToolError::new("No Redis URL provided or configured"))?;
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
 
                 let client = redis::Client::open(url.as_str())
                     .map_err(|e| ToolError::new(format!("Invalid URL: {}", e)))?;
@@ -525,9 +525,12 @@ pub fn xlen(state: Arc<AppState>) -> Tool {
 /// Input for PUBSUB CHANNELS command
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct PubsubChannelsInput {
-    /// Optional Redis URL (uses configured URL if not provided)
+    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
     #[serde(default)]
     pub url: Option<String>,
+    /// Optional profile name to resolve connection from (uses default profile if not set)
+    #[serde(default)]
+    pub profile: Option<String>,
     /// Optional glob-style pattern to filter channels
     #[serde(default)]
     pub pattern: Option<String>,
@@ -546,10 +549,7 @@ pub fn pubsub_channels(state: Arc<AppState>) -> Tool {
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<PubsubChannelsInput>| async move {
-                let url = input
-                    .url
-                    .or_else(|| state.database_url.clone())
-                    .ok_or_else(|| ToolError::new("No Redis URL provided or configured"))?;
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
 
                 let client = redis::Client::open(url.as_str())
                     .map_err(|e| ToolError::new(format!("Invalid URL: {}", e)))?;
@@ -588,9 +588,12 @@ pub fn pubsub_channels(state: Arc<AppState>) -> Tool {
 /// Input for PUBSUB NUMSUB command
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct PubsubNumsubInput {
-    /// Optional Redis URL (uses configured URL if not provided)
+    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
     #[serde(default)]
     pub url: Option<String>,
+    /// Optional profile name to resolve connection from (uses default profile if not set)
+    #[serde(default)]
+    pub profile: Option<String>,
     /// Channel names to get subscriber counts for (omit for all)
     #[serde(default)]
     pub channels: Option<Vec<String>>,
@@ -608,10 +611,7 @@ pub fn pubsub_numsub(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, PubsubNumsubInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<PubsubNumsubInput>| async move {
-                let url = input
-                    .url
-                    .or_else(|| state.database_url.clone())
-                    .ok_or_else(|| ToolError::new("No Redis URL provided or configured"))?;
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
 
                 let client = redis::Client::open(url.as_str())
                     .map_err(|e| ToolError::new(format!("Invalid URL: {}", e)))?;


### PR DESCRIPTION
## Summary

Adds profile-based connection resolution to all 32 Redis database MCP tools. Instead of requiring a raw Redis URL, tools now accept an optional `profile` parameter that resolves connection details from the redisctl profile system, matching how Cloud/Enterprise tools work.

Resolution order:
1. `url` provided directly (backward compatible)
2. `profile` name resolves via profile system -> Redis URL
3. Default profile resolution if no `database_url` configured
4. Fall back to `state.database_url`

## Scope

- Affected areas: `crates/redisctl-mcp/src/state.rs`, `crates/redisctl-mcp/src/tools/redis/`
- API surface changes: All 32 Redis tool input structs gain `profile: Option<String>` field; new `database_url_for_profile()` on AppState; new `resolve_redis_url()` helper in redis/mod.rs
- Docs/tests updates: INSTRUCTIONS constant updated to document profile support

## Checklist

- [x] Scope and plan documented in this description
- [x] cargo fmt, clippy (-D warnings), tests pass locally
- [x] `cargo check -p redisctl-mcp --no-default-features` passes

## Links

- Fixes #738
- Part of #708 (Database tools epic)