### PR TITLE
fix(docs): update MCP install instructions for redisctl-mcp

### DIFF
--- a/docs/docs/integrations/mcp.md
+++ b/docs/docs/integrations/mcp.md
@@ -14,21 +14,39 @@ All operations use your existing redisctl profiles for authentication.
 
 ## Installation
 
-### macOS (Homebrew)
+The MCP server is a separate binary called `redisctl-mcp`. Install it using one of the methods below.
+
+### Installer Script (Recommended)
 
 ```bash
-brew install redis-developer/homebrew-tap/redisctl
+# macOS / Linux
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/redis-developer/redisctl/releases/latest/download/redisctl-mcp-installer.sh | sh
 ```
 
-### Linux/Windows
+```powershell
+# Windows
+powershell -ExecutionPolicy Bypass -c "irm https://github.com/redis-developer/redisctl/releases/latest/download/redisctl-mcp-installer.ps1 | iex"
+```
 
-Download from [GitHub Releases](https://github.com/redis-developer/redisctl/releases) or use Docker:
+### Cargo
+
+```bash
+cargo install redisctl-mcp
+```
+
+### Binary Downloads
+
+Download pre-built binaries from [GitHub Releases](https://github.com/redis-developer/redisctl/releases/latest).
+
+### Docker
+
+No local install required:
 
 ```bash
 docker pull ghcr.io/redis-developer/redisctl
 ```
 
-See the [Installation Guide](../getting-started/installation.md) for all options.
+See the [Getting Started guide](../mcp/getting-started.md) for Docker MCP configuration examples.
 
 ## Setting Up Credentials
 

--- a/docs/docs/mcp/getting-started.md
+++ b/docs/docs/mcp/getting-started.md
@@ -4,17 +4,29 @@ This guide walks you through installing and configuring the redisctl MCP server 
 
 ## Installation
 
-### macOS (Homebrew)
+The MCP server is a separate binary called `redisctl-mcp`. Install it using one of the methods below.
+
+### Installer Script (Recommended)
 
 ```bash
-brew install redis-developer/homebrew-tap/redisctl
+# macOS / Linux
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/redis-developer/redisctl/releases/latest/download/redisctl-mcp-installer.sh | sh
 ```
 
-### Linux/Windows
+```powershell
+# Windows
+powershell -ExecutionPolicy Bypass -c "irm https://github.com/redis-developer/redisctl/releases/latest/download/redisctl-mcp-installer.ps1 | iex"
+```
 
-Download from [GitHub Releases](https://github.com/redis-developer/redisctl/releases).
+### Cargo
 
-See the [Installation Guide](../getting-started/installation.md) for all options.
+```bash
+cargo install redisctl-mcp
+```
+
+### Binary Downloads
+
+Download pre-built binaries from [GitHub Releases](https://github.com/redis-developer/redisctl/releases/latest).
 
 ### Docker (Zero-Install)
 


### PR DESCRIPTION
## Summary

- Replace Homebrew `redisctl` instructions with methods that actually install `redisctl-mcp`
- Add installer script (recommended), `cargo install`, and binary download options
- Update both `docs/integrations/mcp.md` and `docs/mcp/getting-started.md`

The Homebrew formula only installs `redisctl`, not the MCP server binary. Users following the existing docs couldn't start the MCP server.

## Test plan

- [ ] Verify installer script URL resolves: `curl -LsSf https://github.com/redis-developer/redisctl/releases/latest/download/redisctl-mcp-installer.sh | head`
- [ ] Verify `cargo install redisctl-mcp` works
- [ ] Verify docs render correctly with `mkdocs serve`

Closes #797