### PR TITLE
feat(mcp): migrate to tower-mcp 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4165,9 +4165,9 @@ checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-mcp"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a65dc3cd2b853a0aa855ebd2d8d353a21c8351573758339d4ba4e323622977a0"
+checksum = "d1017efd62d6f26270d93e32c5908e22547da8eeb9cfbaf6ca5b037305e55581"
 dependencies = [
  "async-trait",
  "axum",

--- a/crates/redisctl-mcp/Cargo.toml
+++ b/crates/redisctl-mcp/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 # MCP framework
-tower-mcp = { version = "0.5.0", features = ["http", "oauth"] }
+tower-mcp = { version = "0.7.0", features = ["http", "oauth"] }
 schemars = "1.2"
 
 # Internal crates

--- a/crates/redisctl-mcp/src/prompts.rs
+++ b/crates/redisctl-mcp/src/prompts.rs
@@ -58,8 +58,11 @@ Based on the results and the reported symptoms, identify the root cause and sugg
                     content: Content::Text {
                         text: prompt_text,
                         annotations: None,
+                        meta: None,
                     },
+                    meta: None,
                 }],
+                meta: None,
             })
         })
         .build()
@@ -116,8 +119,11 @@ Provide actionable recommendations with expected impact."#,
                     content: Content::Text {
                         text: prompt_text,
                         annotations: None,
+                        meta: None,
                     },
+                    meta: None,
                 }],
+                meta: None,
             })
         })
         .build()
@@ -172,8 +178,11 @@ Please help me by:
                     content: Content::Text {
                         text: prompt_text,
                         annotations: None,
+                        meta: None,
                     },
+                    meta: None,
                 }],
+                meta: None,
             })
         })
         .build()
@@ -227,8 +236,11 @@ Please help me create a migration plan by:
                     content: Content::Text {
                         text: prompt_text,
                         annotations: None,
+                        meta: None,
                     },
+                    meta: None,
                 }],
+                meta: None,
             })
         })
         .build()

--- a/crates/redisctl-mcp/src/resources.rs
+++ b/crates/redisctl-mcp/src/resources.rs
@@ -23,7 +23,9 @@ pub fn config_path_resource() -> Resource {
                     mime_type: Some("text/plain".to_string()),
                     text: Some(path),
                     blob: None,
+                    meta: None,
                 }],
+                meta: None,
             })
         })
         .build()
@@ -55,7 +57,9 @@ pub fn profiles_resource() -> Resource {
                     mime_type: Some("application/json".to_string()),
                     text: Some(profiles),
                     blob: None,
+                    meta: None,
                 }],
+                meta: None,
             })
         })
         .build()

--- a/crates/redisctl-mcp/src/tools/cloud/mod.rs
+++ b/crates/redisctl-mcp/src/tools/cloud/mod.rs
@@ -14,26 +14,11 @@ pub use networking::*;
 #[allow(unused_imports)]
 pub use subscriptions::*;
 
-use std::sync::{Arc, LazyLock};
+use std::sync::Arc;
 
 use tower_mcp::McpRouter;
 
 use crate::state::AppState;
-
-static INSTRUCTIONS: LazyLock<String> = LazyLock::new(|| {
-    [
-        subscriptions::INSTRUCTIONS,
-        account::INSTRUCTIONS,
-        networking::INSTRUCTIONS,
-        fixed::INSTRUCTIONS,
-    ]
-    .concat()
-});
-
-/// Instructions text describing all Cloud tools
-pub fn instructions() -> &'static str {
-    &INSTRUCTIONS
-}
 
 /// Build an MCP sub-router containing all Cloud tools
 pub fn router(state: Arc<AppState>) -> McpRouter {

--- a/crates/redisctl-mcp/src/tools/enterprise/mod.rs
+++ b/crates/redisctl-mcp/src/tools/enterprise/mod.rs
@@ -14,26 +14,11 @@ pub use observability::*;
 #[allow(unused_imports)]
 pub use rbac::*;
 
-use std::sync::{Arc, LazyLock};
+use std::sync::Arc;
 
 use tower_mcp::McpRouter;
 
 use crate::state::AppState;
-
-static INSTRUCTIONS: LazyLock<String> = LazyLock::new(|| {
-    [
-        cluster::INSTRUCTIONS,
-        databases::INSTRUCTIONS,
-        rbac::INSTRUCTIONS,
-        observability::INSTRUCTIONS,
-    ]
-    .concat()
-});
-
-/// Instructions text describing all Enterprise tools
-pub fn instructions() -> &'static str {
-    &INSTRUCTIONS
-}
 
 /// Build an MCP sub-router containing all Enterprise tools
 pub fn router(state: Arc<AppState>) -> McpRouter {

--- a/crates/redisctl-mcp/src/tools/redis/mod.rs
+++ b/crates/redisctl-mcp/src/tools/redis/mod.rs
@@ -14,26 +14,11 @@ pub use server::*;
 #[allow(unused_imports)]
 pub use structures::*;
 
-use std::sync::{Arc, LazyLock};
+use std::sync::Arc;
 
 use tower_mcp::{McpRouter, ToolError};
 
 use crate::state::AppState;
-
-static INSTRUCTIONS: LazyLock<String> = LazyLock::new(|| {
-    [
-        server::INSTRUCTIONS,
-        keys::INSTRUCTIONS,
-        structures::INSTRUCTIONS,
-        diagnostics::INSTRUCTIONS,
-    ]
-    .concat()
-});
-
-/// Instructions text describing all Redis database tools
-pub fn instructions() -> &'static str {
-    &INSTRUCTIONS
-}
 
 /// Resolve a Redis URL from the provided inputs.
 ///


### PR DESCRIPTION
## Summary

- Bump tower-mcp 0.5.0 -> 0.7.0 and adopt its new ergonomic APIs across all 142 MCP tools
- Replace `.read_only().idempotent().non_destructive()` chains with `.read_only_safe()` (142 tools)
- Add explicit `.destructive()` annotations to 29 destructive tools (previously relied on `annotations: None`)
- Replace ~380 `.map_err(|e| ToolError::new(format!(...)))` sites with `.tool_context()`
- Replace 13 manual `INSTRUCTIONS` constants + `LazyLock` assembly with `auto_instructions_with(prefix, suffix)`
- Migrate `CapabilityFilter::new(closure)` to `CapabilityFilter::write_guard()`
- Simplify `assert_destructive` test helper now that destructive tools have explicit annotations
- Net -1039 lines across 21 files

Closes #747

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p redisctl-mcp --all-features -- -D warnings`
- [x] `cargo test --lib -p redisctl-mcp --all-features` (17/17 pass)
- [x] `cargo test --bin redisctl-mcp --all-features` (26/26 pass)
- [x] `cargo check -p redisctl-mcp --no-default-features`
- [x] `cargo check -p redisctl-mcp --features cloud`
- [x] `cargo check -p redisctl-mcp --features enterprise`
- [x] `cargo check -p redisctl-mcp --features database`