### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2890,7 +2890,7 @@ dependencies = [
 
 [[package]]
 name = "redisctl"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2961,7 +2961,7 @@ dependencies = [
 
 [[package]]
 name = "redisctl-mcp"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/redisctl-mcp/CHANGELOG.md
+++ b/crates/redisctl-mcp/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/redis-developer/redisctl/compare/redisctl-mcp-v0.4.0...redisctl-mcp-v0.5.0) - 2026-03-04
+
+### Added
+
+- *(mcp)* add sub-module syntax for --tools CLI flag ([#783](https://github.com/redis-developer/redisctl/pull/783)) ([#790](https://github.com/redis-developer/redisctl/pull/790))
+- *(mcp)* add `enabled = false` per toolset in policy file ([#782](https://github.com/redis-developer/redisctl/pull/782)) ([#788](https://github.com/redis-developer/redisctl/pull/788))
+- *(mcp)* add tool visibility presets for manageable tool surfaces ([#786](https://github.com/redis-developer/redisctl/pull/786)) ([#787](https://github.com/redis-developer/redisctl/pull/787))
+- *(mcp)* add raw API passthrough tools ([#785](https://github.com/redis-developer/redisctl/pull/785))
+- *(mcp)* add 27 Enterprise tools for coverage parity (#769, #770, #771, #772) ([#779](https://github.com/redis-developer/redisctl/pull/779))
+- *(mcp)* close Cloud tool coverage gaps ([#773](https://github.com/redis-developer/redisctl/pull/773)) ([#778](https://github.com/redis-developer/redisctl/pull/778))
+- *(mcp)* add audit logging for tool invocations ([#767](https://github.com/redis-developer/redisctl/pull/767)) ([#777](https://github.com/redis-developer/redisctl/pull/777))
+- *(mcp)* add granular allow/deny policy configuration ([#776](https://github.com/redis-developer/redisctl/pull/776))
+
+### Other
+
+- *(mcp)* optimize tool descriptions for token efficiency ([#784](https://github.com/redis-developer/redisctl/pull/784)) ([#792](https://github.com/redis-developer/redisctl/pull/792))
+
 ## [0.4.0](https://github.com/redis-developer/redisctl/compare/redisctl-mcp-v0.3.0...redisctl-mcp-v0.4.0) - 2026-02-28
 
 ### Added

--- a/crates/redisctl-mcp/Cargo.toml
+++ b/crates/redisctl-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redisctl-mcp"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/redisctl/CHANGELOG.md
+++ b/crates/redisctl/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.2](https://github.com/redis-developer/redisctl/compare/redisctl-v0.8.1...redisctl-v0.8.2) - 2026-03-04
+
+### Added
+
+- *(enterprise)* add curated table formatters for list/get commands ([#761](https://github.com/redis-developer/redisctl/pull/761)) ([#763](https://github.com/redis-developer/redisctl/pull/763))
+- *(cli)* add dynamic shell completions and ValueHint annotations ([#758](https://github.com/redis-developer/redisctl/pull/758))
+
+### Fixed
+
+- *(output)* standardize table styles and add Cloud ACL formatters ([#764](https://github.com/redis-developer/redisctl/pull/764))
+
+### Other
+
+- *(output)* unify OutputFormat and standardize table library ([#749](https://github.com/redis-developer/redisctl/pull/749)) ([#760](https://github.com/redis-developer/redisctl/pull/760))
+
 ## [0.8.1](https://github.com/redis-developer/redisctl/compare/redisctl-v0.8.0...redisctl-v0.8.1) - 2026-02-28
 
 ### Added

--- a/crates/redisctl/Cargo.toml
+++ b/crates/redisctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redisctl"
-version = "0.8.1"
+version = "0.8.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `redisctl`: 0.8.1 -> 0.8.2 (✓ API compatible changes)
* `redisctl-mcp`: 0.4.0 -> 0.5.0 (⚠ API breaking changes)

### ⚠ `redisctl-mcp` breaking changes

```text
--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field read_only of struct AppState, previously in file /tmp/.tmpcD6sIh/redisctl-mcp/src/state.rs:43
  field read_only of struct AppState, previously in file /tmp/.tmpcD6sIh/redisctl-mcp/src/state.rs:43
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `redisctl`

<blockquote>

## [0.8.2](https://github.com/redis-developer/redisctl/compare/redisctl-v0.8.1...redisctl-v0.8.2) - 2026-03-04

### Added

- *(enterprise)* add curated table formatters for list/get commands ([#761](https://github.com/redis-developer/redisctl/pull/761)) ([#763](https://github.com/redis-developer/redisctl/pull/763))
- *(cli)* add dynamic shell completions and ValueHint annotations ([#758](https://github.com/redis-developer/redisctl/pull/758))

### Fixed

- *(output)* standardize table styles and add Cloud ACL formatters ([#764](https://github.com/redis-developer/redisctl/pull/764))

### Other

- *(output)* unify OutputFormat and standardize table library ([#749](https://github.com/redis-developer/redisctl/pull/749)) ([#760](https://github.com/redis-developer/redisctl/pull/760))
</blockquote>

## `redisctl-mcp`

<blockquote>

## [0.5.0](https://github.com/redis-developer/redisctl/compare/redisctl-mcp-v0.4.0...redisctl-mcp-v0.5.0) - 2026-03-04

### Added

- *(mcp)* add sub-module syntax for --tools CLI flag ([#783](https://github.com/redis-developer/redisctl/pull/783)) ([#790](https://github.com/redis-developer/redisctl/pull/790))
- *(mcp)* add `enabled = false` per toolset in policy file ([#782](https://github.com/redis-developer/redisctl/pull/782)) ([#788](https://github.com/redis-developer/redisctl/pull/788))
- *(mcp)* add tool visibility presets for manageable tool surfaces ([#786](https://github.com/redis-developer/redisctl/pull/786)) ([#787](https://github.com/redis-developer/redisctl/pull/787))
- *(mcp)* add raw API passthrough tools ([#785](https://github.com/redis-developer/redisctl/pull/785))
- *(mcp)* add 27 Enterprise tools for coverage parity (#769, #770, #771, #772) ([#779](https://github.com/redis-developer/redisctl/pull/779))
- *(mcp)* close Cloud tool coverage gaps ([#773](https://github.com/redis-developer/redisctl/pull/773)) ([#778](https://github.com/redis-developer/redisctl/pull/778))
- *(mcp)* add audit logging for tool invocations ([#767](https://github.com/redis-developer/redisctl/pull/767)) ([#777](https://github.com/redis-developer/redisctl/pull/777))
- *(mcp)* add granular allow/deny policy configuration ([#776](https://github.com/redis-developer/redisctl/pull/776))

### Other

- *(mcp)* optimize tool descriptions for token efficiency ([#784](https://github.com/redis-developer/redisctl/pull/784)) ([#792](https://github.com/redis-developer/redisctl/pull/792))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).