### PR TITLE
refactor(mcp): replace extractor_handler_typed with extractor_handler

### DIFF
--- a/crates/redisctl-mcp/src/tools/cloud/account.rs
+++ b/crates/redisctl-mcp/src/tools/cloud/account.rs
@@ -38,7 +38,7 @@ pub fn get_account(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_account")
         .description("Get current account information.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetAccountInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetAccountInput>| async move {
                 let client = state
@@ -77,7 +77,7 @@ pub fn get_system_logs(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_system_logs")
         .description("Get system audit logs.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetSystemLogsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetSystemLogsInput>| async move {
                 let client = state
@@ -116,7 +116,7 @@ pub fn get_session_logs(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_session_logs")
         .description("Get session activity logs.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetSessionLogsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetSessionLogsInput>| async move {
@@ -153,7 +153,7 @@ pub fn get_regions(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_regions")
         .description("Get supported cloud regions. Optionally filter by provider.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetRegionsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetRegionsInput>| async move {
                 let client = state
@@ -186,7 +186,7 @@ pub fn get_modules(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_modules")
         .description("Get supported database modules.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetModulesInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetModulesInput>| async move {
                 let client = state
@@ -223,7 +223,7 @@ pub fn list_account_users(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_account_users")
         .description("List all account users (team members with console access).")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ListAccountUsersInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<ListAccountUsersInput>| async move {
@@ -259,7 +259,7 @@ pub fn get_account_user(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_account_user")
         .description("Get an account user by ID.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetAccountUserInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetAccountUserInput>| async move {
@@ -300,7 +300,7 @@ pub fn update_account_user(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_account_user")
         .description("Update an account user's name or role.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, UpdateAccountUserInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<UpdateAccountUserInput>| async move {
@@ -348,7 +348,7 @@ pub fn delete_account_user(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_account_user")
         .description("DANGEROUS: Delete an account user. The user will lose all access.")
         .destructive()
-        .extractor_handler_typed::<_, _, _, DeleteAccountUserInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<DeleteAccountUserInput>| async move {
@@ -392,7 +392,7 @@ pub fn list_acl_users(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_acl_users")
         .description("List all ACL users.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ListAclUsersInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ListAclUsersInput>| async move {
                 let client = state
@@ -427,7 +427,7 @@ pub fn get_acl_user(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_acl_user")
         .description("Get an ACL user by ID.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetAclUserInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetAclUserInput>| async move {
                 let client = state
@@ -460,7 +460,7 @@ pub fn list_acl_roles(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_acl_roles")
         .description("List all ACL roles.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ListAclRolesInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ListAclRolesInput>| async move {
                 let client = state
@@ -493,7 +493,7 @@ pub fn list_redis_rules(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_redis_rules")
         .description("List all Redis ACL rules.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ListRedisRulesInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<ListRedisRulesInput>| async move {
@@ -537,7 +537,7 @@ pub fn create_acl_user(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_acl_user")
         .description("Create a new ACL user with a database access role.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, CreateAclUserInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<CreateAclUserInput>| async move {
                 if !state.is_write_allowed() {
@@ -590,7 +590,7 @@ pub fn update_acl_user(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_acl_user")
         .description("Update an ACL user's role or password.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, UpdateAclUserInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<UpdateAclUserInput>| async move {
                 if !state.is_write_allowed() {
@@ -637,7 +637,7 @@ pub fn delete_acl_user(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_acl_user")
         .description("DANGEROUS: Delete an ACL user. Active sessions will be terminated.")
         .destructive()
-        .extractor_handler_typed::<_, _, _, DeleteAclUserInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<DeleteAclUserInput>| async move {
                 if !state.is_destructive_allowed() {
@@ -701,7 +701,7 @@ pub fn create_acl_role(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_acl_role")
         .description("Create a new ACL role with Redis rules and database associations.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, CreateAclRoleInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<CreateAclRoleInput>| async move {
                 if !state.is_write_allowed() {
@@ -768,7 +768,7 @@ pub fn update_acl_role(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_acl_role")
         .description("Update an ACL role's name or Redis rule assignments.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, UpdateAclRoleInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<UpdateAclRoleInput>| async move {
                 if !state.is_write_allowed() {
@@ -831,7 +831,7 @@ pub fn delete_acl_role(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_acl_role")
         .description("DANGEROUS: Delete an ACL role. Assigned users will lose their permissions.")
         .destructive()
-        .extractor_handler_typed::<_, _, _, DeleteAclRoleInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<DeleteAclRoleInput>| async move {
                 if !state.is_destructive_allowed() {
@@ -874,7 +874,7 @@ pub fn create_redis_rule(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_redis_rule")
         .description("Create a new Redis ACL rule defining command permissions.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, CreateRedisRuleInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<CreateRedisRuleInput>| async move {
@@ -925,7 +925,7 @@ pub fn update_redis_rule(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_redis_rule")
         .description("Update a Redis ACL rule's name or pattern.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, UpdateRedisRuleInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<UpdateRedisRuleInput>| async move {
@@ -973,7 +973,7 @@ pub fn delete_redis_rule(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_redis_rule")
         .description("DANGEROUS: Delete a Redis ACL rule. Roles using it will lose those permissions.")
         .destructive()
-        .extractor_handler_typed::<_, _, _, DeleteRedisRuleInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<DeleteRedisRuleInput>| async move {
@@ -1036,7 +1036,7 @@ pub fn generate_cost_report(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("generate_cost_report")
         .description("Generate a FOCUS cost report for the specified date range.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, GenerateCostReportInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GenerateCostReportInput>| async move {
@@ -1098,7 +1098,7 @@ pub fn download_cost_report(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("download_cost_report")
         .description("Download a previously generated cost report by ID.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, DownloadCostReportInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<DownloadCostReportInput>| async move {
@@ -1139,7 +1139,7 @@ pub fn list_payment_methods(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_payment_methods")
         .description("List all payment methods.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ListPaymentMethodsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<ListPaymentMethodsInput>| async move {
@@ -1177,7 +1177,7 @@ pub fn list_tasks(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_tasks")
         .description("List all async tasks.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ListTasksInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ListTasksInput>| async move {
                 let client = state
@@ -1212,7 +1212,7 @@ pub fn get_task(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_task")
         .description("Get task status by ID.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetTaskInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetTaskInput>| async move {
                 let client = state
@@ -1261,7 +1261,7 @@ pub fn wait_for_cloud_task(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("wait_for_cloud_task")
         .description("Poll an async task until it reaches a terminal state. Useful for multi-step workflows.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, WaitForCloudTaskInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<WaitForCloudTaskInput>| async move {
@@ -1333,7 +1333,7 @@ pub fn list_cloud_accounts(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_cloud_accounts")
         .description("List all cloud provider accounts (BYOC).")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ListCloudAccountsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<ListCloudAccountsInput>| async move {
@@ -1370,7 +1370,7 @@ pub fn get_cloud_account(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_cloud_account")
         .description("Get a cloud provider account (BYOC) by ID.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetCloudAccountInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetCloudAccountInput>| async move {
@@ -1419,7 +1419,7 @@ pub fn create_cloud_account(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_cloud_account")
         .description("Create a new cloud provider account (BYOC).")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, CreateCloudAccountInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<CreateCloudAccountInput>| async move {
@@ -1485,7 +1485,7 @@ pub fn update_cloud_account(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_cloud_account")
         .description("Update a cloud provider account (BYOC) configuration.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, UpdateCloudAccountInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<UpdateCloudAccountInput>| async move {
@@ -1537,7 +1537,7 @@ pub fn delete_cloud_account(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_cloud_account")
         .description("DANGEROUS: Delete a cloud provider account (BYOC).")
         .destructive()
-        .extractor_handler_typed::<_, _, _, DeleteCloudAccountInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<DeleteCloudAccountInput>| async move {

--- a/crates/redisctl-mcp/src/tools/cloud/fixed.rs
+++ b/crates/redisctl-mcp/src/tools/cloud/fixed.rs
@@ -34,7 +34,7 @@ pub fn list_fixed_subscriptions(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_fixed_subscriptions")
         .description("List all Fixed/Essentials subscriptions.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ListFixedSubscriptionsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<ListFixedSubscriptionsInput>| async move {
@@ -70,7 +70,7 @@ pub fn get_fixed_subscription(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_fixed_subscription")
         .description("Get subscription details by ID.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetFixedSubscriptionInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetFixedSubscriptionInput>| async move {
@@ -114,7 +114,7 @@ pub fn create_fixed_subscription(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_fixed_subscription")
         .description("Create a new Fixed/Essentials subscription.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, CreateFixedSubscriptionInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<CreateFixedSubscriptionInput>| async move {
@@ -176,7 +176,7 @@ pub fn update_fixed_subscription(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_fixed_subscription")
         .description("Update a Fixed/Essentials subscription.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, UpdateFixedSubscriptionInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<UpdateFixedSubscriptionInput>| async move {
@@ -230,7 +230,7 @@ pub fn delete_fixed_subscription(state: Arc<AppState>) -> Tool {
              All databases must be deleted first.",
         )
         .destructive()
-        .extractor_handler_typed::<_, _, _, DeleteFixedSubscriptionInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<DeleteFixedSubscriptionInput>| async move {
@@ -276,7 +276,7 @@ pub fn list_fixed_plans(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_fixed_plans")
         .description("List available Fixed/Essentials plans.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ListFixedPlansInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<ListFixedPlansInput>| async move {
@@ -312,7 +312,7 @@ pub fn get_fixed_plans_by_subscription(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_fixed_plans_by_subscription")
         .description("Get compatible plans for a subscription.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetFixedPlansBySubscriptionInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetFixedPlansBySubscriptionInput>| async move {
@@ -348,7 +348,7 @@ pub fn get_fixed_plan(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_fixed_plan")
         .description("Get plan details by ID.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetFixedPlanInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetFixedPlanInput>| async move {
                 let client = state
@@ -383,7 +383,7 @@ pub fn get_fixed_redis_versions(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_fixed_redis_versions")
         .description("Get available Redis versions for a subscription.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetFixedRedisVersionsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetFixedRedisVersionsInput>| async move {
@@ -429,7 +429,7 @@ pub fn list_fixed_databases(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_fixed_databases")
         .description("List databases in a subscription.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ListFixedDatabasesInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<ListFixedDatabasesInput>| async move {
@@ -467,7 +467,7 @@ pub fn get_fixed_database(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_fixed_database")
         .description("Get database details by ID.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetFixedDatabaseInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetFixedDatabaseInput>| async move {
@@ -538,7 +538,7 @@ pub fn create_fixed_database(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_fixed_database")
         .description("Create a database in a Fixed/Essentials subscription.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, CreateFixedDatabaseInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<CreateFixedDatabaseInput>| async move {
@@ -635,7 +635,7 @@ pub fn update_fixed_database(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_fixed_database")
         .description("Update a database in a Fixed/Essentials subscription.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, UpdateFixedDatabaseInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<UpdateFixedDatabaseInput>| async move {
@@ -707,7 +707,7 @@ pub fn delete_fixed_database(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_fixed_database")
         .description("DANGEROUS: Delete a Fixed/Essentials database and all its data.")
         .destructive()
-        .extractor_handler_typed::<_, _, _, DeleteFixedDatabaseInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<DeleteFixedDatabaseInput>| async move {
@@ -755,7 +755,7 @@ pub fn get_fixed_database_backup_status(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_fixed_database_backup_status")
         .description("Get latest backup status for a database.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetFixedDatabaseBackupStatusInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetFixedDatabaseBackupStatusInput>| async move {
@@ -796,7 +796,7 @@ pub fn backup_fixed_database(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("backup_fixed_database")
         .description("Trigger a manual backup of a database.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, BackupFixedDatabaseInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<BackupFixedDatabaseInput>| async move {
@@ -847,7 +847,7 @@ pub fn get_fixed_database_import_status(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_fixed_database_import_status")
         .description("Get latest import status for a database.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetFixedDatabaseImportStatusInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetFixedDatabaseImportStatusInput>| async move {
@@ -892,7 +892,7 @@ pub fn import_fixed_database(state: Arc<AppState>) -> Tool {
              WARNING: This will overwrite existing data.",
         )
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, ImportFixedDatabaseInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<ImportFixedDatabaseInput>| async move {
@@ -944,7 +944,7 @@ pub fn get_fixed_database_slow_log(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_fixed_database_slow_log")
         .description("Get slow log entries for a database.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetFixedDatabaseSlowLogInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetFixedDatabaseSlowLogInput>| async move {
@@ -986,7 +986,7 @@ pub fn get_fixed_database_tags(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_fixed_database_tags")
         .description("Get tags for a database.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetFixedDatabaseTagsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetFixedDatabaseTagsInput>| async move {
@@ -1028,7 +1028,7 @@ pub fn create_fixed_database_tag(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_fixed_database_tag")
         .description("Create a tag on a database.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, CreateFixedDatabaseTagInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<CreateFixedDatabaseTagInput>| async move {
@@ -1084,7 +1084,7 @@ pub fn update_fixed_database_tag(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_fixed_database_tag")
         .description("Update a tag value on a database.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, UpdateFixedDatabaseTagInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<UpdateFixedDatabaseTagInput>| async move {
@@ -1143,7 +1143,7 @@ pub fn delete_fixed_database_tag(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_fixed_database_tag")
         .description("DANGEROUS: Delete a tag from a database.")
         .destructive()
-        .extractor_handler_typed::<_, _, _, DeleteFixedDatabaseTagInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<DeleteFixedDatabaseTagInput>| async move {
@@ -1198,7 +1198,7 @@ pub fn update_fixed_database_tags(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_fixed_database_tags")
         .description("Update all tags on a database (replaces existing tags).")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, UpdateFixedDatabaseTagsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<UpdateFixedDatabaseTagsInput>| async move {
@@ -1263,7 +1263,7 @@ pub fn get_fixed_database_upgrade_versions(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_fixed_database_upgrade_versions")
         .description("Get available upgrade target Redis versions for a database.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetFixedDatabaseUpgradeVersionsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetFixedDatabaseUpgradeVersionsInput>| async move {
@@ -1301,7 +1301,7 @@ pub fn get_fixed_database_upgrade_status(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_fixed_database_upgrade_status")
         .description("Get latest Redis version upgrade status for a database.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetFixedDatabaseUpgradeStatusInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetFixedDatabaseUpgradeStatusInput>| async move {
@@ -1341,7 +1341,7 @@ pub fn upgrade_fixed_database_redis_version(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("upgrade_fixed_database_redis_version")
         .description("Upgrade the Redis version of a database.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, UpgradeFixedDatabaseRedisVersionInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<UpgradeFixedDatabaseRedisVersionInput>| async move {

--- a/crates/redisctl-mcp/src/tools/cloud/networking.rs
+++ b/crates/redisctl-mcp/src/tools/cloud/networking.rs
@@ -39,7 +39,7 @@ pub fn get_vpc_peering(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_vpc_peering")
         .description("Get VPC peering details.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetVpcPeeringInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetVpcPeeringInput>| async move {
                 let client = state
@@ -98,7 +98,7 @@ pub fn create_vpc_peering(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_vpc_peering")
         .description("Create a VPC peering connection.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, CreateVpcPeeringInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<CreateVpcPeeringInput>| async move {
@@ -178,7 +178,7 @@ pub fn update_vpc_peering(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_vpc_peering")
         .description("Update a VPC peering connection.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, UpdateVpcPeeringInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<UpdateVpcPeeringInput>| async move {
@@ -234,7 +234,7 @@ pub fn delete_vpc_peering(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_vpc_peering")
         .description("DANGEROUS: Delete a VPC peering connection. Causes connectivity loss.")
         .destructive()
-        .extractor_handler_typed::<_, _, _, DeleteVpcPeeringInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<DeleteVpcPeeringInput>| async move {
@@ -280,7 +280,7 @@ pub fn get_aa_vpc_peering(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_aa_vpc_peering")
         .description("Get Active-Active VPC peering details.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetAaVpcPeeringInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetAaVpcPeeringInput>| async move {
@@ -340,7 +340,7 @@ pub fn create_aa_vpc_peering(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_aa_vpc_peering")
         .description("Create an Active-Active VPC peering connection.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, CreateAaVpcPeeringInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<CreateAaVpcPeeringInput>| async move {
@@ -420,7 +420,7 @@ pub fn update_aa_vpc_peering(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_aa_vpc_peering")
         .description("Update an Active-Active VPC peering connection.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, UpdateAaVpcPeeringInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<UpdateAaVpcPeeringInput>| async move {
@@ -476,7 +476,7 @@ pub fn delete_aa_vpc_peering(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_aa_vpc_peering")
         .description("DANGEROUS: Delete an Active-Active VPC peering connection. Causes connectivity loss.")
         .destructive()
-        .extractor_handler_typed::<_, _, _, DeleteAaVpcPeeringInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<DeleteAaVpcPeeringInput>| async move {
@@ -522,7 +522,7 @@ pub fn get_tgw_attachments(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_tgw_attachments")
         .description("Get Transit Gateway attachments.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetTgwAttachmentsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetTgwAttachmentsInput>| async move {
@@ -558,7 +558,7 @@ pub fn get_tgw_invitations(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_tgw_invitations")
         .description("Get Transit Gateway shared invitations.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetTgwInvitationsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetTgwInvitationsInput>| async move {
@@ -596,7 +596,7 @@ pub fn accept_tgw_invitation(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("accept_tgw_invitation")
         .description("Accept a Transit Gateway resource share invitation.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, AcceptTgwInvitationInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<AcceptTgwInvitationInput>| async move {
@@ -640,7 +640,7 @@ pub fn reject_tgw_invitation(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("reject_tgw_invitation")
         .description("Reject a Transit Gateway resource share invitation.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, RejectTgwInvitationInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<RejectTgwInvitationInput>| async move {
@@ -691,7 +691,7 @@ pub fn create_tgw_attachment(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_tgw_attachment")
         .description("Create a Transit Gateway attachment.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, CreateTgwAttachmentInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<CreateTgwAttachmentInput>| async move {
@@ -750,7 +750,7 @@ pub fn update_tgw_attachment_cidrs(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_tgw_attachment_cidrs")
         .description("Update CIDRs for a Transit Gateway attachment.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, UpdateTgwAttachmentCidrsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<UpdateTgwAttachmentCidrsInput>| async move {
@@ -800,7 +800,7 @@ pub fn delete_tgw_attachment(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_tgw_attachment")
         .description("DANGEROUS: Delete a Transit Gateway attachment. Causes connectivity loss.")
         .destructive()
-        .extractor_handler_typed::<_, _, _, DeleteTgwAttachmentInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<DeleteTgwAttachmentInput>| async move {
@@ -846,7 +846,7 @@ pub fn get_aa_tgw_attachments(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_aa_tgw_attachments")
         .description("Get Active-Active Transit Gateway attachments.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetAaTgwAttachmentsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetAaTgwAttachmentsInput>| async move {
@@ -882,7 +882,7 @@ pub fn get_aa_tgw_invitations(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_aa_tgw_invitations")
         .description("Get Active-Active Transit Gateway shared invitations.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetAaTgwInvitationsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetAaTgwInvitationsInput>| async move {
@@ -922,7 +922,7 @@ pub fn accept_aa_tgw_invitation(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("accept_aa_tgw_invitation")
         .description("Accept an Active-Active Transit Gateway resource share invitation.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, AcceptAaTgwInvitationInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<AcceptAaTgwInvitationInput>| async move {
@@ -972,7 +972,7 @@ pub fn reject_aa_tgw_invitation(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("reject_aa_tgw_invitation")
         .description("Reject an Active-Active Transit Gateway resource share invitation.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, RejectAaTgwInvitationInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<RejectAaTgwInvitationInput>| async move {
@@ -1029,7 +1029,7 @@ pub fn create_aa_tgw_attachment(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_aa_tgw_attachment")
         .description("Create an Active-Active Transit Gateway attachment.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, CreateAaTgwAttachmentInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<CreateAaTgwAttachmentInput>| async move {
@@ -1094,7 +1094,7 @@ pub fn update_aa_tgw_attachment_cidrs(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_aa_tgw_attachment_cidrs")
         .description("Update CIDRs for an Active-Active Transit Gateway attachment.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, UpdateAaTgwAttachmentCidrsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<UpdateAaTgwAttachmentCidrsInput>| async move {
@@ -1151,7 +1151,7 @@ pub fn delete_aa_tgw_attachment(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_aa_tgw_attachment")
         .description("DANGEROUS: Delete an Active-Active Transit Gateway attachment. Causes connectivity loss.")
         .destructive()
-        .extractor_handler_typed::<_, _, _, DeleteAaTgwAttachmentInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<DeleteAaTgwAttachmentInput>| async move {
@@ -1201,7 +1201,7 @@ pub fn get_psc_service(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_psc_service")
         .description("Get Private Service Connect (PSC) service.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetPscServiceInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetPscServiceInput>| async move {
                 let client = state
@@ -1236,7 +1236,7 @@ pub fn create_psc_service(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_psc_service")
         .description("Create a Private Service Connect (PSC) service.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, CreatePscServiceInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<CreatePscServiceInput>| async move {
@@ -1278,7 +1278,7 @@ pub fn delete_psc_service(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_psc_service")
         .description("DANGEROUS: Delete a PSC service. Disconnects all endpoints.")
         .destructive()
-        .extractor_handler_typed::<_, _, _, DeletePscServiceInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<DeletePscServiceInput>| async move {
@@ -1320,7 +1320,7 @@ pub fn get_psc_endpoints(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_psc_endpoints")
         .description("Get Private Service Connect (PSC) endpoints.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetPscEndpointsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetPscEndpointsInput>| async move {
@@ -1372,7 +1372,7 @@ pub fn create_psc_endpoint(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_psc_endpoint")
         .description("Create a Private Service Connect (PSC) endpoint.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, CreatePscEndpointInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<CreatePscEndpointInput>| async move {
@@ -1440,7 +1440,7 @@ pub fn update_psc_endpoint(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_psc_endpoint")
         .description("Update a Private Service Connect (PSC) endpoint.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, UpdatePscEndpointInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<UpdatePscEndpointInput>| async move {
@@ -1494,7 +1494,7 @@ pub fn delete_psc_endpoint(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_psc_endpoint")
         .description("DANGEROUS: Delete a PSC endpoint. Causes connectivity loss.")
         .destructive()
-        .extractor_handler_typed::<_, _, _, DeletePscEndpointInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<DeletePscEndpointInput>| async move {
@@ -1538,7 +1538,7 @@ pub fn get_psc_creation_script(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_psc_creation_script")
         .description("Get the creation script for a PSC endpoint.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetPscCreationScriptInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetPscCreationScriptInput>| async move {
@@ -1576,7 +1576,7 @@ pub fn get_psc_deletion_script(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_psc_deletion_script")
         .description("Get the deletion script for a PSC endpoint.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetPscDeletionScriptInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetPscDeletionScriptInput>| async move {
@@ -1616,7 +1616,7 @@ pub fn get_aa_psc_service(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_aa_psc_service")
         .description("Get Active-Active PSC service.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetAaPscServiceInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetAaPscServiceInput>| async move {
@@ -1652,7 +1652,7 @@ pub fn create_aa_psc_service(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_aa_psc_service")
         .description("Create an Active-Active PSC service.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, CreateAaPscServiceInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<CreateAaPscServiceInput>| async move {
@@ -1694,7 +1694,7 @@ pub fn delete_aa_psc_service(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_aa_psc_service")
         .description("DANGEROUS: Delete an Active-Active PSC service. Disconnects all endpoints.")
         .destructive()
-        .extractor_handler_typed::<_, _, _, DeleteAaPscServiceInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<DeleteAaPscServiceInput>| async move {
@@ -1736,7 +1736,7 @@ pub fn get_aa_psc_endpoints(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_aa_psc_endpoints")
         .description("Get Active-Active PSC endpoints.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetAaPscEndpointsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetAaPscEndpointsInput>| async move {
@@ -1788,7 +1788,7 @@ pub fn create_aa_psc_endpoint(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_aa_psc_endpoint")
         .description("Create an Active-Active PSC endpoint.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, CreateAaPscEndpointInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<CreateAaPscEndpointInput>| async move {
@@ -1858,7 +1858,7 @@ pub fn update_aa_psc_endpoint(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_aa_psc_endpoint")
         .description("Update an Active-Active PSC endpoint.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, UpdateAaPscEndpointInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<UpdateAaPscEndpointInput>| async move {
@@ -1919,7 +1919,7 @@ pub fn delete_aa_psc_endpoint(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_aa_psc_endpoint")
         .description("DANGEROUS: Delete an Active-Active PSC endpoint. Causes connectivity loss.")
         .destructive()
-        .extractor_handler_typed::<_, _, _, DeleteAaPscEndpointInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<DeleteAaPscEndpointInput>| async move {
@@ -1971,7 +1971,7 @@ pub fn get_aa_psc_creation_script(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_aa_psc_creation_script")
         .description("Get the creation script for an Active-Active PSC endpoint.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetAaPscCreationScriptInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetAaPscCreationScriptInput>| async move {
@@ -2018,7 +2018,7 @@ pub fn get_aa_psc_deletion_script(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_aa_psc_deletion_script")
         .description("Get the deletion script for an Active-Active PSC endpoint.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetAaPscDeletionScriptInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetAaPscDeletionScriptInput>| async move {
@@ -2063,7 +2063,7 @@ pub fn get_private_link(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_private_link")
         .description("Get AWS PrivateLink configuration.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetPrivateLinkInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetPrivateLinkInput>| async move {
@@ -2123,7 +2123,7 @@ pub fn create_private_link(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_private_link")
         .description("Create an AWS PrivateLink configuration.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, CreatePrivateLinkInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<CreatePrivateLinkInput>| async move {
@@ -2174,7 +2174,7 @@ pub fn delete_private_link(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_private_link")
         .description("DANGEROUS: Delete an AWS PrivateLink configuration. Causes connectivity loss.")
         .destructive()
-        .extractor_handler_typed::<_, _, _, DeletePrivateLinkInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<DeletePrivateLinkInput>| async move {
@@ -2224,7 +2224,7 @@ pub fn add_private_link_principals(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("add_private_link_principals")
         .description("Add AWS principals to a PrivateLink access list.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, AddPrivateLinkPrincipalsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<AddPrivateLinkPrincipalsInput>| async move {
@@ -2285,7 +2285,7 @@ pub fn remove_private_link_principals(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("remove_private_link_principals")
         .description("Remove AWS principals from a PrivateLink access list.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, RemovePrivateLinkPrincipalsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<RemovePrivateLinkPrincipalsInput>| async move {
@@ -2339,7 +2339,7 @@ pub fn get_private_link_endpoint_script(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_private_link_endpoint_script")
         .description("Get the endpoint creation script for an AWS PrivateLink.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetPrivateLinkEndpointScriptInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetPrivateLinkEndpointScriptInput>| async move {
@@ -2381,7 +2381,7 @@ pub fn get_aa_private_link(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_aa_private_link")
         .description("Get Active-Active AWS PrivateLink configuration.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetAaPrivateLinkInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetAaPrivateLinkInput>| async move {
@@ -2428,7 +2428,7 @@ pub fn create_aa_private_link(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_aa_private_link")
         .description("Create an Active-Active AWS PrivateLink configuration.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, CreateAaPrivateLinkInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<CreateAaPrivateLinkInput>| async move {
@@ -2489,7 +2489,7 @@ pub fn add_aa_private_link_principals(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("add_aa_private_link_principals")
         .description("Add AWS principals to an Active-Active PrivateLink access list.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, AddAaPrivateLinkPrincipalsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<AddAaPrivateLinkPrincipalsInput>| async move {
@@ -2552,7 +2552,7 @@ pub fn remove_aa_private_link_principals(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("remove_aa_private_link_principals")
         .description("Remove AWS principals from an Active-Active PrivateLink access list.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, RemoveAaPrivateLinkPrincipalsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<RemoveAaPrivateLinkPrincipalsInput>| async move {
@@ -2612,7 +2612,7 @@ pub fn get_aa_private_link_endpoint_script(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_aa_private_link_endpoint_script")
         .description("Get the endpoint creation script for an Active-Active AWS PrivateLink.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetAaPrivateLinkEndpointScriptInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetAaPrivateLinkEndpointScriptInput>| async move {

--- a/crates/redisctl-mcp/src/tools/cloud/raw.rs
+++ b/crates/redisctl-mcp/src/tools/cloud/raw.rs
@@ -47,7 +47,7 @@ pub fn cloud_raw_api(state: Arc<AppState>) -> Tool {
              Escape hatch for endpoints not covered by dedicated tools.",
         )
         .destructive()
-        .extractor_handler_typed::<_, _, _, CloudRawApiInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<CloudRawApiInput>| async move {
                 // Method-based tier gating

--- a/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs
+++ b/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs
@@ -30,7 +30,7 @@ pub fn list_subscriptions(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_subscriptions")
         .description("List all subscriptions.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ListSubscriptionsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ListSubscriptionsInput>| async move {
                 let client = state
@@ -65,7 +65,7 @@ pub fn get_subscription(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_subscription")
         .description("Get subscription details by ID.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetSubscriptionInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetSubscriptionInput>| async move {
                 let client = state
@@ -100,7 +100,7 @@ pub fn list_databases(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_databases")
         .description("List all databases in a subscription.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ListDatabasesInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ListDatabasesInput>| async move {
                 let client = state
@@ -137,7 +137,7 @@ pub fn get_database(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_database")
         .description("Get database details by ID.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetDatabaseInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetDatabaseInput>| async move {
                 let client = state
@@ -181,7 +181,7 @@ pub fn get_backup_status(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_backup_status")
         .description("Get backup status and history for a database.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetBackupStatusInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetBackupStatusInput>| async move {
@@ -226,7 +226,7 @@ pub fn get_slow_log(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_slow_log")
         .description("Get slow log entries for a database.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetSlowLogInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetSlowLogInput>| async move {
                 let client = state
@@ -263,7 +263,7 @@ pub fn get_tags(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_database_tags")
         .description("Get tags for a database.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetTagsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetTagsInput>| async move {
                 let client = state
@@ -302,7 +302,7 @@ pub fn get_database_certificate(state: Arc<AppState>) -> Tool {
             "Get the TLS/SSL certificate for a database in PEM format.",
         )
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetCertificateInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetCertificateInput>| async move {
@@ -375,7 +375,7 @@ pub fn create_database(state: Arc<AppState>) -> Tool {
             "Create a new database and wait for it to be ready.",
         )
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, CreateDatabaseInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<CreateDatabaseInput>| async move {
@@ -473,7 +473,7 @@ pub fn update_database(state: Arc<AppState>) -> Tool {
             "Update a database configuration.",
         )
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, UpdateDatabaseInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<UpdateDatabaseInput>| async move {
@@ -551,7 +551,7 @@ pub fn delete_database(state: Arc<AppState>) -> Tool {
             "DANGEROUS: Delete a database and all its data.",
         )
         .destructive()
-        .extractor_handler_typed::<_, _, _, DeleteDatabaseInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<DeleteDatabaseInput>| async move {
@@ -613,7 +613,7 @@ pub fn backup_database(state: Arc<AppState>) -> Tool {
             "Trigger a manual backup of a database.",
         )
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, BackupDatabaseInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<BackupDatabaseInput>| async move {
@@ -681,7 +681,7 @@ pub fn import_database(state: Arc<AppState>) -> Tool {
             "Import data into a database from an external source. WARNING: This will overwrite existing data.",
         )
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, ImportDatabaseInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<ImportDatabaseInput>| async move {
@@ -747,7 +747,7 @@ pub fn delete_subscription(state: Arc<AppState>) -> Tool {
             "DANGEROUS: Delete a subscription. All databases must be deleted first.",
         )
         .destructive()
-        .extractor_handler_typed::<_, _, _, DeleteSubscriptionInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<DeleteSubscriptionInput>| async move {
@@ -806,7 +806,7 @@ pub fn flush_database(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("flush_database")
         .description("DANGEROUS: Removes all data from a database.")
         .destructive()
-        .extractor_handler_typed::<_, _, _, FlushDatabaseInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<FlushDatabaseInput>| async move {
                 // Check destructive permission
@@ -862,7 +862,7 @@ pub fn flush_crdb_database(state: Arc<AppState>) -> Tool {
              Use this instead of regular flush for Active-Active databases.",
         )
         .destructive()
-        .extractor_handler_typed::<_, _, _, FlushCrdbDatabaseInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<FlushCrdbDatabaseInput>| async move {
@@ -939,7 +939,7 @@ pub fn create_subscription(state: Arc<AppState>) -> Tool {
             "Create a new Pro subscription with an initial database.",
         )
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, CreateSubscriptionInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<CreateSubscriptionInput>| async move {
@@ -1027,7 +1027,7 @@ pub fn update_subscription(state: Arc<AppState>) -> Tool {
             "Update a subscription.",
         )
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, UpdateSubscriptionInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<UpdateSubscriptionInput>| async move {
@@ -1078,7 +1078,7 @@ pub fn get_subscription_pricing(state: Arc<AppState>) -> Tool {
             "Get pricing details for a subscription.",
         )
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetSubscriptionPricingInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetSubscriptionPricingInput>| async move {
@@ -1117,7 +1117,7 @@ pub fn get_redis_versions(state: Arc<AppState>) -> Tool {
             "Get available Redis versions. Optionally filter by subscription ID.",
         )
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetRedisVersionsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetRedisVersionsInput>| async move {
@@ -1153,7 +1153,7 @@ pub fn get_subscription_cidr_allowlist(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_subscription_cidr_allowlist")
         .description("Get the CIDR allowlist for a subscription.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetSubscriptionCidrAllowlistInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetSubscriptionCidrAllowlistInput>| async move {
@@ -1195,7 +1195,7 @@ pub fn update_subscription_cidr_allowlist(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_subscription_cidr_allowlist")
         .description("Update the CIDR allowlist for a subscription.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, UpdateSubscriptionCidrAllowlistInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<UpdateSubscriptionCidrAllowlistInput>| async move {
@@ -1246,7 +1246,7 @@ pub fn get_subscription_maintenance_windows(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_subscription_maintenance_windows")
         .description("Get maintenance windows for a subscription.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetSubscriptionMaintenanceWindowsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetSubscriptionMaintenanceWindowsInput>| async move {
@@ -1298,7 +1298,7 @@ pub fn update_subscription_maintenance_windows(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_subscription_maintenance_windows")
         .description("Update maintenance windows for a subscription.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, UpdateSubscriptionMaintenanceWindowsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<UpdateSubscriptionMaintenanceWindowsInput>| async move {
@@ -1361,7 +1361,7 @@ pub fn get_active_active_regions(state: Arc<AppState>) -> Tool {
             "Get regions from an Active-Active subscription.",
         )
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetActiveActiveRegionsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetActiveActiveRegionsInput>| async move {
@@ -1413,7 +1413,7 @@ pub fn add_active_active_region(state: Arc<AppState>) -> Tool {
             "Add a new region to an Active-Active subscription.",
         )
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, AddActiveActiveRegionInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<AddActiveActiveRegionInput>| async move {
@@ -1486,7 +1486,7 @@ pub fn delete_active_active_regions(state: Arc<AppState>) -> Tool {
             "DANGEROUS: Remove regions from an Active-Active subscription. May cause data loss in removed regions.",
         )
         .destructive()
-        .extractor_handler_typed::<_, _, _, DeleteActiveActiveRegionsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<DeleteActiveActiveRegionsInput>| async move {
@@ -1549,7 +1549,7 @@ pub fn get_available_database_versions(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_available_database_versions")
         .description("Get available target Redis versions for upgrading a database.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetAvailableDatabaseVersionsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetAvailableDatabaseVersionsInput>| async move {
@@ -1592,7 +1592,7 @@ pub fn upgrade_database_redis_version(state: Arc<AppState>) -> Tool {
              Use get_available_database_versions to find valid target versions.",
         )
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, UpgradeDatabaseRedisVersionInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<UpgradeDatabaseRedisVersionInput>| async move {
@@ -1649,7 +1649,7 @@ pub fn get_database_upgrade_status(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_database_upgrade_status")
         .description("Get the Redis version upgrade status for a database.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetDatabaseUpgradeStatusInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetDatabaseUpgradeStatusInput>| async move {
@@ -1690,7 +1690,7 @@ pub fn get_database_import_status(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_database_import_status")
         .description("Get the import status for a database.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetDatabaseImportStatusInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetDatabaseImportStatusInput>| async move {
@@ -1734,7 +1734,7 @@ pub fn create_database_tag(state: Arc<AppState>) -> Tool {
             "Create a tag on a database.",
         )
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, CreateDatabaseTagInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<CreateDatabaseTagInput>| async move {
@@ -1794,7 +1794,7 @@ pub fn update_database_tag(state: Arc<AppState>) -> Tool {
             "Update a tag on a database.",
         )
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, UpdateDatabaseTagInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<UpdateDatabaseTagInput>| async move {
@@ -1857,7 +1857,7 @@ pub fn delete_database_tag(state: Arc<AppState>) -> Tool {
             "DANGEROUS: Delete a tag from a database.",
         )
         .destructive()
-        .extractor_handler_typed::<_, _, _, DeleteDatabaseTagInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<DeleteDatabaseTagInput>| async move {
@@ -1914,7 +1914,7 @@ pub fn update_database_tags(state: Arc<AppState>) -> Tool {
             "Update all tags on a database (replaces existing tags).",
         )
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, UpdateDatabaseTagsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<UpdateDatabaseTagsInput>| async move {
@@ -2010,7 +2010,7 @@ pub fn update_crdb_local_properties(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_crdb_local_properties")
         .description("Update local properties of an Active-Active (CRDB) database.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, UpdateCrdbLocalPropertiesInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<UpdateCrdbLocalPropertiesInput>| async move {

--- a/crates/redisctl-mcp/src/tools/enterprise/cluster.rs
+++ b/crates/redisctl-mcp/src/tools/enterprise/cluster.rs
@@ -27,7 +27,7 @@ pub fn get_cluster(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_cluster")
         .description("Get cluster information including name, version, and configuration")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetClusterInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetClusterInput>| async move {
                 let client = state
@@ -64,7 +64,7 @@ pub fn get_license(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_license")
         .description("Get license information including type, expiration, and enabled features")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetLicenseInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetLicenseInput>| async move {
                 let client = state
@@ -96,7 +96,7 @@ pub fn get_license_usage(state: Arc<AppState>) -> Tool {
             "Get license utilization statistics including shards, nodes, and RAM usage against limits",
         )
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetLicenseUsageInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetLicenseUsageInput>| async move {
@@ -136,7 +136,7 @@ pub fn update_license(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_enterprise_license")
         .description("Apply a new license key to the cluster.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, UpdateLicenseInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<UpdateLicenseInput>| async move {
                 // Check write permission
@@ -181,7 +181,7 @@ pub fn validate_license(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("validate_enterprise_license")
         .description("Validate a license key without applying it (dry-run).")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ValidateLicenseInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<ValidateLicenseInput>| async move {
@@ -221,7 +221,7 @@ pub fn update_cluster(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_enterprise_cluster")
         .description("Update cluster configuration settings. Pass fields to update as JSON.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, UpdateClusterInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<UpdateClusterInput>| async move {
                 // Check write permission
@@ -264,7 +264,7 @@ pub fn get_cluster_policy(state: Arc<AppState>) -> Tool {
              rack awareness, and default Redis version.",
         )
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetClusterPolicyInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetClusterPolicyInput>| async move {
@@ -303,7 +303,7 @@ pub fn update_cluster_policy(state: Arc<AppState>) -> Tool {
             "Update cluster policy settings. Pass fields to update as JSON.",
         )
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, UpdateClusterPolicyInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<UpdateClusterPolicyInput>| async move {
@@ -351,7 +351,7 @@ pub fn enable_maintenance_mode(state: Arc<AppState>) -> Tool {
              until maintenance mode is disabled.",
         )
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, EnableMaintenanceModeInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<EnableMaintenanceModeInput>| async move {
@@ -396,7 +396,7 @@ pub fn disable_maintenance_mode(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("disable_enterprise_maintenance_mode")
         .description("Disable maintenance mode and re-enable configuration changes.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, DisableMaintenanceModeInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<DisableMaintenanceModeInput>| async move {
@@ -445,7 +445,7 @@ pub fn get_cluster_certificates(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_enterprise_cluster_certificates")
         .description("Get all configured certificates (proxy, syncer, API).")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetClusterCertificatesInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetClusterCertificatesInput>| async move {
@@ -479,7 +479,7 @@ pub fn rotate_cluster_certificates(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("rotate_enterprise_cluster_certificates")
         .description("Rotate all certificates, generating new ones to replace existing.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, RotateClusterCertificatesInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<RotateClusterCertificatesInput>| async move {
@@ -532,7 +532,7 @@ pub fn update_cluster_certificates(state: Arc<AppState>) -> Tool {
              PEM-encoded certificate, and PEM-encoded private key.",
         )
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, UpdateClusterCertificatesInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<UpdateClusterCertificatesInput>| async move {
@@ -586,7 +586,7 @@ pub fn list_nodes(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_nodes")
         .description("List all nodes.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ListNodesInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ListNodesInput>| async move {
                 let client = state
@@ -618,7 +618,7 @@ pub fn get_node(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_node")
         .description("Get detailed information about a specific node by UID.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetNodeInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetNodeInput>| async move {
                 let client = state
@@ -665,7 +665,7 @@ pub fn get_node_stats(state: Arc<AppState>) -> Tool {
              for historical data.",
         )
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetNodeStatsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetNodeStatsInput>| async move {
                 let client = state
@@ -723,7 +723,7 @@ pub fn enable_node_maintenance(state: Arc<AppState>) -> Tool {
             "Enable maintenance mode on a specific node. Shards will be migrated off first.",
         )
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, NodeActionInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<NodeActionInput>| async move {
                 // Check write permission
@@ -762,7 +762,7 @@ pub fn disable_node_maintenance(state: Arc<AppState>) -> Tool {
             "Disable maintenance mode on a specific node. The node will accept shards again.",
         )
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, NodeActionInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<NodeActionInput>| async move {
                 // Check write permission
@@ -799,7 +799,7 @@ pub fn rebalance_node(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("rebalance_enterprise_node")
         .description("Rebalance shards on a specific node for optimal distribution.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, NodeActionInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<NodeActionInput>| async move {
                 // Check write permission
@@ -836,7 +836,7 @@ pub fn drain_node(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("drain_enterprise_node")
         .description("Drain all shards from a specific node, migrating them to other nodes.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, NodeActionInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<NodeActionInput>| async move {
                 // Check write permission
@@ -889,7 +889,7 @@ pub fn update_enterprise_node(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_enterprise_node")
         .description("Update a node's configuration. Pass fields to update as JSON.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, UpdateNodeInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<UpdateNodeInput>| async move {
                 // Check write permission
@@ -931,7 +931,7 @@ pub fn remove_enterprise_node(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("remove_enterprise_node")
         .description("DANGEROUS: Remove a node. All shards must be drained first.")
         .destructive()
-        .extractor_handler_typed::<_, _, _, RemoveNodeInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<RemoveNodeInput>| async move {
                 // Check destructive permission
@@ -978,7 +978,7 @@ pub fn get_enterprise_cluster_services(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_enterprise_cluster_services")
         .description("Get the list of cluster services.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetClusterServicesInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetClusterServicesInput>| async move {
@@ -1024,7 +1024,7 @@ pub fn get_cluster_stats(state: Arc<AppState>) -> Tool {
              for historical data.",
         )
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetClusterStatsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetClusterStatsInput>| async move {

--- a/crates/redisctl-mcp/src/tools/enterprise/databases.rs
+++ b/crates/redisctl-mcp/src/tools/enterprise/databases.rs
@@ -38,7 +38,7 @@ pub fn list_databases(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_enterprise_databases")
         .description("List all databases. Supports filtering by name and status.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ListDatabasesInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ListDatabasesInput>| async move {
                 let client = state
@@ -95,7 +95,7 @@ pub fn get_database(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_enterprise_database")
         .description("Get database details by UID.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetDatabaseInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetDatabaseInput>| async move {
                 let client = state
@@ -142,7 +142,7 @@ pub fn get_database_stats(state: Arc<AppState>) -> Tool {
              for historical data.",
         )
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetDatabaseStatsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetDatabaseStatsInput>| async move {
@@ -195,7 +195,7 @@ pub fn get_database_endpoints(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_database_endpoints")
         .description("Get connection endpoints for a specific database.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetDatabaseEndpointsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetDatabaseEndpointsInput>| async move {
@@ -231,7 +231,7 @@ pub fn list_database_alerts(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_database_alerts")
         .description("List all alerts for a specific database.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ListDatabaseAlertsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<ListDatabaseAlertsInput>| async move {
@@ -278,7 +278,7 @@ pub fn backup_enterprise_database(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("backup_enterprise_database")
         .description("Trigger a database backup and wait for completion.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, BackupDatabaseInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<BackupDatabaseInput>| async move {
@@ -339,7 +339,7 @@ pub fn import_enterprise_database(state: Arc<AppState>) -> Tool {
              WARNING: If flush is true, existing data will be deleted before import.",
         )
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, ImportDatabaseInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<ImportDatabaseInput>| async move {
@@ -408,7 +408,7 @@ pub fn create_enterprise_database(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_enterprise_database")
         .description("Create a new database.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, CreateEnterpriseDatabaseInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<CreateEnterpriseDatabaseInput>| async move {
@@ -471,7 +471,7 @@ pub fn update_enterprise_database(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_enterprise_database")
         .description("Update database configuration. Pass fields to update as JSON.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, UpdateEnterpriseDatabaseInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<UpdateEnterpriseDatabaseInput>| async move {
@@ -514,7 +514,7 @@ pub fn delete_enterprise_database(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_enterprise_database")
         .description("DANGEROUS: Delete a database and all its data.")
         .destructive()
-        .extractor_handler_typed::<_, _, _, DeleteEnterpriseDatabaseInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<DeleteEnterpriseDatabaseInput>| async move {
@@ -563,7 +563,7 @@ pub fn flush_enterprise_database(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("flush_enterprise_database")
         .description("DANGEROUS: Flush all data from a database.")
         .destructive()
-        .extractor_handler_typed::<_, _, _, FlushEnterpriseDatabaseInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<FlushEnterpriseDatabaseInput>| async move {
@@ -615,7 +615,7 @@ pub fn export_enterprise_database(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("export_enterprise_database")
         .description("Export a database to a specified location (e.g., S3, FTP).")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, ExportEnterpriseDatabaseInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<ExportEnterpriseDatabaseInput>| async move {
@@ -661,7 +661,7 @@ pub fn restore_enterprise_database(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("restore_enterprise_database")
         .description("Restore a database from a backup.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, RestoreEnterpriseDatabaseInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<RestoreEnterpriseDatabaseInput>| async move {
@@ -713,7 +713,7 @@ pub fn upgrade_enterprise_database_redis(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("upgrade_enterprise_database_redis")
         .description("Upgrade the Redis version of a database.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, UpgradeEnterpriseDatabaseRedisInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<UpgradeEnterpriseDatabaseRedisInput>| async move {
@@ -765,7 +765,7 @@ pub fn list_enterprise_crdbs(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_enterprise_crdbs")
         .description("List all Active-Active (CRDB) databases.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ListCrdbsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ListCrdbsInput>| async move {
                 let client = state
@@ -797,7 +797,7 @@ pub fn get_enterprise_crdb(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_enterprise_crdb")
         .description("Get details of a specific Active-Active (CRDB) database by GUID.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetCrdbInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetCrdbInput>| async move {
                 let client = state
@@ -832,7 +832,7 @@ pub fn get_enterprise_crdb_tasks(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_enterprise_crdb_tasks")
         .description("Get tasks for a specific Active-Active (CRDB) database.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetCrdbTasksInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetCrdbTasksInput>| async move {
                 let client = state
@@ -867,7 +867,7 @@ pub fn create_enterprise_crdb(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_enterprise_crdb")
         .description("Create a new Active-Active (CRDB) database. Pass full configuration as JSON.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, CreateEnterpriseCrdbInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<CreateEnterpriseCrdbInput>| async move {
@@ -911,7 +911,7 @@ pub fn update_enterprise_crdb(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_enterprise_crdb")
         .description("Update an Active-Active (CRDB) database. Pass fields to update as JSON.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, UpdateEnterpriseCrdbInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<UpdateEnterpriseCrdbInput>| async move {
@@ -954,7 +954,7 @@ pub fn delete_enterprise_crdb(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_enterprise_crdb")
         .description("DANGEROUS: Delete an Active-Active (CRDB) database across all participating clusters.")
         .destructive()
-        .extractor_handler_typed::<_, _, _, DeleteEnterpriseCrdbInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<DeleteEnterpriseCrdbInput>| async move {

--- a/crates/redisctl-mcp/src/tools/enterprise/observability.rs
+++ b/crates/redisctl-mcp/src/tools/enterprise/observability.rs
@@ -33,7 +33,7 @@ pub fn list_alerts(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_alerts")
         .description("List all active alerts.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ListAlertsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ListAlertsInput>| async move {
                 let client = state
@@ -82,7 +82,7 @@ pub fn list_logs(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_logs")
         .description("List cluster event logs. Supports filtering by time range and pagination.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ListLogsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ListLogsInput>| async move {
                 let client = state
@@ -136,7 +136,7 @@ pub fn get_all_nodes_stats(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_all_nodes_stats")
         .description("Get current statistics for all nodes including CPU, memory, and network metrics.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetAllNodesStatsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetAllNodesStatsInput>| async move {
@@ -172,7 +172,7 @@ pub fn get_all_databases_stats(state: Arc<AppState>) -> Tool {
             "Get current statistics for all databases including latency, throughput, and memory usage.",
         )
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetAllDatabasesStatsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetAllDatabasesStatsInput>| async move {
@@ -205,7 +205,7 @@ pub fn get_shard_stats(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_shard_stats")
         .description("Get current statistics for a specific shard.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetShardStatsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetShardStatsInput>| async move {
                 let client = state
@@ -238,7 +238,7 @@ pub fn get_all_shards_stats(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_all_shards_stats")
         .description("Get current statistics for all shards.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetAllShardsStatsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetAllShardsStatsInput>| async move {
@@ -279,7 +279,7 @@ pub fn list_shards(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_shards")
         .description("List all shards. Optionally filter by database UID.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ListShardsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ListShardsInput>| async move {
                 let client = state
@@ -320,7 +320,7 @@ pub fn get_shard(state: Arc<AppState>) -> Tool {
             "Get shard details including role (master/replica), status, and assigned node.",
         )
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetShardInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetShardInput>| async move {
                 let client = state
@@ -357,7 +357,7 @@ pub fn list_debug_info_tasks(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_debug_info_tasks")
         .description("List all debug info collection tasks and their statuses.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ListDebugInfoTasksInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<ListDebugInfoTasksInput>| async move {
@@ -393,7 +393,7 @@ pub fn get_debug_info_status(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_debug_info_status")
         .description("Get the status of a debug info collection task by ID.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetDebugInfoStatusInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetDebugInfoStatusInput>| async move {
@@ -431,7 +431,7 @@ pub fn list_modules(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_modules")
         .description("List all installed Redis modules.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ListModulesInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ListModulesInput>| async move {
                 let client = state
@@ -466,7 +466,7 @@ pub fn get_module(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_module")
         .description("Get details of a specific Redis module by UID.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetModuleInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetModuleInput>| async move {
                 let client = state
@@ -505,7 +505,7 @@ pub fn list_shards_by_database(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_shards_by_database")
         .description("List all shards for a specific database.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ListShardsByDatabaseInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<ListShardsByDatabaseInput>| async move {
@@ -541,7 +541,7 @@ pub fn list_shards_by_node(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_shards_by_node")
         .description("List all shards on a specific node.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ListShardsByNodeInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<ListShardsByNodeInput>| async move {
@@ -581,7 +581,7 @@ pub fn acknowledge_enterprise_alert(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("acknowledge_enterprise_alert")
         .description("Acknowledge (clear) a specific alert by ID.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, AcknowledgeAlertInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<AcknowledgeAlertInput>| async move {
@@ -635,7 +635,7 @@ pub fn create_debug_info(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_debug_info")
         .description("Start a debug info collection task. Optionally scope to specific nodes or databases.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, CreateDebugInfoInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<CreateDebugInfoInput>| async move {

--- a/crates/redisctl-mcp/src/tools/enterprise/proxy.rs
+++ b/crates/redisctl-mcp/src/tools/enterprise/proxy.rs
@@ -25,7 +25,7 @@ pub fn list_proxies(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_enterprise_proxies")
         .description("List all proxy instances.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ListProxiesInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ListProxiesInput>| async move {
                 let client = state
@@ -60,7 +60,7 @@ pub fn get_proxy(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_enterprise_proxy")
         .description("Get proxy details by UID.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetProxyInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetProxyInput>| async move {
                 let client = state
@@ -97,7 +97,7 @@ pub fn get_proxy_stats(state: Arc<AppState>) -> Tool {
             "Get statistics for a specific proxy including connection counts and throughput.",
         )
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetProxyStatsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetProxyStatsInput>| async move {
                 let client = state
@@ -134,7 +134,7 @@ pub fn update_proxy(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_enterprise_proxy")
         .description("Update a proxy's configuration. Pass fields to update as JSON.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, UpdateProxyInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<UpdateProxyInput>| async move {
                 if !state.is_write_allowed() {

--- a/crates/redisctl-mcp/src/tools/enterprise/raw.rs
+++ b/crates/redisctl-mcp/src/tools/enterprise/raw.rs
@@ -47,7 +47,7 @@ pub fn enterprise_raw_api(state: Arc<AppState>) -> Tool {
              Escape hatch for endpoints not covered by dedicated tools.",
         )
         .destructive()
-        .extractor_handler_typed::<_, _, _, EnterpriseRawApiInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<EnterpriseRawApiInput>| async move {

--- a/crates/redisctl-mcp/src/tools/enterprise/rbac.rs
+++ b/crates/redisctl-mcp/src/tools/enterprise/rbac.rs
@@ -32,7 +32,7 @@ pub fn list_users(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_enterprise_users")
         .description("List all users.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ListUsersInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ListUsersInput>| async move {
                 let client = state
@@ -64,7 +64,7 @@ pub fn get_user(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_enterprise_user")
         .description("Get user details by UID.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetUserInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetUserInput>| async move {
                 let client = state
@@ -112,7 +112,7 @@ pub fn create_enterprise_user(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_enterprise_user")
         .description("Create a new user.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, CreateEnterpriseUserInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<CreateEnterpriseUserInput>| async move {
@@ -184,7 +184,7 @@ pub fn update_enterprise_user(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_enterprise_user")
         .description("Update an existing user. Only specified fields will be modified.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, UpdateEnterpriseUserInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<UpdateEnterpriseUserInput>| async move {
@@ -238,7 +238,7 @@ pub fn delete_enterprise_user(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_enterprise_user")
         .description("DANGEROUS: Delete a user. Active sessions will be terminated.")
         .destructive()
-        .extractor_handler_typed::<_, _, _, DeleteEnterpriseUserInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<DeleteEnterpriseUserInput>| async move {
@@ -286,7 +286,7 @@ pub fn list_roles(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_enterprise_roles")
         .description("List all roles.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ListRolesInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ListRolesInput>| async move {
                 let client = state
@@ -318,7 +318,7 @@ pub fn get_role(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_enterprise_role")
         .description("Get role details by UID, including permissions and assignments.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetRoleInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetRoleInput>| async move {
                 let client = state
@@ -359,7 +359,7 @@ pub fn create_enterprise_role(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_enterprise_role")
         .description("Create a new role.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, CreateEnterpriseRoleInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<CreateEnterpriseRoleInput>| async move {
@@ -418,7 +418,7 @@ pub fn update_enterprise_role(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_enterprise_role")
         .description("Update an existing role.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, UpdateEnterpriseRoleInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<UpdateEnterpriseRoleInput>| async move {
@@ -469,7 +469,7 @@ pub fn delete_enterprise_role(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_enterprise_role")
         .description("DANGEROUS: Delete a role. Users assigned to it will lose their permissions.")
         .destructive()
-        .extractor_handler_typed::<_, _, _, DeleteEnterpriseRoleInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<DeleteEnterpriseRoleInput>| async move {
@@ -517,7 +517,7 @@ pub fn list_redis_acls(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_enterprise_acls")
         .description("List all Redis ACLs.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ListRedisAclsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ListRedisAclsInput>| async move {
                 let client = state
@@ -551,7 +551,7 @@ pub fn get_redis_acl(state: Arc<AppState>) -> Tool {
             "Get Redis ACL details by UID, including rule string and associated databases.",
         )
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetRedisAclInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetRedisAclInput>| async move {
                 let client = state
@@ -591,7 +591,7 @@ pub fn create_enterprise_acl(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_enterprise_acl")
         .description("Create a new Redis ACL using Redis ACL syntax (e.g., \"+@all ~*\").")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, CreateEnterpriseAclInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<CreateEnterpriseAclInput>| async move {
@@ -647,7 +647,7 @@ pub fn update_enterprise_acl(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_enterprise_acl")
         .description("Update an existing Redis ACL.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, UpdateEnterpriseAclInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<UpdateEnterpriseAclInput>| async move {
@@ -696,7 +696,7 @@ pub fn delete_enterprise_acl(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("delete_enterprise_acl")
         .description("DANGEROUS: Delete a Redis ACL. Databases using it will lose those access controls.")
         .destructive()
-        .extractor_handler_typed::<_, _, _, DeleteEnterpriseAclInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<DeleteEnterpriseAclInput>| async move {
@@ -746,7 +746,7 @@ pub fn get_enterprise_ldap_config(state: Arc<AppState>) -> Tool {
             "Get the LDAP configuration including server settings, bind DN, and query suffixes.",
         )
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetLdapConfigInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetLdapConfigInput>| async move {
                 let client = state
@@ -782,7 +782,7 @@ pub fn update_enterprise_ldap_config(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_enterprise_ldap_config")
         .description("Update the LDAP configuration. Pass LDAP settings as JSON.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, UpdateLdapConfigInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<UpdateLdapConfigInput>| async move {
@@ -830,7 +830,7 @@ pub fn get_enterprise_user_permissions(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_enterprise_user_permissions")
         .description("Get all available permission types for user management.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetUserPermissionsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetUserPermissionsInput>| async move {
@@ -868,7 +868,7 @@ pub fn get_enterprise_builtin_roles(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_enterprise_builtin_roles")
         .description("Get the list of built-in roles.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetBuiltinRolesInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetBuiltinRolesInput>| async move {
@@ -913,7 +913,7 @@ pub fn validate_enterprise_acl(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("validate_enterprise_acl")
         .description("Validate a Redis ACL rule before creating it.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ValidateEnterpriseAclInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<ValidateEnterpriseAclInput>| async move {

--- a/crates/redisctl-mcp/src/tools/enterprise/services.rs
+++ b/crates/redisctl-mcp/src/tools/enterprise/services.rs
@@ -25,7 +25,7 @@ pub fn list_services(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_enterprise_services")
         .description("List all cluster services.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ListServicesInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ListServicesInput>| async move {
                 let client = state
@@ -60,7 +60,7 @@ pub fn get_service(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_enterprise_service")
         .description("Get service details by ID.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetServiceInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetServiceInput>| async move {
                 let client = state
@@ -95,7 +95,7 @@ pub fn get_service_status(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("get_enterprise_service_status")
         .description("Get service status including per-node status.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetServiceStatusInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<GetServiceStatusInput>| async move {
@@ -133,7 +133,7 @@ pub fn update_service(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("update_enterprise_service")
         .description("Update a service's configuration. Pass fields as JSON.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, UpdateServiceInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<UpdateServiceInput>| async move {
                 if !state.is_write_allowed() {
@@ -176,7 +176,7 @@ pub fn start_service(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("start_enterprise_service")
         .description("Start a stopped service.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, ServiceActionInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ServiceActionInput>| async move {
                 if !state.is_write_allowed() {
@@ -207,7 +207,7 @@ pub fn stop_service(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("stop_enterprise_service")
         .description("Stop a running service.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, ServiceActionInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ServiceActionInput>| async move {
                 if !state.is_write_allowed() {
@@ -238,7 +238,7 @@ pub fn restart_service(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("restart_enterprise_service")
         .description("Restart a service (stop then start).")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, ServiceActionInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ServiceActionInput>| async move {
                 if !state.is_write_allowed() {

--- a/crates/redisctl-mcp/src/tools/profile.rs
+++ b/crates/redisctl-mcp/src/tools/profile.rs
@@ -52,7 +52,7 @@ pub fn list_profiles(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("profile_list")
         .description("List all configured profiles.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ListProfilesInput>(
+        .extractor_handler(
             state,
             |State(_state): State<Arc<AppState>>, Json(_input): Json<ListProfilesInput>| async move {
                 let config = Config::load()
@@ -185,7 +185,7 @@ pub fn show_profile(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("profile_show")
         .description("Show details of a specific profile (credentials masked).")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ShowProfileInput>(
+        .extractor_handler(
             state,
             |State(_state): State<Arc<AppState>>, Json(input): Json<ShowProfileInput>| async move {
                 let config = Config::load().tool_context("Failed to load config")?;
@@ -322,7 +322,7 @@ pub fn validate_config(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("profile_validate")
         .description("Validate configuration for structural issues. Set connect=true to test connectivity.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ValidateConfigInput>(
+        .extractor_handler(
             state,
             |State(_state): State<Arc<AppState>>, Json(input): Json<ValidateConfigInput>| async move {
             let path = Config::config_path()
@@ -597,7 +597,7 @@ pub fn set_default_cloud(state: Arc<AppState>) -> Tool {
         .description("Set the default profile for Cloud commands.")
         .idempotent()
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, SetDefaultCloudInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<SetDefaultCloudInput>| async move {
                 // Check write permission
@@ -648,7 +648,7 @@ pub fn set_default_enterprise(state: Arc<AppState>) -> Tool {
         .description("Set the default profile for Enterprise commands.")
         .idempotent()
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, SetDefaultEnterpriseInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<SetDefaultEnterpriseInput>| async move {
                 // Check write permission
@@ -698,7 +698,7 @@ pub fn delete_profile(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("profile_delete")
         .description("DANGEROUS: Delete a profile from the configuration.")
         .destructive()
-        .extractor_handler_typed::<_, _, _, DeleteProfileInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<DeleteProfileInput>| async move {
                 // Check destructive permission
@@ -802,7 +802,7 @@ pub fn create_profile(state: Arc<AppState>) -> Tool {
              database (host). Auto-sets as default if first of its type.",
         )
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, CreateProfileInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<CreateProfileInput>| async move {

--- a/crates/redisctl-mcp/src/tools/redis/diagnostics.rs
+++ b/crates/redisctl-mcp/src/tools/redis/diagnostics.rs
@@ -103,7 +103,7 @@ pub fn health_check(state: Arc<AppState>) -> Tool {
              covering connectivity, version, uptime, memory, ops rate, and key count.",
         )
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, HealthCheckInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<HealthCheckInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -245,7 +245,7 @@ pub fn key_summary(state: Arc<AppState>) -> Tool {
             "Get metadata summary for a key combining TYPE, TTL, MEMORY USAGE, and OBJECT ENCODING.",
         )
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, KeySummaryInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<KeySummaryInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -365,7 +365,7 @@ pub fn hotkeys(state: Arc<AppState>) -> Tool {
              Capped at sample_size (default 1000, max 10000) to limit impact.",
         )
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, HotkeysInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<HotkeysInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -507,7 +507,7 @@ pub fn connection_summary(state: Arc<AppState>) -> Tool {
             "Analyze client connections: totals, top IPs, idle/blocked counts, and oldest connection.",
         )
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ConnectionSummaryInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<ConnectionSummaryInput>| async move {

--- a/crates/redisctl-mcp/src/tools/redis/keys.rs
+++ b/crates/redisctl-mcp/src/tools/redis/keys.rs
@@ -115,7 +115,7 @@ pub fn keys(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_keys")
         .description("List keys matching a pattern using SCAN (production-safe, non-blocking).")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, KeysInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<KeysInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -188,7 +188,7 @@ pub fn get(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_get")
         .description("Get the value of a key.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -236,7 +236,7 @@ pub fn key_type(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_type")
         .description("Get the data type of a key.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, TypeInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<TypeInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -278,7 +278,7 @@ pub fn ttl(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_ttl")
         .description("Get the TTL of a key in seconds (-1 = no expiry, -2 = missing).")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, TtlInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<TtlInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -326,7 +326,7 @@ pub fn exists(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_exists")
         .description("Check if one or more keys exist.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ExistsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ExistsInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -376,7 +376,7 @@ pub fn memory_usage(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_memory_usage")
         .description("Get memory usage of a key in bytes (MEMORY USAGE).")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, MemoryUsageInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<MemoryUsageInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -434,7 +434,7 @@ pub fn scan(state: Arc<AppState>) -> Tool {
             "Scan keys with optional type filter. Prefer over redis_keys when filtering by type.",
         )
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ScanInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ScanInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -524,7 +524,7 @@ pub fn object_encoding(state: Arc<AppState>) -> Tool {
             "Get the internal encoding of a key. Useful for understanding memory usage patterns.",
         )
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ObjectEncodingInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<ObjectEncodingInput>| async move {
@@ -578,7 +578,7 @@ pub fn object_freq(state: Arc<AppState>) -> Tool {
              Only works with allkeys-lfu or volatile-lfu eviction policy.",
         )
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ObjectFreqInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ObjectFreqInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -624,7 +624,7 @@ pub fn object_idletime(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_object_idletime")
         .description("Get idle time of a key in seconds since last access.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ObjectIdletimeInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<ObjectIdletimeInput>| async move {
@@ -670,7 +670,7 @@ pub fn object_help(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_object_help")
         .description("Get available OBJECT subcommands.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ObjectHelpInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ObjectHelpInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -733,7 +733,7 @@ pub fn set(state: Arc<AppState>) -> Tool {
             "Set a key to a string value with optional expiry and conditional flags (NX/XX).",
         )
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, SetInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<SetInput>| async move {
                 if !state.is_write_allowed() {
@@ -810,7 +810,7 @@ pub fn del(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_del")
         .description("DANGEROUS: Delete one or more keys.")
         .destructive()
-        .extractor_handler_typed::<_, _, _, DelInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<DelInput>| async move {
                 if !state.is_destructive_allowed() {
@@ -868,7 +868,7 @@ pub fn expire(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_expire")
         .description("Set a timeout on a key in seconds. Key auto-deletes after expiry.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, ExpireInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ExpireInput>| async move {
                 if !state.is_write_allowed() {
@@ -929,7 +929,7 @@ pub fn rename(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_rename")
         .description("Rename a key. Overwrites the destination key if it exists.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, RenameInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<RenameInput>| async move {
                 if !state.is_write_allowed() {
@@ -983,7 +983,7 @@ pub fn mget(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_mget")
         .description("Get the values of multiple keys in a single call.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, MgetInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<MgetInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -1046,7 +1046,7 @@ pub fn mset(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_mset")
         .description("Set multiple key-value pairs in a single atomic call.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, MsetInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<MsetInput>| async move {
                 if !state.is_write_allowed() {
@@ -1101,7 +1101,7 @@ pub fn persist(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_persist")
         .description("Remove the expiry from a key, making it persistent.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, PersistInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<PersistInput>| async move {
                 if !state.is_write_allowed() {
@@ -1161,7 +1161,7 @@ pub fn unlink(state: Arc<AppState>) -> Tool {
             "DANGEROUS: Asynchronously delete one or more keys (non-blocking version of DEL).",
         )
         .destructive()
-        .extractor_handler_typed::<_, _, _, UnlinkInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<UnlinkInput>| async move {
                 if !state.is_destructive_allowed() {
@@ -1222,7 +1222,7 @@ pub fn copy(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_copy")
         .description("Copy a key to a new key. Use replace=true to overwrite the destination.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, CopyInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<CopyInput>| async move {
                 if !state.is_write_allowed() {
@@ -1288,7 +1288,7 @@ pub fn dump(state: Arc<AppState>) -> Tool {
              for use with RESTORE.",
         )
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, DumpInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<DumpInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -1352,7 +1352,7 @@ pub fn restore(state: Arc<AppState>) -> Tool {
              The serialized_value must be hex-encoded.",
         )
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, RestoreInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<RestoreInput>| async move {
                 if !state.is_write_allowed() {
@@ -1417,7 +1417,7 @@ pub fn randomkey(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_randomkey")
         .description("Return a random key from the database.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, RandomkeyInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<RandomkeyInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -1461,7 +1461,7 @@ pub fn touch(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_touch")
         .description("Update the last access time of one or more keys without modifying them.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, TouchInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<TouchInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -1513,7 +1513,7 @@ pub fn incr(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_incr")
         .description("Increment the integer value of a key by 1. Creates the key with value 1 if it does not exist.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, IncrInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<IncrInput>| async move {
                 if !state.is_write_allowed() {
@@ -1564,7 +1564,7 @@ pub fn decr(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_decr")
         .description("Decrement the integer value of a key by 1. Creates the key with value -1 if it does not exist.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, DecrInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<DecrInput>| async move {
                 if !state.is_write_allowed() {
@@ -1617,7 +1617,7 @@ pub fn append(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_append")
         .description("Append a value to a key. Creates the key if it does not exist. Returns the new string length.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, AppendInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<AppendInput>| async move {
                 if !state.is_write_allowed() {
@@ -1669,7 +1669,7 @@ pub fn strlen(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_strlen")
         .description("Get the length of the string value stored at a key.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, StrlenInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<StrlenInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -1720,7 +1720,7 @@ pub fn getrange(state: Arc<AppState>) -> Tool {
             "Get a substring of the string value at a key by start and end offsets (inclusive).",
         )
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, GetrangeInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<GetrangeInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -1768,7 +1768,7 @@ pub fn setrange(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_setrange")
         .description("Overwrite part of a string value at the given byte offset. Returns the new string length.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, SetrangeInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<SetrangeInput>| async move {
                 if !state.is_write_allowed() {
@@ -1825,7 +1825,7 @@ pub fn setnx(state: Arc<AppState>) -> Tool {
             "Set a key only if it does not already exist. Returns whether the key was set.",
         )
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, SetnxInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<SetnxInput>| async move {
                 if !state.is_write_allowed() {

--- a/crates/redisctl-mcp/src/tools/redis/raw.rs
+++ b/crates/redisctl-mcp/src/tools/redis/raw.rs
@@ -96,7 +96,7 @@ pub fn redis_command(state: Arc<AppState>) -> Tool {
              Certain dangerous commands and subcommands are blocked.",
         )
         .destructive()
-        .extractor_handler_typed::<_, _, _, RedisCommandInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<RedisCommandInput>| async move {
                 if !state.is_destructive_allowed() {

--- a/crates/redisctl-mcp/src/tools/redis/server.rs
+++ b/crates/redisctl-mcp/src/tools/redis/server.rs
@@ -64,7 +64,7 @@ pub fn ping(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_ping")
         .description("Test connectivity by sending a PING command")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, PingInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<PingInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -109,7 +109,7 @@ pub fn info(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_info")
         .description("Get server information and statistics (INFO command).")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, InfoInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<InfoInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -153,7 +153,7 @@ pub fn dbsize(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_dbsize")
         .description("Get the number of keys in the current database.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, DbsizeInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<DbsizeInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -195,7 +195,7 @@ pub fn client_list(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_client_list")
         .description("List client connections (CLIENT LIST).")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ClientListInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ClientListInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -239,7 +239,7 @@ pub fn cluster_info(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_cluster_info")
         .description("Get cluster information (only works on cluster-enabled instances).")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ClusterInfoInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ClusterInfoInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -286,7 +286,7 @@ pub fn slowlog(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_slowlog")
         .description("Get slow query log entries for identifying performance issues.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, SlowlogInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<SlowlogInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -357,7 +357,7 @@ pub fn config_get(state: Arc<AppState>) -> Tool {
              Supports glob-style patterns.",
         )
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ConfigGetInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ConfigGetInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -415,7 +415,7 @@ pub fn memory_stats(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_memory_stats")
         .description("Get memory usage breakdown by category (MEMORY STATS).")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, MemoryStatsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<MemoryStatsInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -461,7 +461,7 @@ pub fn latency_history(state: Arc<AppState>) -> Tool {
              (CONFIG SET latency-monitor-threshold <ms>).",
         )
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, LatencyHistoryInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<LatencyHistoryInput>| async move {
@@ -527,7 +527,7 @@ pub fn acl_list(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_acl_list")
         .description("List all ACL rules (ACL LIST).")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, AclListInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<AclListInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -575,7 +575,7 @@ pub fn acl_whoami(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_acl_whoami")
         .description("Get the current authenticated username (ACL WHOAMI).")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, AclWhoamiInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<AclWhoamiInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -615,7 +615,7 @@ pub fn module_list(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_module_list")
         .description("List loaded modules with names and versions (MODULE LIST).")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ModuleListInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ModuleListInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -672,7 +672,7 @@ pub fn config_set(state: Arc<AppState>) -> Tool {
              Changes may not persist unless CONFIG REWRITE is called.",
         )
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, ConfigSetInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ConfigSetInput>| async move {
                 if !state.is_write_allowed() {
@@ -729,7 +729,7 @@ pub fn flushdb(state: Arc<AppState>) -> Tool {
              Set async_flush=true for non-blocking operation.",
         )
         .destructive()
-        .extractor_handler_typed::<_, _, _, FlushdbInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<FlushdbInput>| async move {
                 if !state.is_destructive_allowed() {

--- a/crates/redisctl-mcp/src/tools/redis/structures.rs
+++ b/crates/redisctl-mcp/src/tools/redis/structures.rs
@@ -120,7 +120,7 @@ pub fn hgetall(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_hgetall")
         .description("Get all fields and values of a hash.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, HgetallInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<HgetallInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -190,7 +190,7 @@ pub fn lrange(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_lrange")
         .description("Get a range of elements from a list (start=0, stop=-1 for all).")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, LrangeInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<LrangeInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -253,7 +253,7 @@ pub fn smembers(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_smembers")
         .description("Get all members of a set.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, SmembersInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<SmembersInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -316,7 +316,7 @@ pub fn zrange(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_zrange")
         .description("Get a range of members from a sorted set by index.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ZrangeInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ZrangeInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -411,7 +411,7 @@ pub fn xinfo_stream(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_xinfo_stream")
         .description("Get stream metadata including length, consumer groups, and entry details (XINFO STREAM).")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, XinfoStreamInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<XinfoStreamInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -475,7 +475,7 @@ pub fn xrange(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_xrange")
         .description("Get stream entries in a range. Use \"-\" to \"+\" for all entries.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, XrangeInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<XrangeInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -540,7 +540,7 @@ pub fn xlen(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_xlen")
         .description("Get the number of entries in a stream.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, XlenInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<XlenInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -586,7 +586,7 @@ pub fn pubsub_channels(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_pubsub_channels")
         .description("List active pub/sub channels, optionally filtered by pattern.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, PubsubChannelsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<PubsubChannelsInput>| async move {
@@ -645,7 +645,7 @@ pub fn pubsub_numsub(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_pubsub_numsub")
         .description("Get subscriber counts for pub/sub channels.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, PubsubNumsubInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<PubsubNumsubInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -713,7 +713,7 @@ pub fn hset(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_hset")
         .description("Set one or more field-value pairs in a hash. Creates the hash if needed.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, HsetInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<HsetInput>| async move {
                 if !state.is_write_allowed() {
@@ -773,7 +773,7 @@ pub fn hdel(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_hdel")
         .description("Delete one or more fields from a hash.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, HdelInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<HdelInput>| async move {
                 if !state.is_write_allowed() {
@@ -833,7 +833,7 @@ pub fn lpush(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_lpush")
         .description("Push elements to the head (left) of a list. Creates the list if needed.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, LpushInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<LpushInput>| async move {
                 if !state.is_write_allowed() {
@@ -893,7 +893,7 @@ pub fn rpush(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_rpush")
         .description("Push elements to the tail (right) of a list. Creates the list if needed.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, RpushInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<RpushInput>| async move {
                 if !state.is_write_allowed() {
@@ -954,7 +954,7 @@ pub fn lpop(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_lpop")
         .description("Pop elements from the head (left) of a list.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, LpopInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<LpopInput>| async move {
                 if !state.is_write_allowed() {
@@ -1014,7 +1014,7 @@ pub fn rpop(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_rpop")
         .description("Pop elements from the tail (right) of a list.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, RpopInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<RpopInput>| async move {
                 if !state.is_write_allowed() {
@@ -1073,7 +1073,7 @@ pub fn sadd(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_sadd")
         .description("Add one or more members to a set. Creates the set if needed.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, SaddInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<SaddInput>| async move {
                 if !state.is_write_allowed() {
@@ -1133,7 +1133,7 @@ pub fn srem(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_srem")
         .description("Remove one or more members from a set.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, SremInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<SremInput>| async move {
                 if !state.is_write_allowed() {
@@ -1220,7 +1220,7 @@ pub fn zadd(state: Arc<AppState>) -> Tool {
              Supports NX, XX, GT, LT, and CH flags.",
         )
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, ZaddInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ZaddInput>| async move {
                 if !state.is_write_allowed() {
@@ -1296,7 +1296,7 @@ pub fn zrem(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_zrem")
         .description("Remove one or more members from a sorted set.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, ZremInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ZremInput>| async move {
                 if !state.is_write_allowed() {
@@ -1373,7 +1373,7 @@ pub fn xadd(state: Arc<AppState>) -> Tool {
             "Append an entry to a stream. Supports NOMKSTREAM, MAXLEN, and MINID trimming.",
         )
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, XaddInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<XaddInput>| async move {
                 if !state.is_write_allowed() {
@@ -1461,7 +1461,7 @@ pub fn xtrim(state: Arc<AppState>) -> Tool {
              Use approximate=true for better performance.",
         )
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, XtrimInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<XtrimInput>| async move {
                 if !state.is_write_allowed() {
@@ -1524,7 +1524,7 @@ pub fn hget(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_hget")
         .description("Get the value of a single field in a hash.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, HgetInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<HgetInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -1575,7 +1575,7 @@ pub fn hmget(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_hmget")
         .description("Get the values of multiple fields in a hash.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, HmgetInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<HmgetInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -1630,7 +1630,7 @@ pub fn hlen(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_hlen")
         .description("Get the number of fields in a hash.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, HlenInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<HlenInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -1677,7 +1677,7 @@ pub fn hexists(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_hexists")
         .description("Check if a field exists in a hash.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, HexistsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<HexistsInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -1725,7 +1725,7 @@ pub fn hkeys(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_hkeys")
         .description("Get all field names in a hash.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, HkeysInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<HkeysInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -1779,7 +1779,7 @@ pub fn hvals(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_hvals")
         .description("Get all values in a hash.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, HvalsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<HvalsInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -1837,7 +1837,7 @@ pub fn hincrby(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_hincrby")
         .description("Increment the integer value of a hash field by the given amount.")
         .non_destructive()
-        .extractor_handler_typed::<_, _, _, HincrbyInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<HincrbyInput>| async move {
                 if !state.is_write_allowed() {
@@ -1892,7 +1892,7 @@ pub fn scard(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_scard")
         .description("Get the number of members in a set (cardinality).")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ScardInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ScardInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -1939,7 +1939,7 @@ pub fn sismember(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_sismember")
         .description("Check if a value is a member of a set.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, SismemberInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<SismemberInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -1987,7 +1987,7 @@ pub fn sunion(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_sunion")
         .description("Return the union of multiple sets.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, SunionInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<SunionInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -2041,7 +2041,7 @@ pub fn sinter(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_sinter")
         .description("Return the intersection of multiple sets.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, SinterInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<SinterInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -2095,7 +2095,7 @@ pub fn sdiff(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_sdiff")
         .description("Return the difference between the first set and all subsequent sets.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, SdiffInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<SdiffInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -2151,7 +2151,7 @@ pub fn zcard(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_zcard")
         .description("Get the number of members in a sorted set (cardinality).")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ZcardInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ZcardInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -2198,7 +2198,7 @@ pub fn zscore(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_zscore")
         .description("Get the score of a member in a sorted set.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ZscoreInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ZscoreInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -2254,7 +2254,7 @@ pub fn zrank(state: Arc<AppState>) -> Tool {
             "Get the rank (0-based index) of a member in a sorted set, ordered low to high.",
         )
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ZrankInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ZrankInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -2310,7 +2310,7 @@ pub fn zcount(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_zcount")
         .description("Count members in a sorted set with scores between min and max (inclusive). Use \"-inf\"/\"+inf\" for unbounded.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ZcountInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<ZcountInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -2370,7 +2370,7 @@ pub fn zrangebyscore(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_zrangebyscore")
         .description("Get members from a sorted set with scores in the given range. Use \"-inf\"/\"+inf\" for unbounded.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, ZrangebyscoreInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>,
              Json(input): Json<ZrangebyscoreInput>| async move {
@@ -2469,7 +2469,7 @@ pub fn llen(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_llen")
         .description("Get the length of a list.")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, LlenInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<LlenInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;
@@ -2516,7 +2516,7 @@ pub fn lindex(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("redis_lindex")
         .description("Get an element from a list by its index (0-based, negative counts from end).")
         .read_only_safe()
-        .extractor_handler_typed::<_, _, _, LindexInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<LindexInput>| async move {
                 let url = super::resolve_redis_url(input.url, input.profile.as_deref(), &state)?;


### PR DESCRIPTION
## Summary

- Replace all 337 usages of `extractor_handler_typed::<_, _, _, InputType>` with `extractor_handler` across 18 files
- `extractor_handler` (available since tower-mcp 0.7.0) auto-detects the JSON schema from `Json<T>` extractors, producing identical tool schemas without the turbofish noise
- No behavioral change, no version bump needed -- 0.7.0 already has both methods

Note: the issue mentioned requiring tower-mcp 0.8.0, but `extractor_handler` is already available in the current 0.7.0. 0.8.0 hasn't been published yet.

Closes #805

## Test plan

- [x] `cargo clippy -p redisctl-mcp --all-features -- -D warnings` (clean)
- [x] `cargo check -p redisctl-mcp --no-default-features` (clean)
- [x] `cargo test --lib -p redisctl-mcp --all-features` (95 passed)
- [x] `cargo fmt --all -- --check` (clean)