### PR TITLE
fix: update Homebrew formula workflow for all platforms and redisctl-mcp

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -278,33 +278,126 @@ jobs:
 
           gh release create "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
 
-  # Update Homebrew formula after successful release
+  # Update Homebrew formulas after successful release
   # NOTE: This job is manually maintained - cargo-dist regenerates release.yml
   # and will remove this job. Re-add it after running `dist generate` or `dist init`.
+  #
+  # Handles both redisctl and redisctl-mcp releases, updating all platform
+  # URLs and SHA256 hashes in the corresponding formula.
   update-homebrew:
     needs:
       - plan
       - host
-    # Only run for redisctl releases (not redisctl-config or redisctl-mcp)
-    if: ${{ always() && needs.host.result == 'success' && startsWith(needs.plan.outputs.tag, 'redisctl-v') }}
+    # Run for redisctl and redisctl-mcp releases (not redisctl-core or redisctl-config)
+    if: ${{ always() && needs.host.result == 'success' && (startsWith(needs.plan.outputs.tag, 'redisctl-v') || startsWith(needs.plan.outputs.tag, 'redisctl-mcp-v')) }}
     runs-on: "ubuntu-22.04"
     steps:
-      - name: Extract version from tag
-        id: version
+      - name: Determine formula and version
+        id: meta
         run: |
           TAG="${{ needs.plan.outputs.tag }}"
-          VERSION="${TAG#redisctl-v}"
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-      - uses: mislav/bump-homebrew-formula-action@v3.2
-        with:
-          formula-name: redisctl
-          formula-path: Formula/redisctl.rb
-          base-branch: main
-          tag-name: v${{ steps.version.outputs.version }}
-          homebrew-tap: redis-developer/homebrew-tap
-          download-url: "https://github.com/redis-developer/redisctl/releases/download/${{ needs.plan.outputs.tag }}/redisctl-x86_64-apple-darwin.tar.xz"
+          if [[ "$TAG" == redisctl-mcp-v* ]]; then
+            echo "crate=redisctl-mcp" >> $GITHUB_OUTPUT
+            echo "formula=redisctl-mcp" >> $GITHUB_OUTPUT
+            echo "formula_class=RedisctlMcp" >> $GITHUB_OUTPUT
+            echo "version=${TAG#redisctl-mcp-v}" >> $GITHUB_OUTPUT
+            echo "binary=redisctl-mcp" >> $GITHUB_OUTPUT
+          else
+            echo "crate=redisctl" >> $GITHUB_OUTPUT
+            echo "formula=redisctl" >> $GITHUB_OUTPUT
+            echo "formula_class=Redisctl" >> $GITHUB_OUTPUT
+            echo "version=${TAG#redisctl-v}" >> $GITHUB_OUTPUT
+            echo "binary=redisctl" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Download SHA256 sums
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ needs.plan.outputs.tag }}"
+          CRATE="${{ steps.meta.outputs.crate }}"
+          gh release download "$TAG" \
+            --repo "${{ github.repository }}" \
+            --pattern "${CRATE}-aarch64-apple-darwin.tar.xz.sha256" \
+            --pattern "${CRATE}-x86_64-apple-darwin.tar.xz.sha256" \
+            --pattern "${CRATE}-x86_64-unknown-linux-gnu.tar.xz.sha256"
+
+          # Extract just the hash from each file (format: "hash *filename")
+          echo "sha_arm_mac=$(awk '{print $1}' ${CRATE}-aarch64-apple-darwin.tar.xz.sha256)" >> $GITHUB_ENV
+          echo "sha_intel_mac=$(awk '{print $1}' ${CRATE}-x86_64-apple-darwin.tar.xz.sha256)" >> $GITHUB_ENV
+          echo "sha_linux=$(awk '{print $1}' ${CRATE}-x86_64-unknown-linux-gnu.tar.xz.sha256)" >> $GITHUB_ENV
+
+      - name: Clone homebrew-tap
         env:
           COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
+        run: |
+          git clone "https://x-access-token:${COMMITTER_TOKEN}@github.com/redis-developer/homebrew-tap.git" tap
+          cd tap
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Generate formula
+        run: |
+          TAG="${{ needs.plan.outputs.tag }}"
+          VERSION="${{ steps.meta.outputs.version }}"
+          CRATE="${{ steps.meta.outputs.crate }}"
+          FORMULA="${{ steps.meta.outputs.formula }}"
+          CLASS="${{ steps.meta.outputs.formula_class }}"
+          BINARY="${{ steps.meta.outputs.binary }}"
+          BASE_URL="https://github.com/${{ github.repository }}/releases/download/${TAG}"
+
+          cat > "tap/Formula/${FORMULA}.rb" << RUBY
+          class ${CLASS} < Formula
+            desc "$( [ "$CRATE" = "redisctl-mcp" ] && echo "MCP server for AI-powered Redis management" || echo "CLI for Redis Cloud and Enterprise management" )"
+            homepage "https://github.com/${{ github.repository }}"
+            version "${VERSION}"
+            license any_of: ["MIT", "Apache-2.0"]
+
+            on_macos do
+              on_arm do
+                url "${BASE_URL}/${CRATE}-aarch64-apple-darwin.tar.xz"
+                sha256 "${sha_arm_mac}"
+              end
+              on_intel do
+                url "${BASE_URL}/${CRATE}-x86_64-apple-darwin.tar.xz"
+                sha256 "${sha_intel_mac}"
+              end
+            end
+
+            on_linux do
+              on_intel do
+                url "${BASE_URL}/${CRATE}-x86_64-unknown-linux-gnu.tar.xz"
+                sha256 "${sha_linux}"
+              end
+            end
+
+            def install
+              bin.install "${BINARY}"
+            end
+
+            test do
+              assert_match "${BINARY}", shell_output("#{bin}/${BINARY} --version")
+            end
+          end
+          RUBY
+
+          # Remove leading whitespace from heredoc indentation
+          sed -i 's/^          //' "tap/Formula/${FORMULA}.rb"
+
+      - name: Commit and push
+        env:
+          COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
+        run: |
+          cd tap
+          FORMULA="${{ steps.meta.outputs.formula }}"
+          VERSION="${{ steps.meta.outputs.version }}"
+          git add "Formula/${FORMULA}.rb"
+          if git diff --cached --quiet; then
+            echo "No changes to formula"
+            exit 0
+          fi
+          git commit -m "Update ${FORMULA} to ${VERSION}"
+          git push
 
   announce:
     needs:


### PR DESCRIPTION
## Summary

- Replace `mislav/bump-homebrew-formula-action` (only updates a single URL) with a custom job that handles all platforms
- Support both `redisctl-v*` and `redisctl-mcp-v*` release tags
- Update ARM mac, Intel mac, and Linux URLs and SHA256 hashes on every release
- Generate the complete formula file from release artifacts

The old workflow only updated one URL per release, which is why the ARM mac block pointed to the wrong architecture and Intel/Linux were stuck on 0.7.2.

## How it works

1. Detect which crate was released from the tag prefix
2. Download `.sha256` files from the GitHub release
3. Generate the full formula `.rb` file with all platform blocks
4. Commit and push directly to `redis-developer/homebrew-tap`

## Companion PR

- https://github.com/redis-developer/homebrew-tap/pull/1 -- fixes current formula and adds `redisctl-mcp.rb` for the 0.8.2/0.5.0 release

## Test plan

- [ ] YAML validates (verified locally)
- [ ] Next release tag triggers the workflow and correctly updates the homebrew-tap formula

Closes #795
Closes #796