### PR TITLE
feat(mcp): add tool visibility presets (#786)

### DIFF
--- a/crates/redisctl-mcp/src/lib.rs
+++ b/crates/redisctl-mcp/src/lib.rs
@@ -55,6 +55,7 @@
 pub mod audit;
 pub mod error;
 pub mod policy;
+pub mod presets;
 pub mod prompts;
 pub mod resources;
 pub mod state;

--- a/crates/redisctl-mcp/src/main.rs
+++ b/crates/redisctl-mcp/src/main.rs
@@ -22,6 +22,7 @@ use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 mod audit;
 mod error;
 mod policy;
+mod presets;
 mod prompts;
 mod resources;
 mod state;
@@ -29,6 +30,7 @@ mod tools;
 
 use audit::AuditLayer;
 use policy::{Policy, PolicyConfig, SafetyTier, ToolsetKind};
+use presets::{ToolVisibility, ToolsConfig};
 use state::{AppState, CredentialSource};
 use tower::Layer;
 
@@ -302,8 +304,15 @@ async fn main() -> Result<()> {
     let tool_toolset = build_tool_toolset_mapping(&enabled);
     let tool_toolset_arc = Arc::new(tool_toolset.clone());
 
+    // Extract tools visibility config before consuming policy_config
+    let tools_config = policy_config.tools.clone();
+
     // Build resolved policy
-    let policy = Arc::new(Policy::new(policy_config, tool_toolset, policy_source));
+    let policy = Arc::new(Policy::new(
+        policy_config,
+        tool_toolset.clone(),
+        policy_source,
+    ));
 
     // Build application state
     let state = Arc::new(AppState::new(
@@ -313,7 +322,7 @@ async fn main() -> Result<()> {
     )?);
 
     // Build router with tools and policy-based filter
-    let router = build_router(state.clone(), policy, &enabled)?;
+    let router = build_router(state.clone(), policy, &enabled, tools_config, &tool_toolset)?;
 
     match args.transport {
         Transport::Stdio => {
@@ -416,6 +425,8 @@ fn build_router(
     state: Arc<AppState>,
     policy: Arc<Policy>,
     enabled: &HashSet<Toolset>,
+    tools_config: ToolsConfig,
+    tool_toolset: &HashMap<String, ToolsetKind>,
 ) -> Result<McpRouter> {
     let mut router = McpRouter::new().server_info("redisctl-mcp", env!("CARGO_PKG_VERSION"));
 
@@ -440,14 +451,48 @@ fn build_router(
         router = router.merge(tools::profile::router(state.clone()));
     }
 
-    // Register the show_policy tool (always available)
+    // Register the show_policy tool (always available, bypasses visibility)
     router = router.tool(policy::show_policy_tool(policy.clone()));
 
+    // Resolve tool visibility from preset config
+    let all_tools: HashSet<String> = tool_toolset.keys().cloned().collect();
+    let visible_set = presets::resolve_visible_tools(&tools_config, &all_tools, tool_toolset);
+    let is_preset_active = !tools_config.is_all();
+
+    if is_preset_active {
+        info!(
+            preset = %tools_config.preset,
+            active = visible_set.len(),
+            total = all_tools.len(),
+            "Tool visibility preset active"
+        );
+    }
+
+    // Register list_available_tools tool (always available, bypasses visibility)
+    let visibility = Arc::new(ToolVisibility {
+        visible: visible_set.clone(),
+        all_tools: tool_toolset.clone(),
+        config: tools_config,
+    });
+    router = router.tool(presets::list_available_tools_tool(visibility));
+
     // Build instructions with policy description
-    let prefix = format!(
+    let mut prefix = format!(
         "# Redis Cloud and Enterprise MCP Server\n\n## Safety Model\n\n{}\n",
         policy.describe()
     );
+
+    if is_preset_active {
+        prefix.push_str(&format!(
+            "\n## Tool Visibility\n\n\
+             A visibility preset is active: {active}/{total} tools are loaded. \
+             Use the `list_available_tools` tool to see all tools grouped by toolset, \
+             including hidden tools that can be enabled via the `include` list in the \
+             policy config.\n",
+            active = visible_set.len(),
+            total = all_tools.len(),
+        ));
+    }
 
     let suffix = "\n## Authentication\n\n\
          In stdio mode, credentials are resolved from redisctl profiles.\n\
@@ -455,14 +500,18 @@ fn build_router(
 
     router = router.auto_instructions_with(Some(prefix), Some(suffix));
 
-    // Apply policy-based tool filter
-    // This hides denied tools from tools/list and returns "unauthorized"
-    // if they're called directly, providing defense in depth beyond handler-level checks
+    // Apply combined visibility + policy filter
+    // System tools (show_policy, list_available_tools) bypass visibility.
+    // All other tools must pass both visibility and policy checks.
     let policy_for_filter = policy.clone();
+    let visible_for_filter = Arc::new(visible_set);
     info!(tier = %policy.global_tier(), "Applying policy filter");
     let router = router.tool_filter(
         CapabilityFilter::<Tool>::new(move |_session, tool: &Tool| {
-            policy_for_filter.is_tool_allowed(tool)
+            let name = tool.name.as_str();
+            let is_system = presets::SYSTEM_TOOLS.contains(&name);
+            let is_visible = is_system || visible_for_filter.contains(name);
+            is_visible && policy_for_filter.is_tool_allowed(tool)
         })
         .denial_behavior(DenialBehavior::Unauthorized),
     );
@@ -1033,20 +1082,57 @@ mod tests {
     fn instructions_contain_safety_model() {
         let state = test_state();
         let enabled: HashSet<Toolset> = [Toolset::App].into_iter().collect();
+        let tool_toolset = build_tool_toolset_mapping(&enabled);
 
         let policy_ro = test_policy_arc(SafetyTier::ReadOnly);
-        let _router = build_router(state.clone(), policy_ro, &enabled).unwrap();
+        let _router = build_router(
+            state.clone(),
+            policy_ro,
+            &enabled,
+            ToolsConfig::default(),
+            &tool_toolset,
+        )
+        .unwrap();
         // Verify the build succeeds (no panics) for both modes.
         let policy_full = test_policy_arc(SafetyTier::Full);
-        let _router_write = build_router(state.clone(), policy_full, &enabled).unwrap();
+        let _router_write = build_router(
+            state.clone(),
+            policy_full,
+            &enabled,
+            ToolsConfig::default(),
+            &tool_toolset,
+        )
+        .unwrap();
     }
 
     #[test]
     fn show_policy_tool_is_always_registered() {
         let state = test_state();
         let enabled: HashSet<Toolset> = [Toolset::App].into_iter().collect();
+        let tool_toolset = build_tool_toolset_mapping(&enabled);
         let policy = test_policy_arc(SafetyTier::ReadOnly);
-        // Build should succeed and include show_policy tool
-        let _router = build_router(state, policy, &enabled).unwrap();
+        // Build should succeed and include show_policy and list_available_tools
+        let _router = build_router(
+            state,
+            policy,
+            &enabled,
+            ToolsConfig::default(),
+            &tool_toolset,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn essentials_preset_filters_tools() {
+        let state = test_state();
+        let enabled: HashSet<Toolset> = [Toolset::App].into_iter().collect();
+        let tool_toolset = build_tool_toolset_mapping(&enabled);
+        let policy = test_policy_arc(SafetyTier::Full);
+        let tools_config = ToolsConfig {
+            preset: "essentials".to_string(),
+            ..Default::default()
+        };
+        // Build should succeed with essentials preset
+        let _router = build_router(state, policy, &enabled, tools_config, &tool_toolset).unwrap();
     }
 }

--- a/crates/redisctl-mcp/src/policy.rs
+++ b/crates/redisctl-mcp/src/policy.rs
@@ -14,6 +14,7 @@ use serde::{Deserialize, Serialize};
 use tower_mcp::{CallToolResult, Error as McpError, Tool, ToolBuilder};
 
 use crate::audit::AuditConfig;
+use crate::presets::ToolsConfig;
 
 /// Safety tier determining which categories of tools are allowed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize, Serialize)]
@@ -82,6 +83,9 @@ pub struct PolicyConfig {
     /// Audit logging configuration
     #[serde(default)]
     pub audit: AuditConfig,
+    /// Tool visibility presets
+    #[serde(default)]
+    pub tools: ToolsConfig,
 }
 
 impl Default for PolicyConfig {
@@ -96,6 +100,7 @@ impl Default for PolicyConfig {
             database: None,
             app: None,
             audit: AuditConfig::default(),
+            tools: ToolsConfig::default(),
         }
     }
 }
@@ -764,6 +769,7 @@ mod tests {
             }),
             app: None,
             audit: AuditConfig::default(),
+            tools: ToolsConfig::default(),
         };
 
         let toml_str = toml::to_string_pretty(&config).unwrap();
@@ -981,5 +987,49 @@ allow = ["redis_set", "redis_expire"]
         assert!(desc.contains("cloud_raw_api"));
         assert!(desc.contains("enterprise_raw_api"));
         assert!(desc.contains("redis_command"));
+    }
+
+    // -- [tools] section TOML tests --
+
+    #[test]
+    fn toml_no_tools_section_defaults_to_all() {
+        let config: PolicyConfig = toml::from_str("tier = \"full\"").unwrap();
+        assert!(config.tools.is_all());
+        assert!(config.tools.include.is_empty());
+        assert!(config.tools.exclude.is_empty());
+    }
+
+    #[test]
+    fn toml_empty_tools_section_defaults_to_all() {
+        let config: PolicyConfig = toml::from_str("[tools]\n").unwrap();
+        assert!(config.tools.is_all());
+    }
+
+    #[test]
+    fn toml_tools_with_preset() {
+        let config: PolicyConfig = toml::from_str("[tools]\npreset = \"essentials\"\n").unwrap();
+        assert_eq!(config.tools.preset, "essentials");
+        assert!(!config.tools.is_all());
+    }
+
+    #[test]
+    fn toml_tools_with_include_exclude() {
+        let toml_str = r#"
+tier = "read-only"
+
+[tools]
+preset = "essentials"
+include = ["enterprise_raw_api", "get_enterprise_crdb"]
+exclude = ["flush_database"]
+"#;
+        let config: PolicyConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.tools.preset, "essentials");
+        assert_eq!(
+            config.tools.include,
+            vec!["enterprise_raw_api", "get_enterprise_crdb"]
+        );
+        assert_eq!(config.tools.exclude, vec!["flush_database"]);
+        // Other fields still parse correctly
+        assert_eq!(config.tier, SafetyTier::ReadOnly);
     }
 }

--- a/crates/redisctl-mcp/src/presets.rs
+++ b/crates/redisctl-mcp/src/presets.rs
@@ -1,0 +1,575 @@
+//! Tool visibility presets for managing the number of tools exposed to MCP clients.
+//!
+//! MCP clients degrade past ~50-100 tools (token overhead, selection confusion,
+//! latency). This module provides curated "essentials" subsets per platform so
+//! users get a manageable tool surface, with raw API passthrough tools (#768)
+//! as an escape hatch for anything not in the preset.
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use tower_mcp::{CallToolResult, Error as McpError, Tool, ToolBuilder};
+
+use crate::policy::ToolsetKind;
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+/// Tool visibility configuration from the `[tools]` section of `mcp-policy.toml`.
+///
+/// ```toml
+/// [tools]
+/// preset = "essentials"
+/// include = ["enterprise_raw_api", "get_enterprise_crdb"]
+/// exclude = ["flush_database"]
+/// ```
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(default)]
+pub struct ToolsConfig {
+    /// Preset name. `"all"` (default) loads every tool; `"essentials"` loads
+    /// a curated subset per enabled toolset.
+    pub preset: String,
+    /// Extra tool names to include on top of the preset.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub include: Vec<String>,
+    /// Tool names to exclude from the resolved set.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub exclude: Vec<String>,
+}
+
+impl ToolsConfig {
+    /// Returns true when visibility is the default "all tools visible" mode.
+    pub fn is_all(&self) -> bool {
+        self.preset.is_empty() || self.preset == "all"
+    }
+}
+
+// ============================================================================
+// Essentials constants
+// ============================================================================
+
+/// Cloud essentials: subscriptions, databases, account, tasks, logs, backups.
+pub const CLOUD_ESSENTIALS: &[&str] = &[
+    "list_subscriptions",
+    "get_subscription",
+    "list_databases",
+    "get_database",
+    "get_account",
+    "get_regions",
+    "list_tasks",
+    "get_task",
+    "wait_for_cloud_task",
+    "get_system_logs",
+    "get_backup_status",
+    "get_slow_log",
+    "get_database_tags",
+    "create_database",
+    "update_database",
+    "backup_database",
+    "list_fixed_subscriptions",
+    "list_fixed_databases",
+    "get_fixed_database",
+    "get_fixed_database_backup_status",
+];
+
+/// Enterprise essentials: cluster, nodes, databases, RBAC, observability.
+pub const ENTERPRISE_ESSENTIALS: &[&str] = &[
+    "get_cluster",
+    "get_license",
+    "list_nodes",
+    "get_node",
+    "get_cluster_stats",
+    "list_enterprise_databases",
+    "get_enterprise_database",
+    "get_database_stats",
+    "get_database_endpoints",
+    "list_enterprise_users",
+    "get_enterprise_user",
+    "list_enterprise_roles",
+    "get_enterprise_role",
+    "list_alerts",
+    "list_logs",
+    "list_shards",
+    "get_all_nodes_stats",
+    "get_all_databases_stats",
+];
+
+/// Database essentials: server info, diagnostics, key inspection.
+pub const DATABASE_ESSENTIALS: &[&str] = &[
+    "redis_ping",
+    "redis_info",
+    "redis_dbsize",
+    "redis_slowlog",
+    "redis_config_get",
+    "redis_memory_stats",
+    "redis_health_check",
+    "redis_key_summary",
+    "redis_connection_summary",
+    "redis_keys",
+    "redis_scan",
+    "redis_get",
+    "redis_type",
+    "redis_ttl",
+    "redis_hgetall",
+];
+
+/// App essentials: all profile tools (always included).
+pub const APP_ESSENTIALS: &[&str] = &[
+    "profile_list",
+    "profile_show",
+    "profile_path",
+    "profile_validate",
+    "profile_set_default_cloud",
+    "profile_set_default_enterprise",
+    "profile_delete",
+    "profile_create",
+];
+
+// ============================================================================
+// Resolution
+// ============================================================================
+
+/// Resolve the set of visible tool names from config, available tools, and
+/// toolset membership.
+///
+/// Resolution: preset base set -> +include -> -exclude
+pub fn resolve_visible_tools(
+    config: &ToolsConfig,
+    all_tools: &HashSet<String>,
+    tool_toolset: &HashMap<String, ToolsetKind>,
+) -> HashSet<String> {
+    if config.is_all() && config.include.is_empty() && config.exclude.is_empty() {
+        return all_tools.clone();
+    }
+
+    let mut visible = if config.is_all() {
+        all_tools.clone()
+    } else if config.preset == "essentials" {
+        build_essentials_set(tool_toolset)
+    } else {
+        // Unknown preset: treat as empty (only include list will populate)
+        tracing::warn!(preset = %config.preset, "Unknown preset, starting with empty tool set");
+        HashSet::new()
+    };
+
+    // +include: add tools that exist in the full set
+    for name in &config.include {
+        if all_tools.contains(name) {
+            visible.insert(name.clone());
+        } else {
+            tracing::warn!(tool = %name, "Include references unknown tool, ignoring");
+        }
+    }
+
+    // -exclude: remove from visible set
+    for name in &config.exclude {
+        visible.remove(name);
+    }
+
+    visible
+}
+
+/// Build the essentials set from only the toolsets that are actually enabled.
+fn build_essentials_set(tool_toolset: &HashMap<String, ToolsetKind>) -> HashSet<String> {
+    let mut set = HashSet::new();
+
+    // Determine which toolsets are present
+    let active_kinds: HashSet<ToolsetKind> = tool_toolset.values().copied().collect();
+
+    if active_kinds.contains(&ToolsetKind::Cloud) {
+        for name in CLOUD_ESSENTIALS {
+            set.insert((*name).to_string());
+        }
+    }
+    if active_kinds.contains(&ToolsetKind::Enterprise) {
+        for name in ENTERPRISE_ESSENTIALS {
+            set.insert((*name).to_string());
+        }
+    }
+    if active_kinds.contains(&ToolsetKind::Database) {
+        for name in DATABASE_ESSENTIALS {
+            set.insert((*name).to_string());
+        }
+    }
+    if active_kinds.contains(&ToolsetKind::App) {
+        for name in APP_ESSENTIALS {
+            set.insert((*name).to_string());
+        }
+    }
+
+    set
+}
+
+// ============================================================================
+// Runtime visibility
+// ============================================================================
+
+/// Runtime tool visibility state, shared via `Arc`.
+pub struct ToolVisibility {
+    /// Tools that passed visibility resolution.
+    pub visible: HashSet<String>,
+    /// Full tool-to-toolset mapping (for grouping in list_available_tools).
+    pub all_tools: HashMap<String, ToolsetKind>,
+    /// The config that produced this visibility.
+    pub config: ToolsConfig,
+}
+
+// ============================================================================
+// list_available_tools tool
+// ============================================================================
+
+/// Serializable summary returned by `list_available_tools`.
+#[derive(Debug, Serialize)]
+struct AvailableToolsSummary {
+    preset: String,
+    active_count: usize,
+    total_count: usize,
+    toolsets: BTreeMap<String, ToolsetGroup>,
+}
+
+/// Per-toolset group showing active and hidden tools.
+#[derive(Debug, Serialize)]
+struct ToolsetGroup {
+    active: Vec<String>,
+    hidden: Vec<String>,
+}
+
+/// Build the `list_available_tools` MCP tool.
+///
+/// Always registered, read-only. Returns the current preset, counts,
+/// and per-toolset active/hidden tool lists so the LLM can discover
+/// what tools are available and request specific ones via `include`.
+pub fn list_available_tools_tool(visibility: Arc<ToolVisibility>) -> Tool {
+    ToolBuilder::new("list_available_tools")
+        .description(
+            "List all available tools grouped by toolset, showing which are active \
+             (visible) and which are hidden by the current preset. Use this to discover \
+             tools you can request be enabled via the include list in the policy config.",
+        )
+        .read_only_safe()
+        .handler(move |_: serde_json::Value| {
+            let vis = visibility.clone();
+            async move {
+                let mut toolsets: BTreeMap<String, ToolsetGroup> = BTreeMap::new();
+
+                // Group tools by toolset
+                for (name, kind) in &vis.all_tools {
+                    let key = kind.to_string();
+                    let group = toolsets.entry(key).or_insert_with(|| ToolsetGroup {
+                        active: Vec::new(),
+                        hidden: Vec::new(),
+                    });
+                    if vis.visible.contains(name) {
+                        group.active.push(name.clone());
+                    } else {
+                        group.hidden.push(name.clone());
+                    }
+                }
+
+                // Sort lists for deterministic output
+                for group in toolsets.values_mut() {
+                    group.active.sort();
+                    group.hidden.sort();
+                }
+
+                let active_count = vis.visible.len();
+                let total_count = vis.all_tools.len();
+
+                let summary = AvailableToolsSummary {
+                    preset: if vis.config.is_all() {
+                        "all".to_string()
+                    } else {
+                        vis.config.preset.clone()
+                    },
+                    active_count,
+                    total_count,
+                    toolsets,
+                };
+
+                CallToolResult::from_serialize(&summary)
+                    .map_err(|e| McpError::tool(format!("Failed to serialize summary: {e}")))
+            }
+        })
+        .build()
+}
+
+/// Names of system tools that bypass visibility filtering.
+pub const SYSTEM_TOOLS: &[&str] = &["show_policy", "list_available_tools"];
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_tool_toolset(entries: &[(&str, ToolsetKind)]) -> HashMap<String, ToolsetKind> {
+        entries.iter().map(|(n, k)| (n.to_string(), *k)).collect()
+    }
+
+    fn make_all_tools(names: &[&str]) -> HashSet<String> {
+        names.iter().map(|n| n.to_string()).collect()
+    }
+
+    // -- ToolsConfig tests --
+
+    #[test]
+    fn default_config_is_all() {
+        let config = ToolsConfig::default();
+        assert!(config.is_all());
+    }
+
+    #[test]
+    fn empty_string_is_all() {
+        let config = ToolsConfig {
+            preset: String::new(),
+            ..Default::default()
+        };
+        assert!(config.is_all());
+    }
+
+    #[test]
+    fn explicit_all() {
+        let config = ToolsConfig {
+            preset: "all".to_string(),
+            ..Default::default()
+        };
+        assert!(config.is_all());
+    }
+
+    #[test]
+    fn essentials_is_not_all() {
+        let config = ToolsConfig {
+            preset: "essentials".to_string(),
+            ..Default::default()
+        };
+        assert!(!config.is_all());
+    }
+
+    // -- resolve_visible_tools tests --
+
+    #[test]
+    fn all_preset_returns_all_tools() {
+        let all = make_all_tools(&["tool_a", "tool_b", "tool_c"]);
+        let mapping = make_tool_toolset(&[("tool_a", ToolsetKind::Cloud)]);
+        let config = ToolsConfig::default();
+
+        let visible = resolve_visible_tools(&config, &all, &mapping);
+        assert_eq!(visible, all);
+    }
+
+    #[test]
+    fn essentials_preset_filters_to_known_tools() {
+        let mut mapping = HashMap::new();
+        // Add some cloud tools
+        for name in CLOUD_ESSENTIALS {
+            mapping.insert(name.to_string(), ToolsetKind::Cloud);
+        }
+        mapping.insert("delete_database".to_string(), ToolsetKind::Cloud);
+        mapping.insert("flush_database".to_string(), ToolsetKind::Cloud);
+
+        let all: HashSet<String> = mapping.keys().cloned().collect();
+        let config = ToolsConfig {
+            preset: "essentials".to_string(),
+            ..Default::default()
+        };
+
+        let visible = resolve_visible_tools(&config, &all, &mapping);
+
+        // Essentials should be present
+        assert!(visible.contains("list_subscriptions"));
+        assert!(visible.contains("get_database"));
+        // Non-essentials should not
+        assert!(!visible.contains("delete_database"));
+        assert!(!visible.contains("flush_database"));
+    }
+
+    #[test]
+    fn include_adds_tools() {
+        let mapping = make_tool_toolset(&[
+            ("tool_a", ToolsetKind::Cloud),
+            ("tool_b", ToolsetKind::Cloud),
+        ]);
+        let all = make_all_tools(&["tool_a", "tool_b"]);
+        let config = ToolsConfig {
+            preset: "essentials".to_string(),
+            include: vec!["tool_b".to_string()],
+            ..Default::default()
+        };
+
+        let visible = resolve_visible_tools(&config, &all, &mapping);
+        assert!(visible.contains("tool_b"));
+    }
+
+    #[test]
+    fn include_ignores_unknown_tools() {
+        let mapping = make_tool_toolset(&[("tool_a", ToolsetKind::Cloud)]);
+        let all = make_all_tools(&["tool_a"]);
+        let config = ToolsConfig {
+            preset: "essentials".to_string(),
+            include: vec!["nonexistent_tool".to_string()],
+            ..Default::default()
+        };
+
+        let visible = resolve_visible_tools(&config, &all, &mapping);
+        assert!(!visible.contains("nonexistent_tool"));
+    }
+
+    #[test]
+    fn exclude_removes_tools() {
+        let all = make_all_tools(&["tool_a", "tool_b", "tool_c"]);
+        let mapping = make_tool_toolset(&[]);
+        let config = ToolsConfig {
+            preset: "all".to_string(),
+            exclude: vec!["tool_b".to_string()],
+            ..Default::default()
+        };
+
+        let visible = resolve_visible_tools(&config, &all, &mapping);
+        assert!(visible.contains("tool_a"));
+        assert!(!visible.contains("tool_b"));
+        assert!(visible.contains("tool_c"));
+    }
+
+    #[test]
+    fn essentials_only_includes_active_toolsets() {
+        // Only enterprise tools in the mapping = only enterprise essentials
+        let mut mapping = HashMap::new();
+        for name in ENTERPRISE_ESSENTIALS {
+            mapping.insert(name.to_string(), ToolsetKind::Enterprise);
+        }
+        let all: HashSet<String> = mapping.keys().cloned().collect();
+
+        let config = ToolsConfig {
+            preset: "essentials".to_string(),
+            ..Default::default()
+        };
+
+        let visible = resolve_visible_tools(&config, &all, &mapping);
+
+        // Enterprise essentials should be present
+        assert!(visible.contains("get_cluster"));
+        // Cloud essentials should NOT (cloud toolset is not active)
+        assert!(!visible.contains("list_subscriptions"));
+    }
+
+    #[test]
+    fn include_and_exclude_compose() {
+        let all = make_all_tools(&["a", "b", "c", "d"]);
+        let mapping = make_tool_toolset(&[]);
+        let config = ToolsConfig {
+            preset: "essentials".to_string(),
+            include: vec!["a".to_string(), "b".to_string()],
+            exclude: vec!["b".to_string()],
+        };
+
+        let visible = resolve_visible_tools(&config, &all, &mapping);
+        assert!(visible.contains("a"));
+        assert!(!visible.contains("b")); // exclude wins
+    }
+
+    // -- Cross-validation: essentials constants vs TOOL_NAMES --
+
+    #[cfg(feature = "cloud")]
+    #[test]
+    fn cloud_essentials_are_valid_tool_names() {
+        let valid: HashSet<&str> = crate::tools::cloud::TOOL_NAMES.iter().copied().collect();
+        for name in CLOUD_ESSENTIALS {
+            assert!(
+                valid.contains(name),
+                "Cloud essentials contains unknown tool: {name}"
+            );
+        }
+    }
+
+    #[cfg(feature = "enterprise")]
+    #[test]
+    fn enterprise_essentials_are_valid_tool_names() {
+        let valid: HashSet<&str> = crate::tools::enterprise::TOOL_NAMES
+            .iter()
+            .copied()
+            .collect();
+        for name in ENTERPRISE_ESSENTIALS {
+            assert!(
+                valid.contains(name),
+                "Enterprise essentials contains unknown tool: {name}"
+            );
+        }
+    }
+
+    #[cfg(feature = "database")]
+    #[test]
+    fn database_essentials_are_valid_tool_names() {
+        let valid: HashSet<&str> = crate::tools::redis::TOOL_NAMES.iter().copied().collect();
+        for name in DATABASE_ESSENTIALS {
+            assert!(
+                valid.contains(name),
+                "Database essentials contains unknown tool: {name}"
+            );
+        }
+    }
+
+    #[test]
+    fn app_essentials_are_valid_tool_names() {
+        let valid: HashSet<&str> = crate::tools::profile::TOOL_NAMES.iter().copied().collect();
+        for name in APP_ESSENTIALS {
+            assert!(
+                valid.contains(name),
+                "App essentials contains unknown tool: {name}"
+            );
+        }
+    }
+
+    // -- list_available_tools tool tests --
+
+    #[test]
+    fn list_available_tools_is_read_only() {
+        let vis = Arc::new(ToolVisibility {
+            visible: HashSet::new(),
+            all_tools: HashMap::new(),
+            config: ToolsConfig::default(),
+        });
+        let tool = list_available_tools_tool(vis);
+        let ann = tool.annotations.as_ref().unwrap();
+        assert!(ann.read_only_hint);
+        assert!(!ann.destructive_hint);
+    }
+
+    // -- TOML deserialization tests --
+
+    #[test]
+    fn toml_empty_tools_section() {
+        let config: ToolsConfig = toml::from_str("").unwrap();
+        assert!(config.is_all());
+        assert!(config.include.is_empty());
+        assert!(config.exclude.is_empty());
+    }
+
+    #[test]
+    fn toml_preset_only() {
+        let config: ToolsConfig = toml::from_str(r#"preset = "essentials""#).unwrap();
+        assert_eq!(config.preset, "essentials");
+        assert!(!config.is_all());
+    }
+
+    #[test]
+    fn toml_full_config() {
+        let config: ToolsConfig = toml::from_str(
+            r#"
+preset = "essentials"
+include = ["enterprise_raw_api", "get_enterprise_crdb"]
+exclude = ["flush_database"]
+"#,
+        )
+        .unwrap();
+        assert_eq!(config.preset, "essentials");
+        assert_eq!(
+            config.include,
+            vec!["enterprise_raw_api", "get_enterprise_crdb"]
+        );
+        assert_eq!(config.exclude, vec!["flush_database"]);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `[tools]` section to `mcp-policy.toml` with `preset`, `include`, and `exclude` fields for per-tool visibility control
- Ship curated "essentials" preset (~61 tools: 20 cloud, 18 enterprise, 15 database, 8 app) to keep MCP clients under the ~50-100 tool degradation threshold
- Add `list_available_tools` system tool so LLMs can discover hidden tools and request specific ones via the `include` list
- Combine visibility + policy in a single `CapabilityFilter` closure; system tools (`show_policy`, `list_available_tools`) bypass visibility
- Backward compatible: no `[tools]` section = `preset = "all"` (current behavior, all tools loaded)

### Configuration example

```toml
[tools]
preset = "essentials"
include = ["enterprise_raw_api", "get_enterprise_crdb"]
exclude = ["flush_database"]
```

Resolution: preset base -> +include -> -exclude -> policy tier/deny/allow

### Files changed

| File | Change |
|------|--------|
| `presets.rs` (new) | `ToolsConfig`, essentials constants, `resolve_visible_tools()`, `ToolVisibility`, `list_available_tools_tool()`, cross-validation tests |
| `policy.rs` | `tools: ToolsConfig` field on `PolicyConfig`, TOML parsing tests |
| `lib.rs` | `pub mod presets;` |
| `main.rs` | Wire visibility into `build_router`, combined filter, instructions prefix, tests |

## Test plan

- [x] `cargo check -p redisctl-mcp --all-features`
- [x] `cargo check -p redisctl-mcp --no-default-features`
- [x] `cargo check -p redisctl-mcp --features cloud`
- [x] `cargo check -p redisctl-mcp --features enterprise`
- [x] `cargo check -p redisctl-mcp --features database`
- [x] `cargo clippy -p redisctl-mcp --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p redisctl-mcp --all-features`
- [x] Cross-validation tests: each essentials constant validated against its toolset's `TOOL_NAMES`

Closes #786