### PR TITLE
feat(mcp): add prerequisite-chain hints to create tool descriptions

### DIFF
--- a/crates/redisctl-mcp/src/tools/cloud/fixed.rs
+++ b/crates/redisctl-mcp/src/tools/cloud/fixed.rs
@@ -112,7 +112,11 @@ pub struct CreateFixedSubscriptionInput {
 /// Build the create_fixed_subscription tool
 pub fn create_fixed_subscription(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_fixed_subscription")
-        .description("Create a new Fixed/Essentials subscription.")
+        .description(
+            "Create a new Fixed/Essentials subscription. \
+             Prerequisites: 1) list_fixed_plans -- choose a plan by size, region, and price. \
+             2) list_payment_methods -- verify a payment method exists.",
+        )
         .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateFixedSubscriptionInput>(
             state,
@@ -536,7 +540,12 @@ pub struct CreateFixedDatabaseInput {
 /// Build the create_fixed_database tool
 pub fn create_fixed_database(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_fixed_database")
-        .description("Create a database in a Fixed/Essentials subscription.")
+        .description(
+            "Create a database in a Fixed/Essentials subscription. \
+             Prerequisites: 1) get_fixed_subscription -- verify the subscription exists and is active. \
+             2) get_fixed_plans_by_subscription -- check compatible plans. \
+             3) get_fixed_redis_versions -- pick a supported Redis version.",
+        )
         .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateFixedDatabaseInput>(
             state,

--- a/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs
+++ b/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs
@@ -372,7 +372,10 @@ pub struct CreateDatabaseInput {
 pub fn create_database(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_database")
         .description(
-            "Create a new database and wait for it to be ready.",
+            "Create a new database in a Pro subscription and wait for it to be ready. \
+             Prerequisites: 1) get_subscription -- verify the target subscription exists and is active. \
+             2) get_modules -- validate desired modules. \
+             3) get_redis_versions -- pick a supported Redis version.",
         )
         .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateDatabaseInput>(
@@ -936,7 +939,11 @@ pub struct CreateSubscriptionInput {
 pub fn create_subscription(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_subscription")
         .description(
-            "Create a new Pro subscription with an initial database.",
+            "Create a new Pro subscription with an initial database. \
+             Prerequisites: 1) list_payment_methods -- verify a payment method exists. \
+             2) get_regions -- validate the target cloud provider and region. \
+             3) get_modules -- confirm desired database modules are available. \
+             4) get_redis_versions -- pick a supported Redis version.",
         )
         .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateSubscriptionInput>(

--- a/crates/redisctl-mcp/src/tools/enterprise/databases.rs
+++ b/crates/redisctl-mcp/src/tools/enterprise/databases.rs
@@ -406,7 +406,11 @@ pub struct CreateEnterpriseDatabaseInput {
 /// Build the create_enterprise_database tool
 pub fn create_enterprise_database(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_enterprise_database")
-        .description("Create a new database.")
+        .description(
+            "Create a new database on the Enterprise cluster. \
+             Prerequisites: 1) get_cluster -- verify the cluster is healthy and has capacity. \
+             2) list_enterprise_databases -- review existing databases.",
+        )
         .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateEnterpriseDatabaseInput>(
             state,

--- a/crates/redisctl-mcp/src/tools/enterprise/rbac.rs
+++ b/crates/redisctl-mcp/src/tools/enterprise/rbac.rs
@@ -110,7 +110,11 @@ pub struct CreateEnterpriseUserInput {
 /// Build the create_enterprise_user tool
 pub fn create_enterprise_user(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_enterprise_user")
-        .description("Create a new user.")
+        .description(
+            "Create a new user. \
+             Prerequisites: 1) list_enterprise_roles -- identify roles to assign. \
+             2) list_enterprise_users -- check for existing users to avoid duplicates.",
+        )
         .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateEnterpriseUserInput>(
             state,
@@ -357,7 +361,11 @@ pub struct CreateEnterpriseRoleInput {
 /// Build the create_enterprise_role tool
 pub fn create_enterprise_role(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_enterprise_role")
-        .description("Create a new role.")
+        .description(
+            "Create a new role. \
+             Prerequisites: 1) get_enterprise_builtin_roles -- review built-in roles before creating custom ones. \
+             2) list_enterprise_acls -- identify Redis ACLs to attach to the role.",
+        )
         .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateEnterpriseRoleInput>(
             state,
@@ -589,7 +597,11 @@ pub struct CreateEnterpriseAclInput {
 /// Build the create_enterprise_acl tool
 pub fn create_enterprise_acl(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("create_enterprise_acl")
-        .description("Create a new Redis ACL using Redis ACL syntax (e.g., \"+@all ~*\").")
+        .description(
+            "Create a new Redis ACL using Redis ACL syntax (e.g., \"+@all ~*\"). \
+             Prerequisites: 1) list_enterprise_acls -- review existing ACLs to avoid duplicates. \
+             2) validate_enterprise_acl -- validate ACL syntax before creation.",
+        )
         .non_destructive()
         .extractor_handler_typed::<_, _, _, CreateEnterpriseAclInput>(
             state,


### PR DESCRIPTION
## Summary

- Add "Prerequisites:" sections to 8 create/provisioning tool descriptions across Cloud and Enterprise
- Guides LLM agents through multi-step workflows by listing which tools to call first for validation
- Pattern borrowed from `redis/mcp-redis-cloud` which uses similar guidance in tool descriptions

### Tools updated

| Tool | Prerequisites |
|------|---------------|
| `create_subscription` | `list_payment_methods`, `get_regions`, `get_modules`, `get_redis_versions` |
| `create_database` | `get_subscription`, `get_modules`, `get_redis_versions` |
| `create_fixed_subscription` | `list_fixed_plans`, `list_payment_methods` |
| `create_fixed_database` | `get_fixed_subscription`, `get_fixed_plans_by_subscription`, `get_fixed_redis_versions` |
| `create_enterprise_database` | `get_cluster`, `list_enterprise_databases` |
| `create_enterprise_user` | `list_enterprise_roles`, `list_enterprise_users` |
| `create_enterprise_role` | `get_enterprise_builtin_roles`, `list_enterprise_acls` |
| `create_enterprise_acl` | `list_enterprise_acls`, `validate_enterprise_acl` |

Description-only changes, no functional impact.

Closes #745

## Test plan

- [x] `cargo clippy -p redisctl-mcp --all-features -- -D warnings` (clean)
- [x] `cargo test --lib -p redisctl-mcp --all-features` (95 passed)
- [x] `cargo fmt --all -- --check` (clean)