### PR TITLE
feat(cli): add --dry-run to write operations

### DIFF
--- a/crates/redisctl/src/cli/cloud.rs
+++ b/crates/redisctl/src/cli/cloud.rs
@@ -1927,6 +1927,10 @@ NOTE: Subscription creation requires complex nested structures for cloud provide
         #[arg(long)]
         data: Option<String>,
 
+        /// Dry run - validate without applying changes
+        #[arg(long)]
+        dry_run: bool,
+
         /// Async operation options
         #[command(flatten)]
         async_ops: crate::commands::cloud::async_utils::AsyncOperationArgs,
@@ -1939,6 +1943,9 @@ NOTE: Subscription creation requires complex nested structures for cloud provide
         /// Skip confirmation prompt
         #[arg(long)]
         force: bool,
+        /// Dry run - show what would be deleted without deleting
+        #[arg(long)]
+        dry_run: bool,
         /// Async operation options
         #[command(flatten)]
         async_ops: crate::commands::cloud::async_utils::AsyncOperationArgs,
@@ -2229,6 +2236,10 @@ pub enum CloudDatabaseCommands {
         #[arg(long)]
         data: Option<String>,
 
+        /// Dry run - validate without creating the database
+        #[arg(long)]
+        dry_run: bool,
+
         /// Async operation options
         #[command(flatten)]
         async_ops: crate::commands::cloud::async_utils::AsyncOperationArgs,
@@ -2299,6 +2310,10 @@ pub enum CloudDatabaseCommands {
         #[arg(long)]
         data: Option<String>,
 
+        /// Dry run - validate without applying changes
+        #[arg(long)]
+        dry_run: bool,
+
         /// Async operation options
         #[command(flatten)]
         async_ops: crate::commands::cloud::async_utils::AsyncOperationArgs,
@@ -2311,6 +2326,9 @@ pub enum CloudDatabaseCommands {
         /// Skip confirmation prompt
         #[arg(long)]
         force: bool,
+        /// Dry run - show what would be deleted without deleting
+        #[arg(long)]
+        dry_run: bool,
         /// Async operation options
         #[command(flatten)]
         async_ops: crate::commands::cloud::async_utils::AsyncOperationArgs,

--- a/crates/redisctl/src/cli/enterprise.rs
+++ b/crates/redisctl/src/cli/enterprise.rs
@@ -342,6 +342,9 @@ pub enum EnterpriseClusterCommands {
         /// Bootstrap configuration (JSON file or inline, overridden by other flags)
         #[arg(long, value_name = "FILE|JSON")]
         data: Option<String>,
+        /// Dry run - show bootstrap config without applying
+        #[arg(long)]
+        dry_run: bool,
     },
 
     /// Join node to cluster
@@ -698,6 +701,10 @@ NOTE: First-class parameters override values in --data when both are provided.")
         /// Advanced: Full update configuration as JSON string or @file.json
         #[arg(long)]
         data: Option<String>,
+
+        /// Dry run - show what would be changed without applying
+        #[arg(long)]
+        dry_run: bool,
     },
 
     /// Delete a database
@@ -707,6 +714,9 @@ NOTE: First-class parameters override values in --data when both are provided.")
         /// Skip confirmation prompt
         #[arg(long)]
         force: bool,
+        /// Dry run - show what would be deleted without deleting
+        #[arg(long)]
+        dry_run: bool,
     },
 
     /// Watch database status changes in real-time

--- a/crates/redisctl/src/commands/cloud/database.rs
+++ b/crates/redisctl/src/commands/cloud/database.rs
@@ -61,6 +61,7 @@ pub async fn handle_database_command(
             oss_cluster,
             port,
             data,
+            dry_run,
             async_ops,
         } => {
             super::database_impl::create_database(
@@ -78,6 +79,7 @@ pub async fn handle_database_command(
                 *oss_cluster,
                 *port,
                 data.as_deref(),
+                *dry_run,
                 async_ops,
                 output_format,
                 query,
@@ -94,6 +96,7 @@ pub async fn handle_database_command(
             oss_cluster,
             regex_rules,
             data,
+            dry_run,
             async_ops,
         } => {
             super::database_impl::update_database(
@@ -108,6 +111,7 @@ pub async fn handle_database_command(
                 *oss_cluster,
                 regex_rules.as_deref(),
                 data.as_deref(),
+                *dry_run,
                 async_ops,
                 output_format,
                 query,
@@ -117,6 +121,7 @@ pub async fn handle_database_command(
         CloudDatabaseCommands::Delete {
             id,
             force,
+            dry_run,
             async_ops,
         } => {
             super::database_impl::delete_database(
@@ -124,6 +129,7 @@ pub async fn handle_database_command(
                 profile_name,
                 id,
                 *force,
+                *dry_run,
                 async_ops,
                 output_format,
                 query,

--- a/crates/redisctl/src/commands/cloud/database_impl.rs
+++ b/crates/redisctl/src/commands/cloud/database_impl.rs
@@ -93,13 +93,15 @@ pub async fn create_database(
     oss_cluster: bool,
     port: Option<i32>,
     data: Option<&str>,
+    dry_run: bool,
     async_ops: &AsyncOperationArgs,
     output_format: OutputFormat,
     query: Option<&str>,
 ) -> CliResult<()> {
     // Use Layer 2 workflow for simple cases with --wait
-    // Fall back to legacy for: --data, --dataset-size, advanced options
+    // Fall back to legacy for: --data, --dataset-size, advanced options, --dry-run
     let use_layer2 = async_ops.wait
+        && !dry_run
         && data.is_none()
         && dataset_size.is_none()
         && eviction_policy == "volatile-lru"
@@ -140,6 +142,7 @@ pub async fn create_database(
             oss_cluster,
             port,
             data,
+            dry_run,
             async_ops,
             output_format,
             query,
@@ -283,6 +286,7 @@ async fn create_database_legacy(
     oss_cluster: bool,
     port: Option<i32>,
     data: Option<&str>,
+    dry_run: bool,
     async_ops: &AsyncOperationArgs,
     output_format: OutputFormat,
     query: Option<&str>,
@@ -359,6 +363,10 @@ async fn create_database_legacy(
         request_obj.insert("port".to_string(), json!(port_val));
     }
 
+    if dry_run {
+        request_obj.insert("dryRun".to_string(), json!(true));
+    }
+
     let response = client
         .post_raw(
             &format!("/subscriptions/{}/databases", subscription_id),
@@ -393,14 +401,15 @@ pub async fn update_database(
     oss_cluster: Option<bool>,
     regex_rules: Option<&str>,
     data: Option<&str>,
+    dry_run: bool,
     async_ops: &AsyncOperationArgs,
     output_format: OutputFormat,
     query: Option<&str>,
 ) -> CliResult<()> {
     let (subscription_id, database_id) = parse_database_id(id)?;
 
-    // Use Layer 2 workflow for simple cases with --wait (no --data, no regex_rules)
-    let use_layer2 = async_ops.wait && data.is_none() && regex_rules.is_none();
+    // Use Layer 2 workflow for simple cases with --wait (no --data, no regex_rules, no --dry-run)
+    let use_layer2 = async_ops.wait && !dry_run && data.is_none() && regex_rules.is_none();
 
     if use_layer2 {
         update_database_with_workflow(
@@ -433,6 +442,7 @@ pub async fn update_database(
             oss_cluster,
             regex_rules,
             data,
+            dry_run,
             async_ops,
             output_format,
             query,
@@ -579,6 +589,7 @@ async fn update_database_legacy(
     oss_cluster: Option<bool>,
     regex_rules: Option<&str>,
     data: Option<&str>,
+    dry_run: bool,
     async_ops: &AsyncOperationArgs,
     output_format: OutputFormat,
     query: Option<&str>,
@@ -630,6 +641,10 @@ async fn update_database_legacy(
         });
     }
 
+    if dry_run {
+        request_obj.insert("dryRun".to_string(), json!(true));
+    }
+
     let response = client
         .put_raw(
             &format!(
@@ -654,16 +669,28 @@ async fn update_database_legacy(
 }
 
 /// Delete a database
+#[allow(clippy::too_many_arguments)]
 pub async fn delete_database(
     conn_mgr: &ConnectionManager,
     profile_name: Option<&str>,
     id: &str,
     force: bool,
+    dry_run: bool,
     async_ops: &AsyncOperationArgs,
     output_format: OutputFormat,
     query: Option<&str>,
 ) -> CliResult<()> {
     let (subscription_id, database_id) = parse_database_id(id)?;
+
+    if dry_run {
+        eprintln!(
+            "Would delete database {} in subscription {}.",
+            database_id, subscription_id
+        );
+        eprintln!();
+        eprintln!("No changes were made.");
+        return Ok(());
+    }
 
     // Confirmation prompt unless --force is used
     if !force {

--- a/crates/redisctl/src/commands/cloud/subscription.rs
+++ b/crates/redisctl/src/commands/cloud/subscription.rs
@@ -83,6 +83,7 @@ pub async fn handle_subscription_command(
             payment_method,
             payment_method_id,
             data,
+            dry_run,
             async_ops,
         } => {
             subscription_impl::update_subscription(
@@ -93,6 +94,7 @@ pub async fn handle_subscription_command(
                 payment_method.as_deref(),
                 *payment_method_id,
                 data.as_deref(),
+                *dry_run,
                 async_ops,
                 output_format,
                 query,
@@ -102,6 +104,7 @@ pub async fn handle_subscription_command(
         CloudSubscriptionCommands::Delete {
             id,
             force,
+            dry_run,
             async_ops,
         } => {
             subscription_impl::delete_subscription(
@@ -109,6 +112,7 @@ pub async fn handle_subscription_command(
                 profile_name,
                 *id,
                 *force,
+                *dry_run,
                 async_ops,
                 output_format,
                 query,

--- a/crates/redisctl/src/commands/cloud/subscription_impl.rs
+++ b/crates/redisctl/src/commands/cloud/subscription_impl.rs
@@ -158,6 +158,7 @@ pub async fn update_subscription(
     payment_method: Option<&str>,
     payment_method_id: Option<i32>,
     data: Option<&str>,
+    dry_run: bool,
     async_ops: &AsyncOperationArgs,
     output_format: OutputFormat,
     query: Option<&str>,
@@ -193,6 +194,10 @@ pub async fn update_subscription(
         });
     }
 
+    if dry_run {
+        request_obj.insert("dryRun".to_string(), serde_json::json!(true));
+    }
+
     let response = client
         .put_raw(&format!("/subscriptions/{}", id), request)
         .await
@@ -211,15 +216,24 @@ pub async fn update_subscription(
 }
 
 /// Delete a subscription
+#[allow(clippy::too_many_arguments)]
 pub async fn delete_subscription(
     conn_mgr: &ConnectionManager,
     profile_name: Option<&str>,
     id: u32,
     force: bool,
+    dry_run: bool,
     async_ops: &AsyncOperationArgs,
     output_format: OutputFormat,
     query: Option<&str>,
 ) -> CliResult<()> {
+    if dry_run {
+        eprintln!("Would delete subscription {}.", id);
+        eprintln!();
+        eprintln!("No changes were made.");
+        return Ok(());
+    }
+
     // Confirmation prompt unless --force is used
     if !force {
         use dialoguer::Confirm;

--- a/crates/redisctl/src/commands/enterprise/cluster.rs
+++ b/crates/redisctl/src/commands/enterprise/cluster.rs
@@ -81,6 +81,7 @@ pub async fn handle_cluster_command(
             username,
             password,
             data,
+            dry_run,
         } => {
             cluster_impl::bootstrap_cluster(
                 conn_mgr,
@@ -89,6 +90,7 @@ pub async fn handle_cluster_command(
                 username.as_deref(),
                 password.as_deref(),
                 data.as_deref(),
+                *dry_run,
                 output_format,
                 query,
             )

--- a/crates/redisctl/src/commands/enterprise/cluster_impl.rs
+++ b/crates/redisctl/src/commands/enterprise/cluster_impl.rs
@@ -232,6 +232,7 @@ pub async fn bootstrap_cluster(
     username: Option<&str>,
     password: Option<&str>,
     data: Option<&str>,
+    dry_run: bool,
     output_format: OutputFormat,
     query: Option<&str>,
 ) -> CliResult<()> {
@@ -296,6 +297,17 @@ pub async fn bootstrap_cluster(
         return Err(RedisCtlError::InvalidInput {
             message: "Bootstrap requires --cluster-name, --username, and --password (or equivalent in --data)".to_string()
         });
+    }
+
+    if dry_run {
+        eprintln!("Would bootstrap cluster with:");
+        eprintln!(
+            "{}",
+            serde_json::to_string_pretty(&bootstrap_data).unwrap_or_default()
+        );
+        eprintln!();
+        eprintln!("No changes were made.");
+        return Ok(());
     }
 
     // Use raw API since BootstrapRequest doesn't have Deserialize trait

--- a/crates/redisctl/src/commands/enterprise/database.rs
+++ b/crates/redisctl/src/commands/enterprise/database.rs
@@ -72,6 +72,7 @@ pub async fn handle_database_command(
             proxy_policy,
             redis_password,
             data,
+            dry_run,
         } => {
             database_impl::update_database(
                 conn_mgr,
@@ -86,17 +87,19 @@ pub async fn handle_database_command(
                 proxy_policy.as_deref(),
                 redis_password.as_deref(),
                 data.as_deref(),
+                *dry_run,
                 output_format,
                 query,
             )
             .await
         }
-        EnterpriseDatabaseCommands::Delete { id, force } => {
+        EnterpriseDatabaseCommands::Delete { id, force, dry_run } => {
             database_impl::delete_database(
                 conn_mgr,
                 profile_name,
                 *id,
                 *force,
+                *dry_run,
                 output_format,
                 query,
             )

--- a/crates/redisctl/src/commands/enterprise/database_impl.rs
+++ b/crates/redisctl/src/commands/enterprise/database_impl.rs
@@ -313,6 +313,7 @@ pub async fn update_database(
     proxy_policy: Option<&str>,
     redis_password: Option<&str>,
     data: Option<&str>,
+    dry_run: bool,
     output_format: OutputFormat,
     query: Option<&str>,
 ) -> CliResult<()> {
@@ -370,6 +371,17 @@ pub async fn update_database(
         });
     }
 
+    if dry_run {
+        eprintln!("Would update database {} with:", id);
+        eprintln!(
+            "{}",
+            serde_json::to_string_pretty(&request).unwrap_or_default()
+        );
+        eprintln!();
+        eprintln!("No changes were made.");
+        return Ok(());
+    }
+
     let response = client
         .put_raw(&format!("/v1/bdbs/{}", id), request)
         .await
@@ -386,9 +398,17 @@ pub async fn delete_database(
     profile_name: Option<&str>,
     id: u32,
     force: bool,
+    dry_run: bool,
     output_format: OutputFormat,
     query: Option<&str>,
 ) -> CliResult<()> {
+    if dry_run {
+        eprintln!("Would delete database {}.", id);
+        eprintln!();
+        eprintln!("No changes were made.");
+        return Ok(());
+    }
+
     if !force && !confirm_action(&format!("Delete database {}?", id))? {
         println!("Operation cancelled");
         return Ok(());


### PR DESCRIPTION
## Summary

- Add `--dry-run` flag to 8 priority write commands per #752
- Server-side dry-run for cloud create/update operations (inserts `"dryRun": true` into API request body)
- Client-side dry-run for delete and enterprise operations (prints preview to stderr, exits early without mutating)
- All dry-run output goes to stderr so it doesn't interfere with `--output json` piping

### Commands updated

| Command | Mechanism |
|---------|-----------|
| `cloud subscription update` | Server-side |
| `cloud subscription delete` | Client-side |
| `cloud database create` | Server-side (forces legacy path) |
| `cloud database update` | Server-side (forces legacy path) |
| `cloud database delete` | Client-side |
| `enterprise database update` | Client-side (shows request JSON) |
| `enterprise database delete` | Client-side |
| `enterprise cluster bootstrap` | Client-side (shows config JSON) |

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p redisctl --all-targets --all-features -- -D warnings`
- [x] `cargo test -p redisctl --lib --all-features` (72 passed)
- [x] `cargo test -p redisctl --bin redisctl --all-features` (105 passed)

Closes #752