### PR TITLE
perf(mcp): URL-keyed connection pooling for Redis database tools

### DIFF
--- a/crates/redisctl-mcp/src/state.rs
+++ b/crates/redisctl-mcp/src/state.rs
@@ -1,6 +1,6 @@
 //! Application state and credential resolution
 
-#[cfg(any(feature = "cloud", feature = "enterprise"))]
+#[cfg(any(feature = "cloud", feature = "enterprise", feature = "database"))]
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -30,12 +30,14 @@ pub enum CredentialSource {
     },
 }
 
-/// Cached API clients (per-profile for multi-cluster support)
+/// Cached API clients and connections (per-profile for multi-cluster support)
 pub struct CachedClients {
     #[cfg(feature = "cloud")]
     pub cloud: HashMap<String, CloudClient>,
     #[cfg(feature = "enterprise")]
     pub enterprise: HashMap<String, EnterpriseClient>,
+    #[cfg(feature = "database")]
+    pub database: HashMap<String, redis::aio::MultiplexedConnection>,
 }
 
 /// Shared application state
@@ -85,6 +87,8 @@ impl AppState {
                 cloud: HashMap::new(),
                 #[cfg(feature = "enterprise")]
                 enterprise: HashMap::new(),
+                #[cfg(feature = "database")]
+                database: HashMap::new(),
             }),
         })
     }
@@ -340,23 +344,46 @@ impl AppState {
         Ok(format!("{}://{}{}:{}{}", scheme, auth, host, port, db_path))
     }
 
-    /// Get Redis connection for direct database operations
+    /// Get or create a cached Redis connection for a resolved URL.
+    ///
+    /// Connections are cached by URL. If a cached connection fails a PING
+    /// health check, it is evicted and a fresh connection is created.
     #[cfg(feature = "database")]
-    #[allow(dead_code)]
-    pub async fn redis_connection(&self) -> Result<redis::aio::MultiplexedConnection> {
-        let url = self
-            .database_url
-            .as_ref()
-            .cloned()
-            .or_else(|| std::env::var("REDIS_URL").ok())
-            .context("No Redis URL configured")?;
+    pub async fn redis_connection_for_url(
+        &self,
+        url: &str,
+    ) -> Result<redis::aio::MultiplexedConnection> {
+        // Check cache first
+        {
+            let clients = self.clients.read().await;
+            if let Some(conn) = clients.database.get(url) {
+                // Quick health check -- if PING fails the connection is stale
+                let mut test_conn = conn.clone();
+                if redis::cmd("PING")
+                    .query_async::<String>(&mut test_conn)
+                    .await
+                    .is_ok()
+                {
+                    return Ok(conn.clone());
+                }
+                // Fall through to evict + reconnect
+            }
+        }
 
-        let client = redis::Client::open(url.as_str()).context("Failed to create Redis client")?;
-
-        client
+        // Create new connection (or reconnect after eviction)
+        let client = redis::Client::open(url).context("Failed to create Redis client")?;
+        let conn = client
             .get_multiplexed_async_connection()
             .await
-            .context("Failed to connect to Redis")
+            .context("Failed to connect to Redis")?;
+
+        // Cache it
+        {
+            let mut clients = self.clients.write().await;
+            clients.database.insert(url.to_string(), conn.clone());
+        }
+
+        Ok(conn)
     }
 
     /// Check if write operations are allowed by the global policy tier.
@@ -395,6 +422,8 @@ impl Clone for AppState {
                 cloud: HashMap::new(),
                 #[cfg(feature = "enterprise")]
                 enterprise: HashMap::new(),
+                #[cfg(feature = "database")]
+                database: HashMap::new(),
             }),
         }
     }
@@ -427,6 +456,8 @@ impl AppState {
                 cloud,
                 #[cfg(feature = "enterprise")]
                 enterprise: HashMap::new(),
+                #[cfg(feature = "database")]
+                database: HashMap::new(),
             }),
         }
     }
@@ -446,6 +477,8 @@ impl AppState {
                 #[cfg(feature = "cloud")]
                 cloud: HashMap::new(),
                 enterprise,
+                #[cfg(feature = "database")]
+                database: HashMap::new(),
             }),
         }
     }
@@ -466,6 +499,8 @@ impl AppState {
             clients: RwLock::new(CachedClients {
                 cloud: cloud_map,
                 enterprise: enterprise_map,
+                #[cfg(feature = "database")]
+                database: HashMap::new(),
             }),
         }
     }

--- a/crates/redisctl-mcp/src/tools/redis/diagnostics.rs
+++ b/crates/redisctl-mcp/src/tools/redis/diagnostics.rs
@@ -106,14 +106,8 @@ pub fn health_check(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, HealthCheckInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<HealthCheckInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 // PING
                 let ping_response: String = redis::cmd("PING")
@@ -248,14 +242,8 @@ pub fn key_summary(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, KeySummaryInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<KeySummaryInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 // TYPE
                 let key_type: String = redis::cmd("TYPE")
@@ -368,14 +356,8 @@ pub fn hotkeys(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, HotkeysInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<HotkeysInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let pattern = input.pattern.as_deref().unwrap_or("*");
                 let sample_size = input.sample_size.unwrap_or(1000).min(MAX_SAMPLE_SIZE);
@@ -511,15 +493,8 @@ pub fn connection_summary(state: Arc<AppState>) -> Tool {
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<ConnectionSummaryInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str())
-                    .tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 // CLIENT LIST
                 let client_list_raw: String = redis::cmd("CLIENT")

--- a/crates/redisctl-mcp/src/tools/redis/keys.rs
+++ b/crates/redisctl-mcp/src/tools/redis/keys.rs
@@ -118,14 +118,8 @@ pub fn keys(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, KeysInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<KeysInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 // Use SCAN to safely iterate keys
                 let mut cursor: u64 = 0;
@@ -191,14 +185,8 @@ pub fn get(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, GetInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let value: Option<String> = redis::cmd("GET")
                     .arg(&input.key)
@@ -239,14 +227,8 @@ pub fn key_type(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, TypeInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<TypeInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let key_type: String = redis::cmd("TYPE")
                     .arg(&input.key)
@@ -281,14 +263,8 @@ pub fn ttl(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, TtlInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<TtlInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let ttl: i64 = redis::cmd("TTL")
                     .arg(&input.key)
@@ -329,14 +305,8 @@ pub fn exists(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, ExistsInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ExistsInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let mut cmd = redis::cmd("EXISTS");
                 for key in &input.keys {
@@ -379,14 +349,8 @@ pub fn memory_usage(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, MemoryUsageInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<MemoryUsageInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let bytes: Option<i64> = redis::cmd("MEMORY")
                     .arg("USAGE")
@@ -437,14 +401,8 @@ pub fn scan(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, ScanInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ScanInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let mut cursor: u64 = 0;
                 let mut all_keys: Vec<String> = Vec::new();
@@ -528,15 +486,8 @@ pub fn object_encoding(state: Arc<AppState>) -> Tool {
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<ObjectEncodingInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str())
-                    .tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let encoding: Option<String> = redis::cmd("OBJECT")
                     .arg("ENCODING")
@@ -581,14 +532,8 @@ pub fn object_freq(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, ObjectFreqInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ObjectFreqInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let freq: i64 = redis::cmd("OBJECT")
                     .arg("FREQ")
@@ -628,15 +573,8 @@ pub fn object_idletime(state: Arc<AppState>) -> Tool {
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<ObjectIdletimeInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str())
-                    .tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let idle: i64 = redis::cmd("OBJECT")
                     .arg("IDLETIME")
@@ -673,14 +611,8 @@ pub fn object_help(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, ObjectHelpInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ObjectHelpInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let result: Vec<String> = redis::cmd("OBJECT")
                     .arg("HELP")
@@ -742,14 +674,8 @@ pub fn set(state: Arc<AppState>) -> Tool {
                     ));
                 }
 
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let mut cmd = redis::cmd("SET");
                 cmd.arg(&input.key).arg(&input.value);
@@ -819,14 +745,8 @@ pub fn del(state: Arc<AppState>) -> Tool {
                     ));
                 }
 
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let mut cmd = redis::cmd("DEL");
                 for key in &input.keys {
@@ -877,14 +797,8 @@ pub fn expire(state: Arc<AppState>) -> Tool {
                     ));
                 }
 
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let result: bool = redis::cmd("EXPIRE")
                     .arg(&input.key)
@@ -938,14 +852,8 @@ pub fn rename(state: Arc<AppState>) -> Tool {
                     ));
                 }
 
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let _: () = redis::cmd("RENAME")
                     .arg(&input.key)
@@ -986,14 +894,8 @@ pub fn mget(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, MgetInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<MgetInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let mut cmd = redis::cmd("MGET");
                 for key in &input.keys {
@@ -1055,14 +957,8 @@ pub fn mset(state: Arc<AppState>) -> Tool {
                     ));
                 }
 
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let mut cmd = redis::cmd("MSET");
                 for entry in &input.entries {
@@ -1110,14 +1006,8 @@ pub fn persist(state: Arc<AppState>) -> Tool {
                     ));
                 }
 
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let result: bool = redis::cmd("PERSIST")
                     .arg(&input.key)
@@ -1170,14 +1060,8 @@ pub fn unlink(state: Arc<AppState>) -> Tool {
                     ));
                 }
 
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let mut cmd = redis::cmd("UNLINK");
                 for key in &input.keys {
@@ -1231,14 +1115,8 @@ pub fn copy(state: Arc<AppState>) -> Tool {
                     ));
                 }
 
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let mut cmd = redis::cmd("COPY");
                 cmd.arg(&input.source).arg(&input.destination);
@@ -1291,14 +1169,8 @@ pub fn dump(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, DumpInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<DumpInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let value: redis::Value = redis::cmd("DUMP")
                     .arg(&input.key)
@@ -1375,14 +1247,8 @@ pub fn restore(state: Arc<AppState>) -> Tool {
                 let bytes =
                     bytes.map_err(|_| McpError::tool("Invalid hex string in serialized_value"))?;
 
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let _: () = redis::cmd("RESTORE")
                     .arg(&input.key)
@@ -1420,14 +1286,8 @@ pub fn randomkey(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, RandomkeyInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<RandomkeyInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let key: Option<String> = redis::cmd("RANDOMKEY")
                     .query_async(&mut conn)
@@ -1464,14 +1324,8 @@ pub fn touch(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, TouchInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<TouchInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let mut cmd = redis::cmd("TOUCH");
                 for key in &input.keys {
@@ -1522,14 +1376,8 @@ pub fn incr(state: Arc<AppState>) -> Tool {
                     ));
                 }
 
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let value: i64 = redis::cmd("INCR")
                     .arg(&input.key)
@@ -1573,14 +1421,8 @@ pub fn decr(state: Arc<AppState>) -> Tool {
                     ));
                 }
 
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let value: i64 = redis::cmd("DECR")
                     .arg(&input.key)
@@ -1626,14 +1468,8 @@ pub fn append(state: Arc<AppState>) -> Tool {
                     ));
                 }
 
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let length: i64 = redis::cmd("APPEND")
                     .arg(&input.key)
@@ -1672,14 +1508,8 @@ pub fn strlen(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, StrlenInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<StrlenInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let length: i64 = redis::cmd("STRLEN")
                     .arg(&input.key)
@@ -1723,14 +1553,8 @@ pub fn getrange(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, GetrangeInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetrangeInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let value: String = redis::cmd("GETRANGE")
                     .arg(&input.key)
@@ -1777,14 +1601,8 @@ pub fn setrange(state: Arc<AppState>) -> Tool {
                     ));
                 }
 
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let length: i64 = redis::cmd("SETRANGE")
                     .arg(&input.key)
@@ -1834,14 +1652,8 @@ pub fn setnx(state: Arc<AppState>) -> Tool {
                     ));
                 }
 
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let was_set: bool = redis::cmd("SETNX")
                     .arg(&input.key)

--- a/crates/redisctl-mcp/src/tools/redis/mod.rs
+++ b/crates/redisctl-mcp/src/tools/redis/mod.rs
@@ -113,6 +113,22 @@ pub(crate) fn resolve_redis_url(
     })
 }
 
+/// Resolve a Redis URL and return a cached multiplexed connection.
+///
+/// This is the main entry point for tool handlers. It resolves the URL from
+/// the input parameters, then returns a pooled connection (creating one if needed).
+pub(crate) async fn get_connection(
+    url: Option<String>,
+    profile: Option<&str>,
+    state: &AppState,
+) -> Result<redis::aio::MultiplexedConnection, ToolError> {
+    let url = resolve_redis_url(url, profile, state)?;
+    state
+        .redis_connection_for_url(&url)
+        .await
+        .map_err(|e| ToolError::new(format!("Connection failed: {}", e)))
+}
+
 /// Helper to format Redis values for display
 pub(crate) fn format_value(v: &redis::Value) -> String {
     match v {

--- a/crates/redisctl-mcp/src/tools/redis/raw.rs
+++ b/crates/redisctl-mcp/src/tools/redis/raw.rs
@@ -131,15 +131,8 @@ pub fn redis_command(state: Arc<AppState>) -> Tool {
                     return CallToolResult::from_serialize(&preview);
                 }
 
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str())
-                    .map_err(|e| McpError::tool(format!("invalid URL: {e}")))?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .map_err(|e| McpError::tool(format!("connection failed: {e}")))?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let mut cmd = redis::cmd(&input.command);
                 for arg in &input.args {

--- a/crates/redisctl-mcp/src/tools/redis/server.rs
+++ b/crates/redisctl-mcp/src/tools/redis/server.rs
@@ -67,14 +67,8 @@ pub fn ping(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, PingInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<PingInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let response: String = redis::cmd("PING")
                     .query_async(&mut conn)
@@ -112,14 +106,8 @@ pub fn info(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, InfoInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<InfoInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let mut cmd = redis::cmd("INFO");
                 if let Some(section) = &input.section {
@@ -156,14 +144,8 @@ pub fn dbsize(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, DbsizeInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<DbsizeInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let size: i64 = redis::cmd("DBSIZE")
                     .query_async(&mut conn)
@@ -198,14 +180,8 @@ pub fn client_list(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, ClientListInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ClientListInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let clients: String = redis::cmd("CLIENT")
                     .arg("LIST")
@@ -242,14 +218,8 @@ pub fn cluster_info(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, ClusterInfoInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ClusterInfoInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let info: String = redis::cmd("CLUSTER")
                     .arg("INFO")
@@ -289,14 +259,8 @@ pub fn slowlog(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, SlowlogInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<SlowlogInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 // SLOWLOG GET returns nested arrays
                 let entries: Vec<Vec<redis::Value>> = redis::cmd("SLOWLOG")
@@ -360,14 +324,8 @@ pub fn config_get(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, ConfigGetInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ConfigGetInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let result: Vec<(String, String)> = redis::cmd("CONFIG")
                     .arg("GET")
@@ -418,14 +376,8 @@ pub fn memory_stats(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, MemoryStatsInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<MemoryStatsInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let result: redis::Value = redis::cmd("MEMORY")
                     .arg("STATS")
@@ -465,15 +417,8 @@ pub fn latency_history(state: Arc<AppState>) -> Tool {
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<LatencyHistoryInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str())
-                    .tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let result: Vec<Vec<redis::Value>> = redis::cmd("LATENCY")
                     .arg("HISTORY")
@@ -530,14 +475,8 @@ pub fn acl_list(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, AclListInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<AclListInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let rules: Vec<String> = redis::cmd("ACL")
                     .arg("LIST")
@@ -578,14 +517,8 @@ pub fn acl_whoami(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, AclWhoamiInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<AclWhoamiInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let username: String = redis::cmd("ACL")
                     .arg("WHOAMI")
@@ -618,14 +551,8 @@ pub fn module_list(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, ModuleListInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ModuleListInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let result: redis::Value = redis::cmd("MODULE")
                     .arg("LIST")
@@ -681,14 +608,8 @@ pub fn config_set(state: Arc<AppState>) -> Tool {
                     ));
                 }
 
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let _: () = redis::cmd("CONFIG")
                     .arg("SET")
@@ -738,14 +659,8 @@ pub fn flushdb(state: Arc<AppState>) -> Tool {
                     ));
                 }
 
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let mut cmd = redis::cmd("FLUSHDB");
                 if input.async_flush {

--- a/crates/redisctl-mcp/src/tools/redis/structures.rs
+++ b/crates/redisctl-mcp/src/tools/redis/structures.rs
@@ -123,14 +123,8 @@ pub fn hgetall(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, HgetallInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<HgetallInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let result: Vec<(String, String)> = redis::cmd("HGETALL")
                     .arg(&input.key)
@@ -193,14 +187,8 @@ pub fn lrange(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, LrangeInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<LrangeInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let result: Vec<String> = redis::cmd("LRANGE")
                     .arg(&input.key)
@@ -256,14 +244,8 @@ pub fn smembers(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, SmembersInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<SmembersInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let result: Vec<String> = redis::cmd("SMEMBERS")
                     .arg(&input.key)
@@ -319,14 +301,8 @@ pub fn zrange(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, ZrangeInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ZrangeInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 if input.withscores {
                     let result: Vec<(String, f64)> = redis::cmd("ZRANGE")
@@ -414,14 +390,8 @@ pub fn xinfo_stream(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, XinfoStreamInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<XinfoStreamInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let result: redis::Value = redis::cmd("XINFO")
                     .arg("STREAM")
@@ -478,14 +448,8 @@ pub fn xrange(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, XrangeInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<XrangeInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let mut cmd = redis::cmd("XRANGE");
                 cmd.arg(&input.key).arg(&input.start).arg(&input.end);
@@ -543,14 +507,8 @@ pub fn xlen(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, XlenInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<XlenInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let len: i64 = redis::cmd("XLEN")
                     .arg(&input.key)
@@ -590,15 +548,8 @@ pub fn pubsub_channels(state: Arc<AppState>) -> Tool {
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<PubsubChannelsInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str())
-                    .tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let mut cmd = redis::cmd("PUBSUB");
                 cmd.arg("CHANNELS");
@@ -648,14 +599,8 @@ pub fn pubsub_numsub(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, PubsubNumsubInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<PubsubNumsubInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let mut cmd = redis::cmd("PUBSUB");
                 cmd.arg("NUMSUB");
@@ -722,14 +667,8 @@ pub fn hset(state: Arc<AppState>) -> Tool {
                     ));
                 }
 
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let mut cmd = redis::cmd("HSET");
                 cmd.arg(&input.key);
@@ -782,14 +721,8 @@ pub fn hdel(state: Arc<AppState>) -> Tool {
                     ));
                 }
 
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let mut cmd = redis::cmd("HDEL");
                 cmd.arg(&input.key);
@@ -842,14 +775,8 @@ pub fn lpush(state: Arc<AppState>) -> Tool {
                     ));
                 }
 
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let mut cmd = redis::cmd("LPUSH");
                 cmd.arg(&input.key);
@@ -902,14 +829,8 @@ pub fn rpush(state: Arc<AppState>) -> Tool {
                     ));
                 }
 
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let mut cmd = redis::cmd("RPUSH");
                 cmd.arg(&input.key);
@@ -963,14 +884,8 @@ pub fn lpop(state: Arc<AppState>) -> Tool {
                     ));
                 }
 
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let mut cmd = redis::cmd("LPOP");
                 cmd.arg(&input.key);
@@ -1023,14 +938,8 @@ pub fn rpop(state: Arc<AppState>) -> Tool {
                     ));
                 }
 
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let mut cmd = redis::cmd("RPOP");
                 cmd.arg(&input.key);
@@ -1082,14 +991,8 @@ pub fn sadd(state: Arc<AppState>) -> Tool {
                     ));
                 }
 
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let mut cmd = redis::cmd("SADD");
                 cmd.arg(&input.key);
@@ -1142,14 +1045,8 @@ pub fn srem(state: Arc<AppState>) -> Tool {
                     ));
                 }
 
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let mut cmd = redis::cmd("SREM");
                 cmd.arg(&input.key);
@@ -1229,14 +1126,8 @@ pub fn zadd(state: Arc<AppState>) -> Tool {
                     ));
                 }
 
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let mut cmd = redis::cmd("ZADD");
                 cmd.arg(&input.key);
@@ -1305,14 +1196,8 @@ pub fn zrem(state: Arc<AppState>) -> Tool {
                     ));
                 }
 
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let mut cmd = redis::cmd("ZREM");
                 cmd.arg(&input.key);
@@ -1382,14 +1267,8 @@ pub fn xadd(state: Arc<AppState>) -> Tool {
                     ));
                 }
 
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let mut cmd = redis::cmd("XADD");
                 cmd.arg(&input.key);
@@ -1470,14 +1349,8 @@ pub fn xtrim(state: Arc<AppState>) -> Tool {
                     ));
                 }
 
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let mut cmd = redis::cmd("XTRIM");
                 cmd.arg(&input.key);
@@ -1527,14 +1400,8 @@ pub fn hget(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, HgetInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<HgetInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let value: Option<String> = redis::cmd("HGET")
                     .arg(&input.key)
@@ -1578,14 +1445,8 @@ pub fn hmget(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, HmgetInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<HmgetInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let mut cmd = redis::cmd("HMGET");
                 cmd.arg(&input.key);
@@ -1633,14 +1494,8 @@ pub fn hlen(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, HlenInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<HlenInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let count: i64 = redis::cmd("HLEN")
                     .arg(&input.key)
@@ -1680,14 +1535,8 @@ pub fn hexists(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, HexistsInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<HexistsInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let exists: bool = redis::cmd("HEXISTS")
                     .arg(&input.key)
@@ -1728,14 +1577,8 @@ pub fn hkeys(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, HkeysInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<HkeysInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let fields: Vec<String> = redis::cmd("HKEYS")
                     .arg(&input.key)
@@ -1782,14 +1625,8 @@ pub fn hvals(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, HvalsInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<HvalsInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let values: Vec<String> = redis::cmd("HVALS")
                     .arg(&input.key)
@@ -1846,14 +1683,8 @@ pub fn hincrby(state: Arc<AppState>) -> Tool {
                     ));
                 }
 
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let value: i64 = redis::cmd("HINCRBY")
                     .arg(&input.key)
@@ -1895,14 +1726,8 @@ pub fn scard(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, ScardInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ScardInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let count: i64 = redis::cmd("SCARD")
                     .arg(&input.key)
@@ -1942,14 +1767,8 @@ pub fn sismember(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, SismemberInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<SismemberInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let is_member: bool = redis::cmd("SISMEMBER")
                     .arg(&input.key)
@@ -1990,14 +1809,8 @@ pub fn sunion(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, SunionInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<SunionInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let mut cmd = redis::cmd("SUNION");
                 for key in &input.keys {
@@ -2044,14 +1857,8 @@ pub fn sinter(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, SinterInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<SinterInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let mut cmd = redis::cmd("SINTER");
                 for key in &input.keys {
@@ -2098,14 +1905,8 @@ pub fn sdiff(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, SdiffInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<SdiffInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let mut cmd = redis::cmd("SDIFF");
                 for key in &input.keys {
@@ -2154,14 +1955,8 @@ pub fn zcard(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, ZcardInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ZcardInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let count: i64 = redis::cmd("ZCARD")
                     .arg(&input.key)
@@ -2201,14 +1996,8 @@ pub fn zscore(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, ZscoreInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ZscoreInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let score: Option<f64> = redis::cmd("ZSCORE")
                     .arg(&input.key)
@@ -2257,14 +2046,8 @@ pub fn zrank(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, ZrankInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ZrankInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let rank: Option<i64> = redis::cmd("ZRANK")
                     .arg(&input.key)
@@ -2313,14 +2096,8 @@ pub fn zcount(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, ZcountInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ZcountInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let count: i64 = redis::cmd("ZCOUNT")
                     .arg(&input.key)
@@ -2374,15 +2151,8 @@ pub fn zrangebyscore(state: Arc<AppState>) -> Tool {
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<ZrangebyscoreInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str())
-                    .tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let mut cmd = redis::cmd("ZRANGEBYSCORE");
                 cmd.arg(&input.key).arg(&input.min).arg(&input.max);
@@ -2472,14 +2242,8 @@ pub fn llen(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, LlenInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<LlenInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let length: i64 = redis::cmd("LLEN")
                     .arg(&input.key)
@@ -2519,14 +2283,8 @@ pub fn lindex(state: Arc<AppState>) -> Tool {
         .extractor_handler_typed::<_, _, _, LindexInput>(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<LindexInput>| async move {
-                let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
-
-                let client = redis::Client::open(url.as_str()).tool_context("Invalid URL")?;
-
-                let mut conn = client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .tool_context("Connection failed")?;
+                let mut conn =
+                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
 
                 let value: Option<String> = redis::cmd("LINDEX")
                     .arg(&input.key)


### PR DESCRIPTION
## Summary

- Add a connection cache to `CachedClients` keyed by resolved URL, returning shared `MultiplexedConnection` instances
- Add `redis_connection_for_url()` on `AppState` with PING health check and automatic reconnect on stale connections
- Add `get_connection()` helper in `tools/redis/mod.rs` combining URL resolution + cached connection retrieval
- Replace per-handler `Client::open` + `get_multiplexed_async_connection` boilerplate across all 55 database tool handlers (-496 lines net)

Connections are keyed by URL (not profile name) so different profiles pointing to the same database share a connection, and raw URL callers benefit from caching too. Users with multiple database profiles get one cached connection per unique URL.

Follows the same `RwLock<HashMap>` pattern already used for Cloud and Enterprise API client caching.

Closes #801

## Test plan

- [x] `cargo clippy -p redisctl-mcp --all-features -- -D warnings` (clean)
- [x] `cargo check -p redisctl-mcp --no-default-features` (clean)
- [x] `cargo check -p redisctl-mcp --features database` (clean)
- [x] `cargo check -p redisctl-mcp --features cloud` (clean)
- [x] `cargo check -p redisctl-mcp --features enterprise` (clean)
- [x] `cargo test --lib -p redisctl-mcp --all-features` (95 passed)
- [x] `cargo fmt --all -- --check` (clean)
- [ ] Integration tests: `cargo test -p redisctl-mcp --test redis_tools --all-features -- --ignored` (requires Docker)