### PR TITLE
feat(mcp): add 27 Enterprise tools for coverage parity

### DIFF
--- a/crates/redisctl-mcp/src/tools/enterprise/cluster.rs
+++ b/crates/redisctl-mcp/src/tools/enterprise/cluster.rs
@@ -915,6 +915,145 @@ pub fn drain_node(state: Arc<AppState>) -> Tool {
         .build()
 }
 
+// ============================================================================
+// Node Update/Remove Operations
+// ============================================================================
+
+/// Input for updating a node
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct UpdateNodeInput {
+    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
+    #[serde(default)]
+    pub profile: Option<String>,
+    /// Node UID
+    pub uid: u32,
+    /// JSON object with node settings to update
+    pub updates: Value,
+}
+
+/// Build the update_enterprise_node tool
+pub fn update_enterprise_node(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("update_enterprise_node")
+        .description(
+            "Update a node's configuration in the Redis Enterprise cluster. \
+             Pass the fields to update as JSON.",
+        )
+        .non_destructive()
+        .extractor_handler_typed::<_, _, _, UpdateNodeInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<UpdateNodeInput>| async move {
+                // Check write permission
+                if !state.is_write_allowed() {
+                    return Err(McpError::tool(
+                        "Write operations not allowed in read-only mode",
+                    ));
+                }
+
+                let client = state
+                    .enterprise_client_for_profile(input.profile.as_deref())
+                    .await
+                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+
+                let handler = NodeHandler::new(client);
+                let node = handler
+                    .update(input.uid, input.updates)
+                    .await
+                    .tool_context("Failed to update node")?;
+
+                CallToolResult::from_serialize(&node)
+            },
+        )
+        .build()
+}
+
+/// Input for removing a node
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct RemoveNodeInput {
+    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
+    #[serde(default)]
+    pub profile: Option<String>,
+    /// Node UID
+    pub uid: u32,
+}
+
+/// Build the remove_enterprise_node tool
+pub fn remove_enterprise_node(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("remove_enterprise_node")
+        .description(
+            "DANGEROUS: Permanently removes a node from the Redis Enterprise cluster. \
+             All shards must be drained first. This action cannot be undone.",
+        )
+        .destructive()
+        .extractor_handler_typed::<_, _, _, RemoveNodeInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<RemoveNodeInput>| async move {
+                // Check destructive permission
+                if !state.is_destructive_allowed() {
+                    return Err(McpError::tool(
+                        "Destructive operations require policy tier 'full'",
+                    ));
+                }
+
+                let client = state
+                    .enterprise_client_for_profile(input.profile.as_deref())
+                    .await
+                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+
+                let handler = NodeHandler::new(client);
+                handler
+                    .remove(input.uid)
+                    .await
+                    .tool_context("Failed to remove node")?;
+
+                CallToolResult::from_serialize(&serde_json::json!({
+                    "message": "Node removed successfully",
+                    "uid": input.uid
+                }))
+            },
+        )
+        .build()
+}
+
+// ============================================================================
+// Cluster Services
+// ============================================================================
+
+/// Input for getting cluster services (no required parameters)
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct GetClusterServicesInput {
+    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
+    #[serde(default)]
+    pub profile: Option<String>,
+}
+
+/// Build the get_enterprise_cluster_services tool
+pub fn get_enterprise_cluster_services(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("get_enterprise_cluster_services")
+        .description(
+            "Get the list of services running on the Redis Enterprise cluster.",
+        )
+        .read_only_safe()
+        .extractor_handler_typed::<_, _, _, GetClusterServicesInput>(
+            state,
+            |State(state): State<Arc<AppState>>,
+             Json(input): Json<GetClusterServicesInput>| async move {
+                let client = state
+                    .enterprise_client_for_profile(input.profile.as_deref())
+                    .await
+                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+
+                let handler = ClusterHandler::new(client);
+                let services = handler
+                    .services_configuration()
+                    .await
+                    .tool_context("Failed to get cluster services")?;
+
+                CallToolResult::from_serialize(&services)
+            },
+        )
+        .build()
+}
+
 /// Input for getting cluster stats
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct GetClusterStatsInput {
@@ -1006,4 +1145,8 @@ pub fn router(state: Arc<AppState>) -> McpRouter {
         .tool(disable_node_maintenance(state.clone()))
         .tool(rebalance_node(state.clone()))
         .tool(drain_node(state.clone()))
+        .tool(update_enterprise_node(state.clone()))
+        .tool(remove_enterprise_node(state.clone()))
+        // Cluster Services
+        .tool(get_enterprise_cluster_services(state.clone()))
 }

--- a/crates/redisctl-mcp/src/tools/enterprise/databases.rs
+++ b/crates/redisctl-mcp/src/tools/enterprise/databases.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use redis_enterprise::alerts::AlertHandler;
-use redis_enterprise::bdb::{CreateDatabaseRequest, DatabaseHandler};
+use redis_enterprise::bdb::{CreateDatabaseRequest, DatabaseHandler, DatabaseUpgradeRequest};
 use redis_enterprise::crdb::CrdbHandler;
 use redis_enterprise::stats::{StatsHandler, StatsQuery};
 use redisctl_core::enterprise::{
@@ -619,6 +619,165 @@ pub fn flush_enterprise_database(state: Arc<AppState>) -> Tool {
         .build()
 }
 
+/// Input for exporting an Enterprise database
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ExportEnterpriseDatabaseInput {
+    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
+    #[serde(default)]
+    pub profile: Option<String>,
+    /// Database UID to export
+    pub uid: u32,
+    /// Export location (e.g., S3 URL or FTP path)
+    pub export_location: String,
+}
+
+/// Build the export_enterprise_database tool
+pub fn export_enterprise_database(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("export_enterprise_database")
+        .description(
+            "Export a Redis Enterprise database to a specified location (e.g., S3, FTP). \
+             Returns an action reference for tracking.",
+        )
+        .non_destructive()
+        .extractor_handler_typed::<_, _, _, ExportEnterpriseDatabaseInput>(
+            state,
+            |State(state): State<Arc<AppState>>,
+             Json(input): Json<ExportEnterpriseDatabaseInput>| async move {
+                // Check write permission
+                if !state.is_write_allowed() {
+                    return Err(McpError::tool(
+                        "Write operations require policy tier 'read-write' or 'full'",
+                    ));
+                }
+
+                let client = state
+                    .enterprise_client_for_profile(input.profile.as_deref())
+                    .await
+                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+
+                let handler = DatabaseHandler::new(client);
+                let response = handler
+                    .export(input.uid, &input.export_location)
+                    .await
+                    .tool_context("Failed to export database")?;
+
+                CallToolResult::from_serialize(&response)
+            },
+        )
+        .build()
+}
+
+/// Input for restoring an Enterprise database
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct RestoreEnterpriseDatabaseInput {
+    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
+    #[serde(default)]
+    pub profile: Option<String>,
+    /// Database UID to restore
+    pub uid: u32,
+    /// Optional backup UID to restore from (uses latest if not specified)
+    #[serde(default)]
+    pub backup_uid: Option<String>,
+}
+
+/// Build the restore_enterprise_database tool
+pub fn restore_enterprise_database(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("restore_enterprise_database")
+        .description(
+            "Restore a Redis Enterprise database from a backup. \
+             Returns an action reference for tracking.",
+        )
+        .non_destructive()
+        .extractor_handler_typed::<_, _, _, RestoreEnterpriseDatabaseInput>(
+            state,
+            |State(state): State<Arc<AppState>>,
+             Json(input): Json<RestoreEnterpriseDatabaseInput>| async move {
+                // Check write permission
+                if !state.is_write_allowed() {
+                    return Err(McpError::tool(
+                        "Write operations require policy tier 'read-write' or 'full'",
+                    ));
+                }
+
+                let client = state
+                    .enterprise_client_for_profile(input.profile.as_deref())
+                    .await
+                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+
+                let handler = DatabaseHandler::new(client);
+                let response = handler
+                    .restore(input.uid, input.backup_uid.as_deref())
+                    .await
+                    .tool_context("Failed to restore database")?;
+
+                CallToolResult::from_serialize(&response)
+            },
+        )
+        .build()
+}
+
+/// Input for upgrading Redis version of an Enterprise database
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct UpgradeEnterpriseDatabaseRedisInput {
+    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
+    #[serde(default)]
+    pub profile: Option<String>,
+    /// Database UID to upgrade
+    pub uid: u32,
+    /// Target Redis version (defaults to latest if not specified)
+    #[serde(default)]
+    pub redis_version: Option<String>,
+    /// Restart shards even if no version change
+    #[serde(default)]
+    pub force_restart: Option<bool>,
+    /// Allow data loss in non-replicated, non-persistent databases
+    #[serde(default)]
+    pub may_discard_data: Option<bool>,
+}
+
+/// Build the upgrade_enterprise_database_redis tool
+pub fn upgrade_enterprise_database_redis(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("upgrade_enterprise_database_redis")
+        .description(
+            "Upgrade the Redis version of a database. Pass redis_version for the target version. \
+             Returns an action reference.",
+        )
+        .non_destructive()
+        .extractor_handler_typed::<_, _, _, UpgradeEnterpriseDatabaseRedisInput>(
+            state,
+            |State(state): State<Arc<AppState>>,
+             Json(input): Json<UpgradeEnterpriseDatabaseRedisInput>| async move {
+                // Check write permission
+                if !state.is_write_allowed() {
+                    return Err(McpError::tool(
+                        "Write operations require policy tier 'read-write' or 'full'",
+                    ));
+                }
+
+                let client = state
+                    .enterprise_client_for_profile(input.profile.as_deref())
+                    .await
+                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+
+                let request = DatabaseUpgradeRequest {
+                    redis_version: input.redis_version,
+                    force_restart: input.force_restart,
+                    may_discard_data: input.may_discard_data,
+                    ..Default::default()
+                };
+
+                let handler = DatabaseHandler::new(client);
+                let response = handler
+                    .upgrade_redis_version(input.uid, request)
+                    .await
+                    .tool_context("Failed to upgrade database Redis version")?;
+
+                CallToolResult::from_serialize(&response)
+            },
+        )
+        .build()
+}
+
 // ============================================================================
 // CRDB (Active-Active) tools
 // ============================================================================
@@ -732,6 +891,148 @@ pub fn get_enterprise_crdb_tasks(state: Arc<AppState>) -> Tool {
         .build()
 }
 
+/// Input for creating an Active-Active (CRDB) database
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CreateEnterpriseCrdbInput {
+    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
+    #[serde(default)]
+    pub profile: Option<String>,
+    /// Full CRDB configuration as JSON (name, memory_size, instances, etc.)
+    pub request: Value,
+}
+
+/// Build the create_enterprise_crdb tool
+pub fn create_enterprise_crdb(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("create_enterprise_crdb")
+        .description(
+            "Create a new Active-Active (CRDB) database across multiple clusters. \
+             Pass the full CRDB configuration as JSON.",
+        )
+        .non_destructive()
+        .extractor_handler_typed::<_, _, _, CreateEnterpriseCrdbInput>(
+            state,
+            |State(state): State<Arc<AppState>>,
+             Json(input): Json<CreateEnterpriseCrdbInput>| async move {
+                // Check write permission
+                if !state.is_write_allowed() {
+                    return Err(McpError::tool(
+                        "Write operations require policy tier 'read-write' or 'full'",
+                    ));
+                }
+
+                let client = state
+                    .enterprise_client_for_profile(input.profile.as_deref())
+                    .await
+                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+
+                let crdb: Value = client
+                    .post("/v1/crdbs", &input.request)
+                    .await
+                    .tool_context("Failed to create CRDB")?;
+
+                CallToolResult::from_serialize(&crdb)
+            },
+        )
+        .build()
+}
+
+/// Input for updating an Active-Active (CRDB) database
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct UpdateEnterpriseCrdbInput {
+    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
+    #[serde(default)]
+    pub profile: Option<String>,
+    /// CRDB GUID (globally unique identifier)
+    pub guid: String,
+    /// JSON object with fields to update
+    pub updates: Value,
+}
+
+/// Build the update_enterprise_crdb tool
+pub fn update_enterprise_crdb(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("update_enterprise_crdb")
+        .description(
+            "Update an existing Active-Active (CRDB) database configuration. \
+             Pass the fields to update as JSON.",
+        )
+        .non_destructive()
+        .extractor_handler_typed::<_, _, _, UpdateEnterpriseCrdbInput>(
+            state,
+            |State(state): State<Arc<AppState>>,
+             Json(input): Json<UpdateEnterpriseCrdbInput>| async move {
+                // Check write permission
+                if !state.is_write_allowed() {
+                    return Err(McpError::tool(
+                        "Write operations require policy tier 'read-write' or 'full'",
+                    ));
+                }
+
+                let client = state
+                    .enterprise_client_for_profile(input.profile.as_deref())
+                    .await
+                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+
+                let handler = CrdbHandler::new(client);
+                let crdb = handler
+                    .update(&input.guid, input.updates)
+                    .await
+                    .tool_context("Failed to update CRDB")?;
+
+                CallToolResult::from_serialize(&crdb)
+            },
+        )
+        .build()
+}
+
+/// Input for deleting an Active-Active (CRDB) database
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct DeleteEnterpriseCrdbInput {
+    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
+    #[serde(default)]
+    pub profile: Option<String>,
+    /// CRDB GUID (globally unique identifier) to delete
+    pub guid: String,
+}
+
+/// Build the delete_enterprise_crdb tool
+pub fn delete_enterprise_crdb(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("delete_enterprise_crdb")
+        .description(
+            "DANGEROUS: Permanently deletes an Active-Active (CRDB) database across all \
+             participating clusters. This action cannot be undone.",
+        )
+        .destructive()
+        .extractor_handler_typed::<_, _, _, DeleteEnterpriseCrdbInput>(
+            state,
+            |State(state): State<Arc<AppState>>,
+             Json(input): Json<DeleteEnterpriseCrdbInput>| async move {
+                // Check destructive permission
+                if !state.is_destructive_allowed() {
+                    return Err(McpError::tool(
+                        "Destructive operations require policy tier 'full'",
+                    ));
+                }
+
+                let client = state
+                    .enterprise_client_for_profile(input.profile.as_deref())
+                    .await
+                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+
+                let handler = CrdbHandler::new(client);
+                handler
+                    .delete(&input.guid)
+                    .await
+                    .tool_context("Failed to delete CRDB")?;
+
+                CallToolResult::from_serialize(&serde_json::json!({
+                    "message": "CRDB deleted successfully",
+                    "guid": input.guid
+                }))
+            },
+        )
+        .build()
+}
+
 /// Build an MCP sub-router containing database tools
 pub fn router(state: Arc<AppState>) -> McpRouter {
     McpRouter::new()
@@ -745,6 +1046,10 @@ pub fn router(state: Arc<AppState>) -> McpRouter {
         .tool(list_enterprise_crdbs(state.clone()))
         .tool(get_enterprise_crdb(state.clone()))
         .tool(get_enterprise_crdb_tasks(state.clone()))
+        // CRDB Write Operations
+        .tool(create_enterprise_crdb(state.clone()))
+        .tool(update_enterprise_crdb(state.clone()))
+        .tool(delete_enterprise_crdb(state.clone()))
         // Database Write Operations
         .tool(backup_enterprise_database(state.clone()))
         .tool(import_enterprise_database(state.clone()))
@@ -752,4 +1057,7 @@ pub fn router(state: Arc<AppState>) -> McpRouter {
         .tool(update_enterprise_database(state.clone()))
         .tool(delete_enterprise_database(state.clone()))
         .tool(flush_enterprise_database(state.clone()))
+        .tool(export_enterprise_database(state.clone()))
+        .tool(restore_enterprise_database(state.clone()))
+        .tool(upgrade_enterprise_database_redis(state.clone()))
 }

--- a/crates/redisctl-mcp/src/tools/enterprise/mod.rs
+++ b/crates/redisctl-mcp/src/tools/enterprise/mod.rs
@@ -3,7 +3,9 @@
 mod cluster;
 mod databases;
 mod observability;
+mod proxy;
 mod rbac;
+mod services;
 
 #[allow(unused_imports)]
 pub use cluster::*;
@@ -12,7 +14,11 @@ pub use databases::*;
 #[allow(unused_imports)]
 pub use observability::*;
 #[allow(unused_imports)]
+pub use proxy::*;
+#[allow(unused_imports)]
 pub use rbac::*;
+#[allow(unused_imports)]
+pub use services::*;
 
 use std::sync::Arc;
 
@@ -36,6 +42,7 @@ pub const TOOL_NAMES: &[&str] = &[
     "get_enterprise_cluster_certificates",
     "rotate_enterprise_cluster_certificates",
     "update_enterprise_cluster_certificates",
+    "get_enterprise_cluster_services",
     "list_nodes",
     "get_node",
     "get_node_stats",
@@ -43,6 +50,8 @@ pub const TOOL_NAMES: &[&str] = &[
     "disable_enterprise_node_maintenance",
     "rebalance_enterprise_node",
     "drain_enterprise_node",
+    "update_enterprise_node",
+    "remove_enterprise_node",
     "get_cluster_stats",
     // databases
     "list_enterprise_databases",
@@ -56,29 +65,39 @@ pub const TOOL_NAMES: &[&str] = &[
     "update_enterprise_database",
     "delete_enterprise_database",
     "flush_enterprise_database",
+    "export_enterprise_database",
+    "restore_enterprise_database",
+    "upgrade_enterprise_database_redis",
     "list_enterprise_crdbs",
     "get_enterprise_crdb",
     "get_enterprise_crdb_tasks",
+    "create_enterprise_crdb",
+    "update_enterprise_crdb",
+    "delete_enterprise_crdb",
     // rbac
     "list_enterprise_users",
     "get_enterprise_user",
     "create_enterprise_user",
     "update_enterprise_user",
     "delete_enterprise_user",
+    "get_enterprise_user_permissions",
     "list_enterprise_roles",
     "get_enterprise_role",
     "create_enterprise_role",
     "update_enterprise_role",
     "delete_enterprise_role",
+    "get_enterprise_builtin_roles",
     "list_enterprise_acls",
     "get_enterprise_acl",
     "create_enterprise_acl",
     "update_enterprise_acl",
     "delete_enterprise_acl",
+    "validate_enterprise_acl",
     "get_enterprise_ldap_config",
     "update_enterprise_ldap_config",
     // observability
     "list_alerts",
+    "acknowledge_enterprise_alert",
     "list_logs",
     "get_all_nodes_stats",
     "get_all_databases_stats",
@@ -86,10 +105,26 @@ pub const TOOL_NAMES: &[&str] = &[
     "get_all_shards_stats",
     "list_shards",
     "get_shard",
+    "list_shards_by_database",
+    "list_shards_by_node",
     "list_debug_info_tasks",
     "get_debug_info_status",
+    "create_debug_info",
     "list_modules",
     "get_module",
+    // proxy
+    "list_enterprise_proxies",
+    "get_enterprise_proxy",
+    "get_enterprise_proxy_stats",
+    "update_enterprise_proxy",
+    // services
+    "list_enterprise_services",
+    "get_enterprise_service",
+    "get_enterprise_service_status",
+    "update_enterprise_service",
+    "start_enterprise_service",
+    "stop_enterprise_service",
+    "restart_enterprise_service",
 ];
 
 /// Get all Enterprise tool names as owned strings.
@@ -103,5 +138,7 @@ pub fn router(state: Arc<AppState>) -> McpRouter {
         .merge(cluster::router(state.clone()))
         .merge(databases::router(state.clone()))
         .merge(rbac::router(state.clone()))
-        .merge(observability::router(state))
+        .merge(observability::router(state.clone()))
+        .merge(proxy::router(state.clone()))
+        .merge(services::router(state))
 }

--- a/crates/redisctl-mcp/src/tools/enterprise/observability.rs
+++ b/crates/redisctl-mcp/src/tools/enterprise/observability.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use redis_enterprise::alerts::AlertHandler;
-use redis_enterprise::debuginfo::DebugInfoHandler;
+use redis_enterprise::debuginfo::{DebugInfoHandler, DebugInfoRequest};
 use redis_enterprise::logs::{LogsHandler, LogsQuery};
 use redis_enterprise::modules::ModuleHandler;
 use redis_enterprise::shards::ShardHandler;
@@ -11,7 +11,7 @@ use redis_enterprise::stats::StatsHandler;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use tower_mcp::extract::{Json, State};
-use tower_mcp::{CallToolResult, McpRouter, ResultExt, Tool, ToolBuilder};
+use tower_mcp::{CallToolResult, Error as McpError, McpRouter, ResultExt, Tool, ToolBuilder};
 
 use crate::state::AppState;
 use crate::tools::wrap_list;
@@ -516,11 +516,209 @@ pub fn get_module(state: Arc<AppState>) -> Tool {
         .build()
 }
 
+// ============================================================================
+// Filtered Shard tools
+// ============================================================================
+
+/// Input for listing shards by database
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ListShardsByDatabaseInput {
+    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
+    #[serde(default)]
+    pub profile: Option<String>,
+    /// Database UID to list shards for
+    pub bdb_uid: u32,
+}
+
+/// Build the list_shards_by_database tool
+pub fn list_shards_by_database(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("list_shards_by_database")
+        .description(
+            "List all shards for a specific database. Returns shard details including role, \
+             status, and node assignment.",
+        )
+        .read_only_safe()
+        .extractor_handler_typed::<_, _, _, ListShardsByDatabaseInput>(
+            state,
+            |State(state): State<Arc<AppState>>,
+             Json(input): Json<ListShardsByDatabaseInput>| async move {
+                let client = state
+                    .enterprise_client_for_profile(input.profile.as_deref())
+                    .await
+                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+
+                let handler = ShardHandler::new(client);
+                let shards = handler
+                    .list_by_database(input.bdb_uid)
+                    .await
+                    .tool_context("Failed to list shards by database")?;
+
+                wrap_list("shards", &shards)
+            },
+        )
+        .build()
+}
+
+/// Input for listing shards by node
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ListShardsByNodeInput {
+    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
+    #[serde(default)]
+    pub profile: Option<String>,
+    /// Node UID to list shards for
+    pub node_uid: u32,
+}
+
+/// Build the list_shards_by_node tool
+pub fn list_shards_by_node(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("list_shards_by_node")
+        .description(
+            "List all shards on a specific node. Useful for understanding shard distribution \
+             and planning rebalance operations.",
+        )
+        .read_only_safe()
+        .extractor_handler_typed::<_, _, _, ListShardsByNodeInput>(
+            state,
+            |State(state): State<Arc<AppState>>,
+             Json(input): Json<ListShardsByNodeInput>| async move {
+                let client = state
+                    .enterprise_client_for_profile(input.profile.as_deref())
+                    .await
+                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+
+                let handler = ShardHandler::new(client);
+                let shards = handler
+                    .list_by_node(input.node_uid)
+                    .await
+                    .tool_context("Failed to list shards by node")?;
+
+                wrap_list("shards", &shards)
+            },
+        )
+        .build()
+}
+
+// ============================================================================
+// Alert Acknowledge
+// ============================================================================
+
+/// Input for acknowledging an alert
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct AcknowledgeAlertInput {
+    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
+    #[serde(default)]
+    pub profile: Option<String>,
+    /// Alert UID to acknowledge
+    pub alert_uid: String,
+}
+
+/// Build the acknowledge_enterprise_alert tool
+pub fn acknowledge_enterprise_alert(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("acknowledge_enterprise_alert")
+        .description(
+            "Acknowledge (clear) a specific alert by ID. The alert will be marked as resolved.",
+        )
+        .non_destructive()
+        .extractor_handler_typed::<_, _, _, AcknowledgeAlertInput>(
+            state,
+            |State(state): State<Arc<AppState>>,
+             Json(input): Json<AcknowledgeAlertInput>| async move {
+                // Check write permission
+                if !state.is_write_allowed() {
+                    return Err(McpError::tool(
+                        "Write operations not allowed in read-only mode",
+                    ));
+                }
+
+                let client = state
+                    .enterprise_client_for_profile(input.profile.as_deref())
+                    .await
+                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+
+                let handler = AlertHandler::new(client);
+                handler
+                    .clear(&input.alert_uid)
+                    .await
+                    .tool_context("Failed to acknowledge alert")?;
+
+                CallToolResult::from_serialize(&serde_json::json!({
+                    "message": "Alert acknowledged successfully",
+                    "alert_uid": input.alert_uid
+                }))
+            },
+        )
+        .build()
+}
+
+// ============================================================================
+// Debug Info Create
+// ============================================================================
+
+/// Input for creating a debug info collection task
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CreateDebugInfoInput {
+    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
+    #[serde(default)]
+    pub profile: Option<String>,
+    /// List of node UIDs to collect debug info from (if not specified, collects from all nodes)
+    #[serde(default)]
+    pub node_uids: Option<Vec<u32>>,
+    /// List of database UIDs to collect debug info for (if not specified, collects for all databases)
+    #[serde(default)]
+    pub bdb_uids: Option<Vec<u32>>,
+}
+
+/// Build the create_debug_info tool
+pub fn create_debug_info(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("create_debug_info")
+        .description(
+            "Start a debug information collection task. Specify node and/or database IDs to \
+             scope the collection. Returns task status for tracking.",
+        )
+        .non_destructive()
+        .extractor_handler_typed::<_, _, _, CreateDebugInfoInput>(
+            state,
+            |State(state): State<Arc<AppState>>,
+             Json(input): Json<CreateDebugInfoInput>| async move {
+                // Check write permission
+                if !state.is_write_allowed() {
+                    return Err(McpError::tool(
+                        "Write operations not allowed in read-only mode",
+                    ));
+                }
+
+                let client = state
+                    .enterprise_client_for_profile(input.profile.as_deref())
+                    .await
+                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+
+                let request = DebugInfoRequest {
+                    node_uids: input.node_uids,
+                    bdb_uids: input.bdb_uids,
+                    include_logs: None,
+                    include_metrics: None,
+                    include_configs: None,
+                    time_range: None,
+                };
+
+                let handler = DebugInfoHandler::new(client);
+                let status = handler
+                    .create(request)
+                    .await
+                    .tool_context("Failed to create debug info collection")?;
+
+                CallToolResult::from_serialize(&status)
+            },
+        )
+        .build()
+}
+
 /// Build an MCP sub-router containing observability tools
 pub fn router(state: Arc<AppState>) -> McpRouter {
     McpRouter::new()
         // Alerts
         .tool(list_alerts(state.clone()))
+        .tool(acknowledge_enterprise_alert(state.clone()))
         // Logs
         .tool(list_logs(state.clone()))
         // Aggregate Stats
@@ -531,9 +729,12 @@ pub fn router(state: Arc<AppState>) -> McpRouter {
         // Shards
         .tool(list_shards(state.clone()))
         .tool(get_shard(state.clone()))
+        .tool(list_shards_by_database(state.clone()))
+        .tool(list_shards_by_node(state.clone()))
         // Debug Info
         .tool(list_debug_info_tasks(state.clone()))
         .tool(get_debug_info_status(state.clone()))
+        .tool(create_debug_info(state.clone()))
         // Modules
         .tool(list_modules(state.clone()))
         .tool(get_module(state.clone()))

--- a/crates/redisctl-mcp/src/tools/enterprise/proxy.rs
+++ b/crates/redisctl-mcp/src/tools/enterprise/proxy.rs
@@ -1,0 +1,173 @@
+//! Proxy management tools for Redis Enterprise
+
+use std::sync::Arc;
+
+use redis_enterprise::proxies::ProxyHandler;
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde_json::Value;
+use tower_mcp::extract::{Json, State};
+use tower_mcp::{CallToolResult, Error as McpError, McpRouter, ResultExt, Tool, ToolBuilder};
+
+use crate::state::AppState;
+use crate::tools::wrap_list;
+
+/// Input for listing proxies
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ListProxiesInput {
+    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
+    #[serde(default)]
+    pub profile: Option<String>,
+}
+
+/// Build the list_enterprise_proxies tool
+pub fn list_proxies(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("list_enterprise_proxies")
+        .description("List all proxy instances in the Redis Enterprise cluster with their status and configuration.")
+        .read_only_safe()
+        .extractor_handler_typed::<_, _, _, ListProxiesInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<ListProxiesInput>| async move {
+                let client = state
+                    .enterprise_client_for_profile(input.profile.as_deref())
+                    .await
+                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+
+                let handler = ProxyHandler::new(client);
+                let proxies = handler
+                    .list()
+                    .await
+                    .tool_context("Failed to list proxies")?;
+
+                wrap_list("proxies", &proxies)
+            },
+        )
+        .build()
+}
+
+/// Input for getting a specific proxy
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct GetProxyInput {
+    /// Proxy UID
+    pub uid: u32,
+    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
+    #[serde(default)]
+    pub profile: Option<String>,
+}
+
+/// Build the get_enterprise_proxy tool
+pub fn get_proxy(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("get_enterprise_proxy")
+        .description("Get detailed information about a specific proxy instance by UID.")
+        .read_only_safe()
+        .extractor_handler_typed::<_, _, _, GetProxyInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<GetProxyInput>| async move {
+                let client = state
+                    .enterprise_client_for_profile(input.profile.as_deref())
+                    .await
+                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+
+                let handler = ProxyHandler::new(client);
+                let proxy = handler
+                    .get(input.uid)
+                    .await
+                    .tool_context("Failed to get proxy")?;
+
+                CallToolResult::from_serialize(&proxy)
+            },
+        )
+        .build()
+}
+
+/// Input for getting proxy stats
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct GetProxyStatsInput {
+    /// Proxy UID
+    pub uid: u32,
+    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
+    #[serde(default)]
+    pub profile: Option<String>,
+}
+
+/// Build the get_enterprise_proxy_stats tool
+pub fn get_proxy_stats(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("get_enterprise_proxy_stats")
+        .description("Get statistics for a specific proxy instance including connection counts and throughput.")
+        .read_only_safe()
+        .extractor_handler_typed::<_, _, _, GetProxyStatsInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<GetProxyStatsInput>| async move {
+                let client = state
+                    .enterprise_client_for_profile(input.profile.as_deref())
+                    .await
+                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+
+                let handler = ProxyHandler::new(client);
+                let stats = handler
+                    .stats(input.uid)
+                    .await
+                    .tool_context("Failed to get proxy stats")?;
+
+                CallToolResult::from_serialize(&stats)
+            },
+        )
+        .build()
+}
+
+/// Input for updating a proxy
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct UpdateProxyInput {
+    /// Proxy UID to update
+    pub uid: u32,
+    /// Updated proxy configuration as JSON (e.g., max_connections, threads)
+    pub updates: Value,
+    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
+    #[serde(default)]
+    pub profile: Option<String>,
+}
+
+/// Build the update_enterprise_proxy tool
+pub fn update_proxy(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("update_enterprise_proxy")
+        .description(
+            "Update a proxy instance's configuration. Pass the fields to update as JSON \
+             (e.g., max_connections, threads). Requires write permission.",
+        )
+        .non_destructive()
+        .extractor_handler_typed::<_, _, _, UpdateProxyInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<UpdateProxyInput>| async move {
+                if !state.is_write_allowed() {
+                    return Err(McpError::tool(
+                        "Write operations require policy tier 'read-write' or 'full'",
+                    ));
+                }
+
+                let client = state
+                    .enterprise_client_for_profile(input.profile.as_deref())
+                    .await
+                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+
+                let handler = ProxyHandler::new(client);
+                let update = serde_json::from_value(input.updates)
+                    .map_err(|e| McpError::tool(format!("Invalid proxy update: {}", e)))?;
+                let result = handler
+                    .update(input.uid, update)
+                    .await
+                    .tool_context("Failed to update proxy")?;
+
+                CallToolResult::from_serialize(&result)
+            },
+        )
+        .build()
+}
+
+/// Build the proxy sub-router
+pub fn router(state: Arc<AppState>) -> McpRouter {
+    McpRouter::new()
+        .tool(list_proxies(state.clone()))
+        .tool(get_proxy(state.clone()))
+        .tool(get_proxy_stats(state.clone()))
+        .tool(update_proxy(state.clone()))
+}

--- a/crates/redisctl-mcp/src/tools/enterprise/rbac.rs
+++ b/crates/redisctl-mcp/src/tools/enterprise/rbac.rs
@@ -857,6 +857,140 @@ pub fn update_enterprise_ldap_config(state: Arc<AppState>) -> Tool {
         .build()
 }
 
+// ============================================================================
+// User Permissions
+// ============================================================================
+
+/// Input for getting user permissions (no required parameters)
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct GetUserPermissionsInput {
+    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
+    #[serde(default)]
+    pub profile: Option<String>,
+}
+
+/// Build the get_enterprise_user_permissions tool
+pub fn get_enterprise_user_permissions(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("get_enterprise_user_permissions")
+        .description(
+            "Get all available permission types for Redis Enterprise user management.",
+        )
+        .read_only_safe()
+        .extractor_handler_typed::<_, _, _, GetUserPermissionsInput>(
+            state,
+            |State(state): State<Arc<AppState>>,
+             Json(input): Json<GetUserPermissionsInput>| async move {
+                let client = state
+                    .enterprise_client_for_profile(input.profile.as_deref())
+                    .await
+                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+
+                let handler = UserHandler::new(client);
+                let permissions = handler
+                    .permissions()
+                    .await
+                    .tool_context("Failed to get user permissions")?;
+
+                CallToolResult::from_serialize(&permissions)
+            },
+        )
+        .build()
+}
+
+// ============================================================================
+// Built-in Roles
+// ============================================================================
+
+/// Input for getting built-in roles (no required parameters)
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct GetBuiltinRolesInput {
+    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
+    #[serde(default)]
+    pub profile: Option<String>,
+}
+
+/// Build the get_enterprise_builtin_roles tool
+pub fn get_enterprise_builtin_roles(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("get_enterprise_builtin_roles")
+        .description(
+            "Get the list of built-in roles available in the Redis Enterprise cluster.",
+        )
+        .read_only_safe()
+        .extractor_handler_typed::<_, _, _, GetBuiltinRolesInput>(
+            state,
+            |State(state): State<Arc<AppState>>,
+             Json(input): Json<GetBuiltinRolesInput>| async move {
+                let client = state
+                    .enterprise_client_for_profile(input.profile.as_deref())
+                    .await
+                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+
+                let handler = RolesHandler::new(client);
+                let roles = handler
+                    .built_in()
+                    .await
+                    .tool_context("Failed to get built-in roles")?;
+
+                wrap_list("roles", &roles)
+            },
+        )
+        .build()
+}
+
+// ============================================================================
+// ACL Validation
+// ============================================================================
+
+/// Input for validating a Redis ACL
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ValidateEnterpriseAclInput {
+    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
+    #[serde(default)]
+    pub profile: Option<String>,
+    /// ACL name
+    pub name: String,
+    /// ACL rule string (e.g., "+@all ~*" or "+get +set ~cache:*")
+    pub acl: String,
+    /// Description of the ACL
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+/// Build the validate_enterprise_acl tool
+pub fn validate_enterprise_acl(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("validate_enterprise_acl")
+        .description(
+            "Validate a Redis ACL rule before creating it. Returns validation results \
+             and any errors.",
+        )
+        .read_only_safe()
+        .extractor_handler_typed::<_, _, _, ValidateEnterpriseAclInput>(
+            state,
+            |State(state): State<Arc<AppState>>,
+             Json(input): Json<ValidateEnterpriseAclInput>| async move {
+                let client = state
+                    .enterprise_client_for_profile(input.profile.as_deref())
+                    .await
+                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+
+                let request = CreateRedisAclRequest {
+                    name: input.name,
+                    acl: input.acl,
+                    description: input.description,
+                };
+
+                let handler = RedisAclHandler::new(client);
+                let result = handler
+                    .validate(request)
+                    .await
+                    .tool_context("Failed to validate ACL")?;
+
+                CallToolResult::from_serialize(&result)
+            },
+        )
+        .build()
+}
+
 /// Build an MCP sub-router containing RBAC and LDAP tools
 pub fn router(state: Arc<AppState>) -> McpRouter {
     McpRouter::new()
@@ -878,6 +1012,12 @@ pub fn router(state: Arc<AppState>) -> McpRouter {
         .tool(create_enterprise_acl(state.clone()))
         .tool(update_enterprise_acl(state.clone()))
         .tool(delete_enterprise_acl(state.clone()))
+        // User Permissions
+        .tool(get_enterprise_user_permissions(state.clone()))
+        // Built-in Roles
+        .tool(get_enterprise_builtin_roles(state.clone()))
+        // ACL Validation
+        .tool(validate_enterprise_acl(state.clone()))
         // LDAP
         .tool(get_enterprise_ldap_config(state.clone()))
         .tool(update_enterprise_ldap_config(state.clone()))

--- a/crates/redisctl-mcp/src/tools/enterprise/services.rs
+++ b/crates/redisctl-mcp/src/tools/enterprise/services.rs
@@ -1,0 +1,285 @@
+//! Cluster service management tools for Redis Enterprise
+
+use std::sync::Arc;
+
+use redis_enterprise::services::ServicesHandler;
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde_json::Value;
+use tower_mcp::extract::{Json, State};
+use tower_mcp::{CallToolResult, Error as McpError, McpRouter, ResultExt, Tool, ToolBuilder};
+
+use crate::state::AppState;
+use crate::tools::wrap_list;
+
+/// Input for listing services
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ListServicesInput {
+    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
+    #[serde(default)]
+    pub profile: Option<String>,
+}
+
+/// Build the list_enterprise_services tool
+pub fn list_services(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("list_enterprise_services")
+        .description("List all services running on the Redis Enterprise cluster.")
+        .read_only_safe()
+        .extractor_handler_typed::<_, _, _, ListServicesInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<ListServicesInput>| async move {
+                let client = state
+                    .enterprise_client_for_profile(input.profile.as_deref())
+                    .await
+                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+
+                let handler = ServicesHandler::new(client);
+                let services = handler
+                    .list()
+                    .await
+                    .tool_context("Failed to list services")?;
+
+                wrap_list("services", &services)
+            },
+        )
+        .build()
+}
+
+/// Input for getting a specific service
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct GetServiceInput {
+    /// Service ID (e.g., "cm_server", "mdns_server", "stats_archiver")
+    pub service_id: String,
+    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
+    #[serde(default)]
+    pub profile: Option<String>,
+}
+
+/// Build the get_enterprise_service tool
+pub fn get_service(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("get_enterprise_service")
+        .description("Get detailed information about a specific cluster service by ID.")
+        .read_only_safe()
+        .extractor_handler_typed::<_, _, _, GetServiceInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<GetServiceInput>| async move {
+                let client = state
+                    .enterprise_client_for_profile(input.profile.as_deref())
+                    .await
+                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+
+                let handler = ServicesHandler::new(client);
+                let service = handler
+                    .get(&input.service_id)
+                    .await
+                    .tool_context("Failed to get service")?;
+
+                CallToolResult::from_serialize(&service)
+            },
+        )
+        .build()
+}
+
+/// Input for getting service status
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct GetServiceStatusInput {
+    /// Service ID
+    pub service_id: String,
+    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
+    #[serde(default)]
+    pub profile: Option<String>,
+}
+
+/// Build the get_enterprise_service_status tool
+pub fn get_service_status(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("get_enterprise_service_status")
+        .description("Get the current status of a specific cluster service, including per-node status.")
+        .read_only_safe()
+        .extractor_handler_typed::<_, _, _, GetServiceStatusInput>(
+            state,
+            |State(state): State<Arc<AppState>>,
+             Json(input): Json<GetServiceStatusInput>| async move {
+                let client = state
+                    .enterprise_client_for_profile(input.profile.as_deref())
+                    .await
+                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+
+                let handler = ServicesHandler::new(client);
+                let status = handler
+                    .status(&input.service_id)
+                    .await
+                    .tool_context("Failed to get service status")?;
+
+                CallToolResult::from_serialize(&status)
+            },
+        )
+        .build()
+}
+
+/// Input for updating a service
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct UpdateServiceInput {
+    /// Service ID to update
+    pub service_id: String,
+    /// Updated service configuration as JSON (e.g., enabled, config, node_uids)
+    pub config: Value,
+    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
+    #[serde(default)]
+    pub profile: Option<String>,
+}
+
+/// Build the update_enterprise_service tool
+pub fn update_service(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("update_enterprise_service")
+        .description(
+            "Update a cluster service's configuration. Pass the configuration fields as JSON. \
+             Requires write permission.",
+        )
+        .non_destructive()
+        .extractor_handler_typed::<_, _, _, UpdateServiceInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<UpdateServiceInput>| async move {
+                if !state.is_write_allowed() {
+                    return Err(McpError::tool(
+                        "Write operations require policy tier 'read-write' or 'full'",
+                    ));
+                }
+
+                let client = state
+                    .enterprise_client_for_profile(input.profile.as_deref())
+                    .await
+                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+
+                let handler = ServicesHandler::new(client);
+                let request = serde_json::from_value(input.config)
+                    .map_err(|e| McpError::tool(format!("Invalid service config: {}", e)))?;
+                let result = handler
+                    .update(&input.service_id, request)
+                    .await
+                    .tool_context("Failed to update service")?;
+
+                CallToolResult::from_serialize(&result)
+            },
+        )
+        .build()
+}
+
+/// Input for service action (start/stop/restart)
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ServiceActionInput {
+    /// Service ID
+    pub service_id: String,
+    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
+    #[serde(default)]
+    pub profile: Option<String>,
+}
+
+/// Build the start_enterprise_service tool
+pub fn start_service(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("start_enterprise_service")
+        .description(
+            "Start a cluster service that is currently stopped. Requires write permission.",
+        )
+        .non_destructive()
+        .extractor_handler_typed::<_, _, _, ServiceActionInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<ServiceActionInput>| async move {
+                if !state.is_write_allowed() {
+                    return Err(McpError::tool(
+                        "Write operations require policy tier 'read-write' or 'full'",
+                    ));
+                }
+
+                let client = state
+                    .enterprise_client_for_profile(input.profile.as_deref())
+                    .await
+                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+
+                let handler = ServicesHandler::new(client);
+                let result = handler
+                    .start(&input.service_id)
+                    .await
+                    .tool_context("Failed to start service")?;
+
+                CallToolResult::from_serialize(&result)
+            },
+        )
+        .build()
+}
+
+/// Build the stop_enterprise_service tool
+pub fn stop_service(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("stop_enterprise_service")
+        .description("Stop a running cluster service. Requires write permission.")
+        .non_destructive()
+        .extractor_handler_typed::<_, _, _, ServiceActionInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<ServiceActionInput>| async move {
+                if !state.is_write_allowed() {
+                    return Err(McpError::tool(
+                        "Write operations require policy tier 'read-write' or 'full'",
+                    ));
+                }
+
+                let client = state
+                    .enterprise_client_for_profile(input.profile.as_deref())
+                    .await
+                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+
+                let handler = ServicesHandler::new(client);
+                let result = handler
+                    .stop(&input.service_id)
+                    .await
+                    .tool_context("Failed to stop service")?;
+
+                CallToolResult::from_serialize(&result)
+            },
+        )
+        .build()
+}
+
+/// Build the restart_enterprise_service tool
+pub fn restart_service(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("restart_enterprise_service")
+        .description(
+            "Restart a cluster service. The service will be stopped and started. \
+             Requires write permission.",
+        )
+        .non_destructive()
+        .extractor_handler_typed::<_, _, _, ServiceActionInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<ServiceActionInput>| async move {
+                if !state.is_write_allowed() {
+                    return Err(McpError::tool(
+                        "Write operations require policy tier 'read-write' or 'full'",
+                    ));
+                }
+
+                let client = state
+                    .enterprise_client_for_profile(input.profile.as_deref())
+                    .await
+                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+
+                let handler = ServicesHandler::new(client);
+                let result = handler
+                    .restart(&input.service_id)
+                    .await
+                    .tool_context("Failed to restart service")?;
+
+                CallToolResult::from_serialize(&result)
+            },
+        )
+        .build()
+}
+
+/// Build the services sub-router
+pub fn router(state: Arc<AppState>) -> McpRouter {
+    McpRouter::new()
+        .tool(list_services(state.clone()))
+        .tool(get_service(state.clone()))
+        .tool(get_service_status(state.clone()))
+        .tool(update_service(state.clone()))
+        .tool(start_service(state.clone()))
+        .tool(stop_service(state.clone()))
+        .tool(restart_service(state.clone()))
+}


### PR DESCRIPTION
## Summary

Batch implementation of 27 new Enterprise MCP tools, closing the high-value items from #769, #770, #771, and #772 in one PR. Every tool uses typed methods from the `redis-enterprise` crate -- no raw HTTP calls.

### New tools by area

| Area | Tools | Issue |
|------|-------|-------|
| Database ops | `export_enterprise_database`, `restore_enterprise_database`, `upgrade_enterprise_database_redis` | #771 |
| CRDB/Active-Active | `create_enterprise_crdb`, `update_enterprise_crdb`, `delete_enterprise_crdb` | #769 |
| Node management | `update_enterprise_node`, `remove_enterprise_node`, `get_enterprise_cluster_services` | #770 |
| Observability | `list_shards_by_database`, `list_shards_by_node`, `acknowledge_enterprise_alert`, `create_debug_info` | #770, #771 |
| RBAC | `get_enterprise_user_permissions`, `get_enterprise_builtin_roles`, `validate_enterprise_acl` | #772 |
| Proxy (new module) | `list_enterprise_proxies`, `get_enterprise_proxy`, `get_enterprise_proxy_stats`, `update_enterprise_proxy` | #772 |
| Services (new module) | `list/get/status/update/start/stop/restart_enterprise_service` | #772 |

### Safety annotations

- 2 destructive: `delete_enterprise_crdb`, `remove_enterprise_node`
- 12 non-destructive writes: all create/update/export/restore/upgrade/start/stop/restart tools
- 13 read-only: all list/get/stats/validate/permissions tools

### Tool count after this PR

| Toolset | Before | After |
|---------|--------|-------|
| Enterprise | 59 | 86 |
| **Total MCP tools** | **203** | **230** |

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p redisctl-mcp --all-targets --all-features -- -D warnings`
- [x] `cargo test -p redisctl-mcp --all-features`
- [x] `cargo check -p redisctl-mcp --no-default-features`