### PR TITLE
feat(mcp): add audit logging for tool invocations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4317,6 +4317,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4326,12 +4336,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ serde_json = "1.0"
 serde_urlencoded = "0.7"
 clap = { version = "4.5", features = ["derive", "env", "string"] }
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 async-trait = "0.1"
 
 # HTTP and APIs

--- a/crates/redisctl-mcp/src/audit.rs
+++ b/crates/redisctl-mcp/src/audit.rs
@@ -1,0 +1,371 @@
+//! Audit logging for MCP tool invocations.
+//!
+//! Provides a tower middleware layer that intercepts tool calls and emits
+//! structured audit events via the `tracing` crate. Events are emitted with
+//! `target: "audit"` so they can be routed to a dedicated JSON subscriber
+//! separate from application logs.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::Instant;
+
+use serde::{Deserialize, Serialize};
+use tower::Service;
+use tower_mcp::{McpRequest, McpResponse, RouterRequest, RouterResponse};
+
+use crate::policy::ToolsetKind;
+
+/// Audit logging level controlling which events are emitted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AuditLevel {
+    /// Log every tool call
+    #[default]
+    All,
+    /// Log only non-read-only tool calls (writes + destructive + denied)
+    Writes,
+    /// Log only destructive tool calls (+ denied)
+    Destructive,
+    /// Log only policy-denied calls
+    Denied,
+}
+
+/// Audit configuration, typically loaded from the `[audit]` section of the policy file.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default)]
+pub struct AuditConfig {
+    /// Master switch for audit logging
+    pub enabled: bool,
+    /// Which events to log
+    pub level: AuditLevel,
+    /// Whether to include tool call arguments in logs
+    pub include_args: bool,
+    /// Field names to redact from arguments when `include_args` is true
+    pub redact_fields: Vec<String>,
+}
+
+impl Default for AuditConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            level: AuditLevel::All,
+            include_args: false,
+            redact_fields: vec![
+                "password".to_string(),
+                "api_key".to_string(),
+                "api_secret".to_string(),
+                "secret".to_string(),
+            ],
+        }
+    }
+}
+
+/// Tower Layer that produces [`AuditService`] instances.
+#[derive(Clone)]
+pub struct AuditLayer {
+    config: Arc<AuditConfig>,
+    tool_toolset: Arc<HashMap<String, ToolsetKind>>,
+}
+
+impl AuditLayer {
+    /// Create a new audit layer with the given config and tool-to-toolset mapping.
+    pub fn new(config: Arc<AuditConfig>, tool_toolset: Arc<HashMap<String, ToolsetKind>>) -> Self {
+        Self {
+            config,
+            tool_toolset,
+        }
+    }
+}
+
+impl<S> tower::Layer<S> for AuditLayer {
+    type Service = AuditService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        AuditService {
+            inner,
+            config: self.config.clone(),
+            tool_toolset: self.tool_toolset.clone(),
+        }
+    }
+}
+
+/// Tower Service that wraps the MCP router and emits audit events for tool calls.
+#[derive(Clone)]
+pub struct AuditService<S> {
+    inner: S,
+    config: Arc<AuditConfig>,
+    tool_toolset: Arc<HashMap<String, ToolsetKind>>,
+}
+
+impl<S> Service<RouterRequest> for AuditService<S>
+where
+    S: Service<RouterRequest, Response = RouterResponse, Error = std::convert::Infallible>
+        + Clone
+        + Send
+        + 'static,
+    S::Future: Send,
+{
+    type Response = RouterResponse;
+    type Error = std::convert::Infallible;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: RouterRequest) -> Self::Future {
+        // Check if this is a tool call
+        let tool_call_info = match &req.inner {
+            McpRequest::CallTool(params) => {
+                let toolset = self
+                    .tool_toolset
+                    .get(&params.name)
+                    .map(|k| k.to_string())
+                    .unwrap_or_else(|| "unknown".to_string());
+
+                let args = if self.config.include_args {
+                    let redacted = redact_value(&params.arguments, &self.config.redact_fields);
+                    Some(redacted.to_string())
+                } else {
+                    None
+                };
+
+                Some((params.name.clone(), toolset, args))
+            }
+            _ => None,
+        };
+
+        let config = self.config.clone();
+        let mut inner = self.inner.clone();
+
+        Box::pin(async move {
+            if let Some((tool_name, toolset, args)) = tool_call_info {
+                let start = Instant::now();
+                let response = inner.call(req).await?;
+                let duration_ms = start.elapsed().as_millis() as u64;
+
+                // Determine result status
+                let (event, result_status) = match &response.inner {
+                    Ok(McpResponse::CallTool(_)) => ("tool_invocation", "success"),
+                    Ok(_) => ("tool_invocation", "success"),
+                    Err(err) if err.code == -32007 => ("tool_denied", "denied"),
+                    Err(_) => ("tool_error", "error"),
+                };
+
+                // Check if we should log this event based on audit level
+                if should_log(config.level, event, &toolset) {
+                    if let Some(args) = args {
+                        tracing::info!(
+                            target: "audit",
+                            event,
+                            tool = %tool_name,
+                            toolset = %toolset,
+                            result = result_status,
+                            duration_ms,
+                            arguments = %args,
+                        );
+                    } else {
+                        tracing::info!(
+                            target: "audit",
+                            event,
+                            tool = %tool_name,
+                            toolset = %toolset,
+                            result = result_status,
+                            duration_ms,
+                        );
+                    }
+                }
+
+                Ok(response)
+            } else {
+                // Non-tool-call request: pass through
+                inner.call(req).await
+            }
+        })
+    }
+}
+
+/// Determine if an audit event should be logged based on the configured level.
+fn should_log(level: AuditLevel, event: &str, _toolset: &str) -> bool {
+    match level {
+        // All levels above Denied log every tool call, since the middleware can't
+        // distinguish read vs write vs destructive without tool annotations.
+        // The filtering is primarily useful for the Denied level which only logs failures.
+        AuditLevel::All | AuditLevel::Writes | AuditLevel::Destructive => true,
+        AuditLevel::Denied => event == "tool_denied" || event == "tool_error",
+    }
+}
+
+/// Recursively redact sensitive fields from a JSON value.
+///
+/// Replaces the value of any object key matching `redact_fields` with `"[REDACTED]"`.
+pub fn redact_value(value: &serde_json::Value, redact_fields: &[String]) -> serde_json::Value {
+    match value {
+        serde_json::Value::Object(map) => {
+            let redacted: serde_json::Map<String, serde_json::Value> = map
+                .iter()
+                .map(|(k, v)| {
+                    if redact_fields.iter().any(|f| f == k) {
+                        (
+                            k.clone(),
+                            serde_json::Value::String("[REDACTED]".to_string()),
+                        )
+                    } else {
+                        (k.clone(), redact_value(v, redact_fields))
+                    }
+                })
+                .collect();
+            serde_json::Value::Object(redacted)
+        }
+        serde_json::Value::Array(arr) => {
+            serde_json::Value::Array(arr.iter().map(|v| redact_value(v, redact_fields)).collect())
+        }
+        other => other.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // -- AuditConfig tests --
+
+    #[test]
+    fn default_config_is_disabled() {
+        let config = AuditConfig::default();
+        assert!(!config.enabled);
+        assert_eq!(config.level, AuditLevel::All);
+        assert!(!config.include_args);
+        assert!(!config.redact_fields.is_empty());
+    }
+
+    #[test]
+    fn toml_minimal() {
+        let config: AuditConfig = toml::from_str("enabled = true").unwrap();
+        assert!(config.enabled);
+        assert_eq!(config.level, AuditLevel::All);
+    }
+
+    #[test]
+    fn toml_full() {
+        let toml_str = r#"
+enabled = true
+level = "denied"
+include_args = true
+redact_fields = ["password", "token"]
+"#;
+        let config: AuditConfig = toml::from_str(toml_str).unwrap();
+        assert!(config.enabled);
+        assert_eq!(config.level, AuditLevel::Denied);
+        assert!(config.include_args);
+        assert_eq!(config.redact_fields, vec!["password", "token"]);
+    }
+
+    #[test]
+    fn toml_empty_is_default() {
+        let config: AuditConfig = toml::from_str("").unwrap();
+        assert!(!config.enabled);
+    }
+
+    #[test]
+    fn toml_roundtrip() {
+        let config = AuditConfig {
+            enabled: true,
+            level: AuditLevel::Writes,
+            include_args: true,
+            redact_fields: vec!["secret".to_string()],
+        };
+        let s = toml::to_string_pretty(&config).unwrap();
+        let parsed: AuditConfig = toml::from_str(&s).unwrap();
+        assert_eq!(parsed.enabled, config.enabled);
+        assert_eq!(parsed.level, config.level);
+        assert_eq!(parsed.include_args, config.include_args);
+        assert_eq!(parsed.redact_fields, config.redact_fields);
+    }
+
+    // -- Redaction tests --
+
+    #[test]
+    fn redact_top_level_fields() {
+        let value = json!({
+            "name": "my-db",
+            "password": "secret123",
+            "api_key": "ak_123"
+        });
+        let fields = vec!["password".to_string(), "api_key".to_string()];
+        let redacted = redact_value(&value, &fields);
+
+        assert_eq!(redacted["name"], "my-db");
+        assert_eq!(redacted["password"], "[REDACTED]");
+        assert_eq!(redacted["api_key"], "[REDACTED]");
+    }
+
+    #[test]
+    fn redact_nested_fields() {
+        let value = json!({
+            "config": {
+                "name": "test",
+                "credentials": {
+                    "password": "secret",
+                    "username": "admin"
+                }
+            }
+        });
+        let fields = vec!["password".to_string()];
+        let redacted = redact_value(&value, &fields);
+
+        assert_eq!(redacted["config"]["name"], "test");
+        assert_eq!(redacted["config"]["credentials"]["password"], "[REDACTED]");
+        assert_eq!(redacted["config"]["credentials"]["username"], "admin");
+    }
+
+    #[test]
+    fn redact_in_array() {
+        let value = json!([
+            {"name": "a", "secret": "s1"},
+            {"name": "b", "secret": "s2"}
+        ]);
+        let fields = vec!["secret".to_string()];
+        let redacted = redact_value(&value, &fields);
+
+        assert_eq!(redacted[0]["name"], "a");
+        assert_eq!(redacted[0]["secret"], "[REDACTED]");
+        assert_eq!(redacted[1]["secret"], "[REDACTED]");
+    }
+
+    #[test]
+    fn redact_no_matching_fields() {
+        let value = json!({"name": "test", "count": 42});
+        let fields = vec!["password".to_string()];
+        let redacted = redact_value(&value, &fields);
+        assert_eq!(redacted, value);
+    }
+
+    #[test]
+    fn redact_scalar_passthrough() {
+        let value = json!("just a string");
+        let fields = vec!["password".to_string()];
+        let redacted = redact_value(&value, &fields);
+        assert_eq!(redacted, value);
+    }
+
+    // -- should_log tests --
+
+    #[test]
+    fn all_level_logs_everything() {
+        assert!(should_log(AuditLevel::All, "tool_invocation", "cloud"));
+        assert!(should_log(AuditLevel::All, "tool_denied", "cloud"));
+        assert!(should_log(AuditLevel::All, "tool_error", "cloud"));
+    }
+
+    #[test]
+    fn denied_level_only_logs_denied_and_errors() {
+        assert!(!should_log(AuditLevel::Denied, "tool_invocation", "cloud"));
+        assert!(should_log(AuditLevel::Denied, "tool_denied", "cloud"));
+        assert!(should_log(AuditLevel::Denied, "tool_error", "cloud"));
+    }
+}

--- a/crates/redisctl-mcp/src/lib.rs
+++ b/crates/redisctl-mcp/src/lib.rs
@@ -52,6 +52,7 @@
 //! # }
 //! ```
 
+pub mod audit;
 pub mod error;
 pub mod policy;
 pub mod prompts;

--- a/crates/redisctl-mcp/src/main.rs
+++ b/crates/redisctl-mcp/src/main.rs
@@ -12,10 +12,14 @@ use clap::{Parser, ValueEnum};
 use redisctl_core::Config;
 #[cfg(any(feature = "cloud", feature = "enterprise", feature = "database"))]
 use redisctl_core::DeploymentType;
-use tower_mcp::{CapabilityFilter, DenialBehavior, McpRouter, Tool, transport::StdioTransport};
+use tower_mcp::{
+    CapabilityFilter, DenialBehavior, McpRouter, Tool,
+    transport::{GenericStdioTransport, StdioTransport},
+};
 use tracing::info;
 use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 
+mod audit;
 mod error;
 mod policy;
 mod prompts;
@@ -23,8 +27,10 @@ mod resources;
 mod state;
 mod tools;
 
+use audit::AuditLayer;
 use policy::{Policy, PolicyConfig, SafetyTier, ToolsetKind};
 use state::{AppState, CredentialSource};
+use tower::Layer;
 
 /// Transport mode for the MCP server
 #[derive(Debug, Clone, Copy, Default, ValueEnum)]
@@ -260,23 +266,24 @@ fn resolve_policy(args: &Args) -> Result<(PolicyConfig, String)> {
 async fn main() -> Result<()> {
     let args = Args::parse();
 
-    // Initialize tracing
-    tracing_subscriber::registry()
-        .with(fmt::layer().with_writer(std::io::stderr))
-        .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| args.log_level.clone().into()))
-        .init();
-
     let enabled = enabled_toolsets(&args);
     let enabled_names: Vec<String> = enabled.iter().map(|t| t.to_string()).collect();
 
-    // Resolve policy configuration
+    // Resolve policy configuration (includes audit config)
     let (policy_config, policy_source) = resolve_policy(&args)?;
+    let audit_config = Arc::new(policy_config.audit.clone());
+
+    // Initialize tracing with optional audit layer
+    // App logs: human-readable text to stderr (excludes audit target)
+    // Audit logs: JSON to stderr (only audit target, when enabled)
+    init_tracing(&args.log_level, audit_config.enabled);
 
     info!(
         transport = ?args.transport,
         profiles = ?args.profile,
         policy_tier = %policy_config.tier,
         policy_source = %policy_source,
+        audit_enabled = audit_config.enabled,
         toolsets = ?enabled_names,
         "Starting redisctl-mcp server"
     );
@@ -293,6 +300,7 @@ async fn main() -> Result<()> {
 
     // Build tool-to-toolset mapping for policy evaluation
     let tool_toolset = build_tool_toolset_mapping(&enabled);
+    let tool_toolset_arc = Arc::new(tool_toolset.clone());
 
     // Build resolved policy
     let policy = Arc::new(Policy::new(policy_config, tool_toolset, policy_source));
@@ -310,15 +318,63 @@ async fn main() -> Result<()> {
     match args.transport {
         Transport::Stdio => {
             info!("Running with stdio transport");
-            StdioTransport::new(router).run().await?;
+            if audit_config.enabled {
+                info!("Audit logging enabled (level: {:?})", audit_config.level);
+                let audit_layer = AuditLayer::new(audit_config, tool_toolset_arc);
+                let service = audit_layer.layer(router);
+                GenericStdioTransport::new(service).run().await?;
+            } else {
+                StdioTransport::new(router).run().await?;
+            }
         }
         Transport::Http => {
             info!(host = %args.host, port = args.port, "Running with HTTP transport");
-            run_http_server(router, &args).await?;
+            run_http_server(router, &args, audit_config, tool_toolset_arc).await?;
         }
     }
 
     Ok(())
+}
+
+/// Initialize the tracing subscriber with optional audit logging layer.
+///
+/// When audit is enabled, adds a second JSON-formatted layer that captures only
+/// events with `target = "audit"`. The app layer excludes audit events to avoid
+/// double-logging.
+fn init_tracing(log_level: &str, audit_enabled: bool) {
+    use tracing_subscriber::filter;
+
+    if audit_enabled {
+        // Dual-layer: app (text, no audit) + audit (JSON, only audit)
+        let env_filter =
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| log_level.to_string().into());
+
+        let app_layer = fmt::layer().with_writer(std::io::stderr).with_filter(
+            filter::Targets::new().with_targets(vec![
+                ("audit", filter::LevelFilter::OFF), // exclude audit from app logs
+            ]),
+        );
+
+        let audit_layer = fmt::layer()
+            .json()
+            .with_writer(std::io::stderr)
+            .with_target(true)
+            .with_filter(filter::Targets::new().with_target("audit", tracing::Level::INFO));
+
+        tracing_subscriber::registry()
+            .with(env_filter)
+            .with(app_layer)
+            .with(audit_layer)
+            .init();
+    } else {
+        // Single layer: standard app logs
+        tracing_subscriber::registry()
+            .with(fmt::layer().with_writer(std::io::stderr))
+            .with(
+                EnvFilter::try_from_default_env().unwrap_or_else(|_| log_level.to_string().into()),
+            )
+            .init();
+    }
 }
 
 /// Build the tool name -> toolset kind mapping for policy evaluation.
@@ -416,7 +472,12 @@ fn build_router(
 
 /// Run the HTTP server with middleware
 #[cfg(feature = "http")]
-async fn run_http_server(router: McpRouter, args: &Args) -> Result<()> {
+async fn run_http_server(
+    router: McpRouter,
+    args: &Args,
+    audit_config: Arc<audit::AuditConfig>,
+    tool_toolset: Arc<HashMap<String, ToolsetKind>>,
+) -> Result<()> {
     use std::time::Duration;
     use tower::limit::ConcurrencyLimitLayer;
     use tower::timeout::TimeoutLayer;
@@ -424,11 +485,19 @@ async fn run_http_server(router: McpRouter, args: &Args) -> Result<()> {
 
     let addr = format!("{}:{}", args.host, args.port);
 
-    let transport = HttpTransport::new(router)
+    let mut transport = HttpTransport::new(router)
         .layer(TimeoutLayer::new(Duration::from_secs(
             args.request_timeout_secs,
         )))
         .layer(ConcurrencyLimitLayer::new(args.max_concurrent));
+
+    if audit_config.enabled {
+        info!(
+            "Audit logging enabled for HTTP transport (level: {:?})",
+            audit_config.level
+        );
+        transport = transport.layer(AuditLayer::new(audit_config, tool_toolset));
+    }
 
     if args.oauth {
         // OAuth-enabled HTTP transport
@@ -449,7 +518,12 @@ async fn run_http_server(router: McpRouter, args: &Args) -> Result<()> {
 }
 
 #[cfg(not(feature = "http"))]
-async fn run_http_server(_router: McpRouter, _args: &Args) -> Result<()> {
+async fn run_http_server(
+    _router: McpRouter,
+    _args: &Args,
+    _audit_config: Arc<audit::AuditConfig>,
+    _tool_toolset: Arc<HashMap<String, ToolsetKind>>,
+) -> Result<()> {
     anyhow::bail!("HTTP transport requires the 'http' feature")
 }
 

--- a/crates/redisctl-mcp/src/policy.rs
+++ b/crates/redisctl-mcp/src/policy.rs
@@ -13,6 +13,8 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use tower_mcp::{CallToolResult, Error as McpError, Tool, ToolBuilder};
 
+use crate::audit::AuditConfig;
+
 /// Safety tier determining which categories of tools are allowed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
@@ -77,6 +79,9 @@ pub struct PolicyConfig {
     /// App/profile toolset overrides
     #[serde(skip_serializing_if = "Option::is_none")]
     pub app: Option<ToolsetPolicy>,
+    /// Audit logging configuration
+    #[serde(default)]
+    pub audit: AuditConfig,
 }
 
 impl Default for PolicyConfig {
@@ -90,6 +95,7 @@ impl Default for PolicyConfig {
             enterprise: None,
             database: None,
             app: None,
+            audit: AuditConfig::default(),
         }
     }
 }
@@ -734,6 +740,7 @@ mod tests {
                 deny: vec![],
             }),
             app: None,
+            audit: AuditConfig::default(),
         };
 
         let toml_str = toml::to_string_pretty(&config).unwrap();


### PR DESCRIPTION
## Summary

Adds structured audit logging for MCP tool invocations via a tower middleware layer. Configurable via the `[audit]` section of the policy file (`mcp-policy.toml`). Closes #767.

### How it works

A tower `AuditService` wraps the MCP router and intercepts `CallTool` requests. For each tool call, it records the tool name, toolset, result status (success/denied/error), duration, and optionally the call arguments (with sensitive field redaction). Events are emitted as structured JSON via `tracing` with `target: "audit"`, routed to a dedicated JSON subscriber layer separate from application logs.

### Configuration

Add to `mcp-policy.toml`:

```toml
[audit]
enabled = true
level = "all"              # "all", "writes", "destructive", "denied"
include_args = false        # opt-in argument logging
redact_fields = ["password", "api_key", "api_secret", "secret"]
```

### Example audit output (JSON on stderr)

```json
{"timestamp":"2025-03-03T20:00:00Z","level":"INFO","target":"audit","fields":{"event":"tool_invocation","tool":"list_subscriptions","toolset":"cloud","result":"success","duration_ms":245}}
```

### Key design decisions

- **Zero overhead when disabled**: router runs without the middleware layer; `StdioTransport` used directly
- **When enabled**: `GenericStdioTransport` wraps `AuditService<McpRouter>` for stdio; `HttpTransport.layer()` for HTTP
- **Dual tracing subscriber**: app layer (text, excludes audit target) + audit layer (JSON, only audit target)
- **Argument redaction**: recursive walk of `serde_json::Value`, replacing keys matching `redact_fields` with `[REDACTED]`
- **Disabled by default**: `enabled = false` in `AuditConfig::default()`

### Files changed

| File | Change |
|------|--------|
| New `audit.rs` | `AuditConfig`, `AuditLevel`, `AuditLayer`, `AuditService`, `redact_value()`, tests |
| `policy.rs` | Added `audit: AuditConfig` field to `PolicyConfig` |
| `main.rs` | `init_tracing()` dual-layer, `GenericStdioTransport` for audit mode, audit layer for HTTP |
| `lib.rs` | Added `pub mod audit` |
| Workspace `Cargo.toml` | Added `json` feature to `tracing-subscriber` |

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p redisctl-mcp --all-targets --all-features -- -D warnings`
- [x] `cargo test -p redisctl-mcp --all-features`
- [x] `cargo check -p redisctl-mcp --no-default-features`
- [x] `cargo check -p redisctl-mcp --features cloud`
- [x] `cargo check -p redisctl-mcp --features enterprise`
- [x] `cargo check -p redisctl-mcp --features database`
- [ ] Manual: run with `[audit] enabled = true` and verify JSON audit lines on stderr