### PR TITLE
feat(cli): add dynamic shell completions and ValueHint annotations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,6 +527,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75bf0b32ad2e152de789bb635ea4d3078f6b838ad7974143e99b99f45a04af4a"
 dependencies = [
  "clap",
+ "clap_lex",
+ "is_executable",
+ "shlex",
 ]
 
 [[package]]
@@ -1813,6 +1816,15 @@ dependencies = [
  "hermit-abi",
  "libc",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "is_executable"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baabb8b4867b26294d818bf3f651a454b6901431711abb96e296245888d6e8c4"
+dependencies = [
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/crates/redisctl/Cargo.toml
+++ b/crates/redisctl/Cargo.toml
@@ -25,7 +25,7 @@ files-sdk = { workspace = true, optional = true }
 
 # CLI dependencies
 clap = { workspace = true }
-clap_complete = "4.5"
+clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 anyhow = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }

--- a/crates/redisctl/src/cli/mod.rs
+++ b/crates/redisctl/src/cli/mod.rs
@@ -5,7 +5,8 @@
 //! 2. Human-friendly interface (`cloud`/`enterprise` commands)
 //! 3. Workflow orchestration (`workflow` commands - future)
 
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueHint};
+use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use redisctl_core::DeploymentType;
 
 pub mod cloud;
@@ -78,11 +79,11 @@ For more help on a specific command, run:
 ")]
 pub struct Cli {
     /// Profile to use for this command
-    #[arg(long, short, global = true, env = "REDISCTL_PROFILE")]
+    #[arg(long, short, global = true, env = "REDISCTL_PROFILE", add = ArgValueCandidates::new(profile_candidates))]
     pub profile: Option<String>,
 
     /// Path to alternate configuration file
-    #[arg(long, global = true, env = "REDISCTL_CONFIG_FILE")]
+    #[arg(long, global = true, env = "REDISCTL_CONFIG_FILE", value_hint = ValueHint::FilePath)]
     pub config_file: Option<String>,
 
     /// Output format
@@ -263,6 +264,10 @@ PROFILE REQUIREMENT:
         /// Shell to generate completions for
         #[arg(value_enum)]
         shell: Shell,
+
+        /// Print dynamic completion registration command instead of static script
+        #[arg(long)]
+        register: bool,
     },
 }
 
@@ -431,11 +436,11 @@ EXAMPLES:
         api_secret: Option<String>,
 
         /// API URL (for Cloud profiles)
-        #[arg(long, default_value = "https://api.redislabs.com/v1")]
+        #[arg(long, default_value = "https://api.redislabs.com/v1", value_hint = ValueHint::Url)]
         api_url: String,
 
         /// Enterprise URL (for Enterprise profiles)
-        #[arg(long, required_if_eq("type", "enterprise"))]
+        #[arg(long, required_if_eq("type", "enterprise"), value_hint = ValueHint::Url)]
         url: Option<String>,
 
         /// Username (for Enterprise profiles)
@@ -451,7 +456,7 @@ EXAMPLES:
         insecure: bool,
 
         /// Path to custom CA certificate for TLS verification (for Enterprise/Kubernetes profiles)
-        #[arg(long)]
+        #[arg(long, value_hint = ValueHint::FilePath)]
         ca_cert: Option<String>,
 
         /// Redis host (for Database profiles)
@@ -624,11 +629,23 @@ pub enum DbCommands {
         dry_run: bool,
 
         /// Path to redis-cli binary (defaults to 'redis-cli' in PATH)
-        #[arg(long, default_value = "redis-cli")]
+        #[arg(long, default_value = "redis-cli", value_hint = ValueHint::ExecutablePath)]
         redis_cli: String,
 
         /// Additional arguments to pass to redis-cli
         #[arg(last = true)]
         args: Vec<String>,
     },
+}
+
+fn profile_candidates() -> Vec<CompletionCandidate> {
+    let config = redisctl_core::Config::load().unwrap_or_default();
+    config
+        .list_profiles()
+        .into_iter()
+        .map(|(name, profile)| {
+            CompletionCandidate::new(name.as_str())
+                .help(Some(format!("{}", profile.deployment_type).into()))
+        })
+        .collect()
 }

--- a/crates/redisctl/src/main.rs
+++ b/crates/redisctl/src/main.rs
@@ -378,6 +378,8 @@ fn load_config_for_prefix(config_file: Option<&str>) -> Option<Config> {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    clap_complete::CompleteEnv::with_factory(cli::Cli::command).complete();
+
     let args: Vec<String> = std::env::args().collect();
     let args = maybe_inject_prefix(args);
     let mut cli = Cli::parse_from(args);
@@ -469,9 +471,14 @@ async fn execute_command(cli: &Cli, conn_mgr: &ConnectionManager) -> Result<(), 
             }
             Ok(())
         }
-        Commands::Completions { shell } => {
-            debug!("Generating completions for {:?}", shell);
-            generate_completions(*shell);
+        Commands::Completions { shell, register } => {
+            if *register {
+                debug!("Printing registration command for {:?}", shell);
+                print_registration_command(*shell);
+            } else {
+                debug!("Generating completions for {:?}", shell);
+                generate_completions(*shell);
+            }
             Ok(())
         }
 
@@ -556,11 +563,29 @@ fn generate_completions(shell: cli::Shell) {
     }
 }
 
+/// Print the shell command to register dynamic completions
+fn print_registration_command(shell: cli::Shell) {
+    let cmd = match shell {
+        cli::Shell::Bash => "source <(COMPLETE=bash redisctl)",
+        cli::Shell::Zsh => "source <(COMPLETE=zsh redisctl)",
+        cli::Shell::Fish => "source (COMPLETE=fish redisctl | psub)",
+        cli::Shell::PowerShell => "COMPLETE=powershell redisctl | Invoke-Expression",
+        cli::Shell::Elvish => "eval (E:COMPLETE=elvish redisctl)",
+    };
+    println!("{cmd}");
+}
+
 /// Format command for human-readable logging (without sensitive data)
 fn format_command(command: &Commands) -> String {
     match command {
         Commands::Version => "version".to_string(),
-        Commands::Completions { shell } => format!("completions {:?}", shell),
+        Commands::Completions { shell, register } => {
+            if *register {
+                format!("completions {:?} --register", shell)
+            } else {
+                format!("completions {:?}", shell)
+            }
+        }
         Commands::Profile(cmd) => {
             use cli::ProfileCommands::*;
             match cmd {

--- a/docs/docs/reference/shell-completions.md
+++ b/docs/docs/reference/shell-completions.md
@@ -2,15 +2,73 @@
 
 Enable tab completion for redisctl commands.
 
-## Generate Completions
+Supported shells: `bash`, `zsh`, `fish`, `powershell`, `elvish`
+
+## Dynamic Completions (Recommended)
+
+Dynamic completions query the `redisctl` binary at runtime, enabling context-aware
+completions such as profile names from your config file, file path hints, and URL hints.
+
+To enable, add the registration one-liner to your shell's config file. You can print
+the command with `--register`:
+
+```bash
+redisctl completions <shell> --register
+```
+
+=== "Bash"
+
+    ```bash
+    # Add to ~/.bashrc
+    source <(COMPLETE=bash redisctl)
+    ```
+
+=== "Zsh"
+
+    ```bash
+    # Add to ~/.zshrc
+    source <(COMPLETE=zsh redisctl)
+    ```
+
+=== "Fish"
+
+    ```bash
+    # Add to ~/.config/fish/config.fish
+    source (COMPLETE=fish redisctl | psub)
+    ```
+
+=== "PowerShell"
+
+    ```powershell
+    # Add to $PROFILE
+    COMPLETE=powershell redisctl | Invoke-Expression
+    ```
+
+=== "Elvish"
+
+    ```elvish
+    # Add to ~/.elvish/rc.elv
+    eval (E:COMPLETE=elvish redisctl)
+    ```
+
+Dynamic completions provide:
+
+- Profile names from your config (e.g., `--profile my<Tab>` completes to configured profiles)
+- File path hints for `--config-file` and `--ca-cert`
+- URL hints for `--url` and `--api-url`
+- Executable path hints for `--redis-cli`
+
+## Static Completions (Fallback)
+
+Static scripts complete subcommands and flags but have no awareness of runtime
+values like profile names. Use these if dynamic completions are not supported
+in your environment.
 
 ```bash
 redisctl completions <shell>
 ```
 
-Supported shells: `bash`, `zsh`, `fish`, `powershell`
-
-## Installation
+### Installation
 
 === "Bash"
 


### PR DESCRIPTION
## Summary

- Enable runtime-aware tab completions via `clap_complete`'s `CompleteEnv`, adding profile name completion from the config file, file/URL/executable path hints for relevant args
- Add `--register` flag to `redisctl completions <shell>` that prints the shell one-liner for dynamic completion setup
- Static script generation (`redisctl completions <shell>`) preserved for backward compatibility

## Changes

| File | What |
|------|------|
| `crates/redisctl/Cargo.toml` | Enable `unstable-dynamic` feature on `clap_complete` |
| `crates/redisctl/src/cli/mod.rs` | `ValueHint` annotations (`FilePath`, `Url`, `ExecutablePath`), `ArgValueCandidates` on `--profile`, `--register` flag, `profile_candidates()` completer |
| `crates/redisctl/src/main.rs` | `CompleteEnv` at top of `main()`, `print_registration_command()`, updated handler and `format_command` |
| `docs/docs/reference/shell-completions.md` | "Dynamic Completions (Recommended)" section, static completions moved to fallback |

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p redisctl --all-targets --all-features -- -D warnings`
- [x] `cargo test -p redisctl --lib --all-features` (72 tests)
- [x] `cargo test -p redisctl --bin redisctl --all-features` (105 tests)
- [ ] `redisctl completions bash` -- static script still generated
- [ ] `redisctl completions bash --register` -- prints `source <(COMPLETE=bash redisctl)`
- [ ] Add registration line to shell rc, verify profile names complete with `--profile <Tab>`

Closes #750