### PR TITLE
feat(mcp): add safety annotations and normalize instructions

### DIFF
--- a/crates/redisctl-mcp/src/tools/cloud/account.rs
+++ b/crates/redisctl-mcp/src/tools/cloud/account.rs
@@ -38,6 +38,7 @@ pub fn get_account(state: Arc<AppState>) -> Tool {
         .description("Get information about the current Redis Cloud account including name, ID, and settings.")
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetAccountInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetAccountInput>| async move {
@@ -81,6 +82,7 @@ pub fn get_system_logs(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetSystemLogsInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetSystemLogsInput>| async move {
@@ -124,6 +126,7 @@ pub fn get_session_logs(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetSessionLogsInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -164,6 +167,7 @@ pub fn get_regions(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetRegionsInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetRegionsInput>| async move {
@@ -200,6 +204,7 @@ pub fn get_modules(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetModulesInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetModulesInput>| async move {
@@ -240,6 +245,7 @@ pub fn list_account_users(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, ListAccountUsersInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -279,6 +285,7 @@ pub fn get_account_user(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetAccountUserInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -318,6 +325,7 @@ pub fn list_acl_users(state: Arc<AppState>) -> Tool {
         .description("List all ACL users (database-level Redis users for authentication).")
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, ListAclUsersInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ListAclUsersInput>| async move {
@@ -354,6 +362,7 @@ pub fn get_acl_user(state: Arc<AppState>) -> Tool {
         .description("Get detailed information about a specific ACL user by ID.")
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetAclUserInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetAclUserInput>| async move {
@@ -388,6 +397,7 @@ pub fn list_acl_roles(state: Arc<AppState>) -> Tool {
         .description("List all ACL roles (permission templates for database access).")
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, ListAclRolesInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ListAclRolesInput>| async move {
@@ -422,6 +432,7 @@ pub fn list_redis_rules(state: Arc<AppState>) -> Tool {
         .description("List all Redis ACL rules (command permissions for Redis users).")
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, ListRedisRulesInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -468,6 +479,7 @@ pub fn create_acl_user(state: Arc<AppState>) -> Tool {
             "Create a new ACL user with the assigned database access role. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateAclUserInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<CreateAclUserInput>| async move {
@@ -523,6 +535,7 @@ pub fn update_acl_user(state: Arc<AppState>) -> Tool {
             "Update an ACL user's role or password. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateAclUserInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<UpdateAclUserInput>| async move {
@@ -569,8 +582,8 @@ pub struct DeleteAclUserInput {
 pub fn delete_acl_user(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_acl_user")
         .description(
-            "Delete an ACL user. This is a destructive operation. \
-             Requires write permission.",
+            "DANGEROUS: Permanently deletes an ACL user. Active sessions using this user \
+             will be terminated. Requires write permission.",
         )
         .extractor_handler_typed::<_, _, _, DeleteAclUserInput>(
             state,
@@ -638,6 +651,7 @@ pub fn create_acl_role(state: Arc<AppState>) -> Tool {
             "Create a new ACL role with assigned Redis rules and database associations. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateAclRoleInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<CreateAclRoleInput>| async move {
@@ -707,6 +721,7 @@ pub fn update_acl_role(state: Arc<AppState>) -> Tool {
             "Update an ACL role's name or Redis rule assignments. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateAclRoleInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<UpdateAclRoleInput>| async move {
@@ -769,8 +784,8 @@ pub struct DeleteAclRoleInput {
 pub fn delete_acl_role(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_acl_role")
         .description(
-            "Delete an ACL role. This is a destructive operation. \
-             Requires write permission.",
+            "DANGEROUS: Permanently deletes an ACL role. Users assigned to this role \
+             will lose their permissions. Requires write permission.",
         )
         .extractor_handler_typed::<_, _, _, DeleteAclRoleInput>(
             state,
@@ -817,6 +832,7 @@ pub fn create_redis_rule(state: Arc<AppState>) -> Tool {
             "Create a new Redis ACL rule defining command permissions. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateRedisRuleInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -872,6 +888,7 @@ pub fn update_redis_rule(state: Arc<AppState>) -> Tool {
             "Update a Redis ACL rule's name or pattern. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateRedisRuleInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -921,8 +938,8 @@ pub struct DeleteRedisRuleInput {
 pub fn delete_redis_rule(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_redis_rule")
         .description(
-            "Delete a Redis ACL rule. This is a destructive operation. \
-             Requires write permission.",
+            "DANGEROUS: Permanently deletes a Redis ACL rule. Roles using this rule \
+             will lose those permissions. Requires write permission.",
         )
         .extractor_handler_typed::<_, _, _, DeleteRedisRuleInput>(
             state,
@@ -992,6 +1009,7 @@ pub fn generate_cost_report(state: Arc<AppState>) -> Tool {
              Returns a task ID to track generation progress. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GenerateCostReportInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -1060,6 +1078,7 @@ pub fn download_cost_report(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, DownloadCostReportInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -1104,6 +1123,7 @@ pub fn list_payment_methods(state: Arc<AppState>) -> Tool {
         .description("List all payment methods for the Redis Cloud account.")
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, ListPaymentMethodsInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -1145,6 +1165,7 @@ pub fn list_tasks(state: Arc<AppState>) -> Tool {
         .description("List all async tasks in the Redis Cloud account. Tasks track long-running operations like database creation.")
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, ListTasksInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ListTasksInput>| async move {
@@ -1181,6 +1202,7 @@ pub fn get_task(state: Arc<AppState>) -> Tool {
         .description("Get status and details of a specific async task by ID.")
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetTaskInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetTaskInput>| async move {
@@ -1222,6 +1244,7 @@ pub fn list_cloud_accounts(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, ListCloudAccountsInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -1265,6 +1288,7 @@ pub fn get_cloud_account(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetCloudAccountInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -1319,6 +1343,7 @@ pub fn create_cloud_account(state: Arc<AppState>) -> Tool {
              Registers cloud credentials with Redis Cloud for resource provisioning. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateCloudAccountInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -1390,6 +1415,7 @@ pub fn update_cloud_account(state: Arc<AppState>) -> Tool {
              including credentials and console access details. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateCloudAccountInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -1443,9 +1469,8 @@ pub struct DeleteCloudAccountInput {
 pub fn delete_cloud_account(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_cloud_account")
         .description(
-            "Delete a cloud provider account (BYOC). This is a destructive operation \
-             that removes the cloud account integration. \
-             Requires write permission.",
+            "DANGEROUS: Permanently deletes a cloud provider account (BYOC). This removes \
+             the cloud account integration and cannot be undone. Requires write permission.",
         )
         .extractor_handler_typed::<_, _, _, DeleteCloudAccountInput>(
             state,
@@ -1489,26 +1514,26 @@ pub(super) const INSTRUCTIONS: &str = r#"
 - list_redis_rules: List Redis ACL rules
 - list_payment_methods: List account payment methods
 
-### Redis Cloud - ACL Write Operations (require --read-only=false)
-- create_acl_user: Create a new ACL user with a role and password
-- update_acl_user: Update an ACL user's role or password
-- delete_acl_user: Delete an ACL user
-- create_acl_role: Create a new ACL role with Redis rules and database associations
-- update_acl_role: Update an ACL role's name or rule assignments
-- delete_acl_role: Delete an ACL role
-- create_redis_rule: Create a new Redis ACL rule pattern
-- update_redis_rule: Update a Redis ACL rule's name or pattern
-- delete_redis_rule: Delete a Redis ACL rule
+### Redis Cloud - ACL Write Operations
+- create_acl_user: Create a new ACL user with a role and password [write]
+- update_acl_user: Update an ACL user's role or password [write]
+- create_acl_role: Create a new ACL role with Redis rules and database associations [write]
+- update_acl_role: Update an ACL role's name or rule assignments [write]
+- create_redis_rule: Create a new Redis ACL rule pattern [write]
+- update_redis_rule: Update a Redis ACL rule's name or pattern [write]
+- delete_acl_user: Permanently delete an ACL user [destructive]
+- delete_acl_role: Permanently delete an ACL role [destructive]
+- delete_redis_rule: Permanently delete a Redis ACL rule [destructive]
 
 ### Redis Cloud - Cloud Accounts (BYOC)
 - list_cloud_accounts: List configured cloud provider accounts (AWS, GCP, Azure)
 - get_cloud_account: Get cloud account details by ID
-- create_cloud_account: Create a new cloud provider account (require --read-only=false)
-- update_cloud_account: Update cloud account configuration (require --read-only=false)
-- delete_cloud_account: Delete a cloud provider account (require --read-only=false)
+- create_cloud_account: Create a new cloud provider account [write]
+- update_cloud_account: Update cloud account configuration [write]
+- delete_cloud_account: Permanently delete a cloud provider account [destructive]
 
 ### Redis Cloud - Cost Reports
-- generate_cost_report: Generate a FOCUS cost report (require --read-only=false)
+- generate_cost_report: Generate a FOCUS cost report [write]
 - download_cost_report: Download a generated cost report
 
 ### Redis Cloud - Logs

--- a/crates/redisctl-mcp/src/tools/cloud/fixed.rs
+++ b/crates/redisctl-mcp/src/tools/cloud/fixed.rs
@@ -37,6 +37,7 @@ pub fn list_fixed_subscriptions(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, ListFixedSubscriptionsInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -76,6 +77,7 @@ pub fn get_fixed_subscription(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetFixedSubscriptionInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -124,6 +126,7 @@ pub fn create_fixed_subscription(state: Arc<AppState>) -> Tool {
             "Create a new Redis Cloud Fixed/Essentials subscription. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateFixedSubscriptionInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -187,6 +190,7 @@ pub fn update_fixed_subscription(state: Arc<AppState>) -> Tool {
             "Update a Redis Cloud Fixed/Essentials subscription. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateFixedSubscriptionInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -239,8 +243,9 @@ pub struct DeleteFixedSubscriptionInput {
 pub fn delete_fixed_subscription(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_fixed_subscription")
         .description(
-            "Delete a Redis Cloud Fixed/Essentials subscription. \
-             All databases must be deleted first. Requires write permission.",
+            "DANGEROUS: Permanently deletes a Fixed/Essentials subscription. \
+             All databases must be deleted first. This action cannot be undone. \
+             Requires write permission.",
         )
         .extractor_handler_typed::<_, _, _, DeleteFixedSubscriptionInput>(
             state,
@@ -294,6 +299,7 @@ pub fn list_fixed_plans(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, ListFixedPlansInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -336,6 +342,7 @@ pub fn get_fixed_plans_by_subscription(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetFixedPlansBySubscriptionInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -378,6 +385,7 @@ pub fn get_fixed_plan(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetFixedPlanInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetFixedPlanInput>| async move {
@@ -416,6 +424,7 @@ pub fn get_fixed_redis_versions(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetFixedRedisVersionsInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -467,6 +476,7 @@ pub fn list_fixed_databases(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, ListFixedDatabasesInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -511,6 +521,7 @@ pub fn get_fixed_database(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetFixedDatabaseInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -586,6 +597,7 @@ pub fn create_fixed_database(state: Arc<AppState>) -> Tool {
             "Create a new database in a Redis Cloud Fixed/Essentials subscription. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateFixedDatabaseInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -687,6 +699,7 @@ pub fn update_fixed_database(state: Arc<AppState>) -> Tool {
             "Update a database in a Redis Cloud Fixed/Essentials subscription. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateFixedDatabaseInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -760,8 +773,8 @@ pub struct DeleteFixedDatabaseInput {
 pub fn delete_fixed_database(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_fixed_database")
         .description(
-            "Delete a database from a Redis Cloud Fixed/Essentials subscription. \
-             This is a destructive operation. Requires write permission.",
+            "DANGEROUS: Permanently deletes a Fixed/Essentials database and all its data. \
+             This action cannot be undone. Requires write permission.",
         )
         .extractor_handler_typed::<_, _, _, DeleteFixedDatabaseInput>(
             state,
@@ -814,6 +827,7 @@ pub fn get_fixed_database_backup_status(state: Arc<AppState>) -> Tool {
         .description("Get the latest backup status for a Fixed/Essentials database.")
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetFixedDatabaseBackupStatusInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -859,6 +873,7 @@ pub fn backup_fixed_database(state: Arc<AppState>) -> Tool {
             "Trigger a manual backup of a Fixed/Essentials database. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, BackupFixedDatabaseInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -913,6 +928,7 @@ pub fn get_fixed_database_import_status(state: Arc<AppState>) -> Tool {
         .description("Get the latest import status for a Fixed/Essentials database.")
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetFixedDatabaseImportStatusInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -959,6 +975,7 @@ pub fn import_fixed_database(state: Arc<AppState>) -> Tool {
             "Import data into a Fixed/Essentials database from an external source. \
              WARNING: This will overwrite existing data. Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, ImportFixedDatabaseInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -1017,6 +1034,7 @@ pub fn get_fixed_database_slow_log(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetFixedDatabaseSlowLogInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -1062,6 +1080,7 @@ pub fn get_fixed_database_tags(state: Arc<AppState>) -> Tool {
         .description("Get tags attached to a Fixed/Essentials database.")
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetFixedDatabaseTagsInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -1108,6 +1127,7 @@ pub fn create_fixed_database_tag(state: Arc<AppState>) -> Tool {
             "Create a tag on a Fixed/Essentials database. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateFixedDatabaseTagInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -1168,6 +1188,7 @@ pub fn update_fixed_database_tag(state: Arc<AppState>) -> Tool {
             "Update a tag value on a Fixed/Essentials database. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateFixedDatabaseTagInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -1228,8 +1249,8 @@ pub struct DeleteFixedDatabaseTagInput {
 pub fn delete_fixed_database_tag(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_fixed_database_tag")
         .description(
-            "Delete a tag from a Fixed/Essentials database. \
-             Requires write permission.",
+            "DANGEROUS: Permanently deletes a tag from a Fixed/Essentials database. \
+             This action cannot be undone. Requires write permission.",
         )
         .extractor_handler_typed::<_, _, _, DeleteFixedDatabaseTagInput>(
             state,
@@ -1290,6 +1311,7 @@ pub fn update_fixed_database_tags(state: Arc<AppState>) -> Tool {
             "Update all tags on a Fixed/Essentials database (replaces existing tags). \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateFixedDatabaseTagsInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -1360,6 +1382,7 @@ pub fn get_fixed_database_upgrade_versions(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetFixedDatabaseUpgradeVersionsInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -1404,6 +1427,7 @@ pub fn get_fixed_database_upgrade_status(state: Arc<AppState>) -> Tool {
         .description("Get the latest Redis version upgrade status for a Fixed/Essentials database.")
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetFixedDatabaseUpgradeStatusInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -1451,6 +1475,7 @@ pub fn upgrade_fixed_database_redis_version(state: Arc<AppState>) -> Tool {
             "Upgrade the Redis version of a Fixed/Essentials database. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, UpgradeFixedDatabaseRedisVersionInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -1510,20 +1535,20 @@ pub(super) const INSTRUCTIONS: &str = r#"
 - get_fixed_database_upgrade_versions: Get available Redis upgrade versions
 - get_fixed_database_upgrade_status: Get Redis version upgrade status
 
-### Redis Cloud - Fixed/Essentials Write Operations (require --read-only=false)
-- create_fixed_subscription: Create a new Fixed/Essentials subscription
-- update_fixed_subscription: Update a Fixed/Essentials subscription
-- delete_fixed_subscription: Delete a Fixed/Essentials subscription
-- create_fixed_database: Create a new Fixed/Essentials database
-- update_fixed_database: Update a Fixed/Essentials database
-- delete_fixed_database: Delete a Fixed/Essentials database
-- backup_fixed_database: Trigger a manual backup
-- import_fixed_database: Import data into a Fixed/Essentials database
-- create_fixed_database_tag: Create a tag on a Fixed/Essentials database
-- update_fixed_database_tag: Update a tag on a Fixed/Essentials database
-- delete_fixed_database_tag: Delete a tag from a Fixed/Essentials database
-- update_fixed_database_tags: Update all tags on a Fixed/Essentials database
-- upgrade_fixed_database_redis_version: Upgrade the Redis version of a Fixed/Essentials database
+### Redis Cloud - Fixed/Essentials Write Operations
+- create_fixed_subscription: Create a new Fixed/Essentials subscription [write]
+- update_fixed_subscription: Update a Fixed/Essentials subscription [write]
+- create_fixed_database: Create a new Fixed/Essentials database [write]
+- update_fixed_database: Update a Fixed/Essentials database [write]
+- backup_fixed_database: Trigger a manual backup [write]
+- import_fixed_database: Import data into a Fixed/Essentials database [write]
+- create_fixed_database_tag: Create a tag on a Fixed/Essentials database [write]
+- update_fixed_database_tag: Update a tag on a Fixed/Essentials database [write]
+- update_fixed_database_tags: Update all tags on a Fixed/Essentials database [write]
+- upgrade_fixed_database_redis_version: Upgrade the Redis version [write]
+- delete_fixed_subscription: Permanently delete a Fixed/Essentials subscription [destructive]
+- delete_fixed_database: Permanently delete a Fixed/Essentials database [destructive]
+- delete_fixed_database_tag: Delete a tag from a Fixed/Essentials database [destructive]
 "#;
 
 /// Build an MCP sub-router containing all Fixed/Essentials tools

--- a/crates/redisctl-mcp/src/tools/cloud/networking.rs
+++ b/crates/redisctl-mcp/src/tools/cloud/networking.rs
@@ -38,6 +38,7 @@ pub fn get_vpc_peering(state: Arc<AppState>) -> Tool {
         .description("Get VPC peering details for a Redis Cloud subscription.")
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetVpcPeeringInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetVpcPeeringInput>| async move {
@@ -99,6 +100,7 @@ pub fn create_vpc_peering(state: Arc<AppState>) -> Tool {
             "Create a VPC peering connection for a Redis Cloud subscription. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateVpcPeeringInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -181,6 +183,7 @@ pub fn update_vpc_peering(state: Arc<AppState>) -> Tool {
             "Update a VPC peering connection for a Redis Cloud subscription. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateVpcPeeringInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -236,8 +239,8 @@ pub struct DeleteVpcPeeringInput {
 pub fn delete_vpc_peering(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_vpc_peering")
         .description(
-            "Delete a VPC peering connection for a Redis Cloud subscription. \
-             Requires write permission.",
+            "DANGEROUS: Permanently deletes a VPC peering connection. \
+             Network connectivity will be immediately lost. Requires write permission.",
         )
         .extractor_handler_typed::<_, _, _, DeleteVpcPeeringInput>(
             state,
@@ -288,6 +291,7 @@ pub fn get_aa_vpc_peering(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetAaVpcPeeringInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -352,6 +356,7 @@ pub fn create_aa_vpc_peering(state: Arc<AppState>) -> Tool {
             "Create an Active-Active VPC peering connection for a Redis Cloud subscription. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateAaVpcPeeringInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -436,6 +441,7 @@ pub fn update_aa_vpc_peering(state: Arc<AppState>) -> Tool {
             "Update an Active-Active VPC peering connection for a Redis Cloud subscription. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateAaVpcPeeringInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -493,8 +499,8 @@ pub struct DeleteAaVpcPeeringInput {
 pub fn delete_aa_vpc_peering(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_aa_vpc_peering")
         .description(
-            "Delete an Active-Active VPC peering connection for a Redis Cloud subscription. \
-             Requires write permission.",
+            "DANGEROUS: Permanently deletes an Active-Active VPC peering connection. \
+             Network connectivity will be immediately lost. Requires write permission.",
         )
         .extractor_handler_typed::<_, _, _, DeleteAaVpcPeeringInput>(
             state,
@@ -547,6 +553,7 @@ pub fn get_tgw_attachments(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetTgwAttachmentsInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -588,6 +595,7 @@ pub fn get_tgw_invitations(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetTgwInvitationsInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -630,6 +638,7 @@ pub fn accept_tgw_invitation(state: Arc<AppState>) -> Tool {
             "Accept a Transit Gateway resource share invitation. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, AcceptTgwInvitationInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -678,6 +687,7 @@ pub fn reject_tgw_invitation(state: Arc<AppState>) -> Tool {
             "Reject a Transit Gateway resource share invitation. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, RejectTgwInvitationInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -733,6 +743,7 @@ pub fn create_tgw_attachment(state: Arc<AppState>) -> Tool {
             "Create a Transit Gateway attachment for a Redis Cloud subscription. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateTgwAttachmentInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -796,6 +807,7 @@ pub fn update_tgw_attachment_cidrs(state: Arc<AppState>) -> Tool {
             "Update CIDRs for a Transit Gateway attachment. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateTgwAttachmentCidrsInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -847,8 +859,8 @@ pub struct DeleteTgwAttachmentInput {
 pub fn delete_tgw_attachment(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_tgw_attachment")
         .description(
-            "Delete a Transit Gateway attachment. \
-             Requires write permission.",
+            "DANGEROUS: Permanently deletes a Transit Gateway attachment. \
+             Network connectivity will be immediately lost. Requires write permission.",
         )
         .extractor_handler_typed::<_, _, _, DeleteTgwAttachmentInput>(
             state,
@@ -901,6 +913,7 @@ pub fn get_aa_tgw_attachments(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetAaTgwAttachmentsInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -942,6 +955,7 @@ pub fn get_aa_tgw_invitations(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetAaTgwInvitationsInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -986,6 +1000,7 @@ pub fn accept_aa_tgw_invitation(state: Arc<AppState>) -> Tool {
             "Accept an Active-Active Transit Gateway resource share invitation. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, AcceptAaTgwInvitationInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -1040,6 +1055,7 @@ pub fn reject_aa_tgw_invitation(state: Arc<AppState>) -> Tool {
             "Reject an Active-Active Transit Gateway resource share invitation. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, RejectAaTgwInvitationInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -1101,6 +1117,7 @@ pub fn create_aa_tgw_attachment(state: Arc<AppState>) -> Tool {
             "Create an Active-Active Transit Gateway attachment. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateAaTgwAttachmentInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -1170,6 +1187,7 @@ pub fn update_aa_tgw_attachment_cidrs(state: Arc<AppState>) -> Tool {
             "Update CIDRs for an Active-Active Transit Gateway attachment. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateAaTgwAttachmentCidrsInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -1228,8 +1246,8 @@ pub struct DeleteAaTgwAttachmentInput {
 pub fn delete_aa_tgw_attachment(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_aa_tgw_attachment")
         .description(
-            "Delete an Active-Active Transit Gateway attachment. \
-             Requires write permission.",
+            "DANGEROUS: Permanently deletes an Active-Active Transit Gateway attachment. \
+             Network connectivity will be immediately lost. Requires write permission.",
         )
         .extractor_handler_typed::<_, _, _, DeleteAaTgwAttachmentInput>(
             state,
@@ -1284,6 +1302,7 @@ pub fn get_psc_service(state: Arc<AppState>) -> Tool {
         .description("Get Private Service Connect service for a Redis Cloud subscription.")
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetPscServiceInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetPscServiceInput>| async move {
@@ -1321,6 +1340,7 @@ pub fn create_psc_service(state: Arc<AppState>) -> Tool {
             "Create a Private Service Connect service for a Redis Cloud subscription. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, CreatePscServiceInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -1364,8 +1384,8 @@ pub struct DeletePscServiceInput {
 pub fn delete_psc_service(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_psc_service")
         .description(
-            "Delete a Private Service Connect service for a Redis Cloud subscription. \
-             Requires write permission.",
+            "DANGEROUS: Permanently deletes a Private Service Connect service. \
+             All endpoints will be disconnected. Requires write permission.",
         )
         .extractor_handler_typed::<_, _, _, DeletePscServiceInput>(
             state,
@@ -1414,6 +1434,7 @@ pub fn get_psc_endpoints(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetPscEndpointsInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -1470,6 +1491,7 @@ pub fn create_psc_endpoint(state: Arc<AppState>) -> Tool {
             "Create a Private Service Connect endpoint. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, CreatePscEndpointInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -1542,6 +1564,7 @@ pub fn update_psc_endpoint(state: Arc<AppState>) -> Tool {
             "Update a Private Service Connect endpoint. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdatePscEndpointInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -1597,8 +1620,8 @@ pub struct DeletePscEndpointInput {
 pub fn delete_psc_endpoint(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_psc_endpoint")
         .description(
-            "Delete a Private Service Connect endpoint. \
-             Requires write permission.",
+            "DANGEROUS: Permanently deletes a Private Service Connect endpoint. \
+             Connectivity will be immediately lost. Requires write permission.",
         )
         .extractor_handler_typed::<_, _, _, DeletePscEndpointInput>(
             state,
@@ -1649,6 +1672,7 @@ pub fn get_psc_creation_script(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetPscCreationScriptInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -1692,6 +1716,7 @@ pub fn get_psc_deletion_script(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetPscDeletionScriptInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -1737,6 +1762,7 @@ pub fn get_aa_psc_service(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetAaPscServiceInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -1777,6 +1803,7 @@ pub fn create_aa_psc_service(state: Arc<AppState>) -> Tool {
             "Create an Active-Active Private Service Connect service. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateAaPscServiceInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -1820,8 +1847,8 @@ pub struct DeleteAaPscServiceInput {
 pub fn delete_aa_psc_service(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_aa_psc_service")
         .description(
-            "Delete an Active-Active Private Service Connect service. \
-             Requires write permission.",
+            "DANGEROUS: Permanently deletes an Active-Active Private Service Connect service. \
+             All endpoints will be disconnected. Requires write permission.",
         )
         .extractor_handler_typed::<_, _, _, DeleteAaPscServiceInput>(
             state,
@@ -1870,6 +1897,7 @@ pub fn get_aa_psc_endpoints(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetAaPscEndpointsInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -1926,6 +1954,7 @@ pub fn create_aa_psc_endpoint(state: Arc<AppState>) -> Tool {
             "Create an Active-Active Private Service Connect endpoint. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateAaPscEndpointInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -2000,6 +2029,7 @@ pub fn update_aa_psc_endpoint(state: Arc<AppState>) -> Tool {
             "Update an Active-Active Private Service Connect endpoint. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateAaPscEndpointInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -2062,8 +2092,8 @@ pub struct DeleteAaPscEndpointInput {
 pub fn delete_aa_psc_endpoint(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_aa_psc_endpoint")
         .description(
-            "Delete an Active-Active Private Service Connect endpoint. \
-             Requires write permission.",
+            "DANGEROUS: Permanently deletes an Active-Active Private Service Connect endpoint. \
+             Connectivity will be immediately lost. Requires write permission.",
         )
         .extractor_handler_typed::<_, _, _, DeleteAaPscEndpointInput>(
             state,
@@ -2122,6 +2152,7 @@ pub fn get_aa_psc_creation_script(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetAaPscCreationScriptInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -2174,6 +2205,7 @@ pub fn get_aa_psc_deletion_script(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetAaPscDeletionScriptInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -2224,6 +2256,7 @@ pub fn get_private_link(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetPrivateLinkInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -2288,6 +2321,7 @@ pub fn create_private_link(state: Arc<AppState>) -> Tool {
             "Create an AWS PrivateLink configuration for a Redis Cloud subscription. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, CreatePrivateLinkInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -2340,8 +2374,8 @@ pub struct DeletePrivateLinkInput {
 pub fn delete_private_link(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_private_link")
         .description(
-            "Delete an AWS PrivateLink configuration for a Redis Cloud subscription. \
-             Requires write permission.",
+            "DANGEROUS: Permanently deletes an AWS PrivateLink configuration. \
+             Connectivity will be immediately lost. Requires write permission.",
         )
         .extractor_handler_typed::<_, _, _, DeletePrivateLinkInput>(
             state,
@@ -2397,6 +2431,7 @@ pub fn add_private_link_principals(state: Arc<AppState>) -> Tool {
             "Add AWS principals to a PrivateLink access list. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, AddPrivateLinkPrincipalsInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -2462,6 +2497,7 @@ pub fn remove_private_link_principals(state: Arc<AppState>) -> Tool {
             "Remove AWS principals from a PrivateLink access list. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, RemovePrivateLinkPrincipalsInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -2519,6 +2555,7 @@ pub fn get_private_link_endpoint_script(state: Arc<AppState>) -> Tool {
         .description("Get the endpoint creation script for an AWS PrivateLink configuration.")
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetPrivateLinkEndpointScriptInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -2566,6 +2603,7 @@ pub fn get_aa_private_link(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetAaPrivateLinkInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -2617,6 +2655,7 @@ pub fn create_aa_private_link(state: Arc<AppState>) -> Tool {
             "Create an Active-Active AWS PrivateLink configuration. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateAaPrivateLinkInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -2682,6 +2721,7 @@ pub fn add_aa_private_link_principals(state: Arc<AppState>) -> Tool {
             "Add AWS principals to an Active-Active PrivateLink access list. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, AddAaPrivateLinkPrincipalsInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -2749,6 +2789,7 @@ pub fn remove_aa_private_link_principals(state: Arc<AppState>) -> Tool {
             "Remove AWS principals from an Active-Active PrivateLink access list. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, RemoveAaPrivateLinkPrincipalsInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -2814,6 +2855,7 @@ pub fn get_aa_private_link_endpoint_script(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetAaPrivateLinkEndpointScriptInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -2846,63 +2888,63 @@ pub fn get_aa_private_link_endpoint_script(state: Arc<AppState>) -> Tool {
 
 pub(super) const INSTRUCTIONS: &str = "\n\
 ### Redis Cloud - VPC Peering\n\
-- `get_vpc_peering`: Get VPC peering details for a subscription\n\
-- `create_vpc_peering`: Create a VPC peering connection (WRITE)\n\
-- `update_vpc_peering`: Update a VPC peering connection (WRITE)\n\
-- `delete_vpc_peering`: Delete a VPC peering connection (WRITE)\n\
-- `get_aa_vpc_peering`: Get Active-Active VPC peering details\n\
-- `create_aa_vpc_peering`: Create an Active-Active VPC peering (WRITE)\n\
-- `update_aa_vpc_peering`: Update an Active-Active VPC peering (WRITE)\n\
-- `delete_aa_vpc_peering`: Delete an Active-Active VPC peering (WRITE)\n\
+- get_vpc_peering: Get VPC peering details for a subscription\n\
+- get_aa_vpc_peering: Get Active-Active VPC peering details\n\
+- create_vpc_peering: Create a VPC peering connection [write]\n\
+- update_vpc_peering: Update a VPC peering connection [write]\n\
+- create_aa_vpc_peering: Create an Active-Active VPC peering [write]\n\
+- update_aa_vpc_peering: Update an Active-Active VPC peering [write]\n\
+- delete_vpc_peering: Permanently delete a VPC peering connection [destructive]\n\
+- delete_aa_vpc_peering: Permanently delete an Active-Active VPC peering [destructive]\n\
 \n\
 ### Redis Cloud - Transit Gateway\n\
-- `get_tgw_attachments`: Get Transit Gateway attachments\n\
-- `get_tgw_invitations`: Get Transit Gateway shared invitations\n\
-- `accept_tgw_invitation`: Accept a TGW resource share invitation (WRITE)\n\
-- `reject_tgw_invitation`: Reject a TGW resource share invitation (WRITE)\n\
-- `create_tgw_attachment`: Create a TGW attachment (WRITE)\n\
-- `update_tgw_attachment_cidrs`: Update TGW attachment CIDRs (WRITE)\n\
-- `delete_tgw_attachment`: Delete a TGW attachment (WRITE)\n\
-- `get_aa_tgw_attachments`: Get Active-Active TGW attachments\n\
-- `get_aa_tgw_invitations`: Get Active-Active TGW shared invitations\n\
-- `accept_aa_tgw_invitation`: Accept an AA TGW resource share invitation (WRITE)\n\
-- `reject_aa_tgw_invitation`: Reject an AA TGW resource share invitation (WRITE)\n\
-- `create_aa_tgw_attachment`: Create an AA TGW attachment (WRITE)\n\
-- `update_aa_tgw_attachment_cidrs`: Update AA TGW attachment CIDRs (WRITE)\n\
-- `delete_aa_tgw_attachment`: Delete an AA TGW attachment (WRITE)\n\
+- get_tgw_attachments: Get Transit Gateway attachments\n\
+- get_tgw_invitations: Get Transit Gateway shared invitations\n\
+- get_aa_tgw_attachments: Get Active-Active TGW attachments\n\
+- get_aa_tgw_invitations: Get Active-Active TGW shared invitations\n\
+- accept_tgw_invitation: Accept a TGW resource share invitation [write]\n\
+- reject_tgw_invitation: Reject a TGW resource share invitation [write]\n\
+- create_tgw_attachment: Create a TGW attachment [write]\n\
+- update_tgw_attachment_cidrs: Update TGW attachment CIDRs [write]\n\
+- accept_aa_tgw_invitation: Accept an AA TGW resource share invitation [write]\n\
+- reject_aa_tgw_invitation: Reject an AA TGW resource share invitation [write]\n\
+- create_aa_tgw_attachment: Create an AA TGW attachment [write]\n\
+- update_aa_tgw_attachment_cidrs: Update AA TGW attachment CIDRs [write]\n\
+- delete_tgw_attachment: Permanently delete a TGW attachment [destructive]\n\
+- delete_aa_tgw_attachment: Permanently delete an AA TGW attachment [destructive]\n\
 \n\
 ### Redis Cloud - Private Service Connect (PSC)\n\
-- `get_psc_service`: Get PSC service for a subscription\n\
-- `create_psc_service`: Create a PSC service (WRITE)\n\
-- `delete_psc_service`: Delete a PSC service (WRITE)\n\
-- `get_psc_endpoints`: Get PSC endpoints\n\
-- `create_psc_endpoint`: Create a PSC endpoint (WRITE)\n\
-- `update_psc_endpoint`: Update a PSC endpoint (WRITE)\n\
-- `delete_psc_endpoint`: Delete a PSC endpoint (WRITE)\n\
-- `get_psc_creation_script`: Get PSC endpoint creation script\n\
-- `get_psc_deletion_script`: Get PSC endpoint deletion script\n\
-- `get_aa_psc_service`: Get Active-Active PSC service\n\
-- `create_aa_psc_service`: Create an AA PSC service (WRITE)\n\
-- `delete_aa_psc_service`: Delete an AA PSC service (WRITE)\n\
-- `get_aa_psc_endpoints`: Get AA PSC endpoints\n\
-- `create_aa_psc_endpoint`: Create an AA PSC endpoint (WRITE)\n\
-- `update_aa_psc_endpoint`: Update an AA PSC endpoint (WRITE)\n\
-- `delete_aa_psc_endpoint`: Delete an AA PSC endpoint (WRITE)\n\
-- `get_aa_psc_creation_script`: Get AA PSC endpoint creation script\n\
-- `get_aa_psc_deletion_script`: Get AA PSC endpoint deletion script\n\
+- get_psc_service: Get PSC service for a subscription\n\
+- get_psc_endpoints: Get PSC endpoints\n\
+- get_psc_creation_script: Get PSC endpoint creation script\n\
+- get_psc_deletion_script: Get PSC endpoint deletion script\n\
+- get_aa_psc_service: Get Active-Active PSC service\n\
+- get_aa_psc_endpoints: Get AA PSC endpoints\n\
+- get_aa_psc_creation_script: Get AA PSC endpoint creation script\n\
+- get_aa_psc_deletion_script: Get AA PSC endpoint deletion script\n\
+- create_psc_service: Create a PSC service [write]\n\
+- create_psc_endpoint: Create a PSC endpoint [write]\n\
+- update_psc_endpoint: Update a PSC endpoint [write]\n\
+- create_aa_psc_service: Create an AA PSC service [write]\n\
+- create_aa_psc_endpoint: Create an AA PSC endpoint [write]\n\
+- update_aa_psc_endpoint: Update an AA PSC endpoint [write]\n\
+- delete_psc_service: Permanently delete a PSC service [destructive]\n\
+- delete_psc_endpoint: Permanently delete a PSC endpoint [destructive]\n\
+- delete_aa_psc_service: Permanently delete an AA PSC service [destructive]\n\
+- delete_aa_psc_endpoint: Permanently delete an AA PSC endpoint [destructive]\n\
 \n\
 ### Redis Cloud - PrivateLink\n\
-- `get_private_link`: Get AWS PrivateLink configuration\n\
-- `create_private_link`: Create an AWS PrivateLink (WRITE)\n\
-- `delete_private_link`: Delete an AWS PrivateLink (WRITE)\n\
-- `add_private_link_principals`: Add principals to PrivateLink (WRITE)\n\
-- `remove_private_link_principals`: Remove principals from PrivateLink (WRITE)\n\
-- `get_private_link_endpoint_script`: Get PrivateLink endpoint script\n\
-- `get_aa_private_link`: Get AA PrivateLink configuration\n\
-- `create_aa_private_link`: Create an AA PrivateLink (WRITE)\n\
-- `add_aa_private_link_principals`: Add principals to AA PrivateLink (WRITE)\n\
-- `remove_aa_private_link_principals`: Remove principals from AA PrivateLink (WRITE)\n\
-- `get_aa_private_link_endpoint_script`: Get AA PrivateLink endpoint script\n\
+- get_private_link: Get AWS PrivateLink configuration\n\
+- get_private_link_endpoint_script: Get PrivateLink endpoint script\n\
+- get_aa_private_link: Get AA PrivateLink configuration\n\
+- get_aa_private_link_endpoint_script: Get AA PrivateLink endpoint script\n\
+- create_private_link: Create an AWS PrivateLink [write]\n\
+- add_private_link_principals: Add principals to PrivateLink [write]\n\
+- remove_private_link_principals: Remove principals from PrivateLink [write]\n\
+- create_aa_private_link: Create an AA PrivateLink [write]\n\
+- add_aa_private_link_principals: Add principals to AA PrivateLink [write]\n\
+- remove_aa_private_link_principals: Remove principals from AA PrivateLink [write]\n\
+- delete_private_link: Permanently delete an AWS PrivateLink [destructive]\n\
 ";
 
 /// Build an MCP sub-router containing all networking tools

--- a/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs
+++ b/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs
@@ -31,6 +31,7 @@ pub fn list_subscriptions(state: Arc<AppState>) -> Tool {
         .description("List all Redis Cloud subscriptions accessible with the current credentials. Returns JSON with subscription details.")
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, ListSubscriptionsInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ListSubscriptionsInput>| async move {
@@ -67,6 +68,7 @@ pub fn get_subscription(state: Arc<AppState>) -> Tool {
         .description("Get detailed information about a specific Redis Cloud subscription. Returns JSON with full subscription details.")
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetSubscriptionInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetSubscriptionInput>| async move {
@@ -105,6 +107,7 @@ pub fn list_databases(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, ListDatabasesInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ListDatabasesInput>| async move {
@@ -143,6 +146,7 @@ pub fn get_database(state: Arc<AppState>) -> Tool {
         .description("Get detailed information about a specific Redis Cloud database. Returns JSON with full database configuration.")
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetDatabaseInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetDatabaseInput>| async move {
@@ -188,6 +192,7 @@ pub fn get_backup_status(state: Arc<AppState>) -> Tool {
         .description("Get backup status and history for a Redis Cloud database.")
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetBackupStatusInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -236,6 +241,7 @@ pub fn get_slow_log(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetSlowLogInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetSlowLogInput>| async move {
@@ -274,6 +280,7 @@ pub fn get_tags(state: Arc<AppState>) -> Tool {
         .description("Get tags attached to a Redis Cloud database.")
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetTagsInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetTagsInput>| async move {
@@ -315,6 +322,7 @@ pub fn get_database_certificate(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetCertificateInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -388,6 +396,7 @@ pub fn create_database(state: Arc<AppState>) -> Tool {
             "Create a new Redis Cloud database and wait for it to be ready. \
              Returns the created database details. Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateDatabaseInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -486,6 +495,7 @@ pub fn update_database(state: Arc<AppState>) -> Tool {
             "Update an existing Redis Cloud database configuration. \
              Returns the updated database details. Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateDatabaseInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -561,7 +571,7 @@ pub struct DeleteDatabaseInput {
 pub fn delete_database(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_database")
         .description(
-            "Delete a Redis Cloud database. This is a destructive operation. \
+            "DANGEROUS: Permanently deletes a database and all its data. This action cannot be undone. \
              Requires write permission.",
         )
         .extractor_handler_typed::<_, _, _, DeleteDatabaseInput>(
@@ -626,6 +636,7 @@ pub fn backup_database(state: Arc<AppState>) -> Tool {
             "Trigger a manual backup of a Redis Cloud database. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, BackupDatabaseInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -694,6 +705,7 @@ pub fn import_database(state: Arc<AppState>) -> Tool {
             "Import data into a Redis Cloud database from an external source. \
              WARNING: This will overwrite existing data. Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, ImportDatabaseInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -757,8 +769,8 @@ pub struct DeleteSubscriptionInput {
 pub fn delete_subscription(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_subscription")
         .description(
-            "Delete a Redis Cloud subscription. WARNING: All databases in the subscription \
-             must be deleted first. This is a destructive operation. Requires write permission.",
+            "DANGEROUS: Permanently deletes a subscription. All databases must be deleted first. \
+             This action cannot be undone. Requires write permission.",
         )
         .extractor_handler_typed::<_, _, _, DeleteSubscriptionInput>(
             state,
@@ -818,8 +830,7 @@ pub struct FlushDatabaseInput {
 pub fn flush_database(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("flush_database")
         .description(
-            "Flush all data from a Redis Cloud database and wait for completion. \
-             WARNING: This permanently deletes ALL data in the database! \
+            "DANGEROUS: Removes all data from a database. This action cannot be undone. \
              Requires write permission.",
         )
         .extractor_handler_typed::<_, _, _, FlushDatabaseInput>(
@@ -904,6 +915,7 @@ pub fn create_subscription(state: Arc<AppState>) -> Tool {
              This is a simplified interface for common subscription creation scenarios. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateSubscriptionInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -994,6 +1006,7 @@ pub fn update_subscription(state: Arc<AppState>) -> Tool {
             "Update a Redis Cloud subscription. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateSubscriptionInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -1048,6 +1061,7 @@ pub fn get_subscription_pricing(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetSubscriptionPricingInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -1090,6 +1104,7 @@ pub fn get_redis_versions(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetRedisVersionsInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -1129,6 +1144,7 @@ pub fn get_subscription_cidr_allowlist(state: Arc<AppState>) -> Tool {
         .description("Get the CIDR allowlist for a Redis Cloud subscription.")
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetSubscriptionCidrAllowlistInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -1175,6 +1191,7 @@ pub fn update_subscription_cidr_allowlist(state: Arc<AppState>) -> Tool {
             "Update the CIDR allowlist for a Redis Cloud subscription. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateSubscriptionCidrAllowlistInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -1232,6 +1249,7 @@ pub fn get_subscription_maintenance_windows(state: Arc<AppState>) -> Tool {
         .description("Get maintenance windows for a Redis Cloud subscription.")
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetSubscriptionMaintenanceWindowsInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -1291,6 +1309,7 @@ pub fn update_subscription_maintenance_windows(state: Arc<AppState>) -> Tool {
             "Update maintenance windows for a Redis Cloud subscription. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateSubscriptionMaintenanceWindowsInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -1360,6 +1379,7 @@ pub fn get_active_active_regions(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetActiveActiveRegionsInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -1417,6 +1437,7 @@ pub fn add_active_active_region(state: Arc<AppState>) -> Tool {
             "Add a new region to an Active-Active Redis Cloud subscription. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, AddActiveActiveRegionInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -1492,8 +1513,8 @@ pub struct DeleteActiveActiveRegionsInput {
 pub fn delete_active_active_regions(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_active_active_regions")
         .description(
-            "Delete regions from an Active-Active Redis Cloud subscription. \
-             Requires write permission.",
+            "DANGEROUS: Permanently removes regions from an Active-Active subscription. \
+             This may cause data loss in the removed regions. Requires write permission.",
         )
         .extractor_handler_typed::<_, _, _, DeleteActiveActiveRegionsInput>(
             state,
@@ -1561,6 +1582,7 @@ pub fn get_available_database_versions(state: Arc<AppState>) -> Tool {
         .description("Get available target Redis versions for upgrading a database.")
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetAvailableDatabaseVersionsInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -1606,6 +1628,7 @@ pub fn upgrade_database_redis_version(state: Arc<AppState>) -> Tool {
              Use get_available_database_versions to find valid target versions. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, UpgradeDatabaseRedisVersionInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -1666,6 +1689,7 @@ pub fn get_database_upgrade_status(state: Arc<AppState>) -> Tool {
         .description("Get the Redis version upgrade status for a database.")
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetDatabaseUpgradeStatusInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -1710,6 +1734,7 @@ pub fn get_database_import_status(state: Arc<AppState>) -> Tool {
         .description("Get the import status for a Redis Cloud database.")
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetDatabaseImportStatusInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -1756,6 +1781,7 @@ pub fn create_database_tag(state: Arc<AppState>) -> Tool {
             "Create a tag on a Redis Cloud database. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateDatabaseTagInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -1818,6 +1844,7 @@ pub fn update_database_tag(state: Arc<AppState>) -> Tool {
             "Update a tag on a Redis Cloud database. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateDatabaseTagInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -1880,7 +1907,7 @@ pub struct DeleteDatabaseTagInput {
 pub fn delete_database_tag(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_database_tag")
         .description(
-            "Delete a tag from a Redis Cloud database. \
+            "DANGEROUS: Permanently deletes a tag from a database. This action cannot be undone. \
              Requires write permission.",
         )
         .extractor_handler_typed::<_, _, _, DeleteDatabaseTagInput>(
@@ -1942,6 +1969,7 @@ pub fn update_database_tags(state: Arc<AppState>) -> Tool {
             "Update all tags on a Redis Cloud database (replaces existing tags). \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateDatabaseTagsInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -2042,6 +2070,7 @@ pub fn update_crdb_local_properties(state: Arc<AppState>) -> Tool {
             "Update local properties of an Active-Active (CRDB) database. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateCrdbLocalPropertiesInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -2118,25 +2147,26 @@ pub(super) const INSTRUCTIONS: &str = r#"
 - get_database_upgrade_status: Get Redis version upgrade status
 - get_database_import_status: Get database import status
 
-### Redis Cloud - Write Operations (require --read-only=false)
-- create_database: Create a new database and wait for it to be ready
-- update_database: Update a database configuration
-- delete_database: Delete a database
-- backup_database: Trigger a manual backup
-- import_database: Import data into a database
-- delete_subscription: Delete a subscription (all databases must be deleted first)
-- flush_database: Flush all data from a database
-- update_subscription: Update a subscription
-- update_subscription_cidr_allowlist: Update CIDR allowlist for a subscription
-- update_subscription_maintenance_windows: Update maintenance windows for a subscription
-- add_active_active_region: Add a region to an Active-Active subscription
-- delete_active_active_regions: Delete regions from an Active-Active subscription
-- upgrade_database_redis_version: Upgrade the Redis version of a database
-- create_database_tag: Create a tag on a database
-- update_database_tag: Update a tag on a database
-- delete_database_tag: Delete a tag from a database
-- update_database_tags: Update all tags on a database
-- update_crdb_local_properties: Update local properties of an Active-Active database
+### Redis Cloud - Write Operations
+- create_database: Create a new database and wait for it to be ready [write]
+- update_database: Update a database configuration [write]
+- backup_database: Trigger a manual backup [write]
+- import_database: Import data into a database [write]
+- create_subscription: Create a new subscription [write]
+- update_subscription: Update a subscription [write]
+- update_subscription_cidr_allowlist: Update CIDR allowlist for a subscription [write]
+- update_subscription_maintenance_windows: Update maintenance windows [write]
+- add_active_active_region: Add a region to an Active-Active subscription [write]
+- upgrade_database_redis_version: Upgrade the Redis version of a database [write]
+- create_database_tag: Create a tag on a database [write]
+- update_database_tag: Update a tag on a database [write]
+- update_database_tags: Update all tags on a database [write]
+- update_crdb_local_properties: Update local properties of an Active-Active database [write]
+- delete_database: Permanently delete a database and all its data [destructive]
+- delete_subscription: Permanently delete a subscription [destructive]
+- flush_database: Remove all data from a database [destructive]
+- delete_active_active_regions: Remove regions from an Active-Active subscription [destructive]
+- delete_database_tag: Delete a tag from a database [destructive]
 "#;
 
 /// Build an MCP sub-router containing subscription and database tools

--- a/crates/redisctl-mcp/src/tools/enterprise/cluster.rs
+++ b/crates/redisctl-mcp/src/tools/enterprise/cluster.rs
@@ -30,6 +30,7 @@ pub fn get_cluster(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetClusterInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetClusterInput>| async move {
@@ -71,6 +72,7 @@ pub fn get_license(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetLicenseInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetLicenseInput>| async move {
@@ -108,6 +110,7 @@ pub fn get_license_usage(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetLicenseUsageInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -150,6 +153,7 @@ pub fn update_license(state: Arc<AppState>) -> Tool {
             "Update the Redis Enterprise cluster license with a new license key. \
              This applies a new license to the cluster. Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateLicenseInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<UpdateLicenseInput>| async move {
@@ -200,6 +204,7 @@ pub fn validate_license(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, ValidateLicenseInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -243,6 +248,7 @@ pub fn update_cluster(state: Arc<AppState>) -> Tool {
              Pass a JSON object with the fields to update (e.g., name, email_alerts, rack_aware). \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateClusterInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<UpdateClusterInput>| async move {
@@ -287,6 +293,7 @@ pub fn get_cluster_policy(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetClusterPolicyInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -328,6 +335,7 @@ pub fn update_cluster_policy(state: Arc<AppState>) -> Tool {
              default_provisioned_redis_version, persistent_node_removal. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateClusterPolicyInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -378,6 +386,7 @@ pub fn enable_maintenance_mode(state: Arc<AppState>) -> Tool {
              When enabled, cluster configuration changes are blocked, allowing safe \
              maintenance operations like upgrades. Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, EnableMaintenanceModeInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -428,6 +437,7 @@ pub fn disable_maintenance_mode(state: Arc<AppState>) -> Tool {
              This re-enables cluster configuration changes after maintenance is complete. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, DisableMaintenanceModeInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -483,6 +493,7 @@ pub fn get_cluster_certificates(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetClusterCertificatesInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -520,6 +531,7 @@ pub fn rotate_cluster_certificates(state: Arc<AppState>) -> Tool {
              This generates new certificates and replaces the existing ones. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, RotateClusterCertificatesInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -573,6 +585,7 @@ pub fn update_cluster_certificates(state: Arc<AppState>) -> Tool {
              Provide the certificate name (proxy, syncer, api), the PEM-encoded certificate, \
              and the PEM-encoded private key. Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateClusterCertificatesInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -628,6 +641,7 @@ pub fn list_nodes(state: Arc<AppState>) -> Tool {
         .description("List all nodes in the Redis Enterprise cluster")
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, ListNodesInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ListNodesInput>| async move {
@@ -666,6 +680,7 @@ pub fn get_node(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetNodeInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetNodeInput>| async move {
@@ -714,6 +729,7 @@ pub fn get_node_stats(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetNodeStatsInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetNodeStatsInput>| async move {
@@ -773,6 +789,7 @@ pub fn enable_node_maintenance(state: Arc<AppState>) -> Tool {
              Shards will be migrated off the node before maintenance begins. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, NodeActionInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<NodeActionInput>| async move {
@@ -815,6 +832,7 @@ pub fn disable_node_maintenance(state: Arc<AppState>) -> Tool {
              The node will rejoin the cluster and accept shards again. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, NodeActionInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<NodeActionInput>| async move {
@@ -857,6 +875,7 @@ pub fn rebalance_node(state: Arc<AppState>) -> Tool {
              Redistributes shards across nodes for optimal performance. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, NodeActionInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<NodeActionInput>| async move {
@@ -897,6 +916,7 @@ pub fn drain_node(state: Arc<AppState>) -> Tool {
              All shards will be migrated to other available nodes. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, NodeActionInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<NodeActionInput>| async move {
@@ -955,6 +975,7 @@ pub fn get_cluster_stats(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetClusterStatsInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -1002,29 +1023,29 @@ pub(super) const INSTRUCTIONS: &str = r#"
 ### Redis Enterprise - Cluster
 - get_cluster: Get cluster information
 - get_cluster_stats: Get cluster statistics
-- update_enterprise_cluster: Update cluster configuration (write)
 - get_enterprise_cluster_policy: Get cluster policy settings
-- update_enterprise_cluster_policy: Update cluster policy (write)
-- enable_enterprise_maintenance_mode: Enable maintenance mode (write)
-- disable_enterprise_maintenance_mode: Disable maintenance mode (write)
 - get_enterprise_cluster_certificates: Get cluster certificates
-- rotate_enterprise_cluster_certificates: Rotate all certificates (write)
-- update_enterprise_cluster_certificates: Update a specific certificate (write)
+- update_enterprise_cluster: Update cluster configuration [write]
+- update_enterprise_cluster_policy: Update cluster policy [write]
+- enable_enterprise_maintenance_mode: Enable maintenance mode [write]
+- disable_enterprise_maintenance_mode: Disable maintenance mode [write]
+- rotate_enterprise_cluster_certificates: Rotate all certificates [write]
+- update_enterprise_cluster_certificates: Update a specific certificate [write]
 
 ### Redis Enterprise - License
 - get_license: Get license information (type, expiration, features)
 - get_license_usage: Get license utilization (shards, nodes, RAM vs limits)
-- update_enterprise_license: Update cluster license with a new key (write)
 - validate_enterprise_license: Validate a license key before applying
+- update_enterprise_license: Update cluster license with a new key [write]
 
 ### Redis Enterprise - Nodes
 - list_nodes: List cluster nodes
 - get_node: Get node details
 - get_node_stats: Get node statistics
-- enable_enterprise_node_maintenance: Enable maintenance on a node (write)
-- disable_enterprise_node_maintenance: Disable maintenance on a node (write)
-- rebalance_enterprise_node: Rebalance shards on a node (write)
-- drain_enterprise_node: Drain all shards from a node (write)
+- enable_enterprise_node_maintenance: Enable maintenance on a node [write]
+- disable_enterprise_node_maintenance: Disable maintenance on a node [write]
+- rebalance_enterprise_node: Rebalance shards on a node [write]
+- drain_enterprise_node: Drain all shards from a node [write]
 "#;
 
 /// Build an MCP sub-router containing cluster, license, and node tools

--- a/crates/redisctl-mcp/src/tools/enterprise/databases.rs
+++ b/crates/redisctl-mcp/src/tools/enterprise/databases.rs
@@ -42,6 +42,7 @@ pub fn list_databases(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, ListDatabasesInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ListDatabasesInput>| async move {
@@ -100,6 +101,7 @@ pub fn get_database(state: Arc<AppState>) -> Tool {
         .description("Get detailed information about a specific Redis Enterprise database")
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetDatabaseInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetDatabaseInput>| async move {
@@ -148,6 +150,7 @@ pub fn get_database_stats(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetDatabaseStatsInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -208,6 +211,7 @@ pub fn get_database_endpoints(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetDatabaseEndpointsInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -245,6 +249,7 @@ pub fn list_database_alerts(state: Arc<AppState>) -> Tool {
         .description("List all alerts for a specific database in the Redis Enterprise cluster")
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, ListDatabaseAlertsInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -296,6 +301,7 @@ pub fn backup_enterprise_database(state: Arc<AppState>) -> Tool {
             "Trigger a backup of a Redis Enterprise database and wait for completion. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, BackupDatabaseInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -357,6 +363,7 @@ pub fn import_enterprise_database(state: Arc<AppState>) -> Tool {
              WARNING: If flush is true, existing data will be deleted before import. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, ImportDatabaseInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -428,6 +435,7 @@ pub fn create_enterprise_database(state: Arc<AppState>) -> Tool {
             "Create a new database in the Redis Enterprise cluster. \
              Returns the created database details. Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateEnterpriseDatabaseInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -493,6 +501,7 @@ pub fn update_enterprise_database(state: Arc<AppState>) -> Tool {
             "Update configuration of an existing Redis Enterprise database. \
              Pass a JSON object with the fields to update. Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateEnterpriseDatabaseInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -535,9 +544,8 @@ pub struct DeleteEnterpriseDatabaseInput {
 pub fn delete_enterprise_database(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_enterprise_database")
         .description(
-            "Delete a database from the Redis Enterprise cluster. \
-             WARNING: This permanently deletes the database and all its data! \
-             Requires write permission.",
+            "DANGEROUS: Permanently deletes a database from the Redis Enterprise cluster \
+             and all its data. This action cannot be undone. Requires write permission.",
         )
         .extractor_handler_typed::<_, _, _, DeleteEnterpriseDatabaseInput>(
             state,
@@ -587,9 +595,8 @@ pub struct FlushEnterpriseDatabaseInput {
 pub fn flush_enterprise_database(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("flush_enterprise_database")
         .description(
-            "Flush all data from a Redis Enterprise database and wait for completion. \
-             WARNING: This permanently deletes ALL data in the database! \
-             Requires write permission.",
+            "DANGEROUS: Removes all data from a Redis Enterprise database. \
+             This action cannot be undone. Requires write permission.",
         )
         .extractor_handler_typed::<_, _, _, FlushEnterpriseDatabaseInput>(
             state,
@@ -647,6 +654,7 @@ pub fn list_enterprise_crdbs(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, ListCrdbsInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ListCrdbsInput>| async move {
@@ -686,6 +694,7 @@ pub fn get_enterprise_crdb(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetCrdbInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetCrdbInput>| async move {
@@ -725,6 +734,7 @@ pub fn get_enterprise_crdb_tasks(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetCrdbTasksInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetCrdbTasksInput>| async move {
@@ -758,13 +768,13 @@ pub(super) const INSTRUCTIONS: &str = r#"
 - get_enterprise_crdb: Get Active-Active database details by GUID
 - get_enterprise_crdb_tasks: Get tasks for an Active-Active database
 
-### Redis Enterprise - Database Write Operations (require --read-only=false)
-- backup_enterprise_database: Trigger a database backup and wait for completion
-- import_enterprise_database: Import data into a database and wait for completion
-- create_enterprise_database: Create a new database
-- update_enterprise_database: Update database configuration
-- delete_enterprise_database: Delete a database
-- flush_enterprise_database: Flush all data from a database
+### Redis Enterprise - Database Write Operations
+- backup_enterprise_database: Trigger a database backup and wait for completion [write]
+- import_enterprise_database: Import data into a database and wait for completion [write]
+- create_enterprise_database: Create a new database [write]
+- update_enterprise_database: Update database configuration [write]
+- delete_enterprise_database: Permanently delete a database and all its data [destructive]
+- flush_enterprise_database: Remove all data from a database [destructive]
 "#;
 
 /// Build an MCP sub-router containing database tools

--- a/crates/redisctl-mcp/src/tools/enterprise/observability.rs
+++ b/crates/redisctl-mcp/src/tools/enterprise/observability.rs
@@ -34,6 +34,7 @@ pub fn list_alerts(state: Arc<AppState>) -> Tool {
         .description("List all active alerts in the Redis Enterprise cluster")
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, ListAlertsInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ListAlertsInput>| async move {
@@ -91,6 +92,7 @@ pub fn list_logs(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, ListLogsInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ListLogsInput>| async move {
@@ -149,6 +151,7 @@ pub fn get_all_nodes_stats(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetAllNodesStatsInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -190,6 +193,7 @@ pub fn get_all_databases_stats(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetAllDatabasesStatsInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -226,6 +230,7 @@ pub fn get_shard_stats(state: Arc<AppState>) -> Tool {
         .description("Get current statistics for a specific shard in the Redis Enterprise cluster")
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetShardStatsInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetShardStatsInput>| async move {
@@ -263,6 +268,7 @@ pub fn get_all_shards_stats(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetAllShardsStatsInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -309,6 +315,7 @@ pub fn list_shards(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, ListShardsInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ListShardsInput>| async move {
@@ -355,6 +362,7 @@ pub fn get_shard(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetShardInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetShardInput>| async move {
@@ -397,6 +405,7 @@ pub fn list_debug_info_tasks(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, ListDebugInfoTasksInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -440,6 +449,7 @@ pub fn get_debug_info_status(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetDebugInfoStatusInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -485,6 +495,7 @@ pub fn list_modules(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, ListModulesInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ListModulesInput>| async move {
@@ -524,6 +535,7 @@ pub fn get_module(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetModuleInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetModuleInput>| async move {

--- a/crates/redisctl-mcp/src/tools/enterprise/rbac.rs
+++ b/crates/redisctl-mcp/src/tools/enterprise/rbac.rs
@@ -33,6 +33,7 @@ pub fn list_users(state: Arc<AppState>) -> Tool {
         .description("List all users in the Redis Enterprise cluster")
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, ListUsersInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ListUsersInput>| async move {
@@ -71,6 +72,7 @@ pub fn get_user(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetUserInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetUserInput>| async move {
@@ -121,6 +123,7 @@ pub fn create_enterprise_user(state: Arc<AppState>) -> Tool {
             "Create a new user in the Redis Enterprise cluster. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateEnterpriseUserInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -195,6 +198,7 @@ pub fn update_enterprise_user(state: Arc<AppState>) -> Tool {
             "Update an existing user in the Redis Enterprise cluster. \
              Only specified fields will be modified. Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateEnterpriseUserInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -248,8 +252,8 @@ pub struct DeleteEnterpriseUserInput {
 pub fn delete_enterprise_user(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_enterprise_user")
         .description(
-            "Delete a user from the Redis Enterprise cluster. \
-             WARNING: This permanently removes the user! Requires write permission.",
+            "DANGEROUS: Permanently deletes a user from the Redis Enterprise cluster. \
+             Active sessions using this user will be terminated. Requires write permission.",
         )
         .extractor_handler_typed::<_, _, _, DeleteEnterpriseUserInput>(
             state,
@@ -303,6 +307,7 @@ pub fn list_roles(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, ListRolesInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ListRolesInput>| async move {
@@ -342,6 +347,7 @@ pub fn get_role(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetRoleInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetRoleInput>| async move {
@@ -385,6 +391,7 @@ pub fn create_enterprise_role(state: Arc<AppState>) -> Tool {
             "Create a new role in the Redis Enterprise cluster. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateEnterpriseRoleInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -446,6 +453,7 @@ pub fn update_enterprise_role(state: Arc<AppState>) -> Tool {
             "Update an existing role in the Redis Enterprise cluster. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateEnterpriseRoleInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -496,8 +504,8 @@ pub struct DeleteEnterpriseRoleInput {
 pub fn delete_enterprise_role(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_enterprise_role")
         .description(
-            "Delete a role from the Redis Enterprise cluster. \
-             WARNING: This permanently removes the role! Requires write permission.",
+            "DANGEROUS: Permanently deletes a role from the Redis Enterprise cluster. \
+             Users assigned to this role will lose their permissions. Requires write permission.",
         )
         .extractor_handler_typed::<_, _, _, DeleteEnterpriseRoleInput>(
             state,
@@ -551,6 +559,7 @@ pub fn list_redis_acls(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, ListRedisAclsInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ListRedisAclsInput>| async move {
@@ -590,6 +599,7 @@ pub fn get_redis_acl(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetRedisAclInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetRedisAclInput>| async move {
@@ -633,6 +643,7 @@ pub fn create_enterprise_acl(state: Arc<AppState>) -> Tool {
              The ACL rule string follows Redis ACL syntax (e.g., \"+@all ~*\"). \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateEnterpriseAclInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -691,6 +702,7 @@ pub fn update_enterprise_acl(state: Arc<AppState>) -> Tool {
             "Update an existing Redis ACL in the Redis Enterprise cluster. \
              Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateEnterpriseAclInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -739,8 +751,8 @@ pub struct DeleteEnterpriseAclInput {
 pub fn delete_enterprise_acl(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_enterprise_acl")
         .description(
-            "Delete a Redis ACL from the Redis Enterprise cluster. \
-             WARNING: This permanently removes the ACL! Requires write permission.",
+            "DANGEROUS: Permanently deletes a Redis ACL from the cluster. \
+             Databases using this ACL will lose those access controls. Requires write permission.",
         )
         .extractor_handler_typed::<_, _, _, DeleteEnterpriseAclInput>(
             state,
@@ -794,6 +806,7 @@ pub fn get_enterprise_ldap_config(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetLdapConfigInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetLdapConfigInput>| async move {
@@ -832,6 +845,7 @@ pub fn update_enterprise_ldap_config(state: Arc<AppState>) -> Tool {
             "Update the LDAP configuration for the Redis Enterprise cluster. \
              Accepts a JSON object with LDAP settings. Requires write permission.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateLdapConfigInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -869,27 +883,27 @@ pub(super) const INSTRUCTIONS: &str = r#"
 ### Redis Enterprise - Users
 - list_enterprise_users: List cluster users
 - get_enterprise_user: Get user details
-- create_enterprise_user: Create a new user (write)
-- update_enterprise_user: Update user settings (write)
-- delete_enterprise_user: Delete a user (write)
+- create_enterprise_user: Create a new user [write]
+- update_enterprise_user: Update user settings [write]
+- delete_enterprise_user: Permanently delete a user [destructive]
 
 ### Redis Enterprise - Roles
 - list_enterprise_roles: List all roles in the cluster
 - get_enterprise_role: Get role details and permissions
-- create_enterprise_role: Create a new role (write)
-- update_enterprise_role: Update role settings (write)
-- delete_enterprise_role: Delete a role (write)
+- create_enterprise_role: Create a new role [write]
+- update_enterprise_role: Update role settings [write]
+- delete_enterprise_role: Permanently delete a role [destructive]
 
 ### Redis Enterprise - ACLs
 - list_enterprise_acls: List all Redis ACLs
 - get_enterprise_acl: Get ACL details and rules
-- create_enterprise_acl: Create a new ACL (write)
-- update_enterprise_acl: Update ACL rules (write)
-- delete_enterprise_acl: Delete an ACL (write)
+- create_enterprise_acl: Create a new ACL [write]
+- update_enterprise_acl: Update ACL rules [write]
+- delete_enterprise_acl: Permanently delete an ACL [destructive]
 
 ### Redis Enterprise - LDAP
 - get_enterprise_ldap_config: Get LDAP configuration
-- update_enterprise_ldap_config: Update LDAP configuration (write)
+- update_enterprise_ldap_config: Update LDAP configuration [write]
 "#;
 
 /// Build an MCP sub-router containing RBAC and LDAP tools

--- a/crates/redisctl-mcp/src/tools/redis/diagnostics.rs
+++ b/crates/redisctl-mcp/src/tools/redis/diagnostics.rs
@@ -105,6 +105,7 @@ pub fn health_check(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, HealthCheckInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<HealthCheckInput>| async move {
@@ -251,6 +252,7 @@ pub fn key_summary(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, KeySummaryInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<KeySummaryInput>| async move {
@@ -375,6 +377,7 @@ pub fn hotkeys(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, HotkeysInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<HotkeysInput>| async move {
@@ -521,6 +524,7 @@ pub fn connection_summary(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, ConnectionSummaryInput>(
             state,
             |State(state): State<Arc<AppState>>,

--- a/crates/redisctl-mcp/src/tools/redis/keys.rs
+++ b/crates/redisctl-mcp/src/tools/redis/keys.rs
@@ -24,9 +24,9 @@ pub(super) const INSTRUCTIONS: &str = "\
 - redis_object_idletime: Get key idle time in seconds\n\
 - redis_object_help: Get available OBJECT subcommands\n\
 - redis_set: Set key to string value with optional expiry and conditional flags [write]\n\
-- redis_del: Delete one or more keys [write]\n\
 - redis_expire: Set TTL on a key in seconds [write]\n\
 - redis_rename: Rename a key [write]\n\
+- redis_del: Permanently delete one or more keys [destructive]\n\
 ";
 
 /// Build a sub-router containing all key-level Redis tools
@@ -83,6 +83,7 @@ pub fn keys(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, KeysInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<KeysInput>| async move {
@@ -158,6 +159,7 @@ pub fn get(state: Arc<AppState>) -> Tool {
         .description("Get the value of a key from Redis")
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, GetInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetInput>| async move {
@@ -208,6 +210,7 @@ pub fn key_type(state: Arc<AppState>) -> Tool {
         .description("Get the type of a key (string, list, set, zset, hash, stream)")
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, TypeInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<TypeInput>| async move {
@@ -252,6 +255,7 @@ pub fn ttl(state: Arc<AppState>) -> Tool {
         .description("Get the time-to-live (TTL) of a key in seconds. Returns -1 if no expiry, -2 if key doesn't exist.")
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, TtlInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<TtlInput>| async move {
@@ -302,6 +306,7 @@ pub fn exists(state: Arc<AppState>) -> Tool {
         .description("Check if one or more keys exist. Returns the count of keys that exist.")
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, ExistsInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ExistsInput>| async move {
@@ -354,6 +359,7 @@ pub fn memory_usage(state: Arc<AppState>) -> Tool {
         .description("Get the memory usage of a key in bytes")
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, MemoryUsageInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<MemoryUsageInput>| async move {
@@ -415,6 +421,7 @@ pub fn scan(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, ScanInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ScanInput>| async move {
@@ -508,6 +515,7 @@ pub fn object_encoding(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, ObjectEncodingInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -563,6 +571,7 @@ pub fn object_freq(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, ObjectFreqInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ObjectFreqInput>| async move {
@@ -614,6 +623,7 @@ pub fn object_idletime(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, ObjectIdletimeInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -661,6 +671,7 @@ pub fn object_help(state: Arc<AppState>) -> Tool {
         .description("Get available OBJECT subcommands using OBJECT HELP")
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, ObjectHelpInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ObjectHelpInput>| async move {
@@ -726,6 +737,7 @@ pub fn set(state: Arc<AppState>) -> Tool {
              Use EX for seconds, PX for milliseconds expiry. Use NX to only set if \
              the key does not exist, XX to only set if it exists.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, SetInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<SetInput>| async move {
@@ -802,7 +814,10 @@ pub struct DelInput {
 /// Build the del tool
 pub fn del(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_del")
-        .description("Delete one or more keys. Returns the number of keys that were removed.")
+        .description(
+            "DANGEROUS: Permanently deletes one or more keys and their data. \
+             This action cannot be undone. Returns the number of keys removed.",
+        )
         .extractor_handler_typed::<_, _, _, DelInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<DelInput>| async move {
@@ -864,6 +879,7 @@ pub fn expire(state: Arc<AppState>) -> Tool {
             "Set a timeout on a key in seconds. The key will be automatically deleted \
              after the timeout expires. Returns whether the timeout was set.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, ExpireInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ExpireInput>| async move {
@@ -928,6 +944,7 @@ pub fn rename(state: Arc<AppState>) -> Tool {
             "Rename a key. Returns an error if the source key does not exist. \
              If the destination key already exists, it is overwritten.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, RenameInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<RenameInput>| async move {

--- a/crates/redisctl-mcp/src/tools/redis/server.rs
+++ b/crates/redisctl-mcp/src/tools/redis/server.rs
@@ -28,7 +28,7 @@ or a `url` parameter for direct connections. If neither is provided, the default
 - redis_acl_whoami: Get current authenticated username\n\
 - redis_module_list: List loaded modules\n\
 - redis_config_set: Set configuration parameter at runtime [write]\n\
-- redis_flushdb: Flush current database (DANGEROUS) [write]\n\
+- redis_flushdb: Permanently remove all data from the current database [destructive]\n\
 ";
 
 /// Build a sub-router containing all server-level Redis tools
@@ -67,6 +67,7 @@ pub fn ping(state: Arc<AppState>) -> Tool {
         .description("Test connectivity to a Redis database by sending a PING command")
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, PingInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<PingInput>| async move {
@@ -114,6 +115,7 @@ pub fn info(state: Arc<AppState>) -> Tool {
         .description("Get Redis server information using the INFO command")
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, InfoInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<InfoInput>| async move {
@@ -160,6 +162,7 @@ pub fn dbsize(state: Arc<AppState>) -> Tool {
         .description("Get the number of keys in the currently selected database")
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, DbsizeInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<DbsizeInput>| async move {
@@ -204,6 +207,7 @@ pub fn client_list(state: Arc<AppState>) -> Tool {
         .description("Get list of client connections to the Redis server")
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, ClientListInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ClientListInput>| async move {
@@ -250,6 +254,7 @@ pub fn cluster_info(state: Arc<AppState>) -> Tool {
         .description("Get Redis Cluster information (only works on cluster-enabled databases)")
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, ClusterInfoInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ClusterInfoInput>| async move {
@@ -301,6 +306,7 @@ pub fn slowlog(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, SlowlogInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<SlowlogInput>| async move {
@@ -374,6 +380,7 @@ pub fn config_get(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, ConfigGetInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ConfigGetInput>| async move {
@@ -437,6 +444,7 @@ pub fn memory_stats(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, MemoryStatsInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<MemoryStatsInput>| async move {
@@ -486,6 +494,7 @@ pub fn latency_history(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, LatencyHistoryInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -553,6 +562,7 @@ pub fn acl_list(state: Arc<AppState>) -> Tool {
         .description("List all ACL rules configured on the Redis server using ACL LIST")
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, AclListInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<AclListInput>| async move {
@@ -603,6 +613,7 @@ pub fn acl_whoami(state: Arc<AppState>) -> Tool {
         .description("Get the username of the current authenticated connection using ACL WHOAMI")
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, AclWhoamiInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<AclWhoamiInput>| async move {
@@ -645,6 +656,7 @@ pub fn module_list(state: Arc<AppState>) -> Tool {
         .description("List loaded Redis modules with their names and versions using MODULE LIST")
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, ModuleListInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ModuleListInput>| async move {
@@ -702,6 +714,7 @@ pub fn config_set(state: Arc<AppState>) -> Tool {
             "Set a Redis configuration parameter at runtime using CONFIG SET. \
              Changes may not persist across restarts unless CONFIG REWRITE is called.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, ConfigSetInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ConfigSetInput>| async move {

--- a/crates/redisctl-mcp/src/tools/redis/structures.rs
+++ b/crates/redisctl-mcp/src/tools/redis/structures.rs
@@ -82,6 +82,7 @@ pub fn hgetall(state: Arc<AppState>) -> Tool {
         .description("Get all fields and values from a hash")
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, HgetallInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<HgetallInput>| async move {
@@ -154,6 +155,7 @@ pub fn lrange(state: Arc<AppState>) -> Tool {
         .description("Get a range of elements from a list. Use start=0, stop=-1 for all elements.")
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, LrangeInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<LrangeInput>| async move {
@@ -219,6 +221,7 @@ pub fn smembers(state: Arc<AppState>) -> Tool {
         .description("Get all members of a set")
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, SmembersInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<SmembersInput>| async move {
@@ -284,6 +287,7 @@ pub fn zrange(state: Arc<AppState>) -> Tool {
         .description("Get a range of members from a sorted set by index. Use withscores=true to include scores.")
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, ZrangeInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ZrangeInput>| async move {
@@ -384,6 +388,7 @@ pub fn xinfo_stream(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, XinfoStreamInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<XinfoStreamInput>| async move {
@@ -453,6 +458,7 @@ pub fn xrange(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, XrangeInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<XrangeInput>| async move {
@@ -520,6 +526,7 @@ pub fn xlen(state: Arc<AppState>) -> Tool {
         .description("Get the number of entries in a stream using XLEN")
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, XlenInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<XlenInput>| async move {
@@ -571,6 +578,7 @@ pub fn pubsub_channels(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, PubsubChannelsInput>(
             state,
             |State(state): State<Arc<AppState>>,
@@ -634,6 +642,7 @@ pub fn pubsub_numsub(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, PubsubNumsubInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<PubsubNumsubInput>| async move {
@@ -705,6 +714,7 @@ pub fn hset(state: Arc<AppState>) -> Tool {
             "Set one or more field-value pairs in a hash. Creates the hash if it does not \
              exist. Returns the number of fields that were added (not updated).",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, HsetInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<HsetInput>| async move {
@@ -767,6 +777,7 @@ pub fn hdel(state: Arc<AppState>) -> Tool {
         .description(
             "Delete one or more fields from a hash. Returns the number of fields that were removed.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, HdelInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<HdelInput>| async move {
@@ -830,6 +841,7 @@ pub fn lpush(state: Arc<AppState>) -> Tool {
             "Push one or more elements to the head (left) of a list. Creates the list \
              if it does not exist. Returns the new list length.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, LpushInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<LpushInput>| async move {
@@ -893,6 +905,7 @@ pub fn rpush(state: Arc<AppState>) -> Tool {
             "Push one or more elements to the tail (right) of a list. Creates the list \
              if it does not exist. Returns the new list length.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, RpushInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<RpushInput>| async move {
@@ -957,6 +970,7 @@ pub fn lpop(state: Arc<AppState>) -> Tool {
             "Pop one or more elements from the head (left) of a list. Returns the \
              popped element(s), or nil if the list is empty.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, LpopInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<LpopInput>| async move {
@@ -1020,6 +1034,7 @@ pub fn rpop(state: Arc<AppState>) -> Tool {
             "Pop one or more elements from the tail (right) of a list. Returns the \
              popped element(s), or nil if the list is empty.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, RpopInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<RpopInput>| async move {
@@ -1082,6 +1097,7 @@ pub fn sadd(state: Arc<AppState>) -> Tool {
             "Add one or more members to a set. Creates the set if it does not exist. \
              Returns the number of members that were added (not already present).",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, SaddInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<SaddInput>| async move {
@@ -1145,6 +1161,7 @@ pub fn srem(state: Arc<AppState>) -> Tool {
             "Remove one or more members from a set. Returns the number of members \
              that were removed.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, SremInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<SremInput>| async move {
@@ -1233,6 +1250,7 @@ pub fn zadd(state: Arc<AppState>) -> Tool {
              does not exist. Supports NX (only add new), XX (only update existing), \
              GT/LT (score comparison), and CH (count changed) flags.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, ZaddInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ZaddInput>| async move {
@@ -1312,6 +1330,7 @@ pub fn zrem(state: Arc<AppState>) -> Tool {
             "Remove one or more members from a sorted set. Returns the number of \
              members that were removed.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, ZremInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ZremInput>| async move {
@@ -1391,6 +1410,7 @@ pub fn xadd(state: Arc<AppState>) -> Tool {
              Supports NOMKSTREAM, MAXLEN, and MINID trimming options. \
              Returns the ID of the added entry.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, XaddInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<XaddInput>| async move {
@@ -1480,6 +1500,7 @@ pub fn xtrim(state: Arc<AppState>) -> Tool {
              Use approximate=true for better performance with near-exact trimming. \
              Returns the number of entries removed.",
         )
+        .non_destructive()
         .extractor_handler_typed::<_, _, _, XtrimInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<XtrimInput>| async move {


### PR DESCRIPTION
## Summary

- Add MCP safety annotations across all 269 tools to make the safety model clear and explicit for AI agents managing Redis infrastructure. This is PR 1 of 4 for #610 (MCP Safeguards and Rate Limiting). Zero behavior change -- all changes are metadata, documentation, and tests.

## Scope

- Affected areas (crates/paths):
  - `crates/redisctl-mcp/src/main.rs` -- safety model preamble, dynamic tier, 26 annotation tests
  - `crates/redisctl-mcp/src/tools/cloud/` -- all 4 submodules (subscriptions, account, networking, fixed)
  - `crates/redisctl-mcp/src/tools/enterprise/` -- all 4 submodules (cluster, databases, rbac, observability)
  - `crates/redisctl-mcp/src/tools/redis/` -- all 4 submodules (server, keys, structures, diagnostics)
  - `crates/redisctl-mcp/src/tools/profile.rs`
- API surface changes: None (annotations are metadata only)
- Docs/tests updates: 26 new annotation verification tests

## Checklist

- [x] Draft PR opened early; incremental commits pushed
- [x] Scope and plan documented in this description
- [x] Tests added/updated; both success and error cases covered
- [x] Docs updated (lib/module overviews, examples)
- [x] cargo fmt, clippy (-D warnings), tests pass locally
- [ ] CI status is green
- [ ] Ready for review (remove Draft)
- [ ] Squash and merge when approved

## Links

- Related issues (Fixes #610 -- PR 1 of 4):
- Follow-ups: PR 2 (destructive blocking + granular filtering), PR 3 (audit logging), PR 4 (rate limiting)

## Plan & Progress

- [x] Add `.non_destructive()` to all 142 read-only tools
- [x] Add `.non_destructive()` to 98 non-destructive write tools
- [x] Prefix 29 destructive tool descriptions with `DANGEROUS:`
- [x] Normalize INSTRUCTIONS tags: (no tag) = read-only, `[write]` = non-destructive, `[destructive]` = destructive
- [x] Rewrite server instructions preamble with Safety Model section + dynamic safety tier
- [x] Add 26 annotation verification tests covering profile, cloud, enterprise, and redis categories