### PR TITLE
feat(mcp): add `enabled = false` per toolset in policy file

### DIFF
--- a/crates/redisctl-mcp/src/main.rs
+++ b/crates/redisctl-mcp/src/main.rs
@@ -223,6 +223,19 @@ fn enabled_toolsets(args: &Args) -> HashSet<Toolset> {
     set
 }
 
+/// Map a CLI `Toolset` to its corresponding `ToolsetKind` for policy lookup.
+fn toolset_to_kind(t: &Toolset) -> ToolsetKind {
+    match t {
+        #[cfg(feature = "cloud")]
+        Toolset::Cloud => ToolsetKind::Cloud,
+        #[cfg(feature = "enterprise")]
+        Toolset::Enterprise => ToolsetKind::Enterprise,
+        #[cfg(feature = "database")]
+        Toolset::Database => ToolsetKind::Database,
+        Toolset::App => ToolsetKind::App,
+    }
+}
+
 /// Resolve the policy configuration.
 ///
 /// If a policy file is found (via `--policy`, env var, or default path), it takes precedence
@@ -268,11 +281,20 @@ fn resolve_policy(args: &Args) -> Result<(PolicyConfig, String)> {
 async fn main() -> Result<()> {
     let args = Args::parse();
 
-    let enabled = enabled_toolsets(&args);
-    let enabled_names: Vec<String> = enabled.iter().map(|t| t.to_string()).collect();
+    let mut enabled = enabled_toolsets(&args);
 
     // Resolve policy configuration (includes audit config)
     let (policy_config, policy_source) = resolve_policy(&args)?;
+
+    // Apply policy-based toolset disabling (only when --tools was not explicit)
+    if args.tools.is_none() {
+        let disabled = policy_config.disabled_toolsets();
+        if !disabled.is_empty() {
+            enabled.retain(|t| !disabled.contains(&toolset_to_kind(t)));
+        }
+    }
+
+    let enabled_names: Vec<String> = enabled.iter().map(|t| t.to_string()).collect();
     let audit_config = Arc::new(policy_config.audit.clone());
 
     // Initialize tracing with optional audit layer
@@ -1134,5 +1156,48 @@ mod tests {
         };
         // Build should succeed with essentials preset
         let _router = build_router(state, policy, &enabled, tools_config, &tool_toolset).unwrap();
+    }
+
+    #[test]
+    fn policy_disabled_toolset_removes_from_enabled() {
+        use policy::ToolsetPolicy;
+
+        let config = PolicyConfig {
+            enterprise: Some(ToolsetPolicy {
+                enabled: Some(false),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let disabled = config.disabled_toolsets();
+
+        let mut enabled: HashSet<Toolset> = HashSet::new();
+        #[cfg(feature = "cloud")]
+        enabled.insert(Toolset::Cloud);
+        #[cfg(feature = "enterprise")]
+        enabled.insert(Toolset::Enterprise);
+        enabled.insert(Toolset::App);
+
+        enabled.retain(|t| !disabled.contains(&toolset_to_kind(t)));
+
+        #[cfg(feature = "cloud")]
+        assert!(enabled.contains(&Toolset::Cloud));
+        #[cfg(feature = "enterprise")]
+        assert!(!enabled.contains(&Toolset::Enterprise));
+        assert!(enabled.contains(&Toolset::App));
+    }
+
+    #[test]
+    fn toolset_to_kind_mapping() {
+        #[cfg(feature = "cloud")]
+        assert_eq!(toolset_to_kind(&Toolset::Cloud), ToolsetKind::Cloud);
+        #[cfg(feature = "enterprise")]
+        assert_eq!(
+            toolset_to_kind(&Toolset::Enterprise),
+            ToolsetKind::Enterprise
+        );
+        #[cfg(feature = "database")]
+        assert_eq!(toolset_to_kind(&Toolset::Database), ToolsetKind::Database);
+        assert_eq!(toolset_to_kind(&Toolset::App), ToolsetKind::App);
     }
 }

--- a/crates/redisctl-mcp/src/policy.rs
+++ b/crates/redisctl-mcp/src/policy.rs
@@ -43,6 +43,10 @@ impl fmt::Display for SafetyTier {
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 #[serde(default)]
 pub struct ToolsetPolicy {
+    /// Whether this toolset is enabled. `None` or `Some(true)` = enabled,
+    /// `Some(false)` = disabled (tools are never registered).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
     /// Safety tier for this toolset (overrides the global tier)
     pub tier: Option<SafetyTier>,
     /// Explicit tool names to allow (evaluated after tier)
@@ -112,6 +116,24 @@ pub const RAW_TOOL_DENY_DEFAULTS: &[&str] =
     &["cloud_raw_api", "enterprise_raw_api", "redis_command"];
 
 impl PolicyConfig {
+    /// Return the set of toolsets explicitly disabled via `enabled = false`.
+    pub fn disabled_toolsets(&self) -> HashSet<ToolsetKind> {
+        let mut disabled = HashSet::new();
+        for (kind, policy) in [
+            (ToolsetKind::Cloud, &self.cloud),
+            (ToolsetKind::Enterprise, &self.enterprise),
+            (ToolsetKind::Database, &self.database),
+            (ToolsetKind::App, &self.app),
+        ] {
+            if let Some(tp) = policy
+                && tp.enabled == Some(false)
+            {
+                disabled.insert(kind);
+            }
+        }
+        disabled
+    }
+
     /// Build the synthesized default policy (used when no config file exists).
     /// This adds raw API passthrough tools to the deny list.
     pub fn synthesized_default() -> Self {
@@ -412,6 +434,16 @@ impl Policy {
             ));
         }
 
+        let disabled = self.config.disabled_toolsets();
+        if !disabled.is_empty() {
+            let mut names: Vec<String> = disabled.iter().map(|k| k.to_string()).collect();
+            names.sort();
+            desc.push_str(&format!(
+                "\n\nDisabled toolsets (tools not registered): {}",
+                names.join(", ")
+            ));
+        }
+
         if !self.config.deny.is_empty() {
             desc.push_str(&format!(
                 "\n\nExplicitly denied tools: {}",
@@ -481,6 +513,8 @@ pub struct PolicySummary {
 #[derive(Debug, Serialize)]
 pub struct ToolsetPolicySummary {
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tier: Option<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub allow: Vec<String>,
@@ -491,6 +525,7 @@ pub struct ToolsetPolicySummary {
 impl From<&ToolsetPolicy> for ToolsetPolicySummary {
     fn from(tp: &ToolsetPolicy) -> Self {
         Self {
+            enabled: tp.enabled,
             tier: tp.tier.map(|t| t.to_string()),
             allow: tp.allow.clone(),
             deny: tp.deny.clone(),
@@ -765,7 +800,7 @@ mod tests {
             database: Some(ToolsetPolicy {
                 tier: Some(SafetyTier::ReadOnly),
                 allow: vec!["redis_set".to_string()],
-                deny: vec![],
+                ..Default::default()
             }),
             app: None,
             audit: AuditConfig::default(),
@@ -1031,5 +1066,117 @@ exclude = ["flush_database"]
         assert_eq!(config.tools.exclude, vec!["flush_database"]);
         // Other fields still parse correctly
         assert_eq!(config.tier, SafetyTier::ReadOnly);
+    }
+
+    // -- Toolset enabled/disabled tests --
+
+    #[test]
+    fn toml_enabled_false_parses() {
+        let toml_str = r#"
+tier = "read-only"
+
+[enterprise]
+enabled = false
+
+[database]
+enabled = false
+"#;
+        let config: PolicyConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.enterprise.as_ref().unwrap().enabled, Some(false));
+        assert_eq!(config.database.as_ref().unwrap().enabled, Some(false));
+        // Cloud not mentioned: should be None
+        assert!(config.cloud.is_none());
+    }
+
+    #[test]
+    fn toml_enabled_true_parses() {
+        let toml_str = r#"
+[cloud]
+enabled = true
+tier = "read-write"
+"#;
+        let config: PolicyConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.cloud.as_ref().unwrap().enabled, Some(true));
+    }
+
+    #[test]
+    fn toml_enabled_omitted_defaults_to_none() {
+        let toml_str = r#"
+[cloud]
+tier = "read-write"
+"#;
+        let config: PolicyConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.cloud.as_ref().unwrap().enabled, None);
+    }
+
+    #[test]
+    fn disabled_toolsets_returns_correct_set() {
+        let config = PolicyConfig {
+            enterprise: Some(ToolsetPolicy {
+                enabled: Some(false),
+                ..Default::default()
+            }),
+            database: Some(ToolsetPolicy {
+                enabled: Some(false),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let disabled = config.disabled_toolsets();
+        assert!(disabled.contains(&ToolsetKind::Enterprise));
+        assert!(disabled.contains(&ToolsetKind::Database));
+        assert!(!disabled.contains(&ToolsetKind::Cloud));
+        assert!(!disabled.contains(&ToolsetKind::App));
+    }
+
+    #[test]
+    fn disabled_toolsets_empty_when_all_enabled() {
+        let config = PolicyConfig {
+            cloud: Some(ToolsetPolicy {
+                enabled: Some(true),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert!(config.disabled_toolsets().is_empty());
+    }
+
+    #[test]
+    fn disabled_toolsets_empty_when_no_overrides() {
+        let config = PolicyConfig::default();
+        assert!(config.disabled_toolsets().is_empty());
+    }
+
+    #[test]
+    fn describe_mentions_disabled_toolsets() {
+        let policy = policy_with_config(PolicyConfig {
+            enterprise: Some(ToolsetPolicy {
+                enabled: Some(false),
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
+        let desc = policy.describe();
+        assert!(desc.contains("Disabled toolsets"));
+        assert!(desc.contains("enterprise"));
+    }
+
+    #[test]
+    fn describe_omits_disabled_when_none() {
+        let policy = policy_with_config(PolicyConfig::default());
+        let desc = policy.describe();
+        assert!(!desc.contains("Disabled toolsets"));
+    }
+
+    #[test]
+    fn enabled_false_serializes_in_summary() {
+        let tp = ToolsetPolicy {
+            enabled: Some(false),
+            tier: Some(SafetyTier::ReadOnly),
+            ..Default::default()
+        };
+        let summary = ToolsetPolicySummary::from(&tp);
+        assert_eq!(summary.enabled, Some(false));
+        assert_eq!(summary.tier, Some("read-only".to_string()));
     }
 }


### PR DESCRIPTION
## Summary

- Add `enabled: Option<bool>` to `ToolsetPolicy` allowing toolsets to be disabled from `mcp-policy.toml`
- Add `PolicyConfig::disabled_toolsets()` helper that returns toolsets with `enabled = false`
- Filter disabled toolsets from the enabled set before router/mapping construction (same structural exclusion path as `--tools`)
- Priority: `--tools` CLI > policy `enabled` > config auto-detection > all compiled-in
- Update `Policy::describe()` and `ToolsetPolicySummary` to surface disabled state

Example config:
```toml
tier = "read-only"

[enterprise]
enabled = false

[database]
enabled = false
```

Depends on #786. Closes #782.

## Test plan

- [x] TOML parsing: `enabled = false`, `enabled = true`, omitted (backward compat)
- [x] `disabled_toolsets()` returns correct set, empty when none disabled
- [x] `describe()` mentions disabled toolsets, omits when none
- [x] `ToolsetPolicySummary` includes enabled field
- [x] Policy-disabled toolset removed from enabled set
- [x] `toolset_to_kind()` mapping correctness
- [x] `cargo clippy --all-features -- -D warnings` clean
- [x] `cargo check --no-default-features` clean
- [x] All 110 unit + 41 integration tests pass