### PR TITLE
feat(cli): add command aliases and improve help organization

### DIFF
--- a/crates/redisctl/src/cli/cloud.rs
+++ b/crates/redisctl/src/cli/cloud.rs
@@ -1537,25 +1537,45 @@ pub enum CloudProviderAccountCommands {
 
 /// Cloud-specific commands
 #[derive(Subcommand, Debug)]
+#[command(after_long_help = "\
+COMMAND GROUPS:
+  Core:       database (db), subscription (sub), fixed-database (fixed-db),
+              fixed-subscription (fixed-sub)
+  Access:     user, acl
+  Billing:    account (acct), payment-method, cost-report
+  Networking: connectivity (conn), provider-account
+  Operations: task, workflow
+
+Aliases shown in parentheses (e.g. 'cloud db list' instead of 'cloud database list').")]
 pub enum CloudCommands {
-    // -- Core (display_order 1-9) --
+    // -- Core --
     /// Database operations
-    #[command(subcommand, display_order = 1)]
+    #[command(subcommand, display_order = 1, visible_alias = "db")]
     Database(CloudDatabaseCommands),
 
     /// Subscription operations
-    #[command(subcommand, display_order = 2)]
+    #[command(subcommand, display_order = 2, visible_alias = "sub")]
     Subscription(CloudSubscriptionCommands),
 
     /// Fixed database operations (Essentials)
-    #[command(subcommand, name = "fixed-database", display_order = 3)]
+    #[command(
+        subcommand,
+        name = "fixed-database",
+        display_order = 3,
+        visible_alias = "fixed-db"
+    )]
     FixedDatabase(CloudFixedDatabaseCommands),
 
     /// Fixed subscription operations (Essentials)
-    #[command(subcommand, name = "fixed-subscription", display_order = 4)]
+    #[command(
+        subcommand,
+        name = "fixed-subscription",
+        display_order = 4,
+        visible_alias = "fixed-sub"
+    )]
     FixedSubscription(CloudFixedSubscriptionCommands),
 
-    // -- Access Control (display_order 10-19) --
+    // -- Access Control --
     /// User operations
     #[command(subcommand, display_order = 10)]
     User(CloudUserCommands),
@@ -1564,9 +1584,9 @@ pub enum CloudCommands {
     #[command(subcommand, display_order = 11)]
     Acl(CloudAclCommands),
 
-    // -- Billing (display_order 20-29) --
+    // -- Billing --
     /// Account operations
-    #[command(subcommand, display_order = 20)]
+    #[command(subcommand, display_order = 20, visible_alias = "acct")]
     Account(CloudAccountCommands),
 
     /// Payment method operations
@@ -1577,16 +1597,16 @@ pub enum CloudCommands {
     #[command(subcommand, name = "cost-report", display_order = 22)]
     CostReport(CloudCostReportCommands),
 
-    // -- Networking (display_order 30-39) --
+    // -- Networking --
     /// Network connectivity operations (VPC, PSC, TGW)
-    #[command(subcommand, display_order = 30)]
+    #[command(subcommand, display_order = 30, visible_alias = "conn")]
     Connectivity(CloudConnectivityCommands),
 
     /// Cloud provider account operations
     #[command(subcommand, name = "provider-account", display_order = 31)]
     ProviderAccount(CloudProviderAccountCommands),
 
-    // -- Operations (display_order 40+) --
+    // -- Operations --
     /// Task operations
     #[command(subcommand, display_order = 40)]
     Task(CloudTaskCommands),

--- a/crates/redisctl/src/cli/enterprise.rs
+++ b/crates/redisctl/src/cli/enterprise.rs
@@ -3,10 +3,22 @@
 use clap::Subcommand;
 
 #[derive(Subcommand, Debug)]
+#[command(after_long_help = "\
+COMMAND GROUPS:
+  Core:          database (db), cluster, node, shard, endpoint
+  Access:        user, role, acl, ldap, ldap-mappings, auth
+  Monitoring:    stats, status, alerts (alert), logs (log), diagnostics (diag),
+                 debug-info
+  Admin:         license (lic), module, proxy, services (svc), cm-settings, suffix
+  Advanced:      crdb, crdb-task, bdb-group, migration, bootstrap, job-scheduler
+  Troubleshoot:  support-package, ocsp, usage-report, local
+  Other:         action, jsonschema, workflow
+
+Aliases shown in parentheses (e.g. 'enterprise db list' instead of 'enterprise database list').")]
 pub enum EnterpriseCommands {
-    // -- Core Operations (display_order 1-9) --
+    // -- Core Operations --
     /// Database operations
-    #[command(subcommand, display_order = 1)]
+    #[command(subcommand, display_order = 1, visible_alias = "db")]
     Database(EnterpriseDatabaseCommands),
 
     /// Cluster operations
@@ -25,7 +37,7 @@ pub enum EnterpriseCommands {
     #[command(subcommand, display_order = 5)]
     Endpoint(crate::commands::enterprise::endpoint::EndpointCommands),
 
-    // -- Access Control (display_order 10-19) --
+    // -- Access Control --
     /// User operations
     #[command(subcommand, display_order = 10)]
     User(EnterpriseUserCommands),
@@ -46,11 +58,11 @@ pub enum EnterpriseCommands {
     #[command(subcommand, name = "ldap-mappings", display_order = 14)]
     LdapMappings(crate::commands::enterprise::ldap::LdapMappingsCommands),
 
-    /// Authentication & sessions
+    /// Authentication and sessions
     #[command(subcommand, display_order = 15)]
     Auth(EnterpriseAuthCommands),
 
-    // -- Monitoring (display_order 20-29) --
+    // -- Monitoring --
     /// Statistics and metrics operations
     #[command(subcommand, display_order = 20)]
     Stats(EnterpriseStatsCommands),
@@ -80,24 +92,24 @@ pub enum EnterpriseCommands {
     },
 
     /// Alert management operations
-    #[command(subcommand, display_order = 22)]
+    #[command(subcommand, display_order = 22, visible_alias = "alert")]
     Alerts(crate::commands::enterprise::alerts::AlertsCommands),
 
     /// Log operations
-    #[command(subcommand, display_order = 23)]
+    #[command(subcommand, display_order = 23, visible_alias = "log")]
     Logs(crate::commands::enterprise::logs::LogsCommands),
 
     /// Diagnostics operations
-    #[command(subcommand, display_order = 24)]
+    #[command(subcommand, display_order = 24, visible_alias = "diag")]
     Diagnostics(crate::commands::enterprise::diagnostics::DiagnosticsCommands),
 
     /// Debug info collection
     #[command(subcommand, display_order = 25)]
     DebugInfo(crate::commands::enterprise::debuginfo::DebugInfoCommands),
 
-    // -- Administration (display_order 30-39) --
+    // -- Administration --
     /// License management
-    #[command(subcommand, display_order = 30)]
+    #[command(subcommand, display_order = 30, visible_alias = "lic")]
     License(crate::commands::enterprise::license::LicenseCommands),
 
     /// Module management operations
@@ -109,7 +121,7 @@ pub enum EnterpriseCommands {
     Proxy(crate::commands::enterprise::proxy::ProxyCommands),
 
     /// Service management
-    #[command(subcommand, display_order = 33)]
+    #[command(subcommand, display_order = 33, visible_alias = "svc")]
     Services(crate::commands::enterprise::services::ServicesCommands),
 
     /// Cluster manager settings
@@ -120,7 +132,7 @@ pub enum EnterpriseCommands {
     #[command(subcommand, display_order = 35)]
     Suffix(crate::commands::enterprise::suffix::SuffixCommands),
 
-    // -- Advanced (display_order 40-49) --
+    // -- Advanced --
     /// Active-Active database (CRDB) operations
     #[command(subcommand, display_order = 40)]
     Crdb(EnterpriseCrdbCommands),
@@ -145,7 +157,7 @@ pub enum EnterpriseCommands {
     #[command(subcommand, name = "job-scheduler", display_order = 45)]
     JobScheduler(crate::commands::enterprise::job_scheduler::JobSchedulerCommands),
 
-    // -- Troubleshooting (display_order 50-59) --
+    // -- Troubleshooting --
     /// Support package generation for troubleshooting
     #[command(subcommand, name = "support-package", display_order = 50)]
     SupportPackage(crate::commands::enterprise::support_package::SupportPackageCommands),
@@ -162,7 +174,7 @@ pub enum EnterpriseCommands {
     #[command(subcommand, display_order = 53)]
     Local(crate::commands::enterprise::local::LocalCommands),
 
-    // -- Other (display_order 60+) --
+    // -- Other --
     /// Action (task) operations
     #[command(subcommand, display_order = 60)]
     Action(crate::commands::enterprise::actions::ActionCommands),

--- a/crates/redisctl/src/cli/mod.rs
+++ b/crates/redisctl/src/cli/mod.rs
@@ -201,10 +201,11 @@ pub enum Commands {
     #[command(subcommand, visible_alias = "cl")]
     #[command(before_long_help = "\
 COMMAND GROUPS:
-  Core:       database, subscription, fixed-database, fixed-subscription
+  Core:       database (db), subscription (sub), fixed-database (fixed-db),
+              fixed-subscription (fixed-sub)
   Access:     user, acl
-  Billing:    account, payment-method, cost-report
-  Networking: connectivity, provider-account
+  Billing:    account (acct), payment-method, cost-report
+  Networking: connectivity (conn), provider-account
   Operations: task, workflow")]
     #[command(after_help = "\
 PROFILE REQUIREMENT:
@@ -217,10 +218,11 @@ PROFILE REQUIREMENT:
     #[command(subcommand, visible_alias = "ent", visible_alias = "en")]
     #[command(before_long_help = "\
 COMMAND GROUPS:
-  Core:          database, cluster, node, shard, endpoint
+  Core:          database (db), cluster, node, shard, endpoint
   Access:        user, role, acl, ldap, ldap-mappings, auth
-  Monitoring:    stats, status, alerts, logs, diagnostics, debug-info
-  Admin:         license, module, proxy, services, cm-settings, suffix
+  Monitoring:    stats, status, alerts (alert), logs (log), diagnostics (diag),
+                 debug-info
+  Admin:         license (lic), module, proxy, services (svc), cm-settings, suffix
   Advanced:      crdb, crdb-task, bdb-group, migration, bootstrap, job-scheduler
   Troubleshoot:  support-package, ocsp, usage-report, local
   Other:         action, jsonschema, workflow")]


### PR DESCRIPTION
## Summary
- Add `visible_alias` attributes for commonly used commands (`db`, `sub`, `acct`, `diag`, etc.)
- Add `after_long_help` to Cloud and Enterprise command enums showing grouped command summaries with aliases
- Update top-level `before_long_help` to include alias information

## Aliases added

**Cloud:** `db` (database), `sub` (subscription), `fixed-db` (fixed-database), `fixed-sub` (fixed-subscription), `acct` (account), `conn` (connectivity)

**Enterprise:** `db` (database), `alert` (alerts), `log` (logs), `diag` (diagnostics), `lic` (license), `svc` (services)

## Note on help_heading

Clap 4.x does not support grouping subcommands into multiple heading sections via the derive API. `help_heading` only works on `#[arg]`, not `#[command]`. Instead, this uses `after_long_help` to provide a grouped command reference that appears in `--help` output, complementing the existing `display_order` visual grouping.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p redisctl --all-features -- -D warnings`
- [x] `cargo test --lib -p redisctl --all-features` (67 tests pass)
- [x] `cargo doc -p redisctl --no-deps --all-features`

Closes #665
Closes #751