### PR TITLE
fix(docs): correct tool counts, stale names, and wrong TOML example

### DIFF
--- a/docs/docs/integrations/mcp.md
+++ b/docs/docs/integrations/mcp.md
@@ -247,126 +247,17 @@ See [Configuration](../mcp/configuration.md) for the full `--tools` syntax, safe
 
 ## Available Tools
 
-### Redis Cloud Tools (17 tools)
+The MCP server provides **305 tools** across 4 toolsets:
 
-#### Account & Infrastructure
+| Toolset | Tools | Description |
+|---------|-------|-------------|
+| **Cloud** | 148 | Subscriptions, databases, networking, Essentials, account management |
+| **Enterprise** | 92 | Cluster, databases, RBAC, observability, proxies, services |
+| **Database** | 55 | Direct Redis operations -- keys, data structures, diagnostics |
+| **App** | 8 | Profile and configuration management |
+| **System** | 2 | `list_available_tools`, `show_policy` (always available) |
 
-| Tool | Description |
-|------|-------------|
-| `cloud_account_get` | Get account information |
-| `cloud_payment_methods_get` | List all payment methods configured for your account |
-| `cloud_database_modules_get` | List all available database modules (capabilities) |
-| `cloud_regions_get` | Get available regions across cloud providers (AWS, GCP, Azure) |
-
-#### Pro Subscriptions
-
-| Tool | Description |
-|------|-------------|
-| `cloud_subscriptions_list` | List all Pro subscriptions |
-| `cloud_subscription_get` | Get Pro subscription details |
-| `cloud_pro_subscription_create` | Create a new Pro subscription *(write)* |
-| `cloud_pro_subscription_delete` | Delete a Pro subscription *(write)* |
-
-#### Essentials Subscriptions
-
-| Tool | Description |
-|------|-------------|
-| `cloud_essentials_subscriptions_list` | List all Essentials subscriptions |
-| `cloud_essentials_subscription_get` | Get Essentials subscription details |
-| `cloud_essentials_subscription_create` | Create a new Essentials subscription *(write)* |
-| `cloud_essentials_subscription_delete` | Delete an Essentials subscription *(write)* |
-| `cloud_essentials_plans_list` | List available Essentials plans with pricing |
-
-#### Database & Task Operations
-
-| Tool | Description |
-|------|-------------|
-| `cloud_databases_list` | List databases in a subscription |
-| `cloud_database_get` | Get database details |
-| `cloud_tasks_list` | List recent async tasks |
-| `cloud_task_get` | Get task status |
-
-### Redis Enterprise Tools (48 tools)
-
-#### Cluster Operations
-
-| Tool | Description |
-|------|-------------|
-| `enterprise_cluster_get` | Get cluster information |
-| `enterprise_cluster_stats` | Get cluster statistics |
-| `enterprise_cluster_settings` | Get cluster settings |
-| `enterprise_cluster_topology` | Get cluster topology |
-| `enterprise_cluster_update` | Update cluster configuration *(write)* |
-
-#### Database Operations
-
-| Tool | Description |
-|------|-------------|
-| `enterprise_databases_list` | List all databases |
-| `enterprise_database_get` | Get database details |
-| `enterprise_database_stats` | Get database statistics |
-| `enterprise_database_metrics` | Get database performance metrics |
-| `enterprise_database_create` | Create a new database *(write)* |
-| `enterprise_database_update` | Update database configuration *(write)* |
-| `enterprise_database_delete` | Delete a database *(write)* |
-| `enterprise_database_flush` | Flush all data from database *(write)* |
-| `enterprise_database_export` | Export database to external location *(write)* |
-| `enterprise_database_import` | Import data into database *(write)* |
-| `enterprise_database_backup` | Trigger database backup *(write)* |
-| `enterprise_database_restore` | Restore database from backup *(write)* |
-
-#### Node Operations
-
-| Tool | Description |
-|------|-------------|
-| `enterprise_nodes_list` | List all cluster nodes |
-| `enterprise_node_get` | Get node details |
-| `enterprise_node_stats` | Get node statistics |
-| `enterprise_node_update` | Update node configuration *(write)* |
-| `enterprise_node_remove` | Remove node from cluster *(write)* |
-
-#### Shard & Alert Operations
-
-| Tool | Description |
-|------|-------------|
-| `enterprise_shards_list` | List all shards |
-| `enterprise_shard_get` | Get shard details |
-| `enterprise_alerts_list` | List active alerts |
-| `enterprise_alert_get` | Get alert details |
-
-#### User & Access Management
-
-| Tool | Description |
-|------|-------------|
-| `enterprise_users_list` | List all users |
-| `enterprise_user_get` | Get user details |
-| `enterprise_user_create` | Create a new user *(write)* |
-| `enterprise_user_delete` | Delete a user *(write)* |
-| `enterprise_roles_list` | List all roles |
-| `enterprise_role_get` | Get role details |
-| `enterprise_role_create` | Create a new role *(write)* |
-| `enterprise_role_delete` | Delete a role *(write)* |
-| `enterprise_acls_list` | List all Redis ACLs |
-| `enterprise_acl_get` | Get ACL details |
-| `enterprise_acl_create` | Create a new Redis ACL *(write)* |
-| `enterprise_acl_delete` | Delete a Redis ACL *(write)* |
-
-#### Other Operations
-
-| Tool | Description |
-|------|-------------|
-| `enterprise_logs_get` | Get cluster event logs |
-| `enterprise_license_get` | Get license information |
-| `enterprise_modules_list` | List available modules |
-| `enterprise_module_get` | Get module details |
-| `enterprise_crdbs_list` | List Active-Active databases |
-| `enterprise_crdb_get` | Get Active-Active database details |
-| `enterprise_crdb_update` | Update Active-Active database *(write)* |
-| `enterprise_crdb_delete` | Delete Active-Active database *(write)* |
-| `enterprise_debuginfo_list` | List debug info tasks |
-| `enterprise_debuginfo_status` | Get debug info task status |
-
-**Total: 65 tools** (17 Cloud + 48 Enterprise)
+For the complete tool catalog with sub-module breakdowns, see the [Tools Reference](../mcp/tools-reference.md).
 
 ## Example Conversations
 
@@ -374,7 +265,7 @@ Once configured, you can interact naturally with your Redis infrastructure:
 
 > **You**: What databases do I have in my enterprise cluster?
 >
-> **Claude**: *uses enterprise_databases_list*
+> **Claude**: *uses list_enterprise_databases*
 > You have 2 databases:
 >
 > - `default-db` (uid: 1) - 1GB, active
@@ -382,17 +273,17 @@ Once configured, you can interact naturally with your Redis infrastructure:
 
 > **You**: Create a new database called session-store with 512MB
 >
-> **Claude**: *uses enterprise_database_create*
+> **Claude**: *uses create_enterprise_database*
 > Created database `session-store` (uid: 3) with 512MB memory. Status: active.
 
 > **You**: Show me any active alerts
 >
-> **Claude**: *uses enterprise_alerts_list*
+> **Claude**: *uses list_alerts*
 > No active alerts in your cluster.
 
 > **You**: What Essentials plans are available on AWS?
 >
-> **Claude**: *uses cloud_essentials_plans_list with provider: AWS*
+> **Claude**: *uses list_fixed_plans with provider: AWS*
 > Here are the available Essentials plans on AWS:
 >
 > - 250MB Cache ($5/month) - us-east-1
@@ -402,8 +293,8 @@ Once configured, you can interact naturally with your Redis infrastructure:
 
 > **You**: Create a new Essentials subscription with the 250MB plan
 >
-> **Claude**: *uses cloud_essentials_subscription_create*
-> Created Essentials subscription `my-cache` with plan 250MB. Task ID: abc123. Use cloud_task_get to monitor progress.
+> **Claude**: *uses create_fixed_subscription*
+> Created Essentials subscription `my-cache` with plan 250MB. Task ID: abc123. Use `get_task` to monitor progress.
 
 ## Security Considerations
 

--- a/docs/docs/mcp/configuration.md
+++ b/docs/docs/mcp/configuration.md
@@ -65,9 +65,9 @@ The server resolves which toolsets to load in this order:
 
 | Toolset | Sub-modules | Total Tools |
 |---------|-------------|-------------|
-| `cloud` | `subscriptions`, `account`, `networking`, `fixed`, `raw` | 151 |
+| `cloud` | `subscriptions`, `account`, `networking`, `fixed`, `raw` | 148 |
 | `enterprise` | `cluster`, `databases`, `rbac`, `observability`, `proxy`, `services`, `raw` | 92 |
-| `database` | `server`, `keys`, `structures`, `diagnostics`, `raw` | 56 |
+| `database` | `server`, `keys`, `structures`, `diagnostics`, `raw` | 55 |
 | `app` | *(none -- flat toolset)* | 8 |
 | *(system)* | *(always loaded)* | 2 |
 
@@ -75,13 +75,13 @@ The two system tools (`list_available_tools` and `show_policy`) are always regis
 
 ### Examples
 
-**Cloud only** -- all Cloud sub-modules (149 tools + system):
+**Cloud only** -- all Cloud sub-modules (148 tools + system):
 
 ```bash
 redisctl-mcp --profile my-cloud --tools cloud
 ```
 
-**Cloud subscriptions and networking only** (86 tools + system):
+**Cloud subscriptions and networking only** (87 tools + system):
 
 ```bash
 redisctl-mcp --profile my-cloud --tools cloud:subscriptions,cloud:networking
@@ -152,7 +152,6 @@ The `--read-only` flag maps to the read-only and full tiers. For the intermediat
 
 ```toml
 # mcp-policy.toml
-[safety]
 tier = "read-write"
 ```
 

--- a/docs/docs/mcp/getting-started.md
+++ b/docs/docs/mcp/getting-started.md
@@ -334,7 +334,7 @@ By default, the MCP server runs in read-only mode. This prevents any destructive
 
 ### Write Mode
 
-Use `--allow-writes` only when you need to create or modify resources. Consider:
+Use `--read-only=false` only when you need to create or modify resources. Consider:
 
 - Using separate profiles for read-only vs write access
 - Running write-enabled servers only in development environments

--- a/docs/docs/mcp/tools-reference.md
+++ b/docs/docs/mcp/tools-reference.md
@@ -1,6 +1,6 @@
 # Tools Reference
 
-The redisctl MCP server exposes **309 tools** across 4 toolsets and 2 system tools for managing Redis Cloud, Redis Enterprise, and direct database operations.
+The redisctl MCP server exposes **305 tools** across 4 toolsets and 2 system tools for managing Redis Cloud, Redis Enterprise, and direct database operations.
 
 Tools are organized into **toolsets** (Cloud, Enterprise, Database, App) and further into **sub-modules** that can be selectively loaded with the [`--tools` flag](configuration.md#the-tools-flag).
 
@@ -18,11 +18,11 @@ These tools are always available regardless of `--tools` selection or visibility
 | `list_available_tools` | List all available tools grouped by toolset, showing active vs. hidden |
 | `show_policy` | Show the active safety tier, per-toolset overrides, and allow/deny lists |
 
-## Cloud Toolset (151 tools)
+## Cloud Toolset (148 tools)
 
 Redis Cloud management tools. Select with `--tools cloud` or target specific sub-modules.
 
-### `cloud:subscriptions` (37 tools)
+### `cloud:subscriptions` (36 tools)
 
 Manages flexible subscriptions and their databases -- creation, configuration, backup/import, tagging, CIDR allowlists, maintenance windows, Active-Active regions, and version upgrades.
 
@@ -37,7 +37,7 @@ Manages flexible subscriptions and their databases -- creation, configuration, b
 | `get_backup_status` | Get database backup status |
 | `get_database_tags` | Get database tags |
 
-### `cloud:account` (34 tools)
+### `cloud:account` (33 tools)
 
 Account management -- users, ACL users/roles/rules, cloud provider accounts, payment methods, cost reports, and task tracking.
 
@@ -49,10 +49,10 @@ Account management -- users, ACL users/roles/rules, cloud provider accounts, pay
 | `get_modules` | List available database modules |
 | `list_account_users` | List account users |
 | `list_acl_users` | List ACL users |
-| `list_cost_reports` | List cost reports |
+| `generate_cost_report` | Generate cost reports |
 | `list_tasks` | List recent async tasks |
 
-### `cloud:networking` (52 tools)
+### `cloud:networking` (51 tools)
 
 Network connectivity -- VPC peering, Transit Gateway, Private Service Connect (PSC), and AWS PrivateLink for both standard and Active-Active subscriptions.
 
@@ -61,9 +61,9 @@ Network connectivity -- VPC peering, Transit Gateway, Private Service Connect (P
 | `get_vpc_peering` | Get VPC peering details |
 | `create_vpc_peering` | Create VPC peering *(write)* |
 | `get_aa_vpc_peering` | Get Active-Active VPC peering |
-| `get_transit_gateway` | Get Transit Gateway attachment |
-| `create_transit_gateway` | Create Transit Gateway *(write)* |
-| `get_private_service_connect` | Get PSC configuration |
+| `get_tgw_attachments` | Get Transit Gateway attachments |
+| `create_tgw_attachment` | Create Transit Gateway attachment *(write)* |
+| `get_psc_service` | Get PSC configuration |
 | `get_private_link` | Get PrivateLink configuration |
 | `create_private_link` | Create PrivateLink *(write)* |
 
@@ -134,7 +134,7 @@ Role-based access control -- users, roles, ACL rules, built-in roles, and LDAP c
 | `list_enterprise_roles` | List all roles |
 | `get_enterprise_role` | Get role details |
 | `create_enterprise_role` | Create a role *(write)* |
-| `list_enterprise_acl_rules` | List ACL rules |
+| `list_enterprise_acls` | List ACL rules |
 | `get_enterprise_ldap_config` | Get LDAP configuration |
 
 ### `enterprise:observability` (16 tools)
@@ -150,7 +150,7 @@ Monitoring -- alerts, audit logs, aggregate stats for nodes/databases/shards, de
 | `get_all_databases_stats` | Get aggregate database statistics |
 | `list_shards` | List all shards |
 | `get_shard_stats` | Get shard statistics |
-| `list_enterprise_modules` | List available modules |
+| `list_modules` | List available modules |
 
 ### `enterprise:proxy` (4 tools)
 
@@ -183,7 +183,7 @@ System service lifecycle -- list, inspect, start, stop, restart, and status chec
 |------|-------------|
 | `enterprise_raw_api` | Execute arbitrary Redis Enterprise REST API requests |
 
-## Database Toolset (56 tools)
+## Database Toolset (55 tools)
 
 Direct Redis database operations. Requires `--database-url` connection. Select with `--tools database` or target specific sub-modules.
 
@@ -217,7 +217,7 @@ Key-space operations -- listing, scanning, get/set, type inspection, TTL, existe
 | `redis_del` | Delete keys *(write)* |
 | `redis_expire` | Set key expiration *(write)* |
 
-### `database:structures` (22 tools)
+### `database:structures` (21 tools)
 
 Data structure operations -- hashes, lists, sets, sorted sets, streams, and pub/sub inspection.
 
@@ -268,12 +268,12 @@ Profile and configuration management tools. Always compiled in; no sub-modules.
 
 | Toolset | Sub-modules | Tools |
 |---------|-------------|-------|
-| Cloud | `subscriptions` (37), `account` (34), `networking` (52), `fixed` (27), `raw` (1) | **151** |
+| Cloud | `subscriptions` (36), `account` (33), `networking` (51), `fixed` (27), `raw` (1) | **148** |
 | Enterprise | `cluster` (24), `databases` (20), `rbac` (20), `observability` (16), `proxy` (4), `services` (7), `raw` (1) | **92** |
-| Database | `server` (14), `keys` (15), `structures` (22), `diagnostics` (4), `raw` (1) | **56** |
+| Database | `server` (14), `keys` (15), `structures` (21), `diagnostics` (4), `raw` (1) | **55** |
 | App | *(flat)* | **8** |
 | System | *(always on)* | **2** |
-| **Total** | | **309** |
+| **Total** | | **305** |
 
 ## Example Tool Usage
 


### PR DESCRIPTION
## Summary

Pre-release documentation accuracy fixes found during audit:

- Fix tool counts to match source TOOL_NAMES: Cloud 148 (was 151), Database 55 (was 56), total 305 (was 309)
- Fix 6 representative tool names in tools-reference.md that don't exist in source (e.g., `list_cost_reports` -> `generate_cost_report`, `get_transit_gateway` -> `get_tgw_attachments`)
- Fix safety tier TOML example in configuration.md: `tier` is a top-level field, not nested under `[safety]` (users following the old example would silently get read-only instead of read-write)
- Fix stale `--allow-writes` flag reference in getting-started.md -> `--read-only=false`
- Replace entirely stale "Available Tools" section in integrations/mcp.md (every tool name used old naming scheme, claimed 65 tools) with summary table + cross-link to tools-reference
- Fix example conversation tool names in integrations/mcp.md

## Test plan

- [x] `mkdocs build --strict` passes with no warnings
- [x] All tool counts verified against `TOOL_NAMES` constants via grep
- [x] `cargo clippy --all-features`, `cargo test --lib`, `cargo test --test` all pass