### PR TITLE
feat(mcp): add 35 Redis command tools (P0+P1)

### DIFF
--- a/crates/redisctl-mcp/src/presets.rs
+++ b/crates/redisctl-mcp/src/presets.rs
@@ -113,6 +113,14 @@ pub const DATABASE_ESSENTIALS: &[&str] = &[
     "redis_type",
     "redis_ttl",
     "redis_hgetall",
+    "redis_mget",
+    "redis_hget",
+    "redis_scard",
+    "redis_zcard",
+    "redis_llen",
+    "redis_incr",
+    "redis_zscore",
+    "redis_sismember",
 ];
 
 /// App essentials: all profile tools (always included).

--- a/crates/redisctl-mcp/src/tools/redis/keys.rs
+++ b/crates/redisctl-mcp/src/tools/redis/keys.rs
@@ -1,5 +1,7 @@
 //! Key-level Redis tools (keys, scan, get, key_type, ttl, exists, memory_usage, object_encoding,
-//! object_freq, object_idletime, object_help, set, del, expire, rename)
+//! object_freq, object_idletime, object_help, set, del, expire, rename, mget, mset, persist,
+//! unlink, copy, dump, restore, randomkey, touch, incr, decr, append, strlen, getrange, setrange,
+//! setnx)
 
 use std::sync::Arc;
 
@@ -7,6 +9,8 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use tower_mcp::extract::{Json, State};
 use tower_mcp::{CallToolResult, Error as McpError, McpRouter, ResultExt, Tool, ToolBuilder};
+
+use super::format_value;
 
 use crate::state::AppState;
 
@@ -27,6 +31,22 @@ pub(super) const TOOL_NAMES: &[&str] = &[
     "redis_del",
     "redis_expire",
     "redis_rename",
+    "redis_mget",
+    "redis_mset",
+    "redis_persist",
+    "redis_unlink",
+    "redis_copy",
+    "redis_dump",
+    "redis_restore",
+    "redis_randomkey",
+    "redis_touch",
+    "redis_incr",
+    "redis_decr",
+    "redis_append",
+    "redis_strlen",
+    "redis_getrange",
+    "redis_setrange",
+    "redis_setnx",
 ];
 
 /// Build a sub-router containing all key-level Redis tools
@@ -46,7 +66,23 @@ pub fn router(state: Arc<AppState>) -> McpRouter {
         .tool(set(state.clone()))
         .tool(del(state.clone()))
         .tool(expire(state.clone()))
-        .tool(rename(state))
+        .tool(rename(state.clone()))
+        .tool(mget(state.clone()))
+        .tool(mset(state.clone()))
+        .tool(persist(state.clone()))
+        .tool(unlink(state.clone()))
+        .tool(copy(state.clone()))
+        .tool(dump(state.clone()))
+        .tool(restore(state.clone()))
+        .tool(randomkey(state.clone()))
+        .tool(touch(state.clone()))
+        .tool(incr(state.clone()))
+        .tool(decr(state.clone()))
+        .tool(append(state.clone()))
+        .tool(strlen(state.clone()))
+        .tool(getrange(state.clone()))
+        .tool(setrange(state.clone()))
+        .tool(setnx(state))
 }
 
 /// Input for keys command
@@ -922,6 +958,909 @@ pub fn rename(state: Arc<AppState>) -> Tool {
                     "OK - renamed '{}' to '{}'",
                     input.key, input.newkey
                 )))
+            },
+        )
+        .build()
+}
+
+// --- P0 Key Operations ---
+
+/// Input for MGET command
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct MgetInput {
+    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Optional profile name to resolve connection from (uses default profile if not set)
+    #[serde(default)]
+    pub profile: Option<String>,
+    /// Keys to get
+    pub keys: Vec<String>,
+}
+
+/// Build the mget tool
+pub fn mget(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("redis_mget")
+        .description("Get the values of multiple keys in a single call.")
+        .read_only_safe()
+        .extractor_handler_typed::<_, _, _, MgetInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<MgetInput>| async move {
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
+
+                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
+
+                let mut conn = client
+                    .get_multiplexed_async_connection()
+                    .await
+                    .tool_context("Connection failed")?;
+
+                let mut cmd = redis::cmd("MGET");
+                for key in &input.keys {
+                    cmd.arg(key);
+                }
+
+                let values: Vec<redis::Value> = cmd
+                    .query_async(&mut conn)
+                    .await
+                    .tool_context("MGET failed")?;
+
+                let output = input
+                    .keys
+                    .iter()
+                    .zip(values.iter())
+                    .map(|(k, v)| format!("{}: {}", k, format_value(v)))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+
+                Ok(CallToolResult::text(output))
+            },
+        )
+        .build()
+}
+
+/// A key-value pair for MSET
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct KeyValuePair {
+    /// Key name
+    pub key: String,
+    /// Value to set
+    pub value: String,
+}
+
+/// Input for MSET command
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct MsetInput {
+    /// Optional Redis URL (overrides profile)
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Optional profile name for connection resolution
+    #[serde(default)]
+    pub profile: Option<String>,
+    /// Key-value pairs to set
+    pub entries: Vec<KeyValuePair>,
+}
+
+/// Build the mset tool
+pub fn mset(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("redis_mset")
+        .description("Set multiple key-value pairs in a single atomic call.")
+        .non_destructive()
+        .extractor_handler_typed::<_, _, _, MsetInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<MsetInput>| async move {
+                if !state.is_write_allowed() {
+                    return Err(McpError::tool(
+                        "Write operations not allowed in read-only mode",
+                    ));
+                }
+
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
+
+                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
+
+                let mut conn = client
+                    .get_multiplexed_async_connection()
+                    .await
+                    .tool_context("Connection failed")?;
+
+                let mut cmd = redis::cmd("MSET");
+                for entry in &input.entries {
+                    cmd.arg(&entry.key).arg(&entry.value);
+                }
+
+                let _: () = cmd
+                    .query_async(&mut conn)
+                    .await
+                    .tool_context("MSET failed")?;
+
+                Ok(CallToolResult::text(format!(
+                    "OK - set {} key(s)",
+                    input.entries.len()
+                )))
+            },
+        )
+        .build()
+}
+
+/// Input for PERSIST command
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct PersistInput {
+    /// Optional Redis URL (overrides profile)
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Optional profile name for connection resolution
+    #[serde(default)]
+    pub profile: Option<String>,
+    /// Key to remove expiry from
+    pub key: String,
+}
+
+/// Build the persist tool
+pub fn persist(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("redis_persist")
+        .description("Remove the expiry from a key, making it persistent.")
+        .non_destructive()
+        .extractor_handler_typed::<_, _, _, PersistInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<PersistInput>| async move {
+                if !state.is_write_allowed() {
+                    return Err(McpError::tool(
+                        "Write operations not allowed in read-only mode",
+                    ));
+                }
+
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
+
+                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
+
+                let mut conn = client
+                    .get_multiplexed_async_connection()
+                    .await
+                    .tool_context("Connection failed")?;
+
+                let result: bool = redis::cmd("PERSIST")
+                    .arg(&input.key)
+                    .query_async(&mut conn)
+                    .await
+                    .tool_context("PERSIST failed")?;
+
+                if result {
+                    Ok(CallToolResult::text(format!(
+                        "OK - expiry removed from '{}'",
+                        input.key
+                    )))
+                } else {
+                    Ok(CallToolResult::text(format!(
+                        "Key '{}' does not exist or has no expiry",
+                        input.key
+                    )))
+                }
+            },
+        )
+        .build()
+}
+
+/// Input for UNLINK command
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct UnlinkInput {
+    /// Optional Redis URL (overrides profile)
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Optional profile name for connection resolution
+    #[serde(default)]
+    pub profile: Option<String>,
+    /// Keys to unlink (async delete)
+    pub keys: Vec<String>,
+}
+
+/// Build the unlink tool
+pub fn unlink(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("redis_unlink")
+        .description(
+            "DANGEROUS: Asynchronously delete one or more keys (non-blocking version of DEL).",
+        )
+        .destructive()
+        .extractor_handler_typed::<_, _, _, UnlinkInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<UnlinkInput>| async move {
+                if !state.is_destructive_allowed() {
+                    return Err(McpError::tool(
+                        "Destructive operations require policy tier 'full'",
+                    ));
+                }
+
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
+
+                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
+
+                let mut conn = client
+                    .get_multiplexed_async_connection()
+                    .await
+                    .tool_context("Connection failed")?;
+
+                let mut cmd = redis::cmd("UNLINK");
+                for key in &input.keys {
+                    cmd.arg(key);
+                }
+
+                let count: i64 = cmd
+                    .query_async(&mut conn)
+                    .await
+                    .tool_context("UNLINK failed")?;
+
+                Ok(CallToolResult::text(format!(
+                    "Unlinked {} of {} key(s)",
+                    count,
+                    input.keys.len()
+                )))
+            },
+        )
+        .build()
+}
+
+/// Input for COPY command
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CopyInput {
+    /// Optional Redis URL (overrides profile)
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Optional profile name for connection resolution
+    #[serde(default)]
+    pub profile: Option<String>,
+    /// Source key
+    pub source: String,
+    /// Destination key
+    pub destination: String,
+    /// Replace destination key if it already exists
+    #[serde(default)]
+    pub replace: bool,
+}
+
+/// Build the copy tool
+pub fn copy(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("redis_copy")
+        .description("Copy a key to a new key. Use replace=true to overwrite the destination.")
+        .non_destructive()
+        .extractor_handler_typed::<_, _, _, CopyInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<CopyInput>| async move {
+                if !state.is_write_allowed() {
+                    return Err(McpError::tool(
+                        "Write operations not allowed in read-only mode",
+                    ));
+                }
+
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
+
+                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
+
+                let mut conn = client
+                    .get_multiplexed_async_connection()
+                    .await
+                    .tool_context("Connection failed")?;
+
+                let mut cmd = redis::cmd("COPY");
+                cmd.arg(&input.source).arg(&input.destination);
+                if input.replace {
+                    cmd.arg("REPLACE");
+                }
+
+                let result: bool = cmd
+                    .query_async(&mut conn)
+                    .await
+                    .tool_context("COPY failed")?;
+
+                if result {
+                    Ok(CallToolResult::text(format!(
+                        "OK - copied '{}' to '{}'",
+                        input.source, input.destination
+                    )))
+                } else {
+                    Ok(CallToolResult::text(format!(
+                        "COPY failed: destination '{}' already exists (use replace=true to overwrite)",
+                        input.destination
+                    )))
+                }
+            },
+        )
+        .build()
+}
+
+/// Input for DUMP command
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct DumpInput {
+    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Optional profile name to resolve connection from (uses default profile if not set)
+    #[serde(default)]
+    pub profile: Option<String>,
+    /// Key to dump
+    pub key: String,
+}
+
+/// Build the dump tool
+pub fn dump(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("redis_dump")
+        .description(
+            "Serialize a key's value using Redis internal format. Returns hex-encoded bytes \
+             for use with RESTORE.",
+        )
+        .read_only_safe()
+        .extractor_handler_typed::<_, _, _, DumpInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<DumpInput>| async move {
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
+
+                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
+
+                let mut conn = client
+                    .get_multiplexed_async_connection()
+                    .await
+                    .tool_context("Connection failed")?;
+
+                let value: redis::Value = redis::cmd("DUMP")
+                    .arg(&input.key)
+                    .query_async(&mut conn)
+                    .await
+                    .tool_context("DUMP failed")?;
+
+                match value {
+                    redis::Value::BulkString(bytes) => {
+                        let hex: String = bytes.iter().map(|b| format!("{:02x}", b)).collect();
+                        Ok(CallToolResult::text(format!(
+                            "{}: {} bytes\n{}",
+                            input.key,
+                            bytes.len(),
+                            hex
+                        )))
+                    }
+                    redis::Value::Nil => Ok(CallToolResult::text(format!(
+                        "(nil) - key '{}' not found",
+                        input.key
+                    ))),
+                    _ => Ok(CallToolResult::text(format_value(&value))),
+                }
+            },
+        )
+        .build()
+}
+
+/// Input for RESTORE command
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct RestoreInput {
+    /// Optional Redis URL (overrides profile)
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Optional profile name for connection resolution
+    #[serde(default)]
+    pub profile: Option<String>,
+    /// Key to restore
+    pub key: String,
+    /// TTL in milliseconds (0 = no expiry)
+    pub ttl_ms: u64,
+    /// Hex-encoded serialized value from DUMP
+    pub serialized_value: String,
+}
+
+/// Build the restore tool
+pub fn restore(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("redis_restore")
+        .description(
+            "Restore a key from a serialized value (from DUMP). \
+             The serialized_value must be hex-encoded.",
+        )
+        .non_destructive()
+        .extractor_handler_typed::<_, _, _, RestoreInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<RestoreInput>| async move {
+                if !state.is_write_allowed() {
+                    return Err(McpError::tool(
+                        "Write operations not allowed in read-only mode",
+                    ));
+                }
+
+                // Decode hex string to bytes
+                let bytes: Result<Vec<u8>, _> = (0..input.serialized_value.len())
+                    .step_by(2)
+                    .map(|i| {
+                        u8::from_str_radix(
+                            &input.serialized_value[i..i.min(input.serialized_value.len()) + 2],
+                            16,
+                        )
+                    })
+                    .collect();
+
+                let bytes =
+                    bytes.map_err(|_| McpError::tool("Invalid hex string in serialized_value"))?;
+
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
+
+                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
+
+                let mut conn = client
+                    .get_multiplexed_async_connection()
+                    .await
+                    .tool_context("Connection failed")?;
+
+                let _: () = redis::cmd("RESTORE")
+                    .arg(&input.key)
+                    .arg(input.ttl_ms)
+                    .arg(bytes.as_slice())
+                    .query_async(&mut conn)
+                    .await
+                    .tool_context("RESTORE failed")?;
+
+                Ok(CallToolResult::text(format!(
+                    "OK - restored key '{}'",
+                    input.key
+                )))
+            },
+        )
+        .build()
+}
+
+/// Input for RANDOMKEY command
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct RandomkeyInput {
+    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Optional profile name to resolve connection from (uses default profile if not set)
+    #[serde(default)]
+    pub profile: Option<String>,
+}
+
+/// Build the randomkey tool
+pub fn randomkey(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("redis_randomkey")
+        .description("Return a random key from the database.")
+        .read_only_safe()
+        .extractor_handler_typed::<_, _, _, RandomkeyInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<RandomkeyInput>| async move {
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
+
+                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
+
+                let mut conn = client
+                    .get_multiplexed_async_connection()
+                    .await
+                    .tool_context("Connection failed")?;
+
+                let key: Option<String> = redis::cmd("RANDOMKEY")
+                    .query_async(&mut conn)
+                    .await
+                    .tool_context("RANDOMKEY failed")?;
+
+                match key {
+                    Some(k) => Ok(CallToolResult::text(k)),
+                    None => Ok(CallToolResult::text("(empty) - database has no keys")),
+                }
+            },
+        )
+        .build()
+}
+
+/// Input for TOUCH command
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct TouchInput {
+    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Optional profile name to resolve connection from (uses default profile if not set)
+    #[serde(default)]
+    pub profile: Option<String>,
+    /// Keys to touch (update last access time)
+    pub keys: Vec<String>,
+}
+
+/// Build the touch tool
+pub fn touch(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("redis_touch")
+        .description("Update the last access time of one or more keys without modifying them.")
+        .read_only_safe()
+        .extractor_handler_typed::<_, _, _, TouchInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<TouchInput>| async move {
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
+
+                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
+
+                let mut conn = client
+                    .get_multiplexed_async_connection()
+                    .await
+                    .tool_context("Connection failed")?;
+
+                let mut cmd = redis::cmd("TOUCH");
+                for key in &input.keys {
+                    cmd.arg(key);
+                }
+
+                let count: i64 = cmd
+                    .query_async(&mut conn)
+                    .await
+                    .tool_context("TOUCH failed")?;
+
+                Ok(CallToolResult::text(format!(
+                    "Touched {} of {} key(s)",
+                    count,
+                    input.keys.len()
+                )))
+            },
+        )
+        .build()
+}
+
+// --- P1 String Operations ---
+
+/// Input for INCR command
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct IncrInput {
+    /// Optional Redis URL (overrides profile)
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Optional profile name for connection resolution
+    #[serde(default)]
+    pub profile: Option<String>,
+    /// Key to increment
+    pub key: String,
+}
+
+/// Build the incr tool
+pub fn incr(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("redis_incr")
+        .description("Increment the integer value of a key by 1. Creates the key with value 1 if it does not exist.")
+        .non_destructive()
+        .extractor_handler_typed::<_, _, _, IncrInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<IncrInput>| async move {
+                if !state.is_write_allowed() {
+                    return Err(McpError::tool(
+                        "Write operations not allowed in read-only mode",
+                    ));
+                }
+
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
+
+                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
+
+                let mut conn = client
+                    .get_multiplexed_async_connection()
+                    .await
+                    .tool_context("Connection failed")?;
+
+                let value: i64 = redis::cmd("INCR")
+                    .arg(&input.key)
+                    .query_async(&mut conn)
+                    .await
+                    .tool_context("INCR failed")?;
+
+                Ok(CallToolResult::text(format!(
+                    "{}: {}",
+                    input.key, value
+                )))
+            },
+        )
+        .build()
+}
+
+/// Input for DECR command
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct DecrInput {
+    /// Optional Redis URL (overrides profile)
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Optional profile name for connection resolution
+    #[serde(default)]
+    pub profile: Option<String>,
+    /// Key to decrement
+    pub key: String,
+}
+
+/// Build the decr tool
+pub fn decr(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("redis_decr")
+        .description("Decrement the integer value of a key by 1. Creates the key with value -1 if it does not exist.")
+        .non_destructive()
+        .extractor_handler_typed::<_, _, _, DecrInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<DecrInput>| async move {
+                if !state.is_write_allowed() {
+                    return Err(McpError::tool(
+                        "Write operations not allowed in read-only mode",
+                    ));
+                }
+
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
+
+                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
+
+                let mut conn = client
+                    .get_multiplexed_async_connection()
+                    .await
+                    .tool_context("Connection failed")?;
+
+                let value: i64 = redis::cmd("DECR")
+                    .arg(&input.key)
+                    .query_async(&mut conn)
+                    .await
+                    .tool_context("DECR failed")?;
+
+                Ok(CallToolResult::text(format!(
+                    "{}: {}",
+                    input.key, value
+                )))
+            },
+        )
+        .build()
+}
+
+/// Input for APPEND command
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct AppendInput {
+    /// Optional Redis URL (overrides profile)
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Optional profile name for connection resolution
+    #[serde(default)]
+    pub profile: Option<String>,
+    /// Key to append to
+    pub key: String,
+    /// Value to append
+    pub value: String,
+}
+
+/// Build the append tool
+pub fn append(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("redis_append")
+        .description("Append a value to a key. Creates the key if it does not exist. Returns the new string length.")
+        .non_destructive()
+        .extractor_handler_typed::<_, _, _, AppendInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<AppendInput>| async move {
+                if !state.is_write_allowed() {
+                    return Err(McpError::tool(
+                        "Write operations not allowed in read-only mode",
+                    ));
+                }
+
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
+
+                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
+
+                let mut conn = client
+                    .get_multiplexed_async_connection()
+                    .await
+                    .tool_context("Connection failed")?;
+
+                let length: i64 = redis::cmd("APPEND")
+                    .arg(&input.key)
+                    .arg(&input.value)
+                    .query_async(&mut conn)
+                    .await
+                    .tool_context("APPEND failed")?;
+
+                Ok(CallToolResult::text(format!(
+                    "OK - '{}' new length: {}",
+                    input.key, length
+                )))
+            },
+        )
+        .build()
+}
+
+/// Input for STRLEN command
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct StrlenInput {
+    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Optional profile name to resolve connection from (uses default profile if not set)
+    #[serde(default)]
+    pub profile: Option<String>,
+    /// Key to get string length of
+    pub key: String,
+}
+
+/// Build the strlen tool
+pub fn strlen(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("redis_strlen")
+        .description("Get the length of the string value stored at a key.")
+        .read_only_safe()
+        .extractor_handler_typed::<_, _, _, StrlenInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<StrlenInput>| async move {
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
+
+                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
+
+                let mut conn = client
+                    .get_multiplexed_async_connection()
+                    .await
+                    .tool_context("Connection failed")?;
+
+                let length: i64 = redis::cmd("STRLEN")
+                    .arg(&input.key)
+                    .query_async(&mut conn)
+                    .await
+                    .tool_context("STRLEN failed")?;
+
+                Ok(CallToolResult::text(format!(
+                    "{}: {} bytes",
+                    input.key, length
+                )))
+            },
+        )
+        .build()
+}
+
+/// Input for GETRANGE command
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct GetrangeInput {
+    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Optional profile name to resolve connection from (uses default profile if not set)
+    #[serde(default)]
+    pub profile: Option<String>,
+    /// Key to get substring from
+    pub key: String,
+    /// Start offset (0-based, negative counts from end)
+    pub start: i64,
+    /// End offset (inclusive, negative counts from end)
+    pub end: i64,
+}
+
+/// Build the getrange tool
+pub fn getrange(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("redis_getrange")
+        .description(
+            "Get a substring of the string value at a key by start and end offsets (inclusive).",
+        )
+        .read_only_safe()
+        .extractor_handler_typed::<_, _, _, GetrangeInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<GetrangeInput>| async move {
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
+
+                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
+
+                let mut conn = client
+                    .get_multiplexed_async_connection()
+                    .await
+                    .tool_context("Connection failed")?;
+
+                let value: String = redis::cmd("GETRANGE")
+                    .arg(&input.key)
+                    .arg(input.start)
+                    .arg(input.end)
+                    .query_async(&mut conn)
+                    .await
+                    .tool_context("GETRANGE failed")?;
+
+                Ok(CallToolResult::text(value))
+            },
+        )
+        .build()
+}
+
+/// Input for SETRANGE command
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SetrangeInput {
+    /// Optional Redis URL (overrides profile)
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Optional profile name for connection resolution
+    #[serde(default)]
+    pub profile: Option<String>,
+    /// Key to overwrite substring in
+    pub key: String,
+    /// Byte offset to start overwriting at
+    pub offset: u64,
+    /// Value to write at the offset
+    pub value: String,
+}
+
+/// Build the setrange tool
+pub fn setrange(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("redis_setrange")
+        .description("Overwrite part of a string value at the given byte offset. Returns the new string length.")
+        .non_destructive()
+        .extractor_handler_typed::<_, _, _, SetrangeInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<SetrangeInput>| async move {
+                if !state.is_write_allowed() {
+                    return Err(McpError::tool(
+                        "Write operations not allowed in read-only mode",
+                    ));
+                }
+
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
+
+                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
+
+                let mut conn = client
+                    .get_multiplexed_async_connection()
+                    .await
+                    .tool_context("Connection failed")?;
+
+                let length: i64 = redis::cmd("SETRANGE")
+                    .arg(&input.key)
+                    .arg(input.offset)
+                    .arg(&input.value)
+                    .query_async(&mut conn)
+                    .await
+                    .tool_context("SETRANGE failed")?;
+
+                Ok(CallToolResult::text(format!(
+                    "OK - '{}' new length: {}",
+                    input.key, length
+                )))
+            },
+        )
+        .build()
+}
+
+/// Input for SETNX command
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SetnxInput {
+    /// Optional Redis URL (overrides profile)
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Optional profile name for connection resolution
+    #[serde(default)]
+    pub profile: Option<String>,
+    /// Key to set
+    pub key: String,
+    /// Value to set
+    pub value: String,
+}
+
+/// Build the setnx tool
+pub fn setnx(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("redis_setnx")
+        .description(
+            "Set a key only if it does not already exist. Returns whether the key was set.",
+        )
+        .non_destructive()
+        .extractor_handler_typed::<_, _, _, SetnxInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<SetnxInput>| async move {
+                if !state.is_write_allowed() {
+                    return Err(McpError::tool(
+                        "Write operations not allowed in read-only mode",
+                    ));
+                }
+
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
+
+                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
+
+                let mut conn = client
+                    .get_multiplexed_async_connection()
+                    .await
+                    .tool_context("Connection failed")?;
+
+                let was_set: bool = redis::cmd("SETNX")
+                    .arg(&input.key)
+                    .arg(&input.value)
+                    .query_async(&mut conn)
+                    .await
+                    .tool_context("SETNX failed")?;
+
+                if was_set {
+                    Ok(CallToolResult::text(format!(
+                        "OK - set '{}' (key was new)",
+                        input.key
+                    )))
+                } else {
+                    Ok(CallToolResult::text(format!(
+                        "Key '{}' already exists, not set",
+                        input.key
+                    )))
+                }
             },
         )
         .build()

--- a/crates/redisctl-mcp/src/tools/redis/structures.rs
+++ b/crates/redisctl-mcp/src/tools/redis/structures.rs
@@ -1,6 +1,7 @@
 //! Data structure Redis tools (hgetall, lrange, smembers, zrange, xinfo_stream, xrange, xlen,
 //! pubsub_channels, pubsub_numsub, hset, hdel, lpush, rpush, lpop, rpop, sadd, srem, zadd,
-//! zrem, xadd, xtrim)
+//! zrem, xadd, xtrim, hget, hmget, hlen, hexists, hkeys, hvals, hincrby, scard, sismember,
+//! sunion, sinter, sdiff, zcard, zscore, zrank, zcount, zrangebyscore, llen, lindex)
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -35,6 +36,25 @@ pub(super) const TOOL_NAMES: &[&str] = &[
     "redis_zrem",
     "redis_xadd",
     "redis_xtrim",
+    "redis_hget",
+    "redis_hmget",
+    "redis_hlen",
+    "redis_hexists",
+    "redis_hkeys",
+    "redis_hvals",
+    "redis_hincrby",
+    "redis_scard",
+    "redis_sismember",
+    "redis_sunion",
+    "redis_sinter",
+    "redis_sdiff",
+    "redis_zcard",
+    "redis_zscore",
+    "redis_zrank",
+    "redis_zcount",
+    "redis_zrangebyscore",
+    "redis_llen",
+    "redis_lindex",
 ];
 
 /// Build a sub-router containing all data structure Redis tools
@@ -60,7 +80,26 @@ pub fn router(state: Arc<AppState>) -> McpRouter {
         .tool(zadd(state.clone()))
         .tool(zrem(state.clone()))
         .tool(xadd(state.clone()))
-        .tool(xtrim(state))
+        .tool(xtrim(state.clone()))
+        .tool(hget(state.clone()))
+        .tool(hmget(state.clone()))
+        .tool(hlen(state.clone()))
+        .tool(hexists(state.clone()))
+        .tool(hkeys(state.clone()))
+        .tool(hvals(state.clone()))
+        .tool(hincrby(state.clone()))
+        .tool(scard(state.clone()))
+        .tool(sismember(state.clone()))
+        .tool(sunion(state.clone()))
+        .tool(sinter(state.clone()))
+        .tool(sdiff(state.clone()))
+        .tool(zcard(state.clone()))
+        .tool(zscore(state.clone()))
+        .tool(zrank(state.clone()))
+        .tool(zcount(state.clone()))
+        .tool(zrangebyscore(state.clone()))
+        .tool(llen(state.clone()))
+        .tool(lindex(state))
 }
 
 /// Input for HGETALL command
@@ -1458,6 +1497,1051 @@ pub fn xtrim(state: Arc<AppState>) -> Tool {
                     "OK - trimmed {} entries from stream '{}'",
                     trimmed, input.key
                 )))
+            },
+        )
+        .build()
+}
+
+// --- P1 Hash read tools ---
+
+/// Input for HGET command
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct HgetInput {
+    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Optional profile name to resolve connection from (uses default profile if not set)
+    #[serde(default)]
+    pub profile: Option<String>,
+    /// Hash key
+    pub key: String,
+    /// Field to get
+    pub field: String,
+}
+
+/// Build the hget tool
+pub fn hget(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("redis_hget")
+        .description("Get the value of a single field in a hash.")
+        .read_only_safe()
+        .extractor_handler_typed::<_, _, _, HgetInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<HgetInput>| async move {
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
+
+                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
+
+                let mut conn = client
+                    .get_multiplexed_async_connection()
+                    .await
+                    .tool_context("Connection failed")?;
+
+                let value: Option<String> = redis::cmd("HGET")
+                    .arg(&input.key)
+                    .arg(&input.field)
+                    .query_async(&mut conn)
+                    .await
+                    .tool_context("HGET failed")?;
+
+                match value {
+                    Some(v) => Ok(CallToolResult::text(v)),
+                    None => Ok(CallToolResult::text(format!(
+                        "(nil) - field '{}' not found in '{}'",
+                        input.field, input.key
+                    ))),
+                }
+            },
+        )
+        .build()
+}
+
+/// Input for HMGET command
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct HmgetInput {
+    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Optional profile name to resolve connection from (uses default profile if not set)
+    #[serde(default)]
+    pub profile: Option<String>,
+    /// Hash key
+    pub key: String,
+    /// Fields to get
+    pub fields: Vec<String>,
+}
+
+/// Build the hmget tool
+pub fn hmget(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("redis_hmget")
+        .description("Get the values of multiple fields in a hash.")
+        .read_only_safe()
+        .extractor_handler_typed::<_, _, _, HmgetInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<HmgetInput>| async move {
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
+
+                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
+
+                let mut conn = client
+                    .get_multiplexed_async_connection()
+                    .await
+                    .tool_context("Connection failed")?;
+
+                let mut cmd = redis::cmd("HMGET");
+                cmd.arg(&input.key);
+                for field in &input.fields {
+                    cmd.arg(field);
+                }
+
+                let values: Vec<redis::Value> = cmd
+                    .query_async(&mut conn)
+                    .await
+                    .tool_context("HMGET failed")?;
+
+                let output = input
+                    .fields
+                    .iter()
+                    .zip(values.iter())
+                    .map(|(f, v)| format!("{}: {}", f, super::format_value(v)))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+
+                Ok(CallToolResult::text(output))
+            },
+        )
+        .build()
+}
+
+/// Input for HLEN command
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct HlenInput {
+    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Optional profile name to resolve connection from (uses default profile if not set)
+    #[serde(default)]
+    pub profile: Option<String>,
+    /// Hash key
+    pub key: String,
+}
+
+/// Build the hlen tool
+pub fn hlen(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("redis_hlen")
+        .description("Get the number of fields in a hash.")
+        .read_only_safe()
+        .extractor_handler_typed::<_, _, _, HlenInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<HlenInput>| async move {
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
+
+                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
+
+                let mut conn = client
+                    .get_multiplexed_async_connection()
+                    .await
+                    .tool_context("Connection failed")?;
+
+                let count: i64 = redis::cmd("HLEN")
+                    .arg(&input.key)
+                    .query_async(&mut conn)
+                    .await
+                    .tool_context("HLEN failed")?;
+
+                Ok(CallToolResult::text(format!(
+                    "{}: {} fields",
+                    input.key, count
+                )))
+            },
+        )
+        .build()
+}
+
+/// Input for HEXISTS command
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct HexistsInput {
+    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Optional profile name to resolve connection from (uses default profile if not set)
+    #[serde(default)]
+    pub profile: Option<String>,
+    /// Hash key
+    pub key: String,
+    /// Field to check
+    pub field: String,
+}
+
+/// Build the hexists tool
+pub fn hexists(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("redis_hexists")
+        .description("Check if a field exists in a hash.")
+        .read_only_safe()
+        .extractor_handler_typed::<_, _, _, HexistsInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<HexistsInput>| async move {
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
+
+                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
+
+                let mut conn = client
+                    .get_multiplexed_async_connection()
+                    .await
+                    .tool_context("Connection failed")?;
+
+                let exists: bool = redis::cmd("HEXISTS")
+                    .arg(&input.key)
+                    .arg(&input.field)
+                    .query_async(&mut conn)
+                    .await
+                    .tool_context("HEXISTS failed")?;
+
+                Ok(CallToolResult::text(format!(
+                    "{}.{}: {}",
+                    input.key,
+                    input.field,
+                    if exists { "exists" } else { "does not exist" }
+                )))
+            },
+        )
+        .build()
+}
+
+/// Input for HKEYS command
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct HkeysInput {
+    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Optional profile name to resolve connection from (uses default profile if not set)
+    #[serde(default)]
+    pub profile: Option<String>,
+    /// Hash key
+    pub key: String,
+}
+
+/// Build the hkeys tool
+pub fn hkeys(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("redis_hkeys")
+        .description("Get all field names in a hash.")
+        .read_only_safe()
+        .extractor_handler_typed::<_, _, _, HkeysInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<HkeysInput>| async move {
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
+
+                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
+
+                let mut conn = client
+                    .get_multiplexed_async_connection()
+                    .await
+                    .tool_context("Connection failed")?;
+
+                let fields: Vec<String> = redis::cmd("HKEYS")
+                    .arg(&input.key)
+                    .query_async(&mut conn)
+                    .await
+                    .tool_context("HKEYS failed")?;
+
+                if fields.is_empty() {
+                    return Ok(CallToolResult::text(format!(
+                        "(empty hash or key '{}' not found)",
+                        input.key
+                    )));
+                }
+
+                Ok(CallToolResult::text(format!(
+                    "Hash '{}' ({} fields):\n{}",
+                    input.key,
+                    fields.len(),
+                    fields.join("\n")
+                )))
+            },
+        )
+        .build()
+}
+
+/// Input for HVALS command
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct HvalsInput {
+    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Optional profile name to resolve connection from (uses default profile if not set)
+    #[serde(default)]
+    pub profile: Option<String>,
+    /// Hash key
+    pub key: String,
+}
+
+/// Build the hvals tool
+pub fn hvals(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("redis_hvals")
+        .description("Get all values in a hash.")
+        .read_only_safe()
+        .extractor_handler_typed::<_, _, _, HvalsInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<HvalsInput>| async move {
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
+
+                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
+
+                let mut conn = client
+                    .get_multiplexed_async_connection()
+                    .await
+                    .tool_context("Connection failed")?;
+
+                let values: Vec<String> = redis::cmd("HVALS")
+                    .arg(&input.key)
+                    .query_async(&mut conn)
+                    .await
+                    .tool_context("HVALS failed")?;
+
+                if values.is_empty() {
+                    return Ok(CallToolResult::text(format!(
+                        "(empty hash or key '{}' not found)",
+                        input.key
+                    )));
+                }
+
+                Ok(CallToolResult::text(format!(
+                    "Hash '{}' ({} values):\n{}",
+                    input.key,
+                    values.len(),
+                    values.join("\n")
+                )))
+            },
+        )
+        .build()
+}
+
+/// Input for HINCRBY command
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct HincrbyInput {
+    /// Optional Redis URL (overrides profile)
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Optional profile name for connection resolution
+    #[serde(default)]
+    pub profile: Option<String>,
+    /// Hash key
+    pub key: String,
+    /// Field to increment
+    pub field: String,
+    /// Increment value (can be negative)
+    pub increment: i64,
+}
+
+/// Build the hincrby tool
+pub fn hincrby(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("redis_hincrby")
+        .description("Increment the integer value of a hash field by the given amount.")
+        .non_destructive()
+        .extractor_handler_typed::<_, _, _, HincrbyInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<HincrbyInput>| async move {
+                if !state.is_write_allowed() {
+                    return Err(McpError::tool(
+                        "Write operations not allowed in read-only mode",
+                    ));
+                }
+
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
+
+                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
+
+                let mut conn = client
+                    .get_multiplexed_async_connection()
+                    .await
+                    .tool_context("Connection failed")?;
+
+                let value: i64 = redis::cmd("HINCRBY")
+                    .arg(&input.key)
+                    .arg(&input.field)
+                    .arg(input.increment)
+                    .query_async(&mut conn)
+                    .await
+                    .tool_context("HINCRBY failed")?;
+
+                Ok(CallToolResult::text(format!(
+                    "{}.{}: {}",
+                    input.key, input.field, value
+                )))
+            },
+        )
+        .build()
+}
+
+// --- P1 Set read tools ---
+
+/// Input for SCARD command
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ScardInput {
+    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Optional profile name to resolve connection from (uses default profile if not set)
+    #[serde(default)]
+    pub profile: Option<String>,
+    /// Set key
+    pub key: String,
+}
+
+/// Build the scard tool
+pub fn scard(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("redis_scard")
+        .description("Get the number of members in a set (cardinality).")
+        .read_only_safe()
+        .extractor_handler_typed::<_, _, _, ScardInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<ScardInput>| async move {
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
+
+                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
+
+                let mut conn = client
+                    .get_multiplexed_async_connection()
+                    .await
+                    .tool_context("Connection failed")?;
+
+                let count: i64 = redis::cmd("SCARD")
+                    .arg(&input.key)
+                    .query_async(&mut conn)
+                    .await
+                    .tool_context("SCARD failed")?;
+
+                Ok(CallToolResult::text(format!(
+                    "{}: {} members",
+                    input.key, count
+                )))
+            },
+        )
+        .build()
+}
+
+/// Input for SISMEMBER command
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SismemberInput {
+    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Optional profile name to resolve connection from (uses default profile if not set)
+    #[serde(default)]
+    pub profile: Option<String>,
+    /// Set key
+    pub key: String,
+    /// Member to check
+    pub member: String,
+}
+
+/// Build the sismember tool
+pub fn sismember(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("redis_sismember")
+        .description("Check if a value is a member of a set.")
+        .read_only_safe()
+        .extractor_handler_typed::<_, _, _, SismemberInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<SismemberInput>| async move {
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
+
+                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
+
+                let mut conn = client
+                    .get_multiplexed_async_connection()
+                    .await
+                    .tool_context("Connection failed")?;
+
+                let is_member: bool = redis::cmd("SISMEMBER")
+                    .arg(&input.key)
+                    .arg(&input.member)
+                    .query_async(&mut conn)
+                    .await
+                    .tool_context("SISMEMBER failed")?;
+
+                Ok(CallToolResult::text(format!(
+                    "'{}' {} a member of '{}'",
+                    input.member,
+                    if is_member { "is" } else { "is not" },
+                    input.key
+                )))
+            },
+        )
+        .build()
+}
+
+/// Input for SUNION command
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SunionInput {
+    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Optional profile name to resolve connection from (uses default profile if not set)
+    #[serde(default)]
+    pub profile: Option<String>,
+    /// Set keys to compute union of
+    pub keys: Vec<String>,
+}
+
+/// Build the sunion tool
+pub fn sunion(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("redis_sunion")
+        .description("Return the union of multiple sets.")
+        .read_only_safe()
+        .extractor_handler_typed::<_, _, _, SunionInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<SunionInput>| async move {
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
+
+                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
+
+                let mut conn = client
+                    .get_multiplexed_async_connection()
+                    .await
+                    .tool_context("Connection failed")?;
+
+                let mut cmd = redis::cmd("SUNION");
+                for key in &input.keys {
+                    cmd.arg(key);
+                }
+
+                let members: Vec<String> = cmd
+                    .query_async(&mut conn)
+                    .await
+                    .tool_context("SUNION failed")?;
+
+                if members.is_empty() {
+                    return Ok(CallToolResult::text("(empty set)"));
+                }
+
+                Ok(CallToolResult::text(format!(
+                    "Union ({} members):\n{}",
+                    members.len(),
+                    members.join("\n")
+                )))
+            },
+        )
+        .build()
+}
+
+/// Input for SINTER command
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SinterInput {
+    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Optional profile name to resolve connection from (uses default profile if not set)
+    #[serde(default)]
+    pub profile: Option<String>,
+    /// Set keys to compute intersection of
+    pub keys: Vec<String>,
+}
+
+/// Build the sinter tool
+pub fn sinter(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("redis_sinter")
+        .description("Return the intersection of multiple sets.")
+        .read_only_safe()
+        .extractor_handler_typed::<_, _, _, SinterInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<SinterInput>| async move {
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
+
+                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
+
+                let mut conn = client
+                    .get_multiplexed_async_connection()
+                    .await
+                    .tool_context("Connection failed")?;
+
+                let mut cmd = redis::cmd("SINTER");
+                for key in &input.keys {
+                    cmd.arg(key);
+                }
+
+                let members: Vec<String> = cmd
+                    .query_async(&mut conn)
+                    .await
+                    .tool_context("SINTER failed")?;
+
+                if members.is_empty() {
+                    return Ok(CallToolResult::text("(empty set)"));
+                }
+
+                Ok(CallToolResult::text(format!(
+                    "Intersection ({} members):\n{}",
+                    members.len(),
+                    members.join("\n")
+                )))
+            },
+        )
+        .build()
+}
+
+/// Input for SDIFF command
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SdiffInput {
+    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Optional profile name to resolve connection from (uses default profile if not set)
+    #[serde(default)]
+    pub profile: Option<String>,
+    /// Set keys (first set minus all subsequent sets)
+    pub keys: Vec<String>,
+}
+
+/// Build the sdiff tool
+pub fn sdiff(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("redis_sdiff")
+        .description("Return the difference between the first set and all subsequent sets.")
+        .read_only_safe()
+        .extractor_handler_typed::<_, _, _, SdiffInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<SdiffInput>| async move {
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
+
+                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
+
+                let mut conn = client
+                    .get_multiplexed_async_connection()
+                    .await
+                    .tool_context("Connection failed")?;
+
+                let mut cmd = redis::cmd("SDIFF");
+                for key in &input.keys {
+                    cmd.arg(key);
+                }
+
+                let members: Vec<String> = cmd
+                    .query_async(&mut conn)
+                    .await
+                    .tool_context("SDIFF failed")?;
+
+                if members.is_empty() {
+                    return Ok(CallToolResult::text("(empty set)"));
+                }
+
+                Ok(CallToolResult::text(format!(
+                    "Difference ({} members):\n{}",
+                    members.len(),
+                    members.join("\n")
+                )))
+            },
+        )
+        .build()
+}
+
+// --- P1 Sorted Set read tools ---
+
+/// Input for ZCARD command
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ZcardInput {
+    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Optional profile name to resolve connection from (uses default profile if not set)
+    #[serde(default)]
+    pub profile: Option<String>,
+    /// Sorted set key
+    pub key: String,
+}
+
+/// Build the zcard tool
+pub fn zcard(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("redis_zcard")
+        .description("Get the number of members in a sorted set (cardinality).")
+        .read_only_safe()
+        .extractor_handler_typed::<_, _, _, ZcardInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<ZcardInput>| async move {
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
+
+                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
+
+                let mut conn = client
+                    .get_multiplexed_async_connection()
+                    .await
+                    .tool_context("Connection failed")?;
+
+                let count: i64 = redis::cmd("ZCARD")
+                    .arg(&input.key)
+                    .query_async(&mut conn)
+                    .await
+                    .tool_context("ZCARD failed")?;
+
+                Ok(CallToolResult::text(format!(
+                    "{}: {} members",
+                    input.key, count
+                )))
+            },
+        )
+        .build()
+}
+
+/// Input for ZSCORE command
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ZscoreInput {
+    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Optional profile name to resolve connection from (uses default profile if not set)
+    #[serde(default)]
+    pub profile: Option<String>,
+    /// Sorted set key
+    pub key: String,
+    /// Member to get score for
+    pub member: String,
+}
+
+/// Build the zscore tool
+pub fn zscore(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("redis_zscore")
+        .description("Get the score of a member in a sorted set.")
+        .read_only_safe()
+        .extractor_handler_typed::<_, _, _, ZscoreInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<ZscoreInput>| async move {
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
+
+                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
+
+                let mut conn = client
+                    .get_multiplexed_async_connection()
+                    .await
+                    .tool_context("Connection failed")?;
+
+                let score: Option<f64> = redis::cmd("ZSCORE")
+                    .arg(&input.key)
+                    .arg(&input.member)
+                    .query_async(&mut conn)
+                    .await
+                    .tool_context("ZSCORE failed")?;
+
+                match score {
+                    Some(s) => Ok(CallToolResult::text(format!(
+                        "{}.{}: {}",
+                        input.key, input.member, s
+                    ))),
+                    None => Ok(CallToolResult::text(format!(
+                        "(nil) - '{}' not found in '{}'",
+                        input.member, input.key
+                    ))),
+                }
+            },
+        )
+        .build()
+}
+
+/// Input for ZRANK command
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ZrankInput {
+    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Optional profile name to resolve connection from (uses default profile if not set)
+    #[serde(default)]
+    pub profile: Option<String>,
+    /// Sorted set key
+    pub key: String,
+    /// Member to get rank for
+    pub member: String,
+}
+
+/// Build the zrank tool
+pub fn zrank(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("redis_zrank")
+        .description(
+            "Get the rank (0-based index) of a member in a sorted set, ordered low to high.",
+        )
+        .read_only_safe()
+        .extractor_handler_typed::<_, _, _, ZrankInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<ZrankInput>| async move {
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
+
+                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
+
+                let mut conn = client
+                    .get_multiplexed_async_connection()
+                    .await
+                    .tool_context("Connection failed")?;
+
+                let rank: Option<i64> = redis::cmd("ZRANK")
+                    .arg(&input.key)
+                    .arg(&input.member)
+                    .query_async(&mut conn)
+                    .await
+                    .tool_context("ZRANK failed")?;
+
+                match rank {
+                    Some(r) => Ok(CallToolResult::text(format!(
+                        "{}.{}: rank {}",
+                        input.key, input.member, r
+                    ))),
+                    None => Ok(CallToolResult::text(format!(
+                        "(nil) - '{}' not found in '{}'",
+                        input.member, input.key
+                    ))),
+                }
+            },
+        )
+        .build()
+}
+
+/// Input for ZCOUNT command
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ZcountInput {
+    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Optional profile name to resolve connection from (uses default profile if not set)
+    #[serde(default)]
+    pub profile: Option<String>,
+    /// Sorted set key
+    pub key: String,
+    /// Minimum score (use "-inf" for no lower bound)
+    pub min: String,
+    /// Maximum score (use "+inf" for no upper bound)
+    pub max: String,
+}
+
+/// Build the zcount tool
+pub fn zcount(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("redis_zcount")
+        .description("Count members in a sorted set with scores between min and max (inclusive). Use \"-inf\"/\"+inf\" for unbounded.")
+        .read_only_safe()
+        .extractor_handler_typed::<_, _, _, ZcountInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<ZcountInput>| async move {
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
+
+                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
+
+                let mut conn = client
+                    .get_multiplexed_async_connection()
+                    .await
+                    .tool_context("Connection failed")?;
+
+                let count: i64 = redis::cmd("ZCOUNT")
+                    .arg(&input.key)
+                    .arg(&input.min)
+                    .arg(&input.max)
+                    .query_async(&mut conn)
+                    .await
+                    .tool_context("ZCOUNT failed")?;
+
+                Ok(CallToolResult::text(format!(
+                    "{}: {} members in score range [{}, {}]",
+                    input.key, count, input.min, input.max
+                )))
+            },
+        )
+        .build()
+}
+
+/// Input for ZRANGEBYSCORE command
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ZrangebyscoreInput {
+    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Optional profile name to resolve connection from (uses default profile if not set)
+    #[serde(default)]
+    pub profile: Option<String>,
+    /// Sorted set key
+    pub key: String,
+    /// Minimum score (use "-inf" for no lower bound)
+    pub min: String,
+    /// Maximum score (use "+inf" for no upper bound)
+    pub max: String,
+    /// Include scores in output
+    #[serde(default)]
+    pub withscores: bool,
+    /// Offset for pagination (requires count)
+    #[serde(default)]
+    pub offset: Option<i64>,
+    /// Maximum number of results (requires offset)
+    #[serde(default)]
+    pub count: Option<i64>,
+}
+
+/// Build the zrangebyscore tool
+pub fn zrangebyscore(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("redis_zrangebyscore")
+        .description("Get members from a sorted set with scores in the given range. Use \"-inf\"/\"+inf\" for unbounded.")
+        .read_only_safe()
+        .extractor_handler_typed::<_, _, _, ZrangebyscoreInput>(
+            state,
+            |State(state): State<Arc<AppState>>,
+             Json(input): Json<ZrangebyscoreInput>| async move {
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
+
+                let client = redis::Client::open(url.as_str())
+                    .tool_context("Invalid URL")?;
+
+                let mut conn = client
+                    .get_multiplexed_async_connection()
+                    .await
+                    .tool_context("Connection failed")?;
+
+                let mut cmd = redis::cmd("ZRANGEBYSCORE");
+                cmd.arg(&input.key).arg(&input.min).arg(&input.max);
+
+                if input.withscores {
+                    cmd.arg("WITHSCORES");
+                }
+
+                if let (Some(offset), Some(count)) = (input.offset, input.count) {
+                    cmd.arg("LIMIT").arg(offset).arg(count);
+                }
+
+                if input.withscores {
+                    let result: Vec<(String, f64)> = cmd
+                        .query_async(&mut conn)
+                        .await
+                        .tool_context("ZRANGEBYSCORE failed")?;
+
+                    if result.is_empty() {
+                        return Ok(CallToolResult::text(format!(
+                            "No members in '{}' with scores in [{}, {}]",
+                            input.key, input.min, input.max
+                        )));
+                    }
+
+                    let output = result
+                        .iter()
+                        .map(|(member, score)| format!("{} (score: {})", member, score))
+                        .collect::<Vec<_>>()
+                        .join("\n");
+
+                    Ok(CallToolResult::text(format!(
+                        "'{}' ({} members in [{}, {}]):\n{}",
+                        input.key,
+                        result.len(),
+                        input.min,
+                        input.max,
+                        output
+                    )))
+                } else {
+                    let result: Vec<String> = cmd
+                        .query_async(&mut conn)
+                        .await
+                        .tool_context("ZRANGEBYSCORE failed")?;
+
+                    if result.is_empty() {
+                        return Ok(CallToolResult::text(format!(
+                            "No members in '{}' with scores in [{}, {}]",
+                            input.key, input.min, input.max
+                        )));
+                    }
+
+                    Ok(CallToolResult::text(format!(
+                        "'{}' ({} members in [{}, {}]):\n{}",
+                        input.key,
+                        result.len(),
+                        input.min,
+                        input.max,
+                        result.join("\n")
+                    )))
+                }
+            },
+        )
+        .build()
+}
+
+// --- P1 List read tools ---
+
+/// Input for LLEN command
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct LlenInput {
+    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Optional profile name to resolve connection from (uses default profile if not set)
+    #[serde(default)]
+    pub profile: Option<String>,
+    /// List key
+    pub key: String,
+}
+
+/// Build the llen tool
+pub fn llen(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("redis_llen")
+        .description("Get the length of a list.")
+        .read_only_safe()
+        .extractor_handler_typed::<_, _, _, LlenInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<LlenInput>| async move {
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
+
+                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
+
+                let mut conn = client
+                    .get_multiplexed_async_connection()
+                    .await
+                    .tool_context("Connection failed")?;
+
+                let length: i64 = redis::cmd("LLEN")
+                    .arg(&input.key)
+                    .query_async(&mut conn)
+                    .await
+                    .tool_context("LLEN failed")?;
+
+                Ok(CallToolResult::text(format!(
+                    "{}: {} elements",
+                    input.key, length
+                )))
+            },
+        )
+        .build()
+}
+
+/// Input for LINDEX command
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct LindexInput {
+    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Optional profile name to resolve connection from (uses default profile if not set)
+    #[serde(default)]
+    pub profile: Option<String>,
+    /// List key
+    pub key: String,
+    /// Index (0-based, negative counts from end)
+    pub index: i64,
+}
+
+/// Build the lindex tool
+pub fn lindex(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("redis_lindex")
+        .description("Get an element from a list by its index (0-based, negative counts from end).")
+        .read_only_safe()
+        .extractor_handler_typed::<_, _, _, LindexInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<LindexInput>| async move {
+                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
+
+                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
+
+                let mut conn = client
+                    .get_multiplexed_async_connection()
+                    .await
+                    .tool_context("Connection failed")?;
+
+                let value: Option<String> = redis::cmd("LINDEX")
+                    .arg(&input.key)
+                    .arg(input.index)
+                    .query_async(&mut conn)
+                    .await
+                    .tool_context("LINDEX failed")?;
+
+                match value {
+                    Some(v) => Ok(CallToolResult::text(v)),
+                    None => Ok(CallToolResult::text(format!(
+                        "(nil) - index {} out of range or key '{}' not found",
+                        input.index, input.key
+                    ))),
+                }
             },
         )
         .build()

--- a/docs/docs/integrations/mcp.md
+++ b/docs/docs/integrations/mcp.md
@@ -247,13 +247,13 @@ See [Configuration](../mcp/configuration.md) for the full `--tools` syntax, safe
 
 ## Available Tools
 
-The MCP server provides **305 tools** across 4 toolsets:
+The MCP server provides **340 tools** across 4 toolsets:
 
 | Toolset | Tools | Description |
 |---------|-------|-------------|
 | **Cloud** | 148 | Subscriptions, databases, networking, Essentials, account management |
 | **Enterprise** | 92 | Cluster, databases, RBAC, observability, proxies, services |
-| **Database** | 55 | Direct Redis operations -- keys, data structures, diagnostics |
+| **Database** | 90 | Direct Redis operations -- keys, data structures, diagnostics |
 | **App** | 8 | Profile and configuration management |
 | **System** | 2 | `list_available_tools`, `show_policy` (always available) |
 

--- a/docs/docs/mcp/tools-reference.md
+++ b/docs/docs/mcp/tools-reference.md
@@ -1,6 +1,6 @@
 # Tools Reference
 
-The redisctl MCP server exposes **305 tools** across 4 toolsets and 2 system tools for managing Redis Cloud, Redis Enterprise, and direct database operations.
+The redisctl MCP server exposes **340 tools** across 4 toolsets and 2 system tools for managing Redis Cloud, Redis Enterprise, and direct database operations.
 
 Tools are organized into **toolsets** (Cloud, Enterprise, Database, App) and further into **sub-modules** that can be selectively loaded with the [`--tools` flag](configuration.md#the-tools-flag).
 
@@ -183,7 +183,7 @@ System service lifecycle -- list, inspect, start, stop, restart, and status chec
 |------|-------------|
 | `enterprise_raw_api` | Execute arbitrary Redis Enterprise REST API requests |
 
-## Database Toolset (55 tools)
+## Database Toolset (90 tools)
 
 Direct Redis database operations. Requires `--database-url` connection. Select with `--tools database` or target specific sub-modules.
 
@@ -202,9 +202,9 @@ Server-level operations -- connectivity, server info, client listing, slow log, 
 | `redis_config_get` | Get config values |
 | `redis_config_set` | Set config values *(write)* |
 
-### `database:keys` (15 tools)
+### `database:keys` (31 tools)
 
-Key-space operations -- listing, scanning, get/set, type inspection, TTL, existence checks, memory usage, and key mutation.
+Key-space operations -- listing, scanning, get/set, type inspection, TTL, existence checks, memory usage, key mutation, multi-key operations, atomic counters, and string manipulation.
 
 | Representative Tools | Description |
 |---------------------|-------------|
@@ -212,21 +212,40 @@ Key-space operations -- listing, scanning, get/set, type inspection, TTL, existe
 | `redis_scan` | Scan keys with cursor |
 | `redis_get` | Get string value |
 | `redis_set` | Set string value *(write)* |
+| `redis_mget` | Get multiple key values |
+| `redis_mset` | Set multiple key-value pairs *(write)* |
 | `redis_type` | Get key type |
 | `redis_ttl` | Get key TTL |
 | `redis_del` | Delete keys *(write)* |
+| `redis_unlink` | Async-delete keys *(write)* |
 | `redis_expire` | Set key expiration *(write)* |
+| `redis_incr` | Increment integer value *(write)* |
+| `redis_decr` | Decrement integer value *(write)* |
 
-### `database:structures` (21 tools)
+### `database:structures` (40 tools)
 
-Data structure operations -- hashes, lists, sets, sorted sets, streams, and pub/sub inspection.
+Data structure operations -- hashes, lists, sets, sorted sets, streams, pub/sub inspection, set algebra, and granular field/member accessors.
 
 | Representative Tools | Description |
 |---------------------|-------------|
 | `redis_hgetall` | Get all hash fields |
+| `redis_hget` | Get a single hash field |
+| `redis_hmget` | Get multiple hash fields |
+| `redis_hlen` | Get hash field count |
 | `redis_lrange` | Get list range |
+| `redis_llen` | Get list length |
+| `redis_lindex` | Get list element by index |
 | `redis_smembers` | Get all set members |
+| `redis_scard` | Get set cardinality |
+| `redis_sismember` | Check set membership |
+| `redis_sunion` | Set union |
+| `redis_sinter` | Set intersection |
+| `redis_sdiff` | Set difference |
 | `redis_zrange` | Get sorted set range |
+| `redis_zscore` | Get member score |
+| `redis_zrank` | Get member rank |
+| `redis_zcount` | Count members by score range |
+| `redis_zrangebyscore` | Get members by score range |
 | `redis_xinfo_stream` | Get stream info |
 | `redis_xrange` | Get stream entries by ID range |
 | `redis_xlen` | Get stream length |
@@ -270,10 +289,10 @@ Profile and configuration management tools. Always compiled in; no sub-modules.
 |---------|-------------|-------|
 | Cloud | `subscriptions` (36), `account` (33), `networking` (51), `fixed` (27), `raw` (1) | **148** |
 | Enterprise | `cluster` (24), `databases` (20), `rbac` (20), `observability` (16), `proxy` (4), `services` (7), `raw` (1) | **92** |
-| Database | `server` (14), `keys` (15), `structures` (21), `diagnostics` (4), `raw` (1) | **55** |
+| Database | `server` (14), `keys` (31), `structures` (40), `diagnostics` (4), `raw` (1) | **90** |
 | App | *(flat)* | **8** |
 | System | *(always on)* | **2** |
-| **Total** | | **305** |
+| **Total** | | **340** |
 
 ## Example Tool Usage
 


### PR DESCRIPTION
## Summary

- Add 16 key/string tools to `database:keys` sub-module (15 -> 31 tools): `mget`, `mset`, `persist`, `unlink`, `copy`, `dump`, `restore`, `randomkey`, `touch`, `incr`, `decr`, `append`, `strlen`, `getrange`, `setrange`, `setnx`
- Add 19 data structure tools to `database:structures` sub-module (21 -> 40 tools): `hget`, `hmget`, `hlen`, `hexists`, `hkeys`, `hvals`, `hincrby`, `scard`, `sismember`, `sunion`, `sinter`, `sdiff`, `zcard`, `zscore`, `zrank`, `zcount`, `zrangebyscore`, `llen`, `lindex`
- Update `DATABASE_ESSENTIALS` preset with 8 high-value new tools
- Update documentation: database 55 -> 90, total 305 -> 340
- P2 tools (server ops + scripting) deferred to follow-up per plan

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p redisctl-mcp --all-features -- -D warnings`
- [x] `cargo test --lib --all-features` (167 tests pass, including `database_essentials_are_valid_tool_names`)
- [x] `cargo test --test '*' --all-features` (479 tests pass)
- [x] `cargo check -p redisctl-mcp --no-default-features`
- [ ] Integration tests with Docker Redis (#800)

Closes #774

Follow-ups: #800 (integration tests), #801 (connection pooling)