### PR TITLE
chore(mcp): optimize tool descriptions for token efficiency

### DIFF
--- a/crates/redisctl-mcp/src/tools/cloud/account.rs
+++ b/crates/redisctl-mcp/src/tools/cloud/account.rs
@@ -36,7 +36,7 @@ pub struct GetAccountInput {
 /// Build the get_account tool
 pub fn get_account(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_account")
-        .description("Get information about the current Redis Cloud account including name, ID, and settings.")
+        .description("Get current account information.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetAccountInput>(
             state,
@@ -75,10 +75,7 @@ pub struct GetSystemLogsInput {
 /// Build the get_system_logs tool
 pub fn get_system_logs(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_system_logs")
-        .description(
-            "Get system audit logs for the Redis Cloud account. Includes events like \
-             subscription changes, database modifications, and user actions.",
-        )
+        .description("Get system audit logs.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetSystemLogsInput>(
             state,
@@ -117,10 +114,7 @@ pub struct GetSessionLogsInput {
 /// Build the get_session_logs tool
 pub fn get_session_logs(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_session_logs")
-        .description(
-            "Get session activity logs for the Redis Cloud account. Includes user login/logout \
-             events and session information.",
-        )
+        .description("Get session activity logs.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetSessionLogsInput>(
             state,
@@ -157,9 +151,7 @@ pub struct GetRegionsInput {
 /// Build the get_regions tool
 pub fn get_regions(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_regions")
-        .description(
-            "Get supported cloud regions for Redis Cloud. Optionally filter by provider (AWS, GCP, Azure).",
-        )
+        .description("Get supported cloud regions. Optionally filter by provider.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetRegionsInput>(
             state,
@@ -192,9 +184,7 @@ pub struct GetModulesInput {
 /// Build the get_modules tool
 pub fn get_modules(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_modules")
-        .description(
-            "Get supported Redis database modules (e.g., Search, JSON, TimeSeries, Bloom).",
-        )
+        .description("Get supported database modules.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetModulesInput>(
             state,
@@ -231,9 +221,7 @@ pub struct ListAccountUsersInput {
 /// Build the list_account_users tool
 pub fn list_account_users(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_account_users")
-        .description(
-            "List all users in the Redis Cloud account (team members with console access).",
-        )
+        .description("List all account users (team members with console access).")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, ListAccountUsersInput>(
             state,
@@ -269,9 +257,7 @@ pub struct GetAccountUserInput {
 /// Build the get_account_user tool
 pub fn get_account_user(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_account_user")
-        .description(
-            "Get detailed information about a specific account user (team member) by ID.",
-        )
+        .description("Get an account user by ID.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetAccountUserInput>(
             state,
@@ -312,9 +298,7 @@ pub struct UpdateAccountUserInput {
 /// Build the update_account_user tool
 pub fn update_account_user(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_account_user")
-        .description(
-            "Update an account user's name or role. Returns a task state for the async operation.",
-        )
+        .description("Update an account user's name or role.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateAccountUserInput>(
             state,
@@ -362,10 +346,7 @@ pub struct DeleteAccountUserInput {
 /// Build the delete_account_user tool
 pub fn delete_account_user(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_account_user")
-        .description(
-            "DANGEROUS: Permanently deletes an account user (team member). \
-             The user will lose all access to the account. This action cannot be undone.",
-        )
+        .description("DANGEROUS: Delete an account user. The user will lose all access.")
         .destructive()
         .extractor_handler_typed::<_, _, _, DeleteAccountUserInput>(
             state,
@@ -409,7 +390,7 @@ pub struct ListAclUsersInput {
 /// Build the list_acl_users tool
 pub fn list_acl_users(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_acl_users")
-        .description("List all ACL users (database-level Redis users for authentication).")
+        .description("List all ACL users.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, ListAclUsersInput>(
             state,
@@ -444,7 +425,7 @@ pub struct GetAclUserInput {
 /// Build the get_acl_user tool
 pub fn get_acl_user(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_acl_user")
-        .description("Get detailed information about a specific ACL user by ID.")
+        .description("Get an ACL user by ID.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetAclUserInput>(
             state,
@@ -477,7 +458,7 @@ pub struct ListAclRolesInput {
 /// Build the list_acl_roles tool
 pub fn list_acl_roles(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_acl_roles")
-        .description("List all ACL roles (permission templates for database access).")
+        .description("List all ACL roles.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, ListAclRolesInput>(
             state,
@@ -510,7 +491,7 @@ pub struct ListRedisRulesInput {
 /// Build the list_redis_rules tool
 pub fn list_redis_rules(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_redis_rules")
-        .description("List all Redis ACL rules (command permissions for Redis users).")
+        .description("List all Redis ACL rules.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, ListRedisRulesInput>(
             state,
@@ -554,10 +535,7 @@ pub struct CreateAclUserInput {
 /// Build the create_acl_user tool
 pub fn create_acl_user(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_acl_user")
-        .description(
-            "Create a new ACL user with the assigned database access role. \
-             Requires write permission.",
-        )
+        .description("Create a new ACL user with a database access role.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateAclUserInput>(
             state,
@@ -610,10 +588,7 @@ pub struct UpdateAclUserInput {
 /// Build the update_acl_user tool
 pub fn update_acl_user(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_acl_user")
-        .description(
-            "Update an ACL user's role or password. \
-             Requires write permission.",
-        )
+        .description("Update an ACL user's role or password.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateAclUserInput>(
             state,
@@ -660,10 +635,7 @@ pub struct DeleteAclUserInput {
 /// Build the delete_acl_user tool
 pub fn delete_acl_user(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_acl_user")
-        .description(
-            "DANGEROUS: Permanently deletes an ACL user. Active sessions using this user \
-             will be terminated. Requires write permission.",
-        )
+        .description("DANGEROUS: Delete an ACL user. Active sessions will be terminated.")
         .destructive()
         .extractor_handler_typed::<_, _, _, DeleteAclUserInput>(
             state,
@@ -727,10 +699,7 @@ pub struct CreateAclRoleInput {
 /// Build the create_acl_role tool
 pub fn create_acl_role(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_acl_role")
-        .description(
-            "Create a new ACL role with assigned Redis rules and database associations. \
-             Requires write permission.",
-        )
+        .description("Create a new ACL role with Redis rules and database associations.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateAclRoleInput>(
             state,
@@ -797,10 +766,7 @@ pub struct UpdateAclRoleInput {
 /// Build the update_acl_role tool
 pub fn update_acl_role(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_acl_role")
-        .description(
-            "Update an ACL role's name or Redis rule assignments. \
-             Requires write permission.",
-        )
+        .description("Update an ACL role's name or Redis rule assignments.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateAclRoleInput>(
             state,
@@ -863,10 +829,7 @@ pub struct DeleteAclRoleInput {
 /// Build the delete_acl_role tool
 pub fn delete_acl_role(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_acl_role")
-        .description(
-            "DANGEROUS: Permanently deletes an ACL role. Users assigned to this role \
-             will lose their permissions. Requires write permission.",
-        )
+        .description("DANGEROUS: Delete an ACL role. Assigned users will lose their permissions.")
         .destructive()
         .extractor_handler_typed::<_, _, _, DeleteAclRoleInput>(
             state,
@@ -909,10 +872,7 @@ pub struct CreateRedisRuleInput {
 /// Build the create_redis_rule tool
 pub fn create_redis_rule(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_redis_rule")
-        .description(
-            "Create a new Redis ACL rule defining command permissions. \
-             Requires write permission.",
-        )
+        .description("Create a new Redis ACL rule defining command permissions.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateRedisRuleInput>(
             state,
@@ -963,10 +923,7 @@ pub struct UpdateRedisRuleInput {
 /// Build the update_redis_rule tool
 pub fn update_redis_rule(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_redis_rule")
-        .description(
-            "Update a Redis ACL rule's name or pattern. \
-             Requires write permission.",
-        )
+        .description("Update a Redis ACL rule's name or pattern.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateRedisRuleInput>(
             state,
@@ -1014,10 +971,7 @@ pub struct DeleteRedisRuleInput {
 /// Build the delete_redis_rule tool
 pub fn delete_redis_rule(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_redis_rule")
-        .description(
-            "DANGEROUS: Permanently deletes a Redis ACL rule. Roles using this rule \
-             will lose those permissions. Requires write permission.",
-        )
+        .description("DANGEROUS: Delete a Redis ACL rule. Roles using it will lose those permissions.")
         .destructive()
         .extractor_handler_typed::<_, _, _, DeleteRedisRuleInput>(
             state,
@@ -1080,11 +1034,7 @@ pub struct GenerateCostReportInput {
 /// Build the generate_cost_report tool
 pub fn generate_cost_report(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("generate_cost_report")
-        .description(
-            "Generate a cost report in FOCUS format for the specified date range. \
-             Returns a task ID to track generation progress. \
-             Requires write permission.",
-        )
+        .description("Generate a FOCUS cost report for the specified date range.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, GenerateCostReportInput>(
             state,
@@ -1146,10 +1096,7 @@ pub struct DownloadCostReportInput {
 /// Build the download_cost_report tool
 pub fn download_cost_report(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("download_cost_report")
-        .description(
-            "Download a previously generated cost report by ID. \
-             Returns the report content (CSV or JSON).",
-        )
+        .description("Download a previously generated cost report by ID.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, DownloadCostReportInput>(
             state,
@@ -1190,7 +1137,7 @@ pub struct ListPaymentMethodsInput {
 /// Build the list_payment_methods tool
 pub fn list_payment_methods(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_payment_methods")
-        .description("List all payment methods for the Redis Cloud account.")
+        .description("List all payment methods.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, ListPaymentMethodsInput>(
             state,
@@ -1228,7 +1175,7 @@ pub struct ListTasksInput {
 /// Build the list_tasks tool
 pub fn list_tasks(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_tasks")
-        .description("List all async tasks in the Redis Cloud account. Tasks track long-running operations like database creation.")
+        .description("List all async tasks.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, ListTasksInput>(
             state,
@@ -1263,7 +1210,7 @@ pub struct GetTaskInput {
 /// Build the get_task tool
 pub fn get_task(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_task")
-        .description("Get status and details of a specific async task by ID.")
+        .description("Get task status by ID.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetTaskInput>(
             state,
@@ -1312,12 +1259,7 @@ fn default_task_interval() -> u64 {
 /// Build the wait_for_cloud_task tool
 pub fn wait_for_cloud_task(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("wait_for_cloud_task")
-        .description(
-            "Wait for an async Cloud task to complete by polling until it reaches a terminal \
-             state (completed, failed, error, cancelled). Returns the final task status. \
-             Useful for orchestrating multi-step workflows \
-             (e.g., create subscription -> wait -> create database).",
-        )
+        .description("Poll an async task until it reaches a terminal state. Useful for multi-step workflows.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, WaitForCloudTaskInput>(
             state,
@@ -1389,10 +1331,7 @@ pub struct ListCloudAccountsInput {
 /// Build the list_cloud_accounts tool
 pub fn list_cloud_accounts(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_cloud_accounts")
-        .description(
-            "List all configured cloud provider accounts (BYOC). Returns cloud accounts \
-             for AWS, GCP, or Azure that are integrated with Redis Cloud.",
-        )
+        .description("List all cloud provider accounts (BYOC).")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, ListCloudAccountsInput>(
             state,
@@ -1429,10 +1368,7 @@ pub struct GetCloudAccountInput {
 /// Build the get_cloud_account tool
 pub fn get_cloud_account(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_cloud_account")
-        .description(
-            "Get details for a specific cloud provider account (BYOC) by ID, \
-             including provider type, access credentials, and status.",
-        )
+        .description("Get a cloud provider account (BYOC) by ID.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetCloudAccountInput>(
             state,
@@ -1481,11 +1417,7 @@ pub struct CreateCloudAccountInput {
 /// Build the create_cloud_account tool
 pub fn create_cloud_account(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_cloud_account")
-        .description(
-            "Create a new cloud provider account (BYOC) for AWS, GCP, or Azure. \
-             Registers cloud credentials with Redis Cloud for resource provisioning. \
-             Requires write permission.",
-        )
+        .description("Create a new cloud provider account (BYOC).")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateCloudAccountInput>(
             state,
@@ -1551,11 +1483,7 @@ pub struct UpdateCloudAccountInput {
 /// Build the update_cloud_account tool
 pub fn update_cloud_account(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_cloud_account")
-        .description(
-            "Update an existing cloud provider account (BYOC) configuration, \
-             including credentials and console access details. \
-             Requires write permission.",
-        )
+        .description("Update a cloud provider account (BYOC) configuration.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateCloudAccountInput>(
             state,
@@ -1607,10 +1535,7 @@ pub struct DeleteCloudAccountInput {
 /// Build the delete_cloud_account tool
 pub fn delete_cloud_account(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_cloud_account")
-        .description(
-            "DANGEROUS: Permanently deletes a cloud provider account (BYOC). This removes \
-             the cloud account integration and cannot be undone. Requires write permission.",
-        )
+        .description("DANGEROUS: Delete a cloud provider account (BYOC).")
         .destructive()
         .extractor_handler_typed::<_, _, _, DeleteCloudAccountInput>(
             state,

--- a/crates/redisctl-mcp/src/tools/cloud/fixed.rs
+++ b/crates/redisctl-mcp/src/tools/cloud/fixed.rs
@@ -32,9 +32,7 @@ pub struct ListFixedSubscriptionsInput {
 /// Build the list_fixed_subscriptions tool
 pub fn list_fixed_subscriptions(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_fixed_subscriptions")
-        .description(
-            "List all Redis Cloud Fixed/Essentials subscriptions in the current account.",
-        )
+        .description("List all Fixed/Essentials subscriptions.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, ListFixedSubscriptionsInput>(
             state,
@@ -70,9 +68,7 @@ pub struct GetFixedSubscriptionInput {
 /// Build the get_fixed_subscription tool
 pub fn get_fixed_subscription(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_fixed_subscription")
-        .description(
-            "Get detailed information about a specific Redis Cloud Fixed/Essentials subscription.",
-        )
+        .description("Get subscription details by ID.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetFixedSubscriptionInput>(
             state,
@@ -116,10 +112,7 @@ pub struct CreateFixedSubscriptionInput {
 /// Build the create_fixed_subscription tool
 pub fn create_fixed_subscription(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_fixed_subscription")
-        .description(
-            "Create a new Redis Cloud Fixed/Essentials subscription. \
-             Requires write permission.",
-        )
+        .description("Create a new Fixed/Essentials subscription.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateFixedSubscriptionInput>(
             state,
@@ -181,10 +174,7 @@ pub struct UpdateFixedSubscriptionInput {
 /// Build the update_fixed_subscription tool
 pub fn update_fixed_subscription(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_fixed_subscription")
-        .description(
-            "Update a Redis Cloud Fixed/Essentials subscription. \
-             Requires write permission.",
-        )
+        .description("Update a Fixed/Essentials subscription.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateFixedSubscriptionInput>(
             state,
@@ -236,9 +226,8 @@ pub struct DeleteFixedSubscriptionInput {
 pub fn delete_fixed_subscription(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_fixed_subscription")
         .description(
-            "DANGEROUS: Permanently deletes a Fixed/Essentials subscription. \
-             All databases must be deleted first. This action cannot be undone. \
-             Requires write permission.",
+            "DANGEROUS: Delete a Fixed/Essentials subscription. \
+             All databases must be deleted first.",
         )
         .destructive()
         .extractor_handler_typed::<_, _, _, DeleteFixedSubscriptionInput>(
@@ -285,10 +274,7 @@ pub struct ListFixedPlansInput {
 /// Build the list_fixed_plans tool
 pub fn list_fixed_plans(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_fixed_plans")
-        .description(
-            "List available Redis Cloud Fixed/Essentials plans. \
-             Plans describe dataset size, cloud provider, region, and pricing.",
-        )
+        .description("List available Fixed/Essentials plans.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, ListFixedPlansInput>(
             state,
@@ -324,10 +310,7 @@ pub struct GetFixedPlansBySubscriptionInput {
 /// Build the get_fixed_plans_by_subscription tool
 pub fn get_fixed_plans_by_subscription(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_fixed_plans_by_subscription")
-        .description(
-            "Get compatible Fixed/Essentials plans for a specific subscription. \
-             Useful when upgrading or changing a subscription's plan.",
-        )
+        .description("Get compatible plans for a subscription.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetFixedPlansBySubscriptionInput>(
             state,
@@ -363,10 +346,7 @@ pub struct GetFixedPlanInput {
 /// Build the get_fixed_plan tool
 pub fn get_fixed_plan(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_fixed_plan")
-        .description(
-            "Get detailed information about a specific Fixed/Essentials plan \
-             including pricing, capacity, and feature support.",
-        )
+        .description("Get plan details by ID.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetFixedPlanInput>(
             state,
@@ -401,9 +381,7 @@ pub struct GetFixedRedisVersionsInput {
 /// Build the get_fixed_redis_versions tool
 pub fn get_fixed_redis_versions(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_fixed_redis_versions")
-        .description(
-            "Get available Redis database versions for a specific Fixed/Essentials subscription.",
-        )
+        .description("Get available Redis versions for a subscription.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetFixedRedisVersionsInput>(
             state,
@@ -449,9 +427,7 @@ pub struct ListFixedDatabasesInput {
 /// Build the list_fixed_databases tool
 pub fn list_fixed_databases(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_fixed_databases")
-        .description(
-            "List all databases in a Redis Cloud Fixed/Essentials subscription.",
-        )
+        .description("List databases in a subscription.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, ListFixedDatabasesInput>(
             state,
@@ -489,10 +465,7 @@ pub struct GetFixedDatabaseInput {
 /// Build the get_fixed_database tool
 pub fn get_fixed_database(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_fixed_database")
-        .description(
-            "Get detailed information about a specific database in a \
-             Redis Cloud Fixed/Essentials subscription.",
-        )
+        .description("Get database details by ID.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetFixedDatabaseInput>(
             state,
@@ -563,10 +536,7 @@ pub struct CreateFixedDatabaseInput {
 /// Build the create_fixed_database tool
 pub fn create_fixed_database(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_fixed_database")
-        .description(
-            "Create a new database in a Redis Cloud Fixed/Essentials subscription. \
-             Requires write permission.",
-        )
+        .description("Create a database in a Fixed/Essentials subscription.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateFixedDatabaseInput>(
             state,
@@ -663,10 +633,7 @@ pub struct UpdateFixedDatabaseInput {
 /// Build the update_fixed_database tool
 pub fn update_fixed_database(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_fixed_database")
-        .description(
-            "Update a database in a Redis Cloud Fixed/Essentials subscription. \
-             Requires write permission.",
-        )
+        .description("Update a database in a Fixed/Essentials subscription.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateFixedDatabaseInput>(
             state,
@@ -738,10 +705,7 @@ pub struct DeleteFixedDatabaseInput {
 /// Build the delete_fixed_database tool
 pub fn delete_fixed_database(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_fixed_database")
-        .description(
-            "DANGEROUS: Permanently deletes a Fixed/Essentials database and all its data. \
-             This action cannot be undone. Requires write permission.",
-        )
+        .description("DANGEROUS: Delete a Fixed/Essentials database and all its data.")
         .destructive()
         .extractor_handler_typed::<_, _, _, DeleteFixedDatabaseInput>(
             state,
@@ -789,7 +753,7 @@ pub struct GetFixedDatabaseBackupStatusInput {
 /// Build the get_fixed_database_backup_status tool
 pub fn get_fixed_database_backup_status(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_fixed_database_backup_status")
-        .description("Get the latest backup status for a Fixed/Essentials database.")
+        .description("Get latest backup status for a database.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetFixedDatabaseBackupStatusInput>(
             state,
@@ -830,10 +794,7 @@ pub struct BackupFixedDatabaseInput {
 /// Build the backup_fixed_database tool
 pub fn backup_fixed_database(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("backup_fixed_database")
-        .description(
-            "Trigger a manual backup of a Fixed/Essentials database. \
-             Requires write permission.",
-        )
+        .description("Trigger a manual backup of a database.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, BackupFixedDatabaseInput>(
             state,
@@ -884,7 +845,7 @@ pub struct GetFixedDatabaseImportStatusInput {
 /// Build the get_fixed_database_import_status tool
 pub fn get_fixed_database_import_status(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_fixed_database_import_status")
-        .description("Get the latest import status for a Fixed/Essentials database.")
+        .description("Get latest import status for a database.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetFixedDatabaseImportStatusInput>(
             state,
@@ -927,8 +888,8 @@ pub struct ImportFixedDatabaseInput {
 pub fn import_fixed_database(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("import_fixed_database")
         .description(
-            "Import data into a Fixed/Essentials database from an external source. \
-             WARNING: This will overwrite existing data. Requires write permission.",
+            "Import data into a database from an external source. \
+             WARNING: This will overwrite existing data.",
         )
         .non_destructive()
         .extractor_handler_typed::<_, _, _, ImportFixedDatabaseInput>(
@@ -981,10 +942,7 @@ pub struct GetFixedDatabaseSlowLogInput {
 /// Build the get_fixed_database_slow_log tool
 pub fn get_fixed_database_slow_log(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_fixed_database_slow_log")
-        .description(
-            "Get slow log entries for a Fixed/Essentials database. \
-             Shows slow queries for debugging performance issues.",
-        )
+        .description("Get slow log entries for a database.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetFixedDatabaseSlowLogInput>(
             state,
@@ -1026,7 +984,7 @@ pub struct GetFixedDatabaseTagsInput {
 /// Build the get_fixed_database_tags tool
 pub fn get_fixed_database_tags(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_fixed_database_tags")
-        .description("Get tags attached to a Fixed/Essentials database.")
+        .description("Get tags for a database.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetFixedDatabaseTagsInput>(
             state,
@@ -1068,10 +1026,7 @@ pub struct CreateFixedDatabaseTagInput {
 /// Build the create_fixed_database_tag tool
 pub fn create_fixed_database_tag(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_fixed_database_tag")
-        .description(
-            "Create a tag on a Fixed/Essentials database. \
-             Requires write permission.",
-        )
+        .description("Create a tag on a database.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateFixedDatabaseTagInput>(
             state,
@@ -1127,10 +1082,7 @@ pub struct UpdateFixedDatabaseTagInput {
 /// Build the update_fixed_database_tag tool
 pub fn update_fixed_database_tag(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_fixed_database_tag")
-        .description(
-            "Update a tag value on a Fixed/Essentials database. \
-             Requires write permission.",
-        )
+        .description("Update a tag value on a database.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateFixedDatabaseTagInput>(
             state,
@@ -1189,10 +1141,7 @@ pub struct DeleteFixedDatabaseTagInput {
 /// Build the delete_fixed_database_tag tool
 pub fn delete_fixed_database_tag(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_fixed_database_tag")
-        .description(
-            "DANGEROUS: Permanently deletes a tag from a Fixed/Essentials database. \
-             This action cannot be undone. Requires write permission.",
-        )
+        .description("DANGEROUS: Delete a tag from a database.")
         .destructive()
         .extractor_handler_typed::<_, _, _, DeleteFixedDatabaseTagInput>(
             state,
@@ -1247,10 +1196,7 @@ pub struct UpdateFixedDatabaseTagsInput {
 /// Build the update_fixed_database_tags tool
 pub fn update_fixed_database_tags(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_fixed_database_tags")
-        .description(
-            "Update all tags on a Fixed/Essentials database (replaces existing tags). \
-             Requires write permission.",
-        )
+        .description("Update all tags on a database (replaces existing tags).")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateFixedDatabaseTagsInput>(
             state,
@@ -1315,9 +1261,7 @@ pub struct GetFixedDatabaseUpgradeVersionsInput {
 /// Build the get_fixed_database_upgrade_versions tool
 pub fn get_fixed_database_upgrade_versions(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_fixed_database_upgrade_versions")
-        .description(
-            "Get available target Redis versions that a Fixed/Essentials database can be upgraded to.",
-        )
+        .description("Get available upgrade target Redis versions for a database.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetFixedDatabaseUpgradeVersionsInput>(
             state,
@@ -1355,7 +1299,7 @@ pub struct GetFixedDatabaseUpgradeStatusInput {
 /// Build the get_fixed_database_upgrade_status tool
 pub fn get_fixed_database_upgrade_status(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_fixed_database_upgrade_status")
-        .description("Get the latest Redis version upgrade status for a Fixed/Essentials database.")
+        .description("Get latest Redis version upgrade status for a database.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetFixedDatabaseUpgradeStatusInput>(
             state,
@@ -1395,10 +1339,7 @@ pub struct UpgradeFixedDatabaseRedisVersionInput {
 /// Build the upgrade_fixed_database_redis_version tool
 pub fn upgrade_fixed_database_redis_version(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("upgrade_fixed_database_redis_version")
-        .description(
-            "Upgrade the Redis version of a Fixed/Essentials database. \
-             Requires write permission.",
-        )
+        .description("Upgrade the Redis version of a database.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, UpgradeFixedDatabaseRedisVersionInput>(
             state,

--- a/crates/redisctl-mcp/src/tools/cloud/networking.rs
+++ b/crates/redisctl-mcp/src/tools/cloud/networking.rs
@@ -37,7 +37,7 @@ pub struct GetVpcPeeringInput {
 /// Build the get_vpc_peering tool
 pub fn get_vpc_peering(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_vpc_peering")
-        .description("Get VPC peering details for a Redis Cloud subscription.")
+        .description("Get VPC peering details.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetVpcPeeringInput>(
             state,
@@ -96,10 +96,7 @@ pub struct CreateVpcPeeringInput {
 /// Build the create_vpc_peering tool
 pub fn create_vpc_peering(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_vpc_peering")
-        .description(
-            "Create a VPC peering connection for a Redis Cloud subscription. \
-             Requires write permission.",
-        )
+        .description("Create a VPC peering connection.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateVpcPeeringInput>(
             state,
@@ -179,10 +176,7 @@ pub struct UpdateVpcPeeringInput {
 /// Build the update_vpc_peering tool
 pub fn update_vpc_peering(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_vpc_peering")
-        .description(
-            "Update a VPC peering connection for a Redis Cloud subscription. \
-             Requires write permission.",
-        )
+        .description("Update a VPC peering connection.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateVpcPeeringInput>(
             state,
@@ -238,10 +232,7 @@ pub struct DeleteVpcPeeringInput {
 /// Build the delete_vpc_peering tool
 pub fn delete_vpc_peering(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_vpc_peering")
-        .description(
-            "DANGEROUS: Permanently deletes a VPC peering connection. \
-             Network connectivity will be immediately lost. Requires write permission.",
-        )
+        .description("DANGEROUS: Delete a VPC peering connection. Causes connectivity loss.")
         .destructive()
         .extractor_handler_typed::<_, _, _, DeleteVpcPeeringInput>(
             state,
@@ -287,9 +278,7 @@ pub struct GetAaVpcPeeringInput {
 /// Build the get_aa_vpc_peering tool
 pub fn get_aa_vpc_peering(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_aa_vpc_peering")
-        .description(
-            "Get Active-Active VPC peering details for a Redis Cloud subscription.",
-        )
+        .description("Get Active-Active VPC peering details.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetAaVpcPeeringInput>(
             state,
@@ -349,10 +338,7 @@ pub struct CreateAaVpcPeeringInput {
 /// Build the create_aa_vpc_peering tool
 pub fn create_aa_vpc_peering(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_aa_vpc_peering")
-        .description(
-            "Create an Active-Active VPC peering connection for a Redis Cloud subscription. \
-             Requires write permission.",
-        )
+        .description("Create an Active-Active VPC peering connection.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateAaVpcPeeringInput>(
             state,
@@ -432,10 +418,7 @@ pub struct UpdateAaVpcPeeringInput {
 /// Build the update_aa_vpc_peering tool
 pub fn update_aa_vpc_peering(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_aa_vpc_peering")
-        .description(
-            "Update an Active-Active VPC peering connection for a Redis Cloud subscription. \
-             Requires write permission.",
-        )
+        .description("Update an Active-Active VPC peering connection.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateAaVpcPeeringInput>(
             state,
@@ -491,10 +474,7 @@ pub struct DeleteAaVpcPeeringInput {
 /// Build the delete_aa_vpc_peering tool
 pub fn delete_aa_vpc_peering(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_aa_vpc_peering")
-        .description(
-            "DANGEROUS: Permanently deletes an Active-Active VPC peering connection. \
-             Network connectivity will be immediately lost. Requires write permission.",
-        )
+        .description("DANGEROUS: Delete an Active-Active VPC peering connection. Causes connectivity loss.")
         .destructive()
         .extractor_handler_typed::<_, _, _, DeleteAaVpcPeeringInput>(
             state,
@@ -540,9 +520,7 @@ pub struct GetTgwAttachmentsInput {
 /// Build the get_tgw_attachments tool
 pub fn get_tgw_attachments(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_tgw_attachments")
-        .description(
-            "Get Transit Gateway attachments for a Redis Cloud subscription.",
-        )
+        .description("Get Transit Gateway attachments.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetTgwAttachmentsInput>(
             state,
@@ -578,9 +556,7 @@ pub struct GetTgwInvitationsInput {
 /// Build the get_tgw_invitations tool
 pub fn get_tgw_invitations(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_tgw_invitations")
-        .description(
-            "Get Transit Gateway shared invitations for a Redis Cloud subscription.",
-        )
+        .description("Get Transit Gateway shared invitations.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetTgwInvitationsInput>(
             state,
@@ -618,10 +594,7 @@ pub struct AcceptTgwInvitationInput {
 /// Build the accept_tgw_invitation tool
 pub fn accept_tgw_invitation(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("accept_tgw_invitation")
-        .description(
-            "Accept a Transit Gateway resource share invitation. \
-             Requires write permission.",
-        )
+        .description("Accept a Transit Gateway resource share invitation.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, AcceptTgwInvitationInput>(
             state,
@@ -665,10 +638,7 @@ pub struct RejectTgwInvitationInput {
 /// Build the reject_tgw_invitation tool
 pub fn reject_tgw_invitation(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("reject_tgw_invitation")
-        .description(
-            "Reject a Transit Gateway resource share invitation. \
-             Requires write permission.",
-        )
+        .description("Reject a Transit Gateway resource share invitation.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, RejectTgwInvitationInput>(
             state,
@@ -719,10 +689,7 @@ pub struct CreateTgwAttachmentInput {
 /// Build the create_tgw_attachment tool
 pub fn create_tgw_attachment(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_tgw_attachment")
-        .description(
-            "Create a Transit Gateway attachment for a Redis Cloud subscription. \
-             Requires write permission.",
-        )
+        .description("Create a Transit Gateway attachment.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateTgwAttachmentInput>(
             state,
@@ -781,10 +748,7 @@ pub struct UpdateTgwAttachmentCidrsInput {
 /// Build the update_tgw_attachment_cidrs tool
 pub fn update_tgw_attachment_cidrs(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_tgw_attachment_cidrs")
-        .description(
-            "Update CIDRs for a Transit Gateway attachment. \
-             Requires write permission.",
-        )
+        .description("Update CIDRs for a Transit Gateway attachment.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateTgwAttachmentCidrsInput>(
             state,
@@ -834,10 +798,7 @@ pub struct DeleteTgwAttachmentInput {
 /// Build the delete_tgw_attachment tool
 pub fn delete_tgw_attachment(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_tgw_attachment")
-        .description(
-            "DANGEROUS: Permanently deletes a Transit Gateway attachment. \
-             Network connectivity will be immediately lost. Requires write permission.",
-        )
+        .description("DANGEROUS: Delete a Transit Gateway attachment. Causes connectivity loss.")
         .destructive()
         .extractor_handler_typed::<_, _, _, DeleteTgwAttachmentInput>(
             state,
@@ -883,9 +844,7 @@ pub struct GetAaTgwAttachmentsInput {
 /// Build the get_aa_tgw_attachments tool
 pub fn get_aa_tgw_attachments(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_aa_tgw_attachments")
-        .description(
-            "Get Active-Active Transit Gateway attachments for a Redis Cloud subscription.",
-        )
+        .description("Get Active-Active Transit Gateway attachments.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetAaTgwAttachmentsInput>(
             state,
@@ -921,9 +880,7 @@ pub struct GetAaTgwInvitationsInput {
 /// Build the get_aa_tgw_invitations tool
 pub fn get_aa_tgw_invitations(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_aa_tgw_invitations")
-        .description(
-            "Get Active-Active Transit Gateway shared invitations for a Redis Cloud subscription.",
-        )
+        .description("Get Active-Active Transit Gateway shared invitations.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetAaTgwInvitationsInput>(
             state,
@@ -963,10 +920,7 @@ pub struct AcceptAaTgwInvitationInput {
 /// Build the accept_aa_tgw_invitation tool
 pub fn accept_aa_tgw_invitation(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("accept_aa_tgw_invitation")
-        .description(
-            "Accept an Active-Active Transit Gateway resource share invitation. \
-             Requires write permission.",
-        )
+        .description("Accept an Active-Active Transit Gateway resource share invitation.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, AcceptAaTgwInvitationInput>(
             state,
@@ -1016,10 +970,7 @@ pub struct RejectAaTgwInvitationInput {
 /// Build the reject_aa_tgw_invitation tool
 pub fn reject_aa_tgw_invitation(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("reject_aa_tgw_invitation")
-        .description(
-            "Reject an Active-Active Transit Gateway resource share invitation. \
-             Requires write permission.",
-        )
+        .description("Reject an Active-Active Transit Gateway resource share invitation.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, RejectAaTgwInvitationInput>(
             state,
@@ -1076,10 +1027,7 @@ pub struct CreateAaTgwAttachmentInput {
 /// Build the create_aa_tgw_attachment tool
 pub fn create_aa_tgw_attachment(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_aa_tgw_attachment")
-        .description(
-            "Create an Active-Active Transit Gateway attachment. \
-             Requires write permission.",
-        )
+        .description("Create an Active-Active Transit Gateway attachment.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateAaTgwAttachmentInput>(
             state,
@@ -1144,10 +1092,7 @@ pub struct UpdateAaTgwAttachmentCidrsInput {
 /// Build the update_aa_tgw_attachment_cidrs tool
 pub fn update_aa_tgw_attachment_cidrs(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_aa_tgw_attachment_cidrs")
-        .description(
-            "Update CIDRs for an Active-Active Transit Gateway attachment. \
-             Requires write permission.",
-        )
+        .description("Update CIDRs for an Active-Active Transit Gateway attachment.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateAaTgwAttachmentCidrsInput>(
             state,
@@ -1204,10 +1149,7 @@ pub struct DeleteAaTgwAttachmentInput {
 /// Build the delete_aa_tgw_attachment tool
 pub fn delete_aa_tgw_attachment(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_aa_tgw_attachment")
-        .description(
-            "DANGEROUS: Permanently deletes an Active-Active Transit Gateway attachment. \
-             Network connectivity will be immediately lost. Requires write permission.",
-        )
+        .description("DANGEROUS: Delete an Active-Active Transit Gateway attachment. Causes connectivity loss.")
         .destructive()
         .extractor_handler_typed::<_, _, _, DeleteAaTgwAttachmentInput>(
             state,
@@ -1257,7 +1199,7 @@ pub struct GetPscServiceInput {
 /// Build the get_psc_service tool
 pub fn get_psc_service(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_psc_service")
-        .description("Get Private Service Connect service for a Redis Cloud subscription.")
+        .description("Get Private Service Connect (PSC) service.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetPscServiceInput>(
             state,
@@ -1292,10 +1234,7 @@ pub struct CreatePscServiceInput {
 /// Build the create_psc_service tool
 pub fn create_psc_service(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_psc_service")
-        .description(
-            "Create a Private Service Connect service for a Redis Cloud subscription. \
-             Requires write permission.",
-        )
+        .description("Create a Private Service Connect (PSC) service.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, CreatePscServiceInput>(
             state,
@@ -1337,10 +1276,7 @@ pub struct DeletePscServiceInput {
 /// Build the delete_psc_service tool
 pub fn delete_psc_service(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_psc_service")
-        .description(
-            "DANGEROUS: Permanently deletes a Private Service Connect service. \
-             All endpoints will be disconnected. Requires write permission.",
-        )
+        .description("DANGEROUS: Delete a PSC service. Disconnects all endpoints.")
         .destructive()
         .extractor_handler_typed::<_, _, _, DeletePscServiceInput>(
             state,
@@ -1382,9 +1318,7 @@ pub struct GetPscEndpointsInput {
 /// Build the get_psc_endpoints tool
 pub fn get_psc_endpoints(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_psc_endpoints")
-        .description(
-            "Get Private Service Connect endpoints for a Redis Cloud subscription.",
-        )
+        .description("Get Private Service Connect (PSC) endpoints.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetPscEndpointsInput>(
             state,
@@ -1436,10 +1370,7 @@ pub struct CreatePscEndpointInput {
 /// Build the create_psc_endpoint tool
 pub fn create_psc_endpoint(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_psc_endpoint")
-        .description(
-            "Create a Private Service Connect endpoint. \
-             Requires write permission.",
-        )
+        .description("Create a Private Service Connect (PSC) endpoint.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, CreatePscEndpointInput>(
             state,
@@ -1507,10 +1438,7 @@ pub struct UpdatePscEndpointInput {
 /// Build the update_psc_endpoint tool
 pub fn update_psc_endpoint(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_psc_endpoint")
-        .description(
-            "Update a Private Service Connect endpoint. \
-             Requires write permission.",
-        )
+        .description("Update a Private Service Connect (PSC) endpoint.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdatePscEndpointInput>(
             state,
@@ -1564,10 +1492,7 @@ pub struct DeletePscEndpointInput {
 /// Build the delete_psc_endpoint tool
 pub fn delete_psc_endpoint(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_psc_endpoint")
-        .description(
-            "DANGEROUS: Permanently deletes a Private Service Connect endpoint. \
-             Connectivity will be immediately lost. Requires write permission.",
-        )
+        .description("DANGEROUS: Delete a PSC endpoint. Causes connectivity loss.")
         .destructive()
         .extractor_handler_typed::<_, _, _, DeletePscEndpointInput>(
             state,
@@ -1611,9 +1536,7 @@ pub struct GetPscCreationScriptInput {
 /// Build the get_psc_creation_script tool
 pub fn get_psc_creation_script(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_psc_creation_script")
-        .description(
-            "Get the creation script for a Private Service Connect endpoint.",
-        )
+        .description("Get the creation script for a PSC endpoint.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetPscCreationScriptInput>(
             state,
@@ -1651,9 +1574,7 @@ pub struct GetPscDeletionScriptInput {
 /// Build the get_psc_deletion_script tool
 pub fn get_psc_deletion_script(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_psc_deletion_script")
-        .description(
-            "Get the deletion script for a Private Service Connect endpoint.",
-        )
+        .description("Get the deletion script for a PSC endpoint.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetPscDeletionScriptInput>(
             state,
@@ -1693,9 +1614,7 @@ pub struct GetAaPscServiceInput {
 /// Build the get_aa_psc_service tool
 pub fn get_aa_psc_service(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_aa_psc_service")
-        .description(
-            "Get Active-Active Private Service Connect service for a Redis Cloud subscription.",
-        )
+        .description("Get Active-Active PSC service.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetAaPscServiceInput>(
             state,
@@ -1731,10 +1650,7 @@ pub struct CreateAaPscServiceInput {
 /// Build the create_aa_psc_service tool
 pub fn create_aa_psc_service(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_aa_psc_service")
-        .description(
-            "Create an Active-Active Private Service Connect service. \
-             Requires write permission.",
-        )
+        .description("Create an Active-Active PSC service.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateAaPscServiceInput>(
             state,
@@ -1776,10 +1692,7 @@ pub struct DeleteAaPscServiceInput {
 /// Build the delete_aa_psc_service tool
 pub fn delete_aa_psc_service(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_aa_psc_service")
-        .description(
-            "DANGEROUS: Permanently deletes an Active-Active Private Service Connect service. \
-             All endpoints will be disconnected. Requires write permission.",
-        )
+        .description("DANGEROUS: Delete an Active-Active PSC service. Disconnects all endpoints.")
         .destructive()
         .extractor_handler_typed::<_, _, _, DeleteAaPscServiceInput>(
             state,
@@ -1821,9 +1734,7 @@ pub struct GetAaPscEndpointsInput {
 /// Build the get_aa_psc_endpoints tool
 pub fn get_aa_psc_endpoints(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_aa_psc_endpoints")
-        .description(
-            "Get Active-Active Private Service Connect endpoints for a Redis Cloud subscription.",
-        )
+        .description("Get Active-Active PSC endpoints.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetAaPscEndpointsInput>(
             state,
@@ -1875,10 +1786,7 @@ pub struct CreateAaPscEndpointInput {
 /// Build the create_aa_psc_endpoint tool
 pub fn create_aa_psc_endpoint(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_aa_psc_endpoint")
-        .description(
-            "Create an Active-Active Private Service Connect endpoint. \
-             Requires write permission.",
-        )
+        .description("Create an Active-Active PSC endpoint.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateAaPscEndpointInput>(
             state,
@@ -1948,10 +1856,7 @@ pub struct UpdateAaPscEndpointInput {
 /// Build the update_aa_psc_endpoint tool
 pub fn update_aa_psc_endpoint(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_aa_psc_endpoint")
-        .description(
-            "Update an Active-Active Private Service Connect endpoint. \
-             Requires write permission.",
-        )
+        .description("Update an Active-Active PSC endpoint.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateAaPscEndpointInput>(
             state,
@@ -2012,10 +1917,7 @@ pub struct DeleteAaPscEndpointInput {
 /// Build the delete_aa_psc_endpoint tool
 pub fn delete_aa_psc_endpoint(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_aa_psc_endpoint")
-        .description(
-            "DANGEROUS: Permanently deletes an Active-Active Private Service Connect endpoint. \
-             Connectivity will be immediately lost. Requires write permission.",
-        )
+        .description("DANGEROUS: Delete an Active-Active PSC endpoint. Causes connectivity loss.")
         .destructive()
         .extractor_handler_typed::<_, _, _, DeleteAaPscEndpointInput>(
             state,
@@ -2067,9 +1969,7 @@ pub struct GetAaPscCreationScriptInput {
 /// Build the get_aa_psc_creation_script tool
 pub fn get_aa_psc_creation_script(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_aa_psc_creation_script")
-        .description(
-            "Get the creation script for an Active-Active Private Service Connect endpoint.",
-        )
+        .description("Get the creation script for an Active-Active PSC endpoint.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetAaPscCreationScriptInput>(
             state,
@@ -2116,9 +2016,7 @@ pub struct GetAaPscDeletionScriptInput {
 /// Build the get_aa_psc_deletion_script tool
 pub fn get_aa_psc_deletion_script(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_aa_psc_deletion_script")
-        .description(
-            "Get the deletion script for an Active-Active Private Service Connect endpoint.",
-        )
+        .description("Get the deletion script for an Active-Active PSC endpoint.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetAaPscDeletionScriptInput>(
             state,
@@ -2163,9 +2061,7 @@ pub struct GetPrivateLinkInput {
 /// Build the get_private_link tool
 pub fn get_private_link(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_private_link")
-        .description(
-            "Get AWS PrivateLink configuration for a Redis Cloud subscription.",
-        )
+        .description("Get AWS PrivateLink configuration.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetPrivateLinkInput>(
             state,
@@ -2225,10 +2121,7 @@ fn parse_principal_type(s: &str) -> Result<PrincipalType, ToolError> {
 /// Build the create_private_link tool
 pub fn create_private_link(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_private_link")
-        .description(
-            "Create an AWS PrivateLink configuration for a Redis Cloud subscription. \
-             Requires write permission.",
-        )
+        .description("Create an AWS PrivateLink configuration.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, CreatePrivateLinkInput>(
             state,
@@ -2279,10 +2172,7 @@ pub struct DeletePrivateLinkInput {
 /// Build the delete_private_link tool
 pub fn delete_private_link(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_private_link")
-        .description(
-            "DANGEROUS: Permanently deletes an AWS PrivateLink configuration. \
-             Connectivity will be immediately lost. Requires write permission.",
-        )
+        .description("DANGEROUS: Delete an AWS PrivateLink configuration. Causes connectivity loss.")
         .destructive()
         .extractor_handler_typed::<_, _, _, DeletePrivateLinkInput>(
             state,
@@ -2332,10 +2222,7 @@ pub struct AddPrivateLinkPrincipalsInput {
 /// Build the add_private_link_principals tool
 pub fn add_private_link_principals(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("add_private_link_principals")
-        .description(
-            "Add AWS principals to a PrivateLink access list. \
-             Requires write permission.",
-        )
+        .description("Add AWS principals to a PrivateLink access list.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, AddPrivateLinkPrincipalsInput>(
             state,
@@ -2396,10 +2283,7 @@ pub struct RemovePrivateLinkPrincipalsInput {
 /// Build the remove_private_link_principals tool
 pub fn remove_private_link_principals(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("remove_private_link_principals")
-        .description(
-            "Remove AWS principals from a PrivateLink access list. \
-             Requires write permission.",
-        )
+        .description("Remove AWS principals from a PrivateLink access list.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, RemovePrivateLinkPrincipalsInput>(
             state,
@@ -2453,7 +2337,7 @@ pub struct GetPrivateLinkEndpointScriptInput {
 /// Build the get_private_link_endpoint_script tool
 pub fn get_private_link_endpoint_script(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_private_link_endpoint_script")
-        .description("Get the endpoint creation script for an AWS PrivateLink configuration.")
+        .description("Get the endpoint creation script for an AWS PrivateLink.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetPrivateLinkEndpointScriptInput>(
             state,
@@ -2495,9 +2379,7 @@ pub struct GetAaPrivateLinkInput {
 /// Build the get_aa_private_link tool
 pub fn get_aa_private_link(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_aa_private_link")
-        .description(
-            "Get Active-Active AWS PrivateLink configuration for a Redis Cloud subscription region.",
-        )
+        .description("Get Active-Active AWS PrivateLink configuration.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetAaPrivateLinkInput>(
             state,
@@ -2544,10 +2426,7 @@ pub struct CreateAaPrivateLinkInput {
 /// Build the create_aa_private_link tool
 pub fn create_aa_private_link(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_aa_private_link")
-        .description(
-            "Create an Active-Active AWS PrivateLink configuration. \
-             Requires write permission.",
-        )
+        .description("Create an Active-Active AWS PrivateLink configuration.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateAaPrivateLinkInput>(
             state,
@@ -2608,10 +2487,7 @@ pub struct AddAaPrivateLinkPrincipalsInput {
 /// Build the add_aa_private_link_principals tool
 pub fn add_aa_private_link_principals(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("add_aa_private_link_principals")
-        .description(
-            "Add AWS principals to an Active-Active PrivateLink access list. \
-             Requires write permission.",
-        )
+        .description("Add AWS principals to an Active-Active PrivateLink access list.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, AddAaPrivateLinkPrincipalsInput>(
             state,
@@ -2674,10 +2550,7 @@ pub struct RemoveAaPrivateLinkPrincipalsInput {
 /// Build the remove_aa_private_link_principals tool
 pub fn remove_aa_private_link_principals(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("remove_aa_private_link_principals")
-        .description(
-            "Remove AWS principals from an Active-Active PrivateLink access list. \
-             Requires write permission.",
-        )
+        .description("Remove AWS principals from an Active-Active PrivateLink access list.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, RemoveAaPrivateLinkPrincipalsInput>(
             state,
@@ -2737,9 +2610,7 @@ pub struct GetAaPrivateLinkEndpointScriptInput {
 /// Build the get_aa_private_link_endpoint_script tool
 pub fn get_aa_private_link_endpoint_script(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_aa_private_link_endpoint_script")
-        .description(
-            "Get the endpoint creation script for an Active-Active AWS PrivateLink configuration.",
-        )
+        .description("Get the endpoint creation script for an Active-Active AWS PrivateLink.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetAaPrivateLinkEndpointScriptInput>(
             state,

--- a/crates/redisctl-mcp/src/tools/cloud/raw.rs
+++ b/crates/redisctl-mcp/src/tools/cloud/raw.rs
@@ -43,15 +43,13 @@ pub struct CloudRawApiInput {
 pub fn cloud_raw_api(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("cloud_raw_api")
         .description(
-            "DANGEROUS: Execute a raw HTTP request against the Redis Cloud API. \
-             Use this escape hatch to reach any Cloud API endpoint not covered by a dedicated tool. \
-             GET requires read-write tier; POST/PUT/PATCH/DELETE require full tier.",
+            "DANGEROUS: Execute a raw HTTP request against the Cloud API. \
+             Escape hatch for endpoints not covered by dedicated tools.",
         )
         .destructive()
         .extractor_handler_typed::<_, _, _, CloudRawApiInput>(
             state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<CloudRawApiInput>| async move {
+            |State(state): State<Arc<AppState>>, Json(input): Json<CloudRawApiInput>| async move {
                 // Method-based tier gating
                 match input.method {
                     HttpMethod::Get => {
@@ -61,10 +59,7 @@ pub fn cloud_raw_api(state: Arc<AppState>) -> Tool {
                             ));
                         }
                     }
-                    HttpMethod::Post
-                    | HttpMethod::Put
-                    | HttpMethod::Patch
-                    | HttpMethod::Delete => {
+                    HttpMethod::Post | HttpMethod::Put | HttpMethod::Patch | HttpMethod::Delete => {
                         if !state.is_destructive_allowed() {
                             return Err(McpError::tool(
                                 "cloud_raw_api mutating methods require full tier",

--- a/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs
+++ b/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs
@@ -28,7 +28,7 @@ pub struct ListSubscriptionsInput {
 /// Build the list_subscriptions tool
 pub fn list_subscriptions(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_subscriptions")
-        .description("List all Redis Cloud subscriptions accessible with the current credentials. Returns JSON with subscription details.")
+        .description("List all subscriptions.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, ListSubscriptionsInput>(
             state,
@@ -63,7 +63,7 @@ pub struct GetSubscriptionInput {
 /// Build the get_subscription tool
 pub fn get_subscription(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_subscription")
-        .description("Get detailed information about a specific Redis Cloud subscription. Returns JSON with full subscription details.")
+        .description("Get subscription details by ID.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetSubscriptionInput>(
             state,
@@ -98,9 +98,7 @@ pub struct ListDatabasesInput {
 /// Build the list_databases tool
 pub fn list_databases(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_databases")
-        .description(
-            "List all databases in a Redis Cloud subscription. Returns JSON with database details.",
-        )
+        .description("List all databases in a subscription.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, ListDatabasesInput>(
             state,
@@ -137,7 +135,7 @@ pub struct GetDatabaseInput {
 /// Build the get_database tool
 pub fn get_database(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_database")
-        .description("Get detailed information about a specific Redis Cloud database. Returns JSON with full database configuration.")
+        .description("Get database details by ID.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetDatabaseInput>(
             state,
@@ -181,7 +179,7 @@ pub struct GetBackupStatusInput {
 /// Build the get_backup_status tool
 pub fn get_backup_status(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_backup_status")
-        .description("Get backup status and history for a Redis Cloud database.")
+        .description("Get backup status and history for a database.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetBackupStatusInput>(
             state,
@@ -226,9 +224,7 @@ pub struct GetSlowLogInput {
 /// Build the get_slow_log tool
 pub fn get_slow_log(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_slow_log")
-        .description(
-            "Get slow log entries for a Redis Cloud database. Shows slow queries for debugging.",
-        )
+        .description("Get slow log entries for a database.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetSlowLogInput>(
             state,
@@ -265,7 +261,7 @@ pub struct GetTagsInput {
 /// Build the get_tags tool
 pub fn get_tags(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_database_tags")
-        .description("Get tags attached to a Redis Cloud database.")
+        .description("Get tags for a database.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetTagsInput>(
             state,
@@ -303,8 +299,7 @@ pub struct GetCertificateInput {
 pub fn get_database_certificate(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_database_certificate")
         .description(
-            "Get the TLS/SSL certificate for a Redis Cloud database. \
-             Returns the public certificate in PEM format for TLS connections.",
+            "Get the TLS/SSL certificate for a database in PEM format.",
         )
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetCertificateInput>(
@@ -377,8 +372,7 @@ pub struct CreateDatabaseInput {
 pub fn create_database(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_database")
         .description(
-            "Create a new Redis Cloud database and wait for it to be ready. \
-             Returns the created database details. Requires write permission.",
+            "Create a new database and wait for it to be ready.",
         )
         .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateDatabaseInput>(
@@ -476,8 +470,7 @@ pub struct UpdateDatabaseInput {
 pub fn update_database(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_database")
         .description(
-            "Update an existing Redis Cloud database configuration. \
-             Returns the updated database details. Requires write permission.",
+            "Update a database configuration.",
         )
         .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateDatabaseInput>(
@@ -555,8 +548,7 @@ pub struct DeleteDatabaseInput {
 pub fn delete_database(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_database")
         .description(
-            "DANGEROUS: Permanently deletes a database and all its data. This action cannot be undone. \
-             Requires write permission.",
+            "DANGEROUS: Delete a database and all its data.",
         )
         .destructive()
         .extractor_handler_typed::<_, _, _, DeleteDatabaseInput>(
@@ -618,8 +610,7 @@ pub struct BackupDatabaseInput {
 pub fn backup_database(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("backup_database")
         .description(
-            "Trigger a manual backup of a Redis Cloud database. \
-             Requires write permission.",
+            "Trigger a manual backup of a database.",
         )
         .non_destructive()
         .extractor_handler_typed::<_, _, _, BackupDatabaseInput>(
@@ -687,8 +678,7 @@ pub struct ImportDatabaseInput {
 pub fn import_database(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("import_database")
         .description(
-            "Import data into a Redis Cloud database from an external source. \
-             WARNING: This will overwrite existing data. Requires write permission.",
+            "Import data into a database from an external source. WARNING: This will overwrite existing data.",
         )
         .non_destructive()
         .extractor_handler_typed::<_, _, _, ImportDatabaseInput>(
@@ -754,8 +744,7 @@ pub struct DeleteSubscriptionInput {
 pub fn delete_subscription(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_subscription")
         .description(
-            "DANGEROUS: Permanently deletes a subscription. All databases must be deleted first. \
-             This action cannot be undone. Requires write permission.",
+            "DANGEROUS: Delete a subscription. All databases must be deleted first.",
         )
         .destructive()
         .extractor_handler_typed::<_, _, _, DeleteSubscriptionInput>(
@@ -815,10 +804,7 @@ pub struct FlushDatabaseInput {
 /// Build the flush_database tool
 pub fn flush_database(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("flush_database")
-        .description(
-            "DANGEROUS: Removes all data from a database. This action cannot be undone. \
-             Requires write permission.",
-        )
+        .description("DANGEROUS: Removes all data from a database.")
         .destructive()
         .extractor_handler_typed::<_, _, _, FlushDatabaseInput>(
             state,
@@ -873,8 +859,7 @@ pub fn flush_crdb_database(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("flush_crdb_database")
         .description(
             "DANGEROUS: Removes all data from an Active-Active (CRDB) database. \
-             This uses a different API method than regular flush and is specifically \
-             for Active-Active databases. This action cannot be undone.",
+             Use this instead of regular flush for Active-Active databases.",
         )
         .destructive()
         .extractor_handler_typed::<_, _, _, FlushCrdbDatabaseInput>(
@@ -951,9 +936,7 @@ pub struct CreateSubscriptionInput {
 pub fn create_subscription(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_subscription")
         .description(
-            "Create a new Redis Cloud Pro subscription with an initial database. \
-             This is a simplified interface for common subscription creation scenarios. \
-             Requires write permission.",
+            "Create a new Pro subscription with an initial database.",
         )
         .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateSubscriptionInput>(
@@ -1041,8 +1024,7 @@ pub struct UpdateSubscriptionInput {
 pub fn update_subscription(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_subscription")
         .description(
-            "Update a Redis Cloud subscription. \
-             Requires write permission.",
+            "Update a subscription.",
         )
         .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateSubscriptionInput>(
@@ -1093,7 +1075,7 @@ pub struct GetSubscriptionPricingInput {
 pub fn get_subscription_pricing(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_subscription_pricing")
         .description(
-            "Get pricing details for a Redis Cloud subscription.",
+            "Get pricing details for a subscription.",
         )
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetSubscriptionPricingInput>(
@@ -1169,7 +1151,7 @@ pub struct GetSubscriptionCidrAllowlistInput {
 /// Build the get_subscription_cidr_allowlist tool
 pub fn get_subscription_cidr_allowlist(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_subscription_cidr_allowlist")
-        .description("Get the CIDR allowlist for a Redis Cloud subscription.")
+        .description("Get the CIDR allowlist for a subscription.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetSubscriptionCidrAllowlistInput>(
             state,
@@ -1211,10 +1193,7 @@ pub struct UpdateSubscriptionCidrAllowlistInput {
 /// Build the update_subscription_cidr_allowlist tool
 pub fn update_subscription_cidr_allowlist(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_subscription_cidr_allowlist")
-        .description(
-            "Update the CIDR allowlist for a Redis Cloud subscription. \
-             Requires write permission.",
-        )
+        .description("Update the CIDR allowlist for a subscription.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateSubscriptionCidrAllowlistInput>(
             state,
@@ -1265,7 +1244,7 @@ pub struct GetSubscriptionMaintenanceWindowsInput {
 /// Build the get_subscription_maintenance_windows tool
 pub fn get_subscription_maintenance_windows(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_subscription_maintenance_windows")
-        .description("Get maintenance windows for a Redis Cloud subscription.")
+        .description("Get maintenance windows for a subscription.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetSubscriptionMaintenanceWindowsInput>(
             state,
@@ -1317,10 +1296,7 @@ pub struct UpdateSubscriptionMaintenanceWindowsInput {
 /// Build the update_subscription_maintenance_windows tool
 pub fn update_subscription_maintenance_windows(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_subscription_maintenance_windows")
-        .description(
-            "Update maintenance windows for a Redis Cloud subscription. \
-             Requires write permission.",
-        )
+        .description("Update maintenance windows for a subscription.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateSubscriptionMaintenanceWindowsInput>(
             state,
@@ -1382,7 +1358,7 @@ pub struct GetActiveActiveRegionsInput {
 pub fn get_active_active_regions(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_active_active_regions")
         .description(
-            "Get regions from an Active-Active Redis Cloud subscription.",
+            "Get regions from an Active-Active subscription.",
         )
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetActiveActiveRegionsInput>(
@@ -1434,8 +1410,7 @@ pub struct AddActiveActiveRegionInput {
 pub fn add_active_active_region(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("add_active_active_region")
         .description(
-            "Add a new region to an Active-Active Redis Cloud subscription. \
-             Requires write permission.",
+            "Add a new region to an Active-Active subscription.",
         )
         .non_destructive()
         .extractor_handler_typed::<_, _, _, AddActiveActiveRegionInput>(
@@ -1508,8 +1483,7 @@ pub struct DeleteActiveActiveRegionsInput {
 pub fn delete_active_active_regions(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_active_active_regions")
         .description(
-            "DANGEROUS: Permanently removes regions from an Active-Active subscription. \
-             This may cause data loss in the removed regions. Requires write permission.",
+            "DANGEROUS: Remove regions from an Active-Active subscription. May cause data loss in removed regions.",
         )
         .destructive()
         .extractor_handler_typed::<_, _, _, DeleteActiveActiveRegionsInput>(
@@ -1615,8 +1589,7 @@ pub fn upgrade_database_redis_version(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("upgrade_database_redis_version")
         .description(
             "Upgrade the Redis version of a database. \
-             Use get_available_database_versions to find valid target versions. \
-             Requires write permission.",
+             Use get_available_database_versions to find valid target versions.",
         )
         .non_destructive()
         .extractor_handler_typed::<_, _, _, UpgradeDatabaseRedisVersionInput>(
@@ -1715,7 +1688,7 @@ pub struct GetDatabaseImportStatusInput {
 /// Build the get_database_import_status tool
 pub fn get_database_import_status(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_database_import_status")
-        .description("Get the import status for a Redis Cloud database.")
+        .description("Get the import status for a database.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetDatabaseImportStatusInput>(
             state,
@@ -1758,8 +1731,7 @@ pub struct CreateDatabaseTagInput {
 pub fn create_database_tag(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_database_tag")
         .description(
-            "Create a tag on a Redis Cloud database. \
-             Requires write permission.",
+            "Create a tag on a database.",
         )
         .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateDatabaseTagInput>(
@@ -1819,8 +1791,7 @@ pub struct UpdateDatabaseTagInput {
 pub fn update_database_tag(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_database_tag")
         .description(
-            "Update a tag on a Redis Cloud database. \
-             Requires write permission.",
+            "Update a tag on a database.",
         )
         .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateDatabaseTagInput>(
@@ -1883,8 +1854,7 @@ pub struct DeleteDatabaseTagInput {
 pub fn delete_database_tag(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_database_tag")
         .description(
-            "DANGEROUS: Permanently deletes a tag from a database. This action cannot be undone. \
-             Requires write permission.",
+            "DANGEROUS: Delete a tag from a database.",
         )
         .destructive()
         .extractor_handler_typed::<_, _, _, DeleteDatabaseTagInput>(
@@ -1941,8 +1911,7 @@ pub struct UpdateDatabaseTagsInput {
 pub fn update_database_tags(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_database_tags")
         .description(
-            "Update all tags on a Redis Cloud database (replaces existing tags). \
-             Requires write permission.",
+            "Update all tags on a database (replaces existing tags).",
         )
         .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateDatabaseTagsInput>(
@@ -2039,10 +2008,7 @@ pub struct UpdateCrdbLocalPropertiesInput {
 /// Build the update_crdb_local_properties tool
 pub fn update_crdb_local_properties(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_crdb_local_properties")
-        .description(
-            "Update local properties of an Active-Active (CRDB) database. \
-             Requires write permission.",
-        )
+        .description("Update local properties of an Active-Active (CRDB) database.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateCrdbLocalPropertiesInput>(
             state,

--- a/crates/redisctl-mcp/src/tools/enterprise/cluster.rs
+++ b/crates/redisctl-mcp/src/tools/enterprise/cluster.rs
@@ -25,9 +25,7 @@ pub struct GetClusterInput {
 /// Build the get_cluster tool
 pub fn get_cluster(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_cluster")
-        .description(
-            "Get Redis Enterprise cluster information including name, version, and configuration",
-        )
+        .description("Get cluster information including name, version, and configuration")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetClusterInput>(
             state,
@@ -64,10 +62,7 @@ pub struct GetLicenseInput {
 /// Build the get_license tool
 pub fn get_license(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_license")
-        .description(
-            "Get Redis Enterprise cluster license information including type, expiration date, \
-             cluster name, owner, and enabled features",
-        )
+        .description("Get license information including type, expiration, and enabled features")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetLicenseInput>(
             state,
@@ -98,8 +93,7 @@ pub struct GetLicenseUsageInput {
 pub fn get_license_usage(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_license_usage")
         .description(
-            "Get Redis Enterprise cluster license utilization statistics including shards, \
-             nodes, and RAM usage against license limits",
+            "Get license utilization statistics including shards, nodes, and RAM usage against limits",
         )
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetLicenseUsageInput>(
@@ -140,10 +134,7 @@ pub struct UpdateLicenseInput {
 /// Build the update_license tool
 pub fn update_license(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_enterprise_license")
-        .description(
-            "Update the Redis Enterprise cluster license with a new license key. \
-             This applies a new license to the cluster. Requires write permission.",
-        )
+        .description("Apply a new license key to the cluster.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateLicenseInput>(
             state,
@@ -188,11 +179,7 @@ pub struct ValidateLicenseInput {
 /// Build the validate_license tool
 pub fn validate_license(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("validate_enterprise_license")
-        .description(
-            "Validate a license key before applying it to the Redis Enterprise cluster. \
-             Returns license information if valid, or an error if invalid. \
-             This is a dry-run that does not modify the cluster.",
-        )
+        .description("Validate a license key without applying it (dry-run).")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, ValidateLicenseInput>(
             state,
@@ -232,11 +219,7 @@ pub struct UpdateClusterInput {
 /// Build the update_cluster tool
 pub fn update_cluster(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_enterprise_cluster")
-        .description(
-            "Update Redis Enterprise cluster configuration settings. \
-             Pass a JSON object with the fields to update (e.g., name, email_alerts, rack_aware). \
-             Requires write permission.",
-        )
+        .description("Update cluster configuration settings. Pass fields to update as JSON.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateClusterInput>(
             state,
@@ -277,8 +260,8 @@ pub struct GetClusterPolicyInput {
 pub fn get_cluster_policy(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_enterprise_cluster_policy")
         .description(
-            "Get Redis Enterprise cluster policy settings including default shards placement, \
-             rack awareness, default Redis version, and other cluster-wide defaults.",
+            "Get cluster policy settings including default shards placement, \
+             rack awareness, and default Redis version.",
         )
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetClusterPolicyInput>(
@@ -317,10 +300,7 @@ pub struct UpdateClusterPolicyInput {
 pub fn update_cluster_policy(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_enterprise_cluster_policy")
         .description(
-            "Update Redis Enterprise cluster policy settings. \
-             Common settings: default_shards_placement (dense/sparse), rack_aware, \
-             default_provisioned_redis_version, persistent_node_removal. \
-             Requires write permission.",
+            "Update cluster policy settings. Pass fields to update as JSON.",
         )
         .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateClusterPolicyInput>(
@@ -367,9 +347,8 @@ pub struct EnableMaintenanceModeInput {
 pub fn enable_maintenance_mode(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("enable_enterprise_maintenance_mode")
         .description(
-            "Enable maintenance mode on the Redis Enterprise cluster. \
-             When enabled, cluster configuration changes are blocked, allowing safe \
-             maintenance operations like upgrades. Requires write permission.",
+            "Enable maintenance mode. Configuration changes will be blocked \
+             until maintenance mode is disabled.",
         )
         .non_destructive()
         .extractor_handler_typed::<_, _, _, EnableMaintenanceModeInput>(
@@ -415,11 +394,7 @@ pub struct DisableMaintenanceModeInput {
 /// Build the disable_maintenance_mode tool
 pub fn disable_maintenance_mode(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("disable_enterprise_maintenance_mode")
-        .description(
-            "Disable maintenance mode on the Redis Enterprise cluster. \
-             This re-enables cluster configuration changes after maintenance is complete. \
-             Requires write permission.",
-        )
+        .description("Disable maintenance mode and re-enable configuration changes.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, DisableMaintenanceModeInput>(
             state,
@@ -468,10 +443,7 @@ pub struct GetClusterCertificatesInput {
 /// Build the get_cluster_certificates tool
 pub fn get_cluster_certificates(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_enterprise_cluster_certificates")
-        .description(
-            "Get all certificates configured on the Redis Enterprise cluster including \
-             proxy certificates, syncer certificates, and API certificates.",
-        )
+        .description("Get all configured certificates (proxy, syncer, API).")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetClusterCertificatesInput>(
             state,
@@ -505,11 +477,7 @@ pub struct RotateClusterCertificatesInput {
 /// Build the rotate_cluster_certificates tool
 pub fn rotate_cluster_certificates(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("rotate_enterprise_cluster_certificates")
-        .description(
-            "Rotate all certificates on the Redis Enterprise cluster. \
-             This generates new certificates and replaces the existing ones. \
-             Requires write permission.",
-        )
+        .description("Rotate all certificates, generating new ones to replace existing.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, RotateClusterCertificatesInput>(
             state,
@@ -560,9 +528,8 @@ pub struct UpdateClusterCertificatesInput {
 pub fn update_cluster_certificates(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_enterprise_cluster_certificates")
         .description(
-            "Update a specific certificate on the Redis Enterprise cluster. \
-             Provide the certificate name (proxy, syncer, api), the PEM-encoded certificate, \
-             and the PEM-encoded private key. Requires write permission.",
+            "Update a specific certificate. Provide the certificate name (proxy, syncer, api), \
+             PEM-encoded certificate, and PEM-encoded private key.",
         )
         .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateClusterCertificatesInput>(
@@ -617,7 +584,7 @@ pub struct ListNodesInput {
 /// Build the list_nodes tool
 pub fn list_nodes(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_nodes")
-        .description("List all nodes in the Redis Enterprise cluster")
+        .description("List all nodes.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, ListNodesInput>(
             state,
@@ -649,9 +616,7 @@ pub struct GetNodeInput {
 /// Build the get_node tool
 pub fn get_node(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_node")
-        .description(
-            "Get detailed information about a specific node in the Redis Enterprise cluster",
-        )
+        .description("Get detailed information about a specific node by UID.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetNodeInput>(
             state,
@@ -696,8 +661,8 @@ pub struct GetNodeStatsInput {
 pub fn get_node_stats(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_node_stats")
         .description(
-            "Get statistics for a specific node. By default returns the latest stats. \
-             Optionally specify interval and time range for historical data.",
+            "Get statistics for a specific node. Optionally specify interval and time range \
+             for historical data.",
         )
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetNodeStatsInput>(
@@ -755,9 +720,7 @@ pub struct NodeActionInput {
 pub fn enable_node_maintenance(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("enable_enterprise_node_maintenance")
         .description(
-            "Enable maintenance mode on a specific node in the Redis Enterprise cluster. \
-             Shards will be migrated off the node before maintenance begins. \
-             Requires write permission.",
+            "Enable maintenance mode on a specific node. Shards will be migrated off first.",
         )
         .non_destructive()
         .extractor_handler_typed::<_, _, _, NodeActionInput>(
@@ -796,9 +759,7 @@ pub fn enable_node_maintenance(state: Arc<AppState>) -> Tool {
 pub fn disable_node_maintenance(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("disable_enterprise_node_maintenance")
         .description(
-            "Disable maintenance mode on a specific node in the Redis Enterprise cluster. \
-             The node will rejoin the cluster and accept shards again. \
-             Requires write permission.",
+            "Disable maintenance mode on a specific node. The node will accept shards again.",
         )
         .non_destructive()
         .extractor_handler_typed::<_, _, _, NodeActionInput>(
@@ -836,11 +797,7 @@ pub fn disable_node_maintenance(state: Arc<AppState>) -> Tool {
 /// Build the rebalance_node tool
 pub fn rebalance_node(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("rebalance_enterprise_node")
-        .description(
-            "Rebalance shards on a specific node in the Redis Enterprise cluster. \
-             Redistributes shards across nodes for optimal performance. \
-             Requires write permission.",
-        )
+        .description("Rebalance shards on a specific node for optimal distribution.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, NodeActionInput>(
             state,
@@ -877,11 +834,7 @@ pub fn rebalance_node(state: Arc<AppState>) -> Tool {
 /// Build the drain_node tool
 pub fn drain_node(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("drain_enterprise_node")
-        .description(
-            "Drain all shards from a specific node in the Redis Enterprise cluster. \
-             All shards will be migrated to other available nodes. \
-             Requires write permission.",
-        )
+        .description("Drain all shards from a specific node, migrating them to other nodes.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, NodeActionInput>(
             state,
@@ -934,10 +887,7 @@ pub struct UpdateNodeInput {
 /// Build the update_enterprise_node tool
 pub fn update_enterprise_node(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_enterprise_node")
-        .description(
-            "Update a node's configuration in the Redis Enterprise cluster. \
-             Pass the fields to update as JSON.",
-        )
+        .description("Update a node's configuration. Pass fields to update as JSON.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateNodeInput>(
             state,
@@ -979,10 +929,7 @@ pub struct RemoveNodeInput {
 /// Build the remove_enterprise_node tool
 pub fn remove_enterprise_node(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("remove_enterprise_node")
-        .description(
-            "DANGEROUS: Permanently removes a node from the Redis Enterprise cluster. \
-             All shards must be drained first. This action cannot be undone.",
-        )
+        .description("DANGEROUS: Remove a node. All shards must be drained first.")
         .destructive()
         .extractor_handler_typed::<_, _, _, RemoveNodeInput>(
             state,
@@ -1029,9 +976,7 @@ pub struct GetClusterServicesInput {
 /// Build the get_enterprise_cluster_services tool
 pub fn get_enterprise_cluster_services(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_enterprise_cluster_services")
-        .description(
-            "Get the list of services running on the Redis Enterprise cluster.",
-        )
+        .description("Get the list of cluster services.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetClusterServicesInput>(
             state,
@@ -1075,8 +1020,8 @@ pub struct GetClusterStatsInput {
 pub fn get_cluster_stats(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_cluster_stats")
         .description(
-            "Get statistics for the Redis Enterprise cluster. By default returns the latest \
-             stats. Optionally specify interval and time range for historical data.",
+            "Get cluster-level statistics. Optionally specify interval and time range \
+             for historical data.",
         )
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetClusterStatsInput>(

--- a/crates/redisctl-mcp/src/tools/enterprise/databases.rs
+++ b/crates/redisctl-mcp/src/tools/enterprise/databases.rs
@@ -36,10 +36,7 @@ pub struct ListDatabasesInput {
 /// Build the list_databases tool
 pub fn list_databases(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_enterprise_databases")
-        .description(
-            "List all databases on the Redis Enterprise cluster. Supports filtering by name \
-             (case-insensitive substring match) and status.",
-        )
+        .description("List all databases. Supports filtering by name and status.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, ListDatabasesInput>(
             state,
@@ -96,7 +93,7 @@ pub struct GetDatabaseInput {
 /// Build the get_database tool
 pub fn get_database(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_enterprise_database")
-        .description("Get detailed information about a specific Redis Enterprise database")
+        .description("Get database details by UID.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetDatabaseInput>(
             state,
@@ -141,8 +138,8 @@ pub struct GetDatabaseStatsInput {
 pub fn get_database_stats(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_database_stats")
         .description(
-            "Get statistics for a specific database. By default returns the latest stats. \
-             Optionally specify interval and time range for historical data.",
+            "Get statistics for a specific database. Optionally specify interval and time range \
+             for historical data.",
         )
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetDatabaseStatsInput>(
@@ -196,9 +193,7 @@ pub struct GetDatabaseEndpointsInput {
 /// Build the get_database_endpoints tool
 pub fn get_database_endpoints(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_database_endpoints")
-        .description(
-            "Get connection endpoints for a specific database in the Redis Enterprise cluster",
-        )
+        .description("Get connection endpoints for a specific database.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetDatabaseEndpointsInput>(
             state,
@@ -234,7 +229,7 @@ pub struct ListDatabaseAlertsInput {
 /// Build the list_database_alerts tool
 pub fn list_database_alerts(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_database_alerts")
-        .description("List all alerts for a specific database in the Redis Enterprise cluster")
+        .description("List all alerts for a specific database.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, ListDatabaseAlertsInput>(
             state,
@@ -281,10 +276,7 @@ pub struct BackupDatabaseInput {
 /// Build the backup_enterprise_database tool
 pub fn backup_enterprise_database(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("backup_enterprise_database")
-        .description(
-            "Trigger a backup of a Redis Enterprise database and wait for completion. \
-             Requires write permission.",
-        )
+        .description("Trigger a database backup and wait for completion.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, BackupDatabaseInput>(
             state,
@@ -343,9 +335,8 @@ pub struct ImportDatabaseInput {
 pub fn import_enterprise_database(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("import_enterprise_database")
         .description(
-            "Import data into a Redis Enterprise database from an external source and wait for completion. \
-             WARNING: If flush is true, existing data will be deleted before import. \
-             Requires write permission.",
+            "Import data into a database from an external source and wait for completion. \
+             WARNING: If flush is true, existing data will be deleted before import.",
         )
         .non_destructive()
         .extractor_handler_typed::<_, _, _, ImportDatabaseInput>(
@@ -415,10 +406,7 @@ pub struct CreateEnterpriseDatabaseInput {
 /// Build the create_enterprise_database tool
 pub fn create_enterprise_database(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_enterprise_database")
-        .description(
-            "Create a new database in the Redis Enterprise cluster. \
-             Returns the created database details. Requires write permission.",
-        )
+        .description("Create a new database.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateEnterpriseDatabaseInput>(
             state,
@@ -481,10 +469,7 @@ pub struct UpdateEnterpriseDatabaseInput {
 /// Build the update_enterprise_database tool
 pub fn update_enterprise_database(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_enterprise_database")
-        .description(
-            "Update configuration of an existing Redis Enterprise database. \
-             Pass a JSON object with the fields to update. Requires write permission.",
-        )
+        .description("Update database configuration. Pass fields to update as JSON.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateEnterpriseDatabaseInput>(
             state,
@@ -527,10 +512,7 @@ pub struct DeleteEnterpriseDatabaseInput {
 /// Build the delete_enterprise_database tool
 pub fn delete_enterprise_database(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_enterprise_database")
-        .description(
-            "DANGEROUS: Permanently deletes a database from the Redis Enterprise cluster \
-             and all its data. This action cannot be undone. Requires write permission.",
-        )
+        .description("DANGEROUS: Delete a database and all its data.")
         .destructive()
         .extractor_handler_typed::<_, _, _, DeleteEnterpriseDatabaseInput>(
             state,
@@ -579,10 +561,7 @@ pub struct FlushEnterpriseDatabaseInput {
 /// Build the flush_enterprise_database tool
 pub fn flush_enterprise_database(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("flush_enterprise_database")
-        .description(
-            "DANGEROUS: Removes all data from a Redis Enterprise database. \
-             This action cannot be undone. Requires write permission.",
-        )
+        .description("DANGEROUS: Flush all data from a database.")
         .destructive()
         .extractor_handler_typed::<_, _, _, FlushEnterpriseDatabaseInput>(
             state,
@@ -634,10 +613,7 @@ pub struct ExportEnterpriseDatabaseInput {
 /// Build the export_enterprise_database tool
 pub fn export_enterprise_database(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("export_enterprise_database")
-        .description(
-            "Export a Redis Enterprise database to a specified location (e.g., S3, FTP). \
-             Returns an action reference for tracking.",
-        )
+        .description("Export a database to a specified location (e.g., S3, FTP).")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, ExportEnterpriseDatabaseInput>(
             state,
@@ -683,10 +659,7 @@ pub struct RestoreEnterpriseDatabaseInput {
 /// Build the restore_enterprise_database tool
 pub fn restore_enterprise_database(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("restore_enterprise_database")
-        .description(
-            "Restore a Redis Enterprise database from a backup. \
-             Returns an action reference for tracking.",
-        )
+        .description("Restore a database from a backup.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, RestoreEnterpriseDatabaseInput>(
             state,
@@ -738,10 +711,7 @@ pub struct UpgradeEnterpriseDatabaseRedisInput {
 /// Build the upgrade_enterprise_database_redis tool
 pub fn upgrade_enterprise_database_redis(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("upgrade_enterprise_database_redis")
-        .description(
-            "Upgrade the Redis version of a database. Pass redis_version for the target version. \
-             Returns an action reference.",
-        )
+        .description("Upgrade the Redis version of a database.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, UpgradeEnterpriseDatabaseRedisInput>(
             state,
@@ -793,10 +763,7 @@ pub struct ListCrdbsInput {
 /// Build the list_enterprise_crdbs tool
 pub fn list_enterprise_crdbs(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_enterprise_crdbs")
-        .description(
-            "List all Active-Active (CRDB) databases in the Redis Enterprise cluster. \
-             Returns database names, GUIDs, status, and instance information.",
-        )
+        .description("List all Active-Active (CRDB) databases.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, ListCrdbsInput>(
             state,
@@ -828,10 +795,7 @@ pub struct GetCrdbInput {
 /// Build the get_enterprise_crdb tool
 pub fn get_enterprise_crdb(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_enterprise_crdb")
-        .description(
-            "Get detailed information about a specific Active-Active (CRDB) database \
-             including instances, replication status, and configuration.",
-        )
+        .description("Get details of a specific Active-Active (CRDB) database by GUID.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetCrdbInput>(
             state,
@@ -866,10 +830,7 @@ pub struct GetCrdbTasksInput {
 /// Build the get_enterprise_crdb_tasks tool
 pub fn get_enterprise_crdb_tasks(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_enterprise_crdb_tasks")
-        .description(
-            "Get tasks for a specific Active-Active (CRDB) database. \
-             Returns pending and completed tasks related to CRDB operations.",
-        )
+        .description("Get tasks for a specific Active-Active (CRDB) database.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetCrdbTasksInput>(
             state,
@@ -904,10 +865,7 @@ pub struct CreateEnterpriseCrdbInput {
 /// Build the create_enterprise_crdb tool
 pub fn create_enterprise_crdb(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_enterprise_crdb")
-        .description(
-            "Create a new Active-Active (CRDB) database across multiple clusters. \
-             Pass the full CRDB configuration as JSON.",
-        )
+        .description("Create a new Active-Active (CRDB) database. Pass full configuration as JSON.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateEnterpriseCrdbInput>(
             state,
@@ -951,10 +909,7 @@ pub struct UpdateEnterpriseCrdbInput {
 /// Build the update_enterprise_crdb tool
 pub fn update_enterprise_crdb(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_enterprise_crdb")
-        .description(
-            "Update an existing Active-Active (CRDB) database configuration. \
-             Pass the fields to update as JSON.",
-        )
+        .description("Update an Active-Active (CRDB) database. Pass fields to update as JSON.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateEnterpriseCrdbInput>(
             state,
@@ -997,10 +952,7 @@ pub struct DeleteEnterpriseCrdbInput {
 /// Build the delete_enterprise_crdb tool
 pub fn delete_enterprise_crdb(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_enterprise_crdb")
-        .description(
-            "DANGEROUS: Permanently deletes an Active-Active (CRDB) database across all \
-             participating clusters. This action cannot be undone.",
-        )
+        .description("DANGEROUS: Delete an Active-Active (CRDB) database across all participating clusters.")
         .destructive()
         .extractor_handler_typed::<_, _, _, DeleteEnterpriseCrdbInput>(
             state,

--- a/crates/redisctl-mcp/src/tools/enterprise/observability.rs
+++ b/crates/redisctl-mcp/src/tools/enterprise/observability.rs
@@ -31,7 +31,7 @@ pub struct ListAlertsInput {
 /// Build the list_alerts tool
 pub fn list_alerts(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_alerts")
-        .description("List all active alerts in the Redis Enterprise cluster")
+        .description("List all active alerts.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, ListAlertsInput>(
             state,
@@ -80,11 +80,7 @@ pub struct ListLogsInput {
 /// Build the list_logs tool
 pub fn list_logs(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_logs")
-        .description(
-            "List cluster event logs from Redis Enterprise. Logs include events like database \
-             changes, node status updates, configuration modifications, and alerts. Supports \
-             filtering by time range and pagination.",
-        )
+        .description("List cluster event logs. Supports filtering by time range and pagination.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, ListLogsInput>(
             state,
@@ -138,10 +134,7 @@ pub struct GetAllNodesStatsInput {
 /// Build the get_all_nodes_stats tool
 pub fn get_all_nodes_stats(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_all_nodes_stats")
-        .description(
-            "Get current statistics for all nodes in the Redis Enterprise cluster in a single \
-             call. Returns aggregated stats per node including CPU, memory, and network metrics.",
-        )
+        .description("Get current statistics for all nodes including CPU, memory, and network metrics.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetAllNodesStatsInput>(
             state,
@@ -176,9 +169,7 @@ pub struct GetAllDatabasesStatsInput {
 pub fn get_all_databases_stats(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_all_databases_stats")
         .description(
-            "Get current statistics for all databases in the Redis Enterprise cluster in a \
-             single call. Returns aggregated stats per database including latency, throughput, \
-             and memory usage.",
+            "Get current statistics for all databases including latency, throughput, and memory usage.",
         )
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetAllDatabasesStatsInput>(
@@ -212,7 +203,7 @@ pub struct GetShardStatsInput {
 /// Build the get_shard_stats tool
 pub fn get_shard_stats(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_shard_stats")
-        .description("Get current statistics for a specific shard in the Redis Enterprise cluster")
+        .description("Get current statistics for a specific shard.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetShardStatsInput>(
             state,
@@ -245,10 +236,7 @@ pub struct GetAllShardsStatsInput {
 /// Build the get_all_shards_stats tool
 pub fn get_all_shards_stats(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_all_shards_stats")
-        .description(
-            "Get current statistics for all shards in the Redis Enterprise cluster in a single \
-             call. Returns aggregated stats per shard.",
-        )
+        .description("Get current statistics for all shards.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetAllShardsStatsInput>(
             state,
@@ -289,9 +277,7 @@ pub struct ListShardsInput {
 /// Build the list_shards tool
 pub fn list_shards(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_shards")
-        .description(
-            "List all shards in the Redis Enterprise cluster. Optionally filter by database UID.",
-        )
+        .description("List all shards. Optionally filter by database UID.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, ListShardsInput>(
             state,
@@ -331,8 +317,7 @@ pub struct GetShardInput {
 pub fn get_shard(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_shard")
         .description(
-            "Get detailed information about a specific shard in the Redis Enterprise cluster \
-             including role (master/replica), status, and assigned node.",
+            "Get shard details including role (master/replica), status, and assigned node.",
         )
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetShardInput>(
@@ -370,11 +355,7 @@ pub struct ListDebugInfoTasksInput {
 /// Build the list_debug_info_tasks tool
 pub fn list_debug_info_tasks(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_debug_info_tasks")
-        .description(
-            "List all debug info collection tasks in the Redis Enterprise cluster. Returns task \
-             IDs, statuses (queued, running, completed, failed), and download URLs for completed \
-             collections.",
-        )
+        .description("List all debug info collection tasks and their statuses.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, ListDebugInfoTasksInput>(
             state,
@@ -410,11 +391,7 @@ pub struct GetDebugInfoStatusInput {
 /// Build the get_debug_info_status tool
 pub fn get_debug_info_status(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_debug_info_status")
-        .description(
-            "Get the status of a debug info collection task. Returns status (queued, running, \
-             completed, failed), progress percentage, download URL (when completed), and error \
-             message (if failed).",
-        )
+        .description("Get the status of a debug info collection task by ID.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetDebugInfoStatusInput>(
             state,
@@ -452,11 +429,7 @@ pub struct ListModulesInput {
 /// Build the list_modules tool
 pub fn list_modules(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_modules")
-        .description(
-            "List all Redis modules installed on the Redis Enterprise cluster. Returns module \
-             names, versions, descriptions, and capabilities (e.g., RedisJSON, RediSearch, \
-             RedisTimeSeries).",
-        )
+        .description("List all installed Redis modules.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, ListModulesInput>(
             state,
@@ -491,10 +464,7 @@ pub struct GetModuleInput {
 /// Build the get_module tool
 pub fn get_module(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_module")
-        .description(
-            "Get detailed information about a specific Redis module including version, \
-             description, author, license, capabilities, and platform compatibility.",
-        )
+        .description("Get details of a specific Redis module by UID.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetModuleInput>(
             state,
@@ -533,10 +503,7 @@ pub struct ListShardsByDatabaseInput {
 /// Build the list_shards_by_database tool
 pub fn list_shards_by_database(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_shards_by_database")
-        .description(
-            "List all shards for a specific database. Returns shard details including role, \
-             status, and node assignment.",
-        )
+        .description("List all shards for a specific database.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, ListShardsByDatabaseInput>(
             state,
@@ -572,10 +539,7 @@ pub struct ListShardsByNodeInput {
 /// Build the list_shards_by_node tool
 pub fn list_shards_by_node(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_shards_by_node")
-        .description(
-            "List all shards on a specific node. Useful for understanding shard distribution \
-             and planning rebalance operations.",
-        )
+        .description("List all shards on a specific node.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, ListShardsByNodeInput>(
             state,
@@ -615,9 +579,7 @@ pub struct AcknowledgeAlertInput {
 /// Build the acknowledge_enterprise_alert tool
 pub fn acknowledge_enterprise_alert(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("acknowledge_enterprise_alert")
-        .description(
-            "Acknowledge (clear) a specific alert by ID. The alert will be marked as resolved.",
-        )
+        .description("Acknowledge (clear) a specific alert by ID.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, AcknowledgeAlertInput>(
             state,
@@ -671,10 +633,7 @@ pub struct CreateDebugInfoInput {
 /// Build the create_debug_info tool
 pub fn create_debug_info(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_debug_info")
-        .description(
-            "Start a debug information collection task. Specify node and/or database IDs to \
-             scope the collection. Returns task status for tracking.",
-        )
+        .description("Start a debug info collection task. Optionally scope to specific nodes or databases.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateDebugInfoInput>(
             state,

--- a/crates/redisctl-mcp/src/tools/enterprise/proxy.rs
+++ b/crates/redisctl-mcp/src/tools/enterprise/proxy.rs
@@ -23,7 +23,7 @@ pub struct ListProxiesInput {
 /// Build the list_enterprise_proxies tool
 pub fn list_proxies(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_enterprise_proxies")
-        .description("List all proxy instances in the Redis Enterprise cluster with their status and configuration.")
+        .description("List all proxy instances.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, ListProxiesInput>(
             state,
@@ -58,7 +58,7 @@ pub struct GetProxyInput {
 /// Build the get_enterprise_proxy tool
 pub fn get_proxy(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_enterprise_proxy")
-        .description("Get detailed information about a specific proxy instance by UID.")
+        .description("Get proxy details by UID.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetProxyInput>(
             state,
@@ -93,7 +93,9 @@ pub struct GetProxyStatsInput {
 /// Build the get_enterprise_proxy_stats tool
 pub fn get_proxy_stats(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_enterprise_proxy_stats")
-        .description("Get statistics for a specific proxy instance including connection counts and throughput.")
+        .description(
+            "Get statistics for a specific proxy including connection counts and throughput.",
+        )
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetProxyStatsInput>(
             state,
@@ -130,10 +132,7 @@ pub struct UpdateProxyInput {
 /// Build the update_enterprise_proxy tool
 pub fn update_proxy(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_enterprise_proxy")
-        .description(
-            "Update a proxy instance's configuration. Pass the fields to update as JSON \
-             (e.g., max_connections, threads). Requires write permission.",
-        )
+        .description("Update a proxy's configuration. Pass fields to update as JSON.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateProxyInput>(
             state,

--- a/crates/redisctl-mcp/src/tools/enterprise/raw.rs
+++ b/crates/redisctl-mcp/src/tools/enterprise/raw.rs
@@ -43,9 +43,8 @@ pub struct EnterpriseRawApiInput {
 pub fn enterprise_raw_api(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("enterprise_raw_api")
         .description(
-            "DANGEROUS: Execute a raw HTTP request against the Redis Enterprise REST API. \
-             Use this escape hatch to reach any Enterprise API endpoint not covered by a dedicated tool. \
-             GET requires read-write tier; POST/PUT/PATCH/DELETE require full tier.",
+            "DANGEROUS: Execute a raw REST API request against the Enterprise API. \
+             Escape hatch for endpoints not covered by dedicated tools.",
         )
         .destructive()
         .extractor_handler_typed::<_, _, _, EnterpriseRawApiInput>(

--- a/crates/redisctl-mcp/src/tools/enterprise/rbac.rs
+++ b/crates/redisctl-mcp/src/tools/enterprise/rbac.rs
@@ -30,7 +30,7 @@ pub struct ListUsersInput {
 /// Build the list_users tool
 pub fn list_users(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_enterprise_users")
-        .description("List all users in the Redis Enterprise cluster")
+        .description("List all users.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, ListUsersInput>(
             state,
@@ -62,9 +62,7 @@ pub struct GetUserInput {
 /// Build the get_user tool
 pub fn get_user(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_enterprise_user")
-        .description(
-            "Get detailed information about a specific user in the Redis Enterprise cluster",
-        )
+        .description("Get user details by UID.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetUserInput>(
             state,
@@ -112,10 +110,7 @@ pub struct CreateEnterpriseUserInput {
 /// Build the create_enterprise_user tool
 pub fn create_enterprise_user(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_enterprise_user")
-        .description(
-            "Create a new user in the Redis Enterprise cluster. \
-             Requires write permission.",
-        )
+        .description("Create a new user.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateEnterpriseUserInput>(
             state,
@@ -187,10 +182,7 @@ pub struct UpdateEnterpriseUserInput {
 /// Build the update_enterprise_user tool
 pub fn update_enterprise_user(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_enterprise_user")
-        .description(
-            "Update an existing user in the Redis Enterprise cluster. \
-             Only specified fields will be modified. Requires write permission.",
-        )
+        .description("Update an existing user. Only specified fields will be modified.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateEnterpriseUserInput>(
             state,
@@ -244,10 +236,7 @@ pub struct DeleteEnterpriseUserInput {
 /// Build the delete_enterprise_user tool
 pub fn delete_enterprise_user(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_enterprise_user")
-        .description(
-            "DANGEROUS: Permanently deletes a user from the Redis Enterprise cluster. \
-             Active sessions using this user will be terminated. Requires write permission.",
-        )
+        .description("DANGEROUS: Delete a user. Active sessions will be terminated.")
         .destructive()
         .extractor_handler_typed::<_, _, _, DeleteEnterpriseUserInput>(
             state,
@@ -295,10 +284,7 @@ pub struct ListRolesInput {
 /// Build the list_roles tool
 pub fn list_roles(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_enterprise_roles")
-        .description(
-            "List all roles in the Redis Enterprise cluster. Returns role names, \
-             permissions (management, data_access), and database-specific role assignments.",
-        )
+        .description("List all roles.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, ListRolesInput>(
             state,
@@ -330,10 +316,7 @@ pub struct GetRoleInput {
 /// Build the get_role tool
 pub fn get_role(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_enterprise_role")
-        .description(
-            "Get detailed information about a specific role including permissions \
-             and database role assignments.",
-        )
+        .description("Get role details by UID, including permissions and assignments.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetRoleInput>(
             state,
@@ -374,10 +357,7 @@ pub struct CreateEnterpriseRoleInput {
 /// Build the create_enterprise_role tool
 pub fn create_enterprise_role(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_enterprise_role")
-        .description(
-            "Create a new role in the Redis Enterprise cluster. \
-             Requires write permission.",
-        )
+        .description("Create a new role.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateEnterpriseRoleInput>(
             state,
@@ -436,10 +416,7 @@ pub struct UpdateEnterpriseRoleInput {
 /// Build the update_enterprise_role tool
 pub fn update_enterprise_role(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_enterprise_role")
-        .description(
-            "Update an existing role in the Redis Enterprise cluster. \
-             Requires write permission.",
-        )
+        .description("Update an existing role.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateEnterpriseRoleInput>(
             state,
@@ -490,10 +467,7 @@ pub struct DeleteEnterpriseRoleInput {
 /// Build the delete_enterprise_role tool
 pub fn delete_enterprise_role(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_enterprise_role")
-        .description(
-            "DANGEROUS: Permanently deletes a role from the Redis Enterprise cluster. \
-             Users assigned to this role will lose their permissions. Requires write permission.",
-        )
+        .description("DANGEROUS: Delete a role. Users assigned to it will lose their permissions.")
         .destructive()
         .extractor_handler_typed::<_, _, _, DeleteEnterpriseRoleInput>(
             state,
@@ -541,10 +515,7 @@ pub struct ListRedisAclsInput {
 /// Build the list_redis_acls tool
 pub fn list_redis_acls(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_enterprise_acls")
-        .description(
-            "List all Redis ACLs in the Redis Enterprise cluster. Returns ACL names, \
-             rules, and associated databases.",
-        )
+        .description("List all Redis ACLs.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, ListRedisAclsInput>(
             state,
@@ -577,8 +548,7 @@ pub struct GetRedisAclInput {
 pub fn get_redis_acl(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_enterprise_acl")
         .description(
-            "Get detailed information about a specific Redis ACL including the ACL rule string \
-             and associated databases.",
+            "Get Redis ACL details by UID, including rule string and associated databases.",
         )
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetRedisAclInput>(
@@ -619,11 +589,7 @@ pub struct CreateEnterpriseAclInput {
 /// Build the create_enterprise_acl tool
 pub fn create_enterprise_acl(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_enterprise_acl")
-        .description(
-            "Create a new Redis ACL in the Redis Enterprise cluster. \
-             The ACL rule string follows Redis ACL syntax (e.g., \"+@all ~*\"). \
-             Requires write permission.",
-        )
+        .description("Create a new Redis ACL using Redis ACL syntax (e.g., \"+@all ~*\").")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateEnterpriseAclInput>(
             state,
@@ -679,10 +645,7 @@ pub struct UpdateEnterpriseAclInput {
 /// Build the update_enterprise_acl tool
 pub fn update_enterprise_acl(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_enterprise_acl")
-        .description(
-            "Update an existing Redis ACL in the Redis Enterprise cluster. \
-             Requires write permission.",
-        )
+        .description("Update an existing Redis ACL.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateEnterpriseAclInput>(
             state,
@@ -731,10 +694,7 @@ pub struct DeleteEnterpriseAclInput {
 /// Build the delete_enterprise_acl tool
 pub fn delete_enterprise_acl(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_enterprise_acl")
-        .description(
-            "DANGEROUS: Permanently deletes a Redis ACL from the cluster. \
-             Databases using this ACL will lose those access controls. Requires write permission.",
-        )
+        .description("DANGEROUS: Delete a Redis ACL. Databases using it will lose those access controls.")
         .destructive()
         .extractor_handler_typed::<_, _, _, DeleteEnterpriseAclInput>(
             state,
@@ -783,8 +743,7 @@ pub struct GetLdapConfigInput {
 pub fn get_enterprise_ldap_config(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_enterprise_ldap_config")
         .description(
-            "Get the LDAP configuration for the Redis Enterprise cluster including \
-             server settings, bind DN, and query suffixes.",
+            "Get the LDAP configuration including server settings, bind DN, and query suffixes.",
         )
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetLdapConfigInput>(
@@ -821,10 +780,7 @@ pub struct UpdateLdapConfigInput {
 /// Build the update_enterprise_ldap_config tool
 pub fn update_enterprise_ldap_config(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_enterprise_ldap_config")
-        .description(
-            "Update the LDAP configuration for the Redis Enterprise cluster. \
-             Accepts a JSON object with LDAP settings. Requires write permission.",
-        )
+        .description("Update the LDAP configuration. Pass LDAP settings as JSON.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateLdapConfigInput>(
             state,
@@ -872,9 +828,7 @@ pub struct GetUserPermissionsInput {
 /// Build the get_enterprise_user_permissions tool
 pub fn get_enterprise_user_permissions(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_enterprise_user_permissions")
-        .description(
-            "Get all available permission types for Redis Enterprise user management.",
-        )
+        .description("Get all available permission types for user management.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetUserPermissionsInput>(
             state,
@@ -912,9 +866,7 @@ pub struct GetBuiltinRolesInput {
 /// Build the get_enterprise_builtin_roles tool
 pub fn get_enterprise_builtin_roles(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_enterprise_builtin_roles")
-        .description(
-            "Get the list of built-in roles available in the Redis Enterprise cluster.",
-        )
+        .description("Get the list of built-in roles.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetBuiltinRolesInput>(
             state,
@@ -959,10 +911,7 @@ pub struct ValidateEnterpriseAclInput {
 /// Build the validate_enterprise_acl tool
 pub fn validate_enterprise_acl(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("validate_enterprise_acl")
-        .description(
-            "Validate a Redis ACL rule before creating it. Returns validation results \
-             and any errors.",
-        )
+        .description("Validate a Redis ACL rule before creating it.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, ValidateEnterpriseAclInput>(
             state,

--- a/crates/redisctl-mcp/src/tools/enterprise/services.rs
+++ b/crates/redisctl-mcp/src/tools/enterprise/services.rs
@@ -23,7 +23,7 @@ pub struct ListServicesInput {
 /// Build the list_enterprise_services tool
 pub fn list_services(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_enterprise_services")
-        .description("List all services running on the Redis Enterprise cluster.")
+        .description("List all cluster services.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, ListServicesInput>(
             state,
@@ -58,7 +58,7 @@ pub struct GetServiceInput {
 /// Build the get_enterprise_service tool
 pub fn get_service(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_enterprise_service")
-        .description("Get detailed information about a specific cluster service by ID.")
+        .description("Get service details by ID.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetServiceInput>(
             state,
@@ -93,7 +93,7 @@ pub struct GetServiceStatusInput {
 /// Build the get_enterprise_service_status tool
 pub fn get_service_status(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_enterprise_service_status")
-        .description("Get the current status of a specific cluster service, including per-node status.")
+        .description("Get service status including per-node status.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetServiceStatusInput>(
             state,
@@ -131,10 +131,7 @@ pub struct UpdateServiceInput {
 /// Build the update_enterprise_service tool
 pub fn update_service(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_enterprise_service")
-        .description(
-            "Update a cluster service's configuration. Pass the configuration fields as JSON. \
-             Requires write permission.",
-        )
+        .description("Update a service's configuration. Pass fields as JSON.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, UpdateServiceInput>(
             state,
@@ -177,9 +174,7 @@ pub struct ServiceActionInput {
 /// Build the start_enterprise_service tool
 pub fn start_service(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("start_enterprise_service")
-        .description(
-            "Start a cluster service that is currently stopped. Requires write permission.",
-        )
+        .description("Start a stopped service.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, ServiceActionInput>(
             state,
@@ -210,7 +205,7 @@ pub fn start_service(state: Arc<AppState>) -> Tool {
 /// Build the stop_enterprise_service tool
 pub fn stop_service(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("stop_enterprise_service")
-        .description("Stop a running cluster service. Requires write permission.")
+        .description("Stop a running service.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, ServiceActionInput>(
             state,
@@ -241,10 +236,7 @@ pub fn stop_service(state: Arc<AppState>) -> Tool {
 /// Build the restart_enterprise_service tool
 pub fn restart_service(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("restart_enterprise_service")
-        .description(
-            "Restart a cluster service. The service will be stopped and started. \
-             Requires write permission.",
-        )
+        .description("Restart a service (stop then start).")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, ServiceActionInput>(
             state,

--- a/crates/redisctl-mcp/src/tools/profile.rs
+++ b/crates/redisctl-mcp/src/tools/profile.rs
@@ -50,7 +50,7 @@ struct ProfileSummary {
 /// Build the profile_list tool
 pub fn list_profiles(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("profile_list")
-        .description("List all configured redisctl profiles with their types and default status")
+        .description("List all configured profiles.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, ListProfilesInput>(
             state,
@@ -183,7 +183,7 @@ fn mask_credential(value: &str) -> String {
 /// Build the profile_show tool
 pub fn show_profile(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("profile_show")
-        .description("Show details of a specific profile. Credentials are masked for security.")
+        .description("Show details of a specific profile (credentials masked).")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, ShowProfileInput>(
             state,
@@ -292,7 +292,7 @@ pub struct ConfigPathInput {}
 /// Build the profile_path tool
 pub fn config_path(_state: Arc<AppState>) -> Tool {
     ToolBuilder::new("profile_path")
-        .description("Show the path to the redisctl configuration file")
+        .description("Show the configuration file path.")
         .read_only_safe()
         .handler(|_input: ConfigPathInput| async move {
             let path = Config::config_path().tool_context("Failed to get config path")?;
@@ -320,7 +320,7 @@ pub struct ValidateConfigInput {
 /// Build the profile_validate tool
 pub fn validate_config(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("profile_validate")
-        .description("Validate the redisctl configuration file and check for common issues. Set connect=true to also test actual API/database connectivity for each profile.")
+        .description("Validate configuration for structural issues. Set connect=true to test connectivity.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, ValidateConfigInput>(
             state,
@@ -594,7 +594,7 @@ pub struct SetDefaultCloudInput {
 /// Build the profile_set_default_cloud tool
 pub fn set_default_cloud(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("profile_set_default_cloud")
-        .description("Set the default profile for Cloud commands. Requires write access.")
+        .description("Set the default profile for Cloud commands.")
         .idempotent()
         .non_destructive()
         .extractor_handler_typed::<_, _, _, SetDefaultCloudInput>(
@@ -645,7 +645,7 @@ pub struct SetDefaultEnterpriseInput {
 /// Build the profile_set_default_enterprise tool
 pub fn set_default_enterprise(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("profile_set_default_enterprise")
-        .description("Set the default profile for Enterprise commands. Requires write access.")
+        .description("Set the default profile for Enterprise commands.")
         .idempotent()
         .non_destructive()
         .extractor_handler_typed::<_, _, _, SetDefaultEnterpriseInput>(
@@ -696,10 +696,7 @@ pub struct DeleteProfileInput {
 /// Build the profile_delete tool
 pub fn delete_profile(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("profile_delete")
-        .description(
-            "DANGEROUS: Permanently deletes a profile from the configuration. \
-             This action cannot be undone. Requires write access.",
-        )
+        .description("DANGEROUS: Delete a profile from the configuration.")
         .destructive()
         .extractor_handler_typed::<_, _, _, DeleteProfileInput>(
             state,
@@ -800,13 +797,9 @@ pub struct CreateProfileInput {
 pub fn create_profile(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("profile_create")
         .description(
-            "Create a new redisctl profile with credentials. Requires write access.\n\n\
-             Profile types and required fields:\n\
-             - cloud: api_key, api_secret (api_url optional, defaults to Redis Cloud API)\n\
-             - enterprise: url, username (password, insecure, ca_cert optional)\n\
-             - database: host (port defaults to 6379, tls defaults to true, db_username defaults to 'default')\n\n\
-             The profile is automatically set as default for its type if it's the first of that type, \
-             unless set_default is explicitly false.",
+            "Create a new profile with credentials.\n\n\
+             Types: cloud (api_key, api_secret), enterprise (url, username), \
+             database (host). Auto-sets as default if first of its type.",
         )
         .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateProfileInput>(

--- a/crates/redisctl-mcp/src/tools/redis/diagnostics.rs
+++ b/crates/redisctl-mcp/src/tools/redis/diagnostics.rs
@@ -99,9 +99,8 @@ pub struct HealthCheckInput {
 pub fn health_check(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_health_check")
         .description(
-            "Comprehensive Redis health check combining PING, INFO (server, memory, stats), \
-             and DBSIZE into a single structured summary. Returns connectivity, version, \
-             uptime, memory usage, operations rate, and key count.",
+            "Comprehensive health check combining PING, INFO, and DBSIZE into a single summary \
+             covering connectivity, version, uptime, memory, ops rate, and key count.",
         )
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, HealthCheckInput>(
@@ -243,9 +242,7 @@ pub struct KeySummaryInput {
 pub fn key_summary(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_key_summary")
         .description(
-            "Get a complete metadata summary for a single key combining TYPE, TTL, \
-             MEMORY USAGE, and OBJECT ENCODING into one result. Gracefully handles \
-             cases where MEMORY USAGE or OBJECT ENCODING are unavailable.",
+            "Get metadata summary for a key combining TYPE, TTL, MEMORY USAGE, and OBJECT ENCODING.",
         )
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, KeySummaryInput>(
@@ -364,9 +361,7 @@ pub struct HotkeysInput {
 pub fn hotkeys(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_hotkeys")
         .description(
-            "Sample keys to identify the largest by memory usage and show type distribution. \
-             Uses SCAN to iterate keys, then TYPE and MEMORY USAGE on each sampled key. \
-             Returns top 20 keys by memory, type counts, and total memory sampled. \
+            "Sample keys to find the largest by memory and show type distribution. \
              Capped at sample_size (default 1000, max 10000) to limit impact.",
         )
         .read_only_safe()
@@ -509,9 +504,7 @@ pub struct ConnectionSummaryInput {
 pub fn connection_summary(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_connection_summary")
         .description(
-            "Analyze client connections by combining CLIENT LIST and INFO clients. \
-             Returns total connections, connections by source IP (top 10), idle \
-             connections (>60s), blocked client count, and oldest connection age.",
+            "Analyze client connections: totals, top IPs, idle/blocked counts, and oldest connection.",
         )
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, ConnectionSummaryInput>(

--- a/crates/redisctl-mcp/src/tools/redis/keys.rs
+++ b/crates/redisctl-mcp/src/tools/redis/keys.rs
@@ -77,10 +77,7 @@ fn default_limit() -> usize {
 /// Build the keys tool
 pub fn keys(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_keys")
-        .description(
-            "List keys matching a pattern using SCAN (production-safe, non-blocking). \
-             Returns up to 'limit' keys.",
-        )
+        .description("List keys matching a pattern using SCAN (production-safe, non-blocking).")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, KeysInput>(
             state,
@@ -153,7 +150,7 @@ pub struct GetInput {
 /// Build the get tool
 pub fn get(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_get")
-        .description("Get the value of a key from Redis")
+        .description("Get the value of a key.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, GetInput>(
             state,
@@ -201,7 +198,7 @@ pub struct TypeInput {
 /// Build the type tool
 pub fn key_type(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_type")
-        .description("Get the type of a key (string, list, set, zset, hash, stream)")
+        .description("Get the data type of a key.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, TypeInput>(
             state,
@@ -243,15 +240,14 @@ pub struct TtlInput {
 /// Build the ttl tool
 pub fn ttl(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_ttl")
-        .description("Get the time-to-live (TTL) of a key in seconds. Returns -1 if no expiry, -2 if key doesn't exist.")
+        .description("Get the TTL of a key in seconds (-1 = no expiry, -2 = missing).")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, TtlInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<TtlInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
 
-                let client = redis::Client::open(url.as_str())
-                    .tool_context("Invalid URL")?;
+                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
 
                 let mut conn = client
                     .get_multiplexed_async_connection()
@@ -292,7 +288,7 @@ pub struct ExistsInput {
 /// Build the exists tool
 pub fn exists(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_exists")
-        .description("Check if one or more keys exist. Returns the count of keys that exist.")
+        .description("Check if one or more keys exist.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, ExistsInput>(
             state,
@@ -342,7 +338,7 @@ pub struct MemoryUsageInput {
 /// Build the memory_usage tool
 pub fn memory_usage(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_memory_usage")
-        .description("Get the memory usage of a key in bytes")
+        .description("Get memory usage of a key in bytes (MEMORY USAGE).")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, MemoryUsageInput>(
             state,
@@ -399,8 +395,7 @@ pub struct ScanInput {
 pub fn scan(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_scan")
         .description(
-            "Scan keys with optional type filter. More efficient than redis_keys when filtering \
-             by type (string, list, set, zset, hash, stream).",
+            "Scan keys with optional type filter. Prefer over redis_keys when filtering by type.",
         )
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, ScanInput>(
@@ -490,8 +485,7 @@ pub struct ObjectEncodingInput {
 pub fn object_encoding(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_object_encoding")
         .description(
-            "Get the internal encoding of a key (e.g., embstr, int, raw, quicklist, listpack, \
-             hashtable, intset, skiplist). Useful for understanding memory usage patterns.",
+            "Get the internal encoding of a key. Useful for understanding memory usage patterns.",
         )
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, ObjectEncodingInput>(
@@ -544,8 +538,8 @@ pub struct ObjectFreqInput {
 pub fn object_freq(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_object_freq")
         .description(
-            "Get the LFU access frequency counter for a key using OBJECT FREQ. \
-             Only works when maxmemory-policy is set to allkeys-lfu or volatile-lfu.",
+            "Get the LFU access frequency counter for a key. \
+             Only works with allkeys-lfu or volatile-lfu eviction policy.",
         )
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, ObjectFreqInput>(
@@ -592,10 +586,7 @@ pub struct ObjectIdletimeInput {
 /// Build the object_idletime tool
 pub fn object_idletime(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_object_idletime")
-        .description(
-            "Get the idle time of a key in seconds using OBJECT IDLETIME. \
-             Shows how long since the key was last accessed.",
-        )
+        .description("Get idle time of a key in seconds since last access.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, ObjectIdletimeInput>(
             state,
@@ -641,7 +632,7 @@ pub struct ObjectHelpInput {
 /// Build the object_help tool
 pub fn object_help(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_object_help")
-        .description("Get available OBJECT subcommands using OBJECT HELP")
+        .description("Get available OBJECT subcommands.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, ObjectHelpInput>(
             state,
@@ -703,9 +694,7 @@ pub struct SetInput {
 pub fn set(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_set")
         .description(
-            "Set a key to a string value with optional expiry and conditional flags. \
-             Use EX for seconds, PX for milliseconds expiry. Use NX to only set if \
-             the key does not exist, XX to only set if it exists.",
+            "Set a key to a string value with optional expiry and conditional flags (NX/XX).",
         )
         .non_destructive()
         .extractor_handler_typed::<_, _, _, SetInput>(
@@ -783,10 +772,7 @@ pub struct DelInput {
 /// Build the del tool
 pub fn del(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_del")
-        .description(
-            "DANGEROUS: Permanently deletes one or more keys and their data. \
-             This action cannot be undone. Returns the number of keys removed.",
-        )
+        .description("DANGEROUS: Delete one or more keys.")
         .destructive()
         .extractor_handler_typed::<_, _, _, DelInput>(
             state,
@@ -844,10 +830,7 @@ pub struct ExpireInput {
 /// Build the expire tool
 pub fn expire(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_expire")
-        .description(
-            "Set a timeout on a key in seconds. The key will be automatically deleted \
-             after the timeout expires. Returns whether the timeout was set.",
-        )
+        .description("Set a timeout on a key in seconds. Key auto-deletes after expiry.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, ExpireInput>(
             state,
@@ -908,10 +891,7 @@ pub struct RenameInput {
 /// Build the rename tool
 pub fn rename(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_rename")
-        .description(
-            "Rename a key. Returns an error if the source key does not exist. \
-             If the destination key already exists, it is overwritten.",
-        )
+        .description("Rename a key. Overwrites the destination key if it exists.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, RenameInput>(
             state,

--- a/crates/redisctl-mcp/src/tools/redis/raw.rs
+++ b/crates/redisctl-mcp/src/tools/redis/raw.rs
@@ -92,10 +92,8 @@ pub fn redis_command(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_command")
         .description(
             "DANGEROUS: Execute an arbitrary Redis command. \
-             Use this escape hatch to run any Redis command not covered by a dedicated tool. \
-             Requires full tier. Certain dangerous commands (FLUSHALL, SHUTDOWN, DEBUG, etc.) \
-             and dangerous subcommands (CONFIG SET, ACL DELUSER, CLUSTER RESET, MODULE LOAD, etc.) \
-             are blocked.",
+             Escape hatch for commands not covered by dedicated tools. \
+             Certain dangerous commands and subcommands are blocked.",
         )
         .destructive()
         .extractor_handler_typed::<_, _, _, RedisCommandInput>(

--- a/crates/redisctl-mcp/src/tools/redis/server.rs
+++ b/crates/redisctl-mcp/src/tools/redis/server.rs
@@ -62,7 +62,7 @@ pub struct PingInput {
 /// Build the ping tool
 pub fn ping(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_ping")
-        .description("Test connectivity to a Redis database by sending a PING command")
+        .description("Test connectivity by sending a PING command")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, PingInput>(
             state,
@@ -107,7 +107,7 @@ pub struct InfoInput {
 /// Build the info tool
 pub fn info(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_info")
-        .description("Get Redis server information using the INFO command")
+        .description("Get server information and statistics (INFO command).")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, InfoInput>(
             state,
@@ -151,7 +151,7 @@ pub struct DbsizeInput {
 /// Build the dbsize tool
 pub fn dbsize(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_dbsize")
-        .description("Get the number of keys in the currently selected database")
+        .description("Get the number of keys in the current database.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, DbsizeInput>(
             state,
@@ -193,7 +193,7 @@ pub struct ClientListInput {
 /// Build the client_list tool
 pub fn client_list(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_client_list")
-        .description("Get list of client connections to the Redis server")
+        .description("List client connections (CLIENT LIST).")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, ClientListInput>(
             state,
@@ -237,7 +237,7 @@ pub struct ClusterInfoInput {
 /// Build the cluster_info tool
 pub fn cluster_info(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_cluster_info")
-        .description("Get Redis Cluster information (only works on cluster-enabled databases)")
+        .description("Get cluster information (only works on cluster-enabled instances).")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, ClusterInfoInput>(
             state,
@@ -284,17 +284,14 @@ fn default_slowlog_count() -> usize {
 /// Build the slowlog tool
 pub fn slowlog(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_slowlog")
-        .description(
-            "Get slow query log entries. Useful for identifying slow commands affecting performance.",
-        )
+        .description("Get slow query log entries for identifying performance issues.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, SlowlogInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<SlowlogInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
 
-                let client = redis::Client::open(url.as_str())
-                    .tool_context("Invalid URL")?;
+                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
 
                 let mut conn = client
                     .get_multiplexed_async_connection()
@@ -356,8 +353,8 @@ pub struct ConfigGetInput {
 pub fn config_get(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_config_get")
         .description(
-            "Get Redis configuration parameter values using CONFIG GET. \
-             Supports glob-style patterns (e.g. \"maxmemory\", \"*memory*\", \"*\").",
+            "Get configuration parameter values (CONFIG GET). \
+             Supports glob-style patterns.",
         )
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, ConfigGetInput>(
@@ -416,10 +413,7 @@ pub struct MemoryStatsInput {
 /// Build the memory_stats tool
 pub fn memory_stats(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_memory_stats")
-        .description(
-            "Get detailed memory allocator statistics using MEMORY STATS. \
-             Shows memory usage breakdown by category.",
-        )
+        .description("Get memory usage breakdown by category (MEMORY STATS).")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, MemoryStatsInput>(
             state,
@@ -462,9 +456,8 @@ pub struct LatencyHistoryInput {
 pub fn latency_history(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_latency_history")
         .description(
-            "Get latency history for a specific event using LATENCY HISTORY. \
-             Returns timestamp and latency pairs. Events include \"command\", \
-             \"fast-command\", etc. May return empty if latency monitoring is not enabled \
+            "Get latency history for a specific event (LATENCY HISTORY). \
+             May return empty if latency monitoring is not enabled \
              (CONFIG SET latency-monitor-threshold <ms>).",
         )
         .read_only_safe()
@@ -532,7 +525,7 @@ pub struct AclListInput {
 /// Build the acl_list tool
 pub fn acl_list(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_acl_list")
-        .description("List all ACL rules configured on the Redis server using ACL LIST")
+        .description("List all ACL rules (ACL LIST).")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, AclListInput>(
             state,
@@ -580,7 +573,7 @@ pub struct AclWhoamiInput {
 /// Build the acl_whoami tool
 pub fn acl_whoami(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_acl_whoami")
-        .description("Get the username of the current authenticated connection using ACL WHOAMI")
+        .description("Get the current authenticated username (ACL WHOAMI).")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, AclWhoamiInput>(
             state,
@@ -620,7 +613,7 @@ pub struct ModuleListInput {
 /// Build the module_list tool
 pub fn module_list(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_module_list")
-        .description("List loaded Redis modules with their names and versions using MODULE LIST")
+        .description("List loaded modules with names and versions (MODULE LIST).")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, ModuleListInput>(
             state,
@@ -675,8 +668,8 @@ pub struct ConfigSetInput {
 pub fn config_set(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_config_set")
         .description(
-            "Set a Redis configuration parameter at runtime using CONFIG SET. \
-             Changes may not persist across restarts unless CONFIG REWRITE is called.",
+            "Set a configuration parameter at runtime (CONFIG SET). \
+             Changes may not persist unless CONFIG REWRITE is called.",
         )
         .non_destructive()
         .extractor_handler_typed::<_, _, _, ConfigSetInput>(
@@ -732,8 +725,8 @@ pub struct FlushdbInput {
 pub fn flushdb(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_flushdb")
         .description(
-            "DANGEROUS: Flush all keys from the current database. This permanently deletes \
-             all data. Use with extreme caution. Set async_flush=true for non-blocking operation.",
+            "DANGEROUS: Delete all keys in the current database. \
+             Set async_flush=true for non-blocking operation.",
         )
         .destructive()
         .extractor_handler_typed::<_, _, _, FlushdbInput>(

--- a/crates/redisctl-mcp/src/tools/redis/structures.rs
+++ b/crates/redisctl-mcp/src/tools/redis/structures.rs
@@ -79,7 +79,7 @@ pub struct HgetallInput {
 /// Build the hgetall tool
 pub fn hgetall(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_hgetall")
-        .description("Get all fields and values from a hash")
+        .description("Get all fields and values of a hash.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, HgetallInput>(
             state,
@@ -149,7 +149,7 @@ fn default_stop() -> i64 {
 /// Build the lrange tool
 pub fn lrange(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_lrange")
-        .description("Get a range of elements from a list. Use start=0, stop=-1 for all elements.")
+        .description("Get a range of elements from a list (start=0, stop=-1 for all).")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, LrangeInput>(
             state,
@@ -212,7 +212,7 @@ pub struct SmembersInput {
 /// Build the smembers tool
 pub fn smembers(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_smembers")
-        .description("Get all members of a set")
+        .description("Get all members of a set.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, SmembersInput>(
             state,
@@ -275,15 +275,14 @@ pub struct ZrangeInput {
 /// Build the zrange tool
 pub fn zrange(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_zrange")
-        .description("Get a range of members from a sorted set by index. Use withscores=true to include scores.")
+        .description("Get a range of members from a sorted set by index.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, ZrangeInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ZrangeInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
 
-                let client = redis::Client::open(url.as_str())
-                    .tool_context("Invalid URL")?;
+                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
 
                 let mut conn = client
                     .get_multiplexed_async_connection()
@@ -371,10 +370,7 @@ pub struct XinfoStreamInput {
 /// Build the xinfo_stream tool
 pub fn xinfo_stream(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_xinfo_stream")
-        .description(
-            "Get stream metadata using XINFO STREAM, including length, consumer groups, \
-             first and last entry, and other stream details.",
-        )
+        .description("Get stream metadata including length, consumer groups, and entry details (XINFO STREAM).")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, XinfoStreamInput>(
             state,
@@ -438,10 +434,7 @@ fn default_xrange_end() -> String {
 /// Build the xrange tool
 pub fn xrange(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_xrange")
-        .description(
-            "Get stream entries in a range using XRANGE. Use start=\"-\" and end=\"+\" \
-             for all entries. Optionally limit with count.",
-        )
+        .description("Get stream entries in a range. Use \"-\" to \"+\" for all entries.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, XrangeInput>(
             state,
@@ -506,7 +499,7 @@ pub struct XlenInput {
 /// Build the xlen tool
 pub fn xlen(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_xlen")
-        .description("Get the number of entries in a stream using XLEN")
+        .description("Get the number of entries in a stream.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, XlenInput>(
             state,
@@ -552,10 +545,7 @@ pub struct PubsubChannelsInput {
 /// Build the pubsub_channels tool
 pub fn pubsub_channels(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_pubsub_channels")
-        .description(
-            "List active pub/sub channels using PUBSUB CHANNELS. \
-             Optionally filter with a glob-style pattern.",
-        )
+        .description("List active pub/sub channels, optionally filtered by pattern.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, PubsubChannelsInput>(
             state,
@@ -614,10 +604,7 @@ pub struct PubsubNumsubInput {
 /// Build the pubsub_numsub tool
 pub fn pubsub_numsub(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_pubsub_numsub")
-        .description(
-            "Get subscriber counts for pub/sub channels using PUBSUB NUMSUB. \
-             Provide channel names to query specific channels.",
-        )
+        .description("Get subscriber counts for pub/sub channels.")
         .read_only_safe()
         .extractor_handler_typed::<_, _, _, PubsubNumsubInput>(
             state,
@@ -685,10 +672,7 @@ pub struct HsetInput {
 /// Build the hset tool
 pub fn hset(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_hset")
-        .description(
-            "Set one or more field-value pairs in a hash. Creates the hash if it does not \
-             exist. Returns the number of fields that were added (not updated).",
-        )
+        .description("Set one or more field-value pairs in a hash. Creates the hash if needed.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, HsetInput>(
             state,
@@ -748,9 +732,7 @@ pub struct HdelInput {
 /// Build the hdel tool
 pub fn hdel(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_hdel")
-        .description(
-            "Delete one or more fields from a hash. Returns the number of fields that were removed.",
-        )
+        .description("Delete one or more fields from a hash.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, HdelInput>(
             state,
@@ -763,8 +745,7 @@ pub fn hdel(state: Arc<AppState>) -> Tool {
 
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
 
-                let client = redis::Client::open(url.as_str())
-                    .tool_context("Invalid URL")?;
+                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
 
                 let mut conn = client
                     .get_multiplexed_async_connection()
@@ -811,10 +792,7 @@ pub struct LpushInput {
 /// Build the lpush tool
 pub fn lpush(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_lpush")
-        .description(
-            "Push one or more elements to the head (left) of a list. Creates the list \
-             if it does not exist. Returns the new list length.",
-        )
+        .description("Push elements to the head (left) of a list. Creates the list if needed.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, LpushInput>(
             state,
@@ -874,10 +852,7 @@ pub struct RpushInput {
 /// Build the rpush tool
 pub fn rpush(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_rpush")
-        .description(
-            "Push one or more elements to the tail (right) of a list. Creates the list \
-             if it does not exist. Returns the new list length.",
-        )
+        .description("Push elements to the tail (right) of a list. Creates the list if needed.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, RpushInput>(
             state,
@@ -938,10 +913,7 @@ pub struct LpopInput {
 /// Build the lpop tool
 pub fn lpop(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_lpop")
-        .description(
-            "Pop one or more elements from the head (left) of a list. Returns the \
-             popped element(s), or nil if the list is empty.",
-        )
+        .description("Pop elements from the head (left) of a list.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, LpopInput>(
             state,
@@ -1001,10 +973,7 @@ pub struct RpopInput {
 /// Build the rpop tool
 pub fn rpop(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_rpop")
-        .description(
-            "Pop one or more elements from the tail (right) of a list. Returns the \
-             popped element(s), or nil if the list is empty.",
-        )
+        .description("Pop elements from the tail (right) of a list.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, RpopInput>(
             state,
@@ -1063,10 +1032,7 @@ pub struct SaddInput {
 /// Build the sadd tool
 pub fn sadd(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_sadd")
-        .description(
-            "Add one or more members to a set. Creates the set if it does not exist. \
-             Returns the number of members that were added (not already present).",
-        )
+        .description("Add one or more members to a set. Creates the set if needed.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, SaddInput>(
             state,
@@ -1126,10 +1092,7 @@ pub struct SremInput {
 /// Build the srem tool
 pub fn srem(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_srem")
-        .description(
-            "Remove one or more members from a set. Returns the number of members \
-             that were removed.",
-        )
+        .description("Remove one or more members from a set.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, SremInput>(
             state,
@@ -1214,9 +1177,8 @@ pub struct ZaddInput {
 pub fn zadd(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_zadd")
         .description(
-            "Add one or more members to a sorted set with scores. Creates the set if it \
-             does not exist. Supports NX (only add new), XX (only update existing), \
-             GT/LT (score comparison), and CH (count changed) flags.",
+            "Add members with scores to a sorted set. Creates the set if needed. \
+             Supports NX, XX, GT, LT, and CH flags.",
         )
         .non_destructive()
         .extractor_handler_typed::<_, _, _, ZaddInput>(
@@ -1293,10 +1255,7 @@ pub struct ZremInput {
 /// Build the zrem tool
 pub fn zrem(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_zrem")
-        .description(
-            "Remove one or more members from a sorted set. Returns the number of \
-             members that were removed.",
-        )
+        .description("Remove one or more members from a sorted set.")
         .non_destructive()
         .extractor_handler_typed::<_, _, _, ZremInput>(
             state,
@@ -1372,9 +1331,7 @@ pub struct XaddInput {
 pub fn xadd(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_xadd")
         .description(
-            "Append an entry to a stream. Auto-generates an ID by default (\"*\"). \
-             Supports NOMKSTREAM, MAXLEN, and MINID trimming options. \
-             Returns the ID of the added entry.",
+            "Append an entry to a stream. Supports NOMKSTREAM, MAXLEN, and MINID trimming.",
         )
         .non_destructive()
         .extractor_handler_typed::<_, _, _, XaddInput>(
@@ -1461,9 +1418,8 @@ pub struct XtrimInput {
 pub fn xtrim(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_xtrim")
         .description(
-            "Trim a stream to a given length (MAXLEN) or minimum ID (MINID). \
-             Use approximate=true for better performance with near-exact trimming. \
-             Returns the number of entries removed.",
+            "Trim a stream by length (MAXLEN) or minimum ID (MINID). \
+             Use approximate=true for better performance.",
         )
         .non_destructive()
         .extractor_handler_typed::<_, _, _, XtrimInput>(


### PR DESCRIPTION
## Summary

Closes #784

- Audit and trim all 303 tool descriptions across 18 files (net -594 lines)
- Remove "Requires write permission." (~150 occurrences) -- already conveyed by safety annotations (`non_destructive()`, `destructive()`)
- Remove "This action cannot be undone." -- redundant with `DANGEROUS:` prefix
- Remove "Permanently deletes" -- simplified to "Delete" after `DANGEROUS:`
- Remove "Returns JSON with..." -- implementation detail that wastes tokens
- Remove "for a Redis Cloud subscription" / "Redis Enterprise cluster" -- toolset context already clear
- Remove "accessible with the current credentials", "including name, ID, and settings", "in the current account" -- unnecessary filler

## Test plan

- [x] `cargo check -p redisctl-mcp --all-features`
- [x] `cargo check -p redisctl-mcp --no-default-features`
- [x] `cargo clippy -p redisctl-mcp --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p redisctl-mcp --all-features` (27 tests + doc tests pass)
- [x] Spot-check: zero remaining instances of removed patterns