### PR TITLE
refactor(mcp): convert database tools to declarative macros

### DIFF
--- a/crates/redisctl-mcp/src/tools/redis/diagnostics.rs
+++ b/crates/redisctl-mcp/src/tools/redis/diagnostics.rs
@@ -1,30 +1,16 @@
 //! Composed Redis diagnostic tools (health_check, key_summary, hotkeys, connection_summary)
 
 use std::collections::HashMap;
-use std::sync::Arc;
 
-use schemars::JsonSchema;
-use serde::Deserialize;
-use tower_mcp::extract::{Json, State};
-use tower_mcp::{CallToolResult, McpRouter, ResultExt, Tool, ToolBuilder};
+use tower_mcp::{CallToolResult, ResultExt};
 
-use crate::state::AppState;
+use crate::tools::macros::{database_tool, mcp_module};
 
-/// All tool names registered by this sub-module.
-pub(super) const TOOL_NAMES: &[&str] = &[
-    "redis_health_check",
-    "redis_key_summary",
-    "redis_hotkeys",
-    "redis_connection_summary",
-];
-
-/// Build a sub-router containing all diagnostic Redis tools
-pub fn router(state: Arc<AppState>) -> McpRouter {
-    McpRouter::new()
-        .tool(health_check(state.clone()))
-        .tool(key_summary(state.clone()))
-        .tool(hotkeys(state.clone()))
-        .tool(connection_summary(state))
+mcp_module! {
+    health_check => "redis_health_check",
+    key_summary => "redis_key_summary",
+    hotkeys => "redis_hotkeys",
+    connection_summary => "redis_connection_summary",
 }
 
 // ---------------------------------------------------------------------------
@@ -81,246 +67,193 @@ fn format_bytes(bytes: i64) -> String {
 }
 
 // ---------------------------------------------------------------------------
-// 1. redis_health_check
+// Tools
 // ---------------------------------------------------------------------------
 
-/// Input for redis_health_check
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct HealthCheckInput {
-    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name to resolve connection from (uses default profile if not set)
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+database_tool!(read_only, health_check, "redis_health_check",
+    "Comprehensive health check combining PING, INFO, and DBSIZE into a single summary \
+     covering connectivity, version, uptime, memory, ops rate, and key count.",
+    {} => |conn, _input| {
+        // PING
+        let ping_response: String = redis::cmd("PING")
+            .query_async(&mut conn)
+            .await
+            .tool_context("PING failed")?;
 
-/// Build the health_check tool
-pub fn health_check(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_health_check")
-        .description(
-            "Comprehensive health check combining PING, INFO, and DBSIZE into a single summary \
-             covering connectivity, version, uptime, memory, ops rate, and key count.",
-        )
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<HealthCheckInput>| async move {
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
+        // INFO (server + memory + stats combined)
+        let info_text: String = redis::cmd("INFO")
+            .query_async(&mut conn)
+            .await
+            .tool_context("INFO failed")?;
 
-                // PING
-                let ping_response: String = redis::cmd("PING")
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("PING failed")?;
+        let info = parse_info(&info_text);
 
-                // INFO (server + memory + stats combined)
-                let info_text: String = redis::cmd("INFO")
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("INFO failed")?;
+        // DBSIZE
+        let db_size: i64 = redis::cmd("DBSIZE")
+            .query_async(&mut conn)
+            .await
+            .tool_context("DBSIZE failed")?;
 
-                let info = parse_info(&info_text);
+        // Extract fields with fallbacks
+        let version = info
+            .get("redis_version")
+            .cloned()
+            .unwrap_or_else(|| "unknown".to_string());
+        let uptime_seconds = info
+            .get("uptime_in_seconds")
+            .cloned()
+            .unwrap_or_else(|| "unknown".to_string());
+        let uptime_days = info
+            .get("uptime_in_days")
+            .cloned()
+            .unwrap_or_else(|| "unknown".to_string());
+        let used_memory_human = info
+            .get("used_memory_human")
+            .cloned()
+            .unwrap_or_else(|| "unknown".to_string());
+        let maxmemory = info
+            .get("maxmemory")
+            .cloned()
+            .unwrap_or_else(|| "0".to_string());
+        let maxmemory_human = info
+            .get("maxmemory_human")
+            .cloned()
+            .unwrap_or_else(|| "unlimited".to_string());
+        let frag_ratio = info
+            .get("mem_fragmentation_ratio")
+            .cloned()
+            .unwrap_or_else(|| "unknown".to_string());
+        let ops_per_sec = info
+            .get("instantaneous_ops_per_sec")
+            .cloned()
+            .unwrap_or_else(|| "unknown".to_string());
+        let total_commands = info
+            .get("total_commands_processed")
+            .cloned()
+            .unwrap_or_else(|| "unknown".to_string());
+        let connected_clients = info
+            .get("connected_clients")
+            .cloned()
+            .unwrap_or_else(|| "unknown".to_string());
 
-                // DBSIZE
-                let db_size: i64 = redis::cmd("DBSIZE")
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("DBSIZE failed")?;
+        let maxmemory_display = if maxmemory == "0" {
+            "unlimited".to_string()
+        } else {
+            maxmemory_human
+        };
 
-                // Extract fields with fallbacks
-                let version = info
-                    .get("redis_version")
-                    .cloned()
-                    .unwrap_or_else(|| "unknown".to_string());
-                let uptime_seconds = info
-                    .get("uptime_in_seconds")
-                    .cloned()
-                    .unwrap_or_else(|| "unknown".to_string());
-                let uptime_days = info
-                    .get("uptime_in_days")
-                    .cloned()
-                    .unwrap_or_else(|| "unknown".to_string());
-                let used_memory_human = info
-                    .get("used_memory_human")
-                    .cloned()
-                    .unwrap_or_else(|| "unknown".to_string());
-                let maxmemory = info
-                    .get("maxmemory")
-                    .cloned()
-                    .unwrap_or_else(|| "0".to_string());
-                let maxmemory_human = info
-                    .get("maxmemory_human")
-                    .cloned()
-                    .unwrap_or_else(|| "unlimited".to_string());
-                let frag_ratio = info
-                    .get("mem_fragmentation_ratio")
-                    .cloned()
-                    .unwrap_or_else(|| "unknown".to_string());
-                let ops_per_sec = info
-                    .get("instantaneous_ops_per_sec")
-                    .cloned()
-                    .unwrap_or_else(|| "unknown".to_string());
-                let total_commands = info
-                    .get("total_commands_processed")
-                    .cloned()
-                    .unwrap_or_else(|| "unknown".to_string());
-                let connected_clients = info
-                    .get("connected_clients")
-                    .cloned()
-                    .unwrap_or_else(|| "unknown".to_string());
+        let output = format!(
+            "Redis Health Check\n\
+             ==================\n\
+             \n\
+             Connectivity: {}\n\
+             Version: {}\n\
+             Uptime: {} seconds ({} days)\n\
+             \n\
+             Memory:\n\
+             - Used: {}\n\
+             - Max: {}\n\
+             - Fragmentation ratio: {}\n\
+             \n\
+             Stats:\n\
+             - Ops/sec: {}\n\
+             - Total commands processed: {}\n\
+             - Connected clients: {}\n\
+             \n\
+             Keys: {}",
+            ping_response,
+            version,
+            uptime_seconds,
+            uptime_days,
+            used_memory_human,
+            maxmemory_display,
+            frag_ratio,
+            ops_per_sec,
+            total_commands,
+            connected_clients,
+            db_size,
+        );
 
-                let maxmemory_display = if maxmemory == "0" {
-                    "unlimited".to_string()
-                } else {
-                    maxmemory_human
-                };
+        Ok(CallToolResult::text(output))
+    }
+);
 
-                let output = format!(
-                    "Redis Health Check\n\
-                     ==================\n\
-                     \n\
-                     Connectivity: {}\n\
-                     Version: {}\n\
-                     Uptime: {} seconds ({} days)\n\
-                     \n\
-                     Memory:\n\
-                     - Used: {}\n\
-                     - Max: {}\n\
-                     - Fragmentation ratio: {}\n\
-                     \n\
-                     Stats:\n\
-                     - Ops/sec: {}\n\
-                     - Total commands processed: {}\n\
-                     - Connected clients: {}\n\
-                     \n\
-                     Keys: {}",
-                    ping_response,
-                    version,
-                    uptime_seconds,
-                    uptime_days,
-                    used_memory_human,
-                    maxmemory_display,
-                    frag_ratio,
-                    ops_per_sec,
-                    total_commands,
-                    connected_clients,
-                    db_size,
-                );
+database_tool!(read_only, key_summary, "redis_key_summary",
+    "Get metadata summary for a key combining TYPE, TTL, MEMORY USAGE, and OBJECT ENCODING.",
+    {
+        /// Key to inspect
+        pub key: String,
+    } => |conn, input| {
+        // TYPE
+        let key_type: String = redis::cmd("TYPE")
+            .arg(&input.key)
+            .query_async(&mut conn)
+            .await
+            .tool_context("TYPE failed")?;
 
-                Ok(CallToolResult::text(output))
-            },
-        )
-        .build()
-}
+        if key_type == "none" {
+            return Ok(CallToolResult::text(format!(
+                "Key '{}' does not exist",
+                input.key
+            )));
+        }
 
-// ---------------------------------------------------------------------------
-// 2. redis_key_summary
-// ---------------------------------------------------------------------------
+        // TTL
+        let ttl: i64 = redis::cmd("TTL")
+            .arg(&input.key)
+            .query_async(&mut conn)
+            .await
+            .tool_context("TTL failed")?;
 
-/// Input for redis_key_summary
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct KeySummaryInput {
-    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name to resolve connection from (uses default profile if not set)
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Key to inspect
-    pub key: String,
-}
+        let ttl_display = match ttl {
+            -2 => "key does not exist".to_string(),
+            -1 => "no expiry".to_string(),
+            _ => format!("{} seconds", ttl),
+        };
 
-/// Build the key_summary tool
-pub fn key_summary(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_key_summary")
-        .description(
-            "Get metadata summary for a key combining TYPE, TTL, MEMORY USAGE, and OBJECT ENCODING.",
-        )
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<KeySummaryInput>| async move {
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
+        // MEMORY USAGE (may fail for some key types or Redis versions)
+        let memory_display = match redis::cmd("MEMORY")
+            .arg("USAGE")
+            .arg(&input.key)
+            .query_async::<Option<i64>>(&mut conn)
+            .await
+        {
+            Ok(Some(bytes)) => format_bytes(bytes),
+            Ok(None) => "unknown".to_string(),
+            Err(_) => "unavailable".to_string(),
+        };
 
-                // TYPE
-                let key_type: String = redis::cmd("TYPE")
-                    .arg(&input.key)
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("TYPE failed")?;
+        // OBJECT ENCODING (may fail for some key types)
+        let encoding_display = match redis::cmd("OBJECT")
+            .arg("ENCODING")
+            .arg(&input.key)
+            .query_async::<Option<String>>(&mut conn)
+            .await
+        {
+            Ok(Some(enc)) => enc,
+            Ok(None) => "unknown".to_string(),
+            Err(_) => "unavailable".to_string(),
+        };
 
-                if key_type == "none" {
-                    return Ok(CallToolResult::text(format!(
-                        "Key '{}' does not exist",
-                        input.key
-                    )));
-                }
+        let output = format!(
+            "Key Summary: {}\n\
+             =============={}\n\
+             \n\
+             Type: {}\n\
+             TTL: {}\n\
+             Memory: {}\n\
+             Encoding: {}",
+            input.key,
+            "=".repeat(input.key.len()),
+            key_type,
+            ttl_display,
+            memory_display,
+            encoding_display,
+        );
 
-                // TTL
-                let ttl: i64 = redis::cmd("TTL")
-                    .arg(&input.key)
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("TTL failed")?;
-
-                let ttl_display = match ttl {
-                    -2 => "key does not exist".to_string(),
-                    -1 => "no expiry".to_string(),
-                    _ => format!("{} seconds", ttl),
-                };
-
-                // MEMORY USAGE (may fail for some key types or Redis versions)
-                let memory_display = match redis::cmd("MEMORY")
-                    .arg("USAGE")
-                    .arg(&input.key)
-                    .query_async::<Option<i64>>(&mut conn)
-                    .await
-                {
-                    Ok(Some(bytes)) => format_bytes(bytes),
-                    Ok(None) => "unknown".to_string(),
-                    Err(_) => "unavailable".to_string(),
-                };
-
-                // OBJECT ENCODING (may fail for some key types)
-                let encoding_display = match redis::cmd("OBJECT")
-                    .arg("ENCODING")
-                    .arg(&input.key)
-                    .query_async::<Option<String>>(&mut conn)
-                    .await
-                {
-                    Ok(Some(enc)) => enc,
-                    Ok(None) => "unknown".to_string(),
-                    Err(_) => "unavailable".to_string(),
-                };
-
-                let output = format!(
-                    "Key Summary: {}\n\
-                     =============={}\n\
-                     \n\
-                     Type: {}\n\
-                     TTL: {}\n\
-                     Memory: {}\n\
-                     Encoding: {}",
-                    input.key,
-                    "=".repeat(input.key.len()),
-                    key_type,
-                    ttl_display,
-                    memory_display,
-                    encoding_display,
-                );
-
-                Ok(CallToolResult::text(output))
-            },
-        )
-        .build()
-}
-
-// ---------------------------------------------------------------------------
-// 3. redis_hotkeys
-// ---------------------------------------------------------------------------
+        Ok(CallToolResult::text(output))
+    }
+);
 
 /// Maximum allowed sample size to prevent runaway scans.
 const MAX_SAMPLE_SIZE: usize = 10_000;
@@ -328,270 +261,220 @@ const MAX_SAMPLE_SIZE: usize = 10_000;
 /// Number of top keys to return by memory usage.
 const TOP_N: usize = 20;
 
-/// Input for redis_hotkeys
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct HotkeysInput {
-    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name to resolve connection from (uses default profile if not set)
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Key pattern to match (default: "*")
-    #[serde(default)]
-    pub pattern: Option<String>,
-    /// Maximum number of keys to sample (default: 1000, max: 10000)
-    #[serde(default)]
-    pub sample_size: Option<usize>,
-}
+database_tool!(read_only, hotkeys, "redis_hotkeys",
+    "Sample keys to find the largest by memory and show type distribution. \
+     Capped at sample_size (default 1000, max 10000) to limit impact.",
+    {
+        /// Key pattern to match (default: "*")
+        #[serde(default)]
+        pub pattern: Option<String>,
+        /// Maximum number of keys to sample (default: 1000, max: 10000)
+        #[serde(default)]
+        pub sample_size: Option<usize>,
+    } => |conn, input| {
+        let pattern = input.pattern.as_deref().unwrap_or("*");
+        let sample_size = input.sample_size.unwrap_or(1000).min(MAX_SAMPLE_SIZE);
 
-/// Build the hotkeys tool
-pub fn hotkeys(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_hotkeys")
-        .description(
-            "Sample keys to find the largest by memory and show type distribution. \
-             Capped at sample_size (default 1000, max 10000) to limit impact.",
-        )
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<HotkeysInput>| async move {
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
+        // SCAN to collect keys
+        let mut cursor: u64 = 0;
+        let mut scanned_keys: Vec<String> = Vec::new();
 
-                let pattern = input.pattern.as_deref().unwrap_or("*");
-                let sample_size = input.sample_size.unwrap_or(1000).min(MAX_SAMPLE_SIZE);
+        loop {
+            let (new_cursor, keys): (u64, Vec<String>) = redis::cmd("SCAN")
+                .arg(cursor)
+                .arg("MATCH")
+                .arg(pattern)
+                .arg("COUNT")
+                .arg(100)
+                .query_async(&mut conn)
+                .await
+                .tool_context("SCAN failed")?;
 
-                // SCAN to collect keys
-                let mut cursor: u64 = 0;
-                let mut scanned_keys: Vec<String> = Vec::new();
+            scanned_keys.extend(keys);
+            cursor = new_cursor;
 
-                loop {
-                    let (new_cursor, keys): (u64, Vec<String>) = redis::cmd("SCAN")
-                        .arg(cursor)
-                        .arg("MATCH")
-                        .arg(pattern)
-                        .arg("COUNT")
-                        .arg(100)
-                        .query_async(&mut conn)
-                        .await
-                        .tool_context("SCAN failed")?;
+            if cursor == 0 || scanned_keys.len() >= sample_size {
+                break;
+            }
+        }
 
-                    scanned_keys.extend(keys);
-                    cursor = new_cursor;
+        scanned_keys.truncate(sample_size);
 
-                    if cursor == 0 || scanned_keys.len() >= sample_size {
-                        break;
-                    }
-                }
+        if scanned_keys.is_empty() {
+            return Ok(CallToolResult::text(format!(
+                "No keys found matching pattern '{}'",
+                pattern
+            )));
+        }
 
-                scanned_keys.truncate(sample_size);
+        // Collect TYPE and MEMORY USAGE for each key
+        let mut type_counts: HashMap<String, usize> = HashMap::new();
+        let mut key_sizes: Vec<(String, i64, String)> = Vec::new();
+        let mut total_memory: i64 = 0;
 
-                if scanned_keys.is_empty() {
-                    return Ok(CallToolResult::text(format!(
-                        "No keys found matching pattern '{}'",
-                        pattern
-                    )));
-                }
-
-                // Collect TYPE and MEMORY USAGE for each key
-                let mut type_counts: HashMap<String, usize> = HashMap::new();
-                let mut key_sizes: Vec<(String, i64, String)> = Vec::new();
-                let mut total_memory: i64 = 0;
-
-                for key in &scanned_keys {
-                    // TYPE
-                    let key_type: String =
-                        match redis::cmd("TYPE").arg(key).query_async(&mut conn).await {
-                            Ok(t) => t,
-                            Err(_) => continue,
-                        };
-
-                    *type_counts.entry(key_type.clone()).or_insert(0) += 1;
-
-                    // MEMORY USAGE -- may return None or fail
-                    let mem_bytes: Option<i64> = redis::cmd("MEMORY")
-                        .arg("USAGE")
-                        .arg(key)
-                        .query_async(&mut conn)
-                        .await
-                        .unwrap_or_default();
-
-                    if let Some(bytes) = mem_bytes {
-                        total_memory += bytes;
-                        key_sizes.push((key.clone(), bytes, key_type));
-                    }
-                }
-
-                // Sort by memory descending and take top N
-                key_sizes.sort_by(|a, b| b.1.cmp(&a.1));
-                key_sizes.truncate(TOP_N);
-
-                // Build output
-                let mut output = format!(
-                    "Redis Hotkeys Analysis\n\
-                     ======================\n\
-                     \n\
-                     Keys scanned: {}\n\
-                     Total memory sampled: {}\n\
-                     \n\
-                     Type Distribution:\n",
-                    scanned_keys.len(),
-                    format_bytes(total_memory),
-                );
-
-                let mut type_list: Vec<_> = type_counts.iter().collect();
-                type_list.sort_by(|a, b| b.1.cmp(a.1));
-                for (t, count) in &type_list {
-                    output.push_str(&format!("  {}: {}\n", t, count));
-                }
-
-                output.push_str(&format!(
-                    "\nTop {} Keys by Memory:\n",
-                    key_sizes.len().min(TOP_N)
-                ));
-
-                for (i, (key, bytes, key_type)) in key_sizes.iter().enumerate() {
-                    output.push_str(&format!(
-                        "  {}. {} ({}) - {}\n",
-                        i + 1,
-                        key,
-                        key_type,
-                        format_bytes(*bytes),
-                    ));
-                }
-
-                Ok(CallToolResult::text(output))
-            },
-        )
-        .build()
-}
-
-// ---------------------------------------------------------------------------
-// 4. redis_connection_summary
-// ---------------------------------------------------------------------------
-
-/// Input for redis_connection_summary
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ConnectionSummaryInput {
-    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name to resolve connection from (uses default profile if not set)
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the connection_summary tool
-pub fn connection_summary(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_connection_summary")
-        .description(
-            "Analyze client connections: totals, top IPs, idle/blocked counts, and oldest connection.",
-        )
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<ConnectionSummaryInput>| async move {
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
-
-                // CLIENT LIST
-                let client_list_raw: String = redis::cmd("CLIENT")
-                    .arg("LIST")
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("CLIENT LIST failed")?;
-
-                // INFO clients section
-                let info_text: String = redis::cmd("INFO")
-                    .arg("clients")
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("INFO clients failed")?;
-
-                let info = parse_info(&info_text);
-                let clients = parse_client_list(&client_list_raw);
-
-                let total = clients.len();
-
-                // Connections by source IP
-                let mut ip_counts: HashMap<String, usize> = HashMap::new();
-                for c in &clients {
-                    if let Some(addr) = c.get("addr") {
-                        // addr is "ip:port" -- extract just IP
-                        let ip = addr
-                            .rsplit_once(':')
-                            .map(|(ip, _)| ip.to_string())
-                            .unwrap_or_else(|| addr.clone());
-                        *ip_counts.entry(ip).or_insert(0) += 1;
-                    }
-                }
-                let mut ip_list: Vec<_> = ip_counts.into_iter().collect();
-                ip_list.sort_by(|a, b| b.1.cmp(&a.1));
-                ip_list.truncate(10);
-
-                // Idle connections (idle > 60s)
-                let idle_count = clients
-                    .iter()
-                    .filter(|c| {
-                        c.get("idle")
-                            .and_then(|v| v.parse::<u64>().ok())
-                            .is_some_and(|idle| idle > 60)
-                    })
-                    .count();
-
-                // Blocked clients from INFO
-                let blocked_clients = info
-                    .get("blocked_clients")
-                    .cloned()
-                    .unwrap_or_else(|| "unknown".to_string());
-
-                // Oldest connection age
-                let oldest_age = clients
-                    .iter()
-                    .filter_map(|c| c.get("age").and_then(|v| v.parse::<u64>().ok()))
-                    .max();
-
-                let oldest_display = match oldest_age {
-                    Some(age) => {
-                        let days = age / 86400;
-                        let hours = (age % 86400) / 3600;
-                        let minutes = (age % 3600) / 60;
-                        let secs = age % 60;
-                        if days > 0 {
-                            format!("{}d {}h {}m {}s ({} seconds)", days, hours, minutes, secs, age)
-                        } else if hours > 0 {
-                            format!("{}h {}m {}s ({} seconds)", hours, minutes, secs, age)
-                        } else if minutes > 0 {
-                            format!("{}m {}s ({} seconds)", minutes, secs, age)
-                        } else {
-                            format!("{} seconds", age)
-                        }
-                    }
-                    None => "unknown".to_string(),
+        for key in &scanned_keys {
+            // TYPE
+            let key_type: String =
+                match redis::cmd("TYPE").arg(key).query_async(&mut conn).await {
+                    Ok(t) => t,
+                    Err(_) => continue,
                 };
 
-                // Build output
-                let mut output = format!(
-                    "Redis Connection Summary\n\
-                     ========================\n\
-                     \n\
-                     Total connections: {}\n\
-                     Blocked clients: {}\n\
-                     Idle connections (>60s): {}\n\
-                     Oldest connection: {}\n\
-                     \n\
-                     Connections by IP (top 10):\n",
-                    total, blocked_clients, idle_count, oldest_display,
-                );
+            *type_counts.entry(key_type.clone()).or_insert(0) += 1;
 
-                for (ip, count) in &ip_list {
-                    output.push_str(&format!("  {}: {}\n", ip, count));
+            // MEMORY USAGE -- may return None or fail
+            let mem_bytes: Option<i64> = redis::cmd("MEMORY")
+                .arg("USAGE")
+                .arg(key)
+                .query_async(&mut conn)
+                .await
+                .unwrap_or_default();
+
+            if let Some(bytes) = mem_bytes {
+                total_memory += bytes;
+                key_sizes.push((key.clone(), bytes, key_type));
+            }
+        }
+
+        // Sort by memory descending and take top N
+        key_sizes.sort_by(|a, b| b.1.cmp(&a.1));
+        key_sizes.truncate(TOP_N);
+
+        // Build output
+        let mut output = format!(
+            "Redis Hotkeys Analysis\n\
+             ======================\n\
+             \n\
+             Keys scanned: {}\n\
+             Total memory sampled: {}\n\
+             \n\
+             Type Distribution:\n",
+            scanned_keys.len(),
+            format_bytes(total_memory),
+        );
+
+        let mut type_list: Vec<_> = type_counts.iter().collect();
+        type_list.sort_by(|a, b| b.1.cmp(a.1));
+        for (t, count) in &type_list {
+            output.push_str(&format!("  {}: {}\n", t, count));
+        }
+
+        output.push_str(&format!(
+            "\nTop {} Keys by Memory:\n",
+            key_sizes.len().min(TOP_N)
+        ));
+
+        for (i, (key, bytes, key_type)) in key_sizes.iter().enumerate() {
+            output.push_str(&format!(
+                "  {}. {} ({}) - {}\n",
+                i + 1,
+                key,
+                key_type,
+                format_bytes(*bytes),
+            ));
+        }
+
+        Ok(CallToolResult::text(output))
+    }
+);
+
+database_tool!(read_only, connection_summary, "redis_connection_summary",
+    "Analyze client connections: totals, top IPs, idle/blocked counts, and oldest connection.",
+    {} => |conn, _input| {
+        // CLIENT LIST
+        let client_list_raw: String = redis::cmd("CLIENT")
+            .arg("LIST")
+            .query_async(&mut conn)
+            .await
+            .tool_context("CLIENT LIST failed")?;
+
+        // INFO clients section
+        let info_text: String = redis::cmd("INFO")
+            .arg("clients")
+            .query_async(&mut conn)
+            .await
+            .tool_context("INFO clients failed")?;
+
+        let info = parse_info(&info_text);
+        let clients = parse_client_list(&client_list_raw);
+
+        let total = clients.len();
+
+        // Connections by source IP
+        let mut ip_counts: HashMap<String, usize> = HashMap::new();
+        for c in &clients {
+            if let Some(addr) = c.get("addr") {
+                // addr is "ip:port" -- extract just IP
+                let ip = addr
+                    .rsplit_once(':')
+                    .map(|(ip, _)| ip.to_string())
+                    .unwrap_or_else(|| addr.clone());
+                *ip_counts.entry(ip).or_insert(0) += 1;
+            }
+        }
+        let mut ip_list: Vec<_> = ip_counts.into_iter().collect();
+        ip_list.sort_by(|a, b| b.1.cmp(&a.1));
+        ip_list.truncate(10);
+
+        // Idle connections (idle > 60s)
+        let idle_count = clients
+            .iter()
+            .filter(|c| {
+                c.get("idle")
+                    .and_then(|v| v.parse::<u64>().ok())
+                    .is_some_and(|idle| idle > 60)
+            })
+            .count();
+
+        // Blocked clients from INFO
+        let blocked_clients = info
+            .get("blocked_clients")
+            .cloned()
+            .unwrap_or_else(|| "unknown".to_string());
+
+        // Oldest connection age
+        let oldest_age = clients
+            .iter()
+            .filter_map(|c| c.get("age").and_then(|v| v.parse::<u64>().ok()))
+            .max();
+
+        let oldest_display = match oldest_age {
+            Some(age) => {
+                let days = age / 86400;
+                let hours = (age % 86400) / 3600;
+                let minutes = (age % 3600) / 60;
+                let secs = age % 60;
+                if days > 0 {
+                    format!("{}d {}h {}m {}s ({} seconds)", days, hours, minutes, secs, age)
+                } else if hours > 0 {
+                    format!("{}h {}m {}s ({} seconds)", hours, minutes, secs, age)
+                } else if minutes > 0 {
+                    format!("{}m {}s ({} seconds)", minutes, secs, age)
+                } else {
+                    format!("{} seconds", age)
                 }
+            }
+            None => "unknown".to_string(),
+        };
 
-                Ok(CallToolResult::text(output))
-            },
-        )
-        .build()
-}
+        // Build output
+        let mut output = format!(
+            "Redis Connection Summary\n\
+             ========================\n\
+             \n\
+             Total connections: {}\n\
+             Blocked clients: {}\n\
+             Idle connections (>60s): {}\n\
+             Oldest connection: {}\n\
+             \n\
+             Connections by IP (top 10):\n",
+            total, blocked_clients, idle_count, oldest_display,
+        );
+
+        for (ip, count) in &ip_list {
+            output.push_str(&format!("  {}: {}\n", ip, count));
+        }
+
+        Ok(CallToolResult::text(output))
+    }
+);

--- a/crates/redisctl-mcp/src/tools/redis/keys.rs
+++ b/crates/redisctl-mcp/src/tools/redis/keys.rs
@@ -3,103 +3,43 @@
 //! unlink, copy, dump, restore, randomkey, touch, incr, decr, append, strlen, getrange, setrange,
 //! setnx)
 
-use std::sync::Arc;
-
-use schemars::JsonSchema;
-use serde::Deserialize;
-use tower_mcp::extract::{Json, State};
-use tower_mcp::{CallToolResult, Error as McpError, McpRouter, ResultExt, Tool, ToolBuilder};
+use tower_mcp::{CallToolResult, ResultExt};
 
 use super::format_value;
+use crate::tools::macros::{database_tool, mcp_module};
 
-use crate::state::AppState;
-
-/// All tool names registered by this sub-module.
-pub(super) const TOOL_NAMES: &[&str] = &[
-    "redis_keys",
-    "redis_get",
-    "redis_type",
-    "redis_ttl",
-    "redis_exists",
-    "redis_memory_usage",
-    "redis_scan",
-    "redis_object_encoding",
-    "redis_object_freq",
-    "redis_object_idletime",
-    "redis_object_help",
-    "redis_set",
-    "redis_del",
-    "redis_expire",
-    "redis_rename",
-    "redis_mget",
-    "redis_mset",
-    "redis_persist",
-    "redis_unlink",
-    "redis_copy",
-    "redis_dump",
-    "redis_restore",
-    "redis_randomkey",
-    "redis_touch",
-    "redis_incr",
-    "redis_decr",
-    "redis_append",
-    "redis_strlen",
-    "redis_getrange",
-    "redis_setrange",
-    "redis_setnx",
-];
-
-/// Build a sub-router containing all key-level Redis tools
-pub fn router(state: Arc<AppState>) -> McpRouter {
-    McpRouter::new()
-        .tool(keys(state.clone()))
-        .tool(scan(state.clone()))
-        .tool(get(state.clone()))
-        .tool(key_type(state.clone()))
-        .tool(ttl(state.clone()))
-        .tool(exists(state.clone()))
-        .tool(memory_usage(state.clone()))
-        .tool(object_encoding(state.clone()))
-        .tool(object_freq(state.clone()))
-        .tool(object_idletime(state.clone()))
-        .tool(object_help(state.clone()))
-        .tool(set(state.clone()))
-        .tool(del(state.clone()))
-        .tool(expire(state.clone()))
-        .tool(rename(state.clone()))
-        .tool(mget(state.clone()))
-        .tool(mset(state.clone()))
-        .tool(persist(state.clone()))
-        .tool(unlink(state.clone()))
-        .tool(copy(state.clone()))
-        .tool(dump(state.clone()))
-        .tool(restore(state.clone()))
-        .tool(randomkey(state.clone()))
-        .tool(touch(state.clone()))
-        .tool(incr(state.clone()))
-        .tool(decr(state.clone()))
-        .tool(append(state.clone()))
-        .tool(strlen(state.clone()))
-        .tool(getrange(state.clone()))
-        .tool(setrange(state.clone()))
-        .tool(setnx(state))
-}
-
-/// Input for keys command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct KeysInput {
-    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name to resolve connection from (uses default profile if not set)
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Key pattern to match (default: "*")
-    #[serde(default = "default_pattern")]
-    pub pattern: String,
-    /// Maximum number of keys to return (default: 100)
-    #[serde(default = "default_limit")]
-    pub limit: usize,
+mcp_module! {
+    keys => "redis_keys",
+    scan => "redis_scan",
+    get => "redis_get",
+    key_type => "redis_type",
+    ttl => "redis_ttl",
+    exists => "redis_exists",
+    memory_usage => "redis_memory_usage",
+    object_encoding => "redis_object_encoding",
+    object_freq => "redis_object_freq",
+    object_idletime => "redis_object_idletime",
+    object_help => "redis_object_help",
+    set => "redis_set",
+    del => "redis_del",
+    expire => "redis_expire",
+    rename => "redis_rename",
+    mget => "redis_mget",
+    mset => "redis_mset",
+    persist => "redis_persist",
+    unlink => "redis_unlink",
+    copy => "redis_copy",
+    dump => "redis_dump",
+    restore => "redis_restore",
+    randomkey => "redis_randomkey",
+    touch => "redis_touch",
+    incr => "redis_incr",
+    decr => "redis_decr",
+    append => "redis_append",
+    strlen => "redis_strlen",
+    getrange => "redis_getrange",
+    setrange => "redis_setrange",
+    setnx => "redis_setnx",
 }
 
 fn default_pattern() -> String {
@@ -110,819 +50,479 @@ fn default_limit() -> usize {
     100
 }
 
-/// Build the keys tool
-pub fn keys(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_keys")
-        .description("List keys matching a pattern using SCAN (production-safe, non-blocking).")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<KeysInput>| async move {
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
+database_tool!(read_only, keys, "redis_keys",
+    "List keys matching a pattern using SCAN (production-safe, non-blocking).",
+    {
+        /// Key pattern to match (default: "*")
+        #[serde(default = "default_pattern")]
+        pub pattern: String,
+        /// Maximum number of keys to return (default: 100)
+        #[serde(default = "default_limit")]
+        pub limit: usize,
+    } => |conn, input| {
+        // Use SCAN to safely iterate keys
+        let mut cursor: u64 = 0;
+        let mut all_keys: Vec<String> = Vec::new();
 
-                // Use SCAN to safely iterate keys
-                let mut cursor: u64 = 0;
-                let mut all_keys: Vec<String> = Vec::new();
+        loop {
+            let (new_cursor, keys): (u64, Vec<String>) = redis::cmd("SCAN")
+                .arg(cursor)
+                .arg("MATCH")
+                .arg(&input.pattern)
+                .arg("COUNT")
+                .arg(100)
+                .query_async(&mut conn)
+                .await
+                .tool_context("SCAN failed")?;
 
-                loop {
-                    let (new_cursor, keys): (u64, Vec<String>) = redis::cmd("SCAN")
-                        .arg(cursor)
-                        .arg("MATCH")
-                        .arg(&input.pattern)
-                        .arg("COUNT")
-                        .arg(100)
-                        .query_async(&mut conn)
-                        .await
-                        .tool_context("SCAN failed")?;
+            all_keys.extend(keys);
+            cursor = new_cursor;
 
-                    all_keys.extend(keys);
-                    cursor = new_cursor;
+            if cursor == 0 || all_keys.len() >= input.limit {
+                break;
+            }
+        }
 
-                    if cursor == 0 || all_keys.len() >= input.limit {
-                        break;
-                    }
-                }
+        // Truncate to limit
+        all_keys.truncate(input.limit);
 
-                // Truncate to limit
-                all_keys.truncate(input.limit);
+        let output = if all_keys.is_empty() {
+            format!("No keys found matching pattern '{}'", input.pattern)
+        } else {
+            format!(
+                "Found {} key(s) matching '{}'\n\n{}",
+                all_keys.len(),
+                input.pattern,
+                all_keys.join("\n")
+            )
+        };
 
-                let output = if all_keys.is_empty() {
-                    format!("No keys found matching pattern '{}'", input.pattern)
-                } else {
-                    format!(
-                        "Found {} key(s) matching '{}'\n\n{}",
-                        all_keys.len(),
-                        input.pattern,
-                        all_keys.join("\n")
-                    )
-                };
+        Ok(CallToolResult::text(output))
+    }
+);
 
-                Ok(CallToolResult::text(output))
-            },
-        )
-        .build()
-}
+database_tool!(read_only, scan, "redis_scan",
+    "Scan keys with optional type filter. Prefer over redis_keys when filtering by type.",
+    {
+        /// Key pattern to match (default: "*")
+        #[serde(default = "default_pattern")]
+        pub pattern: String,
+        /// Filter by key type (e.g., "string", "list", "set", "zset", "hash", "stream")
+        #[serde(default)]
+        pub key_type: Option<String>,
+        /// Maximum number of keys to return (default: 100)
+        #[serde(default = "default_limit")]
+        pub limit: usize,
+    } => |conn, input| {
+        let mut cursor: u64 = 0;
+        let mut all_keys: Vec<String> = Vec::new();
 
-/// Input for GET command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetInput {
-    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name to resolve connection from (uses default profile if not set)
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Key to get
-    pub key: String,
-}
+        loop {
+            let mut cmd = redis::cmd("SCAN");
+            cmd.arg(cursor)
+                .arg("MATCH")
+                .arg(&input.pattern)
+                .arg("COUNT")
+                .arg(100);
 
-/// Build the get tool
-pub fn get(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_get")
-        .description("Get the value of a key.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<GetInput>| async move {
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
+            // Add TYPE filter if specified
+            if let Some(ref key_type) = input.key_type {
+                cmd.arg("TYPE").arg(key_type);
+            }
 
-                let value: Option<String> = redis::cmd("GET")
-                    .arg(&input.key)
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("GET failed")?;
+            let (new_cursor, keys): (u64, Vec<String>) = cmd
+                .query_async(&mut conn)
+                .await
+                .tool_context("SCAN failed")?;
 
-                match value {
-                    Some(v) => Ok(CallToolResult::text(v)),
-                    None => Ok(CallToolResult::text(format!(
-                        "(nil) - key '{}' not found",
-                        input.key
-                    ))),
-                }
-            },
-        )
-        .build()
-}
+            all_keys.extend(keys);
+            cursor = new_cursor;
 
-/// Input for TYPE command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct TypeInput {
-    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name to resolve connection from (uses default profile if not set)
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Key to check type
-    pub key: String,
-}
+            if cursor == 0 || all_keys.len() >= input.limit {
+                break;
+            }
+        }
 
-/// Build the type tool
-pub fn key_type(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_type")
-        .description("Get the data type of a key.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<TypeInput>| async move {
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
+        all_keys.truncate(input.limit);
 
-                let key_type: String = redis::cmd("TYPE")
-                    .arg(&input.key)
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("TYPE failed")?;
+        let type_info = input
+            .key_type
+            .as_ref()
+            .map(|t| format!(" of type '{}'", t))
+            .unwrap_or_default();
 
-                Ok(CallToolResult::text(format!("{}: {}", input.key, key_type)))
-            },
-        )
-        .build()
-}
+        let output = if all_keys.is_empty() {
+            format!(
+                "No keys{} found matching pattern '{}'",
+                type_info, input.pattern
+            )
+        } else {
+            format!(
+                "Found {} key(s){} matching '{}'\n\n{}",
+                all_keys.len(),
+                type_info,
+                input.pattern,
+                all_keys.join("\n")
+            )
+        };
 
-/// Input for TTL command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct TtlInput {
-    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name to resolve connection from (uses default profile if not set)
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Key to check TTL
-    pub key: String,
-}
+        Ok(CallToolResult::text(output))
+    }
+);
 
-/// Build the ttl tool
-pub fn ttl(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_ttl")
-        .description("Get the TTL of a key in seconds (-1 = no expiry, -2 = missing).")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<TtlInput>| async move {
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
+database_tool!(read_only, get, "redis_get",
+    "Get the value of a key.",
+    {
+        /// Key to get
+        pub key: String,
+    } => |conn, input| {
+        let value: Option<String> = redis::cmd("GET")
+            .arg(&input.key)
+            .query_async(&mut conn)
+            .await
+            .tool_context("GET failed")?;
 
-                let ttl: i64 = redis::cmd("TTL")
-                    .arg(&input.key)
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("TTL failed")?;
+        match value {
+            Some(v) => Ok(CallToolResult::text(v)),
+            None => Ok(CallToolResult::text(format!(
+                "(nil) - key '{}' not found",
+                input.key
+            ))),
+        }
+    }
+);
 
-                let message = match ttl {
-                    -2 => format!("{}: key does not exist", input.key),
-                    -1 => format!("{}: no expiry set", input.key),
-                    _ => format!("{}: {} seconds remaining", input.key, ttl),
-                };
+database_tool!(read_only, key_type, "redis_type",
+    "Get the data type of a key.",
+    {
+        /// Key to check type
+        pub key: String,
+    } => |conn, input| {
+        let key_type: String = redis::cmd("TYPE")
+            .arg(&input.key)
+            .query_async(&mut conn)
+            .await
+            .tool_context("TYPE failed")?;
 
-                Ok(CallToolResult::text(message))
-            },
-        )
-        .build()
-}
+        Ok(CallToolResult::text(format!("{}: {}", input.key, key_type)))
+    }
+);
 
-/// Input for EXISTS command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ExistsInput {
-    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name to resolve connection from (uses default profile if not set)
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Keys to check existence
-    pub keys: Vec<String>,
-}
+database_tool!(read_only, ttl, "redis_ttl",
+    "Get the TTL of a key in seconds (-1 = no expiry, -2 = missing).",
+    {
+        /// Key to check TTL
+        pub key: String,
+    } => |conn, input| {
+        let ttl: i64 = redis::cmd("TTL")
+            .arg(&input.key)
+            .query_async(&mut conn)
+            .await
+            .tool_context("TTL failed")?;
 
-/// Build the exists tool
-pub fn exists(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_exists")
-        .description("Check if one or more keys exist.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<ExistsInput>| async move {
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
+        let message = match ttl {
+            -2 => format!("{}: key does not exist", input.key),
+            -1 => format!("{}: no expiry set", input.key),
+            _ => format!("{}: {} seconds remaining", input.key, ttl),
+        };
 
-                let mut cmd = redis::cmd("EXISTS");
-                for key in &input.keys {
-                    cmd.arg(key);
-                }
+        Ok(CallToolResult::text(message))
+    }
+);
 
-                let count: i64 = cmd
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("EXISTS failed")?;
+database_tool!(read_only, exists, "redis_exists",
+    "Check if one or more keys exist.",
+    {
+        /// Keys to check existence
+        pub keys: Vec<String>,
+    } => |conn, input| {
+        let mut cmd = redis::cmd("EXISTS");
+        for key in &input.keys {
+            cmd.arg(key);
+        }
 
-                Ok(CallToolResult::text(format!(
-                    "{} of {} key(s) exist",
-                    count,
-                    input.keys.len()
-                )))
-            },
-        )
-        .build()
-}
+        let count: i64 = cmd
+            .query_async(&mut conn)
+            .await
+            .tool_context("EXISTS failed")?;
 
-/// Input for MEMORY USAGE command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct MemoryUsageInput {
-    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name to resolve connection from (uses default profile if not set)
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Key to check memory usage
-    pub key: String,
-}
+        Ok(CallToolResult::text(format!(
+            "{} of {} key(s) exist",
+            count,
+            input.keys.len()
+        )))
+    }
+);
 
-/// Build the memory_usage tool
-pub fn memory_usage(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_memory_usage")
-        .description("Get memory usage of a key in bytes (MEMORY USAGE).")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<MemoryUsageInput>| async move {
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
+database_tool!(read_only, memory_usage, "redis_memory_usage",
+    "Get memory usage of a key in bytes (MEMORY USAGE).",
+    {
+        /// Key to check memory usage
+        pub key: String,
+    } => |conn, input| {
+        let bytes: Option<i64> = redis::cmd("MEMORY")
+            .arg("USAGE")
+            .arg(&input.key)
+            .query_async(&mut conn)
+            .await
+            .tool_context("MEMORY USAGE failed")?;
 
-                let bytes: Option<i64> = redis::cmd("MEMORY")
-                    .arg("USAGE")
-                    .arg(&input.key)
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("MEMORY USAGE failed")?;
+        match bytes {
+            Some(b) => Ok(CallToolResult::text(format!("{}: {} bytes", input.key, b))),
+            None => Ok(CallToolResult::text(format!(
+                "{}: key does not exist",
+                input.key
+            ))),
+        }
+    }
+);
 
-                match bytes {
-                    Some(b) => Ok(CallToolResult::text(format!("{}: {} bytes", input.key, b))),
-                    None => Ok(CallToolResult::text(format!(
-                        "{}: key does not exist",
-                        input.key
-                    ))),
-                }
-            },
-        )
-        .build()
-}
+database_tool!(read_only, object_encoding, "redis_object_encoding",
+    "Get the internal encoding of a key. Useful for understanding memory usage patterns.",
+    {
+        /// Key to check encoding
+        pub key: String,
+    } => |conn, input| {
+        let encoding: Option<String> = redis::cmd("OBJECT")
+            .arg("ENCODING")
+            .arg(&input.key)
+            .query_async(&mut conn)
+            .await
+            .tool_context("OBJECT ENCODING failed")?;
 
-/// Input for SCAN with type filter
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ScanInput {
-    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name to resolve connection from (uses default profile if not set)
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Key pattern to match (default: "*")
-    #[serde(default = "default_pattern")]
-    pub pattern: String,
-    /// Filter by key type (e.g., "string", "list", "set", "zset", "hash", "stream")
-    #[serde(default)]
-    pub key_type: Option<String>,
-    /// Maximum number of keys to return (default: 100)
-    #[serde(default = "default_limit")]
-    pub limit: usize,
-}
+        match encoding {
+            Some(enc) => Ok(CallToolResult::text(format!("{}: {}", input.key, enc))),
+            None => Ok(CallToolResult::text(format!(
+                "{}: key does not exist",
+                input.key
+            ))),
+        }
+    }
+);
 
-/// Build the scan tool with type filter
-pub fn scan(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_scan")
-        .description(
-            "Scan keys with optional type filter. Prefer over redis_keys when filtering by type.",
-        )
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<ScanInput>| async move {
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
+database_tool!(read_only, object_freq, "redis_object_freq",
+    "Get the LFU access frequency counter for a key. \
+     Only works with allkeys-lfu or volatile-lfu eviction policy.",
+    {
+        /// Key to get LFU access frequency for
+        pub key: String,
+    } => |conn, input| {
+        let freq: i64 = redis::cmd("OBJECT")
+            .arg("FREQ")
+            .arg(&input.key)
+            .query_async(&mut conn)
+            .await
+            .tool_context("OBJECT FREQ failed")?;
 
-                let mut cursor: u64 = 0;
-                let mut all_keys: Vec<String> = Vec::new();
+        Ok(CallToolResult::text(format!(
+            "{}: LFU frequency counter = {}",
+            input.key, freq
+        )))
+    }
+);
 
-                loop {
-                    let mut cmd = redis::cmd("SCAN");
-                    cmd.arg(cursor)
-                        .arg("MATCH")
-                        .arg(&input.pattern)
-                        .arg("COUNT")
-                        .arg(100);
+database_tool!(read_only, object_idletime, "redis_object_idletime",
+    "Get idle time of a key in seconds since last access.",
+    {
+        /// Key to get idle time for
+        pub key: String,
+    } => |conn, input| {
+        let idle: i64 = redis::cmd("OBJECT")
+            .arg("IDLETIME")
+            .arg(&input.key)
+            .query_async(&mut conn)
+            .await
+            .tool_context("OBJECT IDLETIME failed")?;
 
-                    // Add TYPE filter if specified
-                    if let Some(ref key_type) = input.key_type {
-                        cmd.arg("TYPE").arg(key_type);
-                    }
+        Ok(CallToolResult::text(format!(
+            "{}: idle for {} seconds",
+            input.key, idle
+        )))
+    }
+);
 
-                    let (new_cursor, keys): (u64, Vec<String>) = cmd
-                        .query_async(&mut conn)
-                        .await
-                        .tool_context("SCAN failed")?;
+database_tool!(read_only, object_help, "redis_object_help",
+    "Get available OBJECT subcommands.",
+    {} => |conn, _input| {
+        let result: Vec<String> = redis::cmd("OBJECT")
+            .arg("HELP")
+            .query_async(&mut conn)
+            .await
+            .tool_context("OBJECT HELP failed")?;
 
-                    all_keys.extend(keys);
-                    cursor = new_cursor;
-
-                    if cursor == 0 || all_keys.len() >= input.limit {
-                        break;
-                    }
-                }
-
-                all_keys.truncate(input.limit);
-
-                let type_info = input
-                    .key_type
-                    .as_ref()
-                    .map(|t| format!(" of type '{}'", t))
-                    .unwrap_or_default();
-
-                let output = if all_keys.is_empty() {
-                    format!(
-                        "No keys{} found matching pattern '{}'",
-                        type_info, input.pattern
-                    )
-                } else {
-                    format!(
-                        "Found {} key(s){} matching '{}'\n\n{}",
-                        all_keys.len(),
-                        type_info,
-                        input.pattern,
-                        all_keys.join("\n")
-                    )
-                };
-
-                Ok(CallToolResult::text(output))
-            },
-        )
-        .build()
-}
-
-/// Input for OBJECT ENCODING command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ObjectEncodingInput {
-    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name to resolve connection from (uses default profile if not set)
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Key to check encoding
-    pub key: String,
-}
-
-/// Build the object_encoding tool
-pub fn object_encoding(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_object_encoding")
-        .description(
-            "Get the internal encoding of a key. Useful for understanding memory usage patterns.",
-        )
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<ObjectEncodingInput>| async move {
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
-
-                let encoding: Option<String> = redis::cmd("OBJECT")
-                    .arg("ENCODING")
-                    .arg(&input.key)
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("OBJECT ENCODING failed")?;
-
-                match encoding {
-                    Some(enc) => Ok(CallToolResult::text(format!("{}: {}", input.key, enc))),
-                    None => Ok(CallToolResult::text(format!(
-                        "{}: key does not exist",
-                        input.key
-                    ))),
-                }
-            },
-        )
-        .build()
-}
-
-/// Input for OBJECT FREQ command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ObjectFreqInput {
-    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name to resolve connection from (uses default profile if not set)
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Key to get LFU access frequency for
-    pub key: String,
-}
-
-/// Build the object_freq tool
-pub fn object_freq(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_object_freq")
-        .description(
-            "Get the LFU access frequency counter for a key. \
-             Only works with allkeys-lfu or volatile-lfu eviction policy.",
-        )
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<ObjectFreqInput>| async move {
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
-
-                let freq: i64 = redis::cmd("OBJECT")
-                    .arg("FREQ")
-                    .arg(&input.key)
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("OBJECT FREQ failed")?;
-
-                Ok(CallToolResult::text(format!(
-                    "{}: LFU frequency counter = {}",
-                    input.key, freq
-                )))
-            },
-        )
-        .build()
-}
-
-/// Input for OBJECT IDLETIME command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ObjectIdletimeInput {
-    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name to resolve connection from (uses default profile if not set)
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Key to get idle time for
-    pub key: String,
-}
-
-/// Build the object_idletime tool
-pub fn object_idletime(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_object_idletime")
-        .description("Get idle time of a key in seconds since last access.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<ObjectIdletimeInput>| async move {
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
-
-                let idle: i64 = redis::cmd("OBJECT")
-                    .arg("IDLETIME")
-                    .arg(&input.key)
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("OBJECT IDLETIME failed")?;
-
-                Ok(CallToolResult::text(format!(
-                    "{}: idle for {} seconds",
-                    input.key, idle
-                )))
-            },
-        )
-        .build()
-}
-
-/// Input for OBJECT HELP command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ObjectHelpInput {
-    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name to resolve connection from (uses default profile if not set)
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the object_help tool
-pub fn object_help(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_object_help")
-        .description("Get available OBJECT subcommands.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<ObjectHelpInput>| async move {
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
-
-                let result: Vec<String> = redis::cmd("OBJECT")
-                    .arg("HELP")
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("OBJECT HELP failed")?;
-
-                Ok(CallToolResult::text(format!(
-                    "OBJECT subcommands:\n{}",
-                    result.join("\n")
-                )))
-            },
-        )
-        .build()
-}
+        Ok(CallToolResult::text(format!(
+            "OBJECT subcommands:\n{}",
+            result.join("\n")
+        )))
+    }
+);
 
 // --- Write tools ---
 
-/// Input for SET command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct SetInput {
-    /// Optional Redis URL (overrides profile)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name for connection resolution
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Key to set
-    pub key: String,
-    /// Value to set
-    pub value: String,
-    /// Expire time in seconds
-    #[serde(default)]
-    pub ex: Option<u64>,
-    /// Expire time in milliseconds
-    #[serde(default)]
-    pub px: Option<u64>,
-    /// Only set if key does not already exist
-    #[serde(default)]
-    pub nx: bool,
-    /// Only set if key already exists
-    #[serde(default)]
-    pub xx: bool,
-}
+database_tool!(write, set, "redis_set",
+    "Set a key to a string value with optional expiry and conditional flags (NX/XX).",
+    {
+        /// Key to set
+        pub key: String,
+        /// Value to set
+        pub value: String,
+        /// Expire time in seconds
+        #[serde(default)]
+        pub ex: Option<u64>,
+        /// Expire time in milliseconds
+        #[serde(default)]
+        pub px: Option<u64>,
+        /// Only set if key does not already exist
+        #[serde(default)]
+        pub nx: bool,
+        /// Only set if key already exists
+        #[serde(default)]
+        pub xx: bool,
+    } => |conn, input| {
+        let mut cmd = redis::cmd("SET");
+        cmd.arg(&input.key).arg(&input.value);
 
-/// Build the set tool
-pub fn set(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_set")
-        .description(
-            "Set a key to a string value with optional expiry and conditional flags (NX/XX).",
-        )
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<SetInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
+        if let Some(ex) = input.ex {
+            cmd.arg("EX").arg(ex);
+        }
+        if let Some(px) = input.px {
+            cmd.arg("PX").arg(px);
+        }
+        if input.nx {
+            cmd.arg("NX");
+        }
+        if input.xx {
+            cmd.arg("XX");
+        }
 
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
+        let result: Option<String> = cmd
+            .query_async(&mut conn)
+            .await
+            .tool_context("SET failed")?;
 
-                let mut cmd = redis::cmd("SET");
-                cmd.arg(&input.key).arg(&input.value);
-
-                if let Some(ex) = input.ex {
-                    cmd.arg("EX").arg(ex);
-                }
-                if let Some(px) = input.px {
-                    cmd.arg("PX").arg(px);
-                }
+        match result {
+            Some(_) => Ok(CallToolResult::text(format!(
+                "OK - set '{}' successfully",
+                input.key
+            ))),
+            None => Ok(CallToolResult::text(format!(
+                "Key '{}' not set (condition not met: {})",
+                input.key,
                 if input.nx {
-                    cmd.arg("NX");
-                }
-                if input.xx {
-                    cmd.arg("XX");
-                }
-
-                let result: Option<String> = cmd
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("SET failed")?;
-
-                match result {
-                    Some(_) => Ok(CallToolResult::text(format!(
-                        "OK - set '{}' successfully",
-                        input.key
-                    ))),
-                    None => Ok(CallToolResult::text(format!(
-                        "Key '{}' not set (condition not met: {})",
-                        input.key,
-                        if input.nx {
-                            "NX - key already exists"
-                        } else {
-                            "XX - key does not exist"
-                        }
-                    ))),
-                }
-            },
-        )
-        .build()
-}
-
-/// Input for DEL command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct DelInput {
-    /// Optional Redis URL (overrides profile)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name for connection resolution
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Keys to delete
-    pub keys: Vec<String>,
-}
-
-/// Build the del tool
-pub fn del(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_del")
-        .description("DANGEROUS: Delete one or more keys.")
-        .destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<DelInput>| async move {
-                if !state.is_destructive_allowed() {
-                    return Err(McpError::tool(
-                        "Destructive operations require policy tier 'full'",
-                    ));
-                }
-
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
-
-                let mut cmd = redis::cmd("DEL");
-                for key in &input.keys {
-                    cmd.arg(key);
-                }
-
-                let count: i64 = cmd
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("DEL failed")?;
-
-                Ok(CallToolResult::text(format!(
-                    "Deleted {} of {} key(s)",
-                    count,
-                    input.keys.len()
-                )))
-            },
-        )
-        .build()
-}
-
-/// Input for EXPIRE command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ExpireInput {
-    /// Optional Redis URL (overrides profile)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name for connection resolution
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Key to set expiry on
-    pub key: String,
-    /// TTL in seconds
-    pub seconds: i64,
-}
-
-/// Build the expire tool
-pub fn expire(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_expire")
-        .description("Set a timeout on a key in seconds. Key auto-deletes after expiry.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<ExpireInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
-
-                let result: bool = redis::cmd("EXPIRE")
-                    .arg(&input.key)
-                    .arg(input.seconds)
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("EXPIRE failed")?;
-
-                if result {
-                    Ok(CallToolResult::text(format!(
-                        "OK - TTL set to {} seconds on '{}'",
-                        input.seconds, input.key
-                    )))
+                    "NX - key already exists"
                 } else {
-                    Ok(CallToolResult::text(format!(
-                        "Key '{}' does not exist or timeout could not be set",
-                        input.key
-                    )))
+                    "XX - key does not exist"
                 }
-            },
-        )
-        .build()
-}
+            ))),
+        }
+    }
+);
 
-/// Input for RENAME command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct RenameInput {
-    /// Optional Redis URL (overrides profile)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name for connection resolution
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Current key name
-    pub key: String,
-    /// New key name
-    pub newkey: String,
-}
+database_tool!(destructive, del, "redis_del",
+    "DANGEROUS: Delete one or more keys.",
+    {
+        /// Keys to delete
+        pub keys: Vec<String>,
+    } => |conn, input| {
+        let mut cmd = redis::cmd("DEL");
+        for key in &input.keys {
+            cmd.arg(key);
+        }
 
-/// Build the rename tool
-pub fn rename(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_rename")
-        .description("Rename a key. Overwrites the destination key if it exists.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<RenameInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
+        let count: i64 = cmd
+            .query_async(&mut conn)
+            .await
+            .tool_context("DEL failed")?;
 
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
+        Ok(CallToolResult::text(format!(
+            "Deleted {} of {} key(s)",
+            count,
+            input.keys.len()
+        )))
+    }
+);
 
-                let _: () = redis::cmd("RENAME")
-                    .arg(&input.key)
-                    .arg(&input.newkey)
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("RENAME failed")?;
+database_tool!(write, expire, "redis_expire",
+    "Set a timeout on a key in seconds. Key auto-deletes after expiry.",
+    {
+        /// Key to set expiry on
+        pub key: String,
+        /// TTL in seconds
+        pub seconds: i64,
+    } => |conn, input| {
+        let result: bool = redis::cmd("EXPIRE")
+            .arg(&input.key)
+            .arg(input.seconds)
+            .query_async(&mut conn)
+            .await
+            .tool_context("EXPIRE failed")?;
 
-                Ok(CallToolResult::text(format!(
-                    "OK - renamed '{}' to '{}'",
-                    input.key, input.newkey
-                )))
-            },
-        )
-        .build()
-}
+        if result {
+            Ok(CallToolResult::text(format!(
+                "OK - TTL set to {} seconds on '{}'",
+                input.seconds, input.key
+            )))
+        } else {
+            Ok(CallToolResult::text(format!(
+                "Key '{}' does not exist or timeout could not be set",
+                input.key
+            )))
+        }
+    }
+);
 
-// --- P0 Key Operations ---
+database_tool!(write, rename, "redis_rename",
+    "Rename a key. Overwrites the destination key if it exists.",
+    {
+        /// Current key name
+        pub key: String,
+        /// New key name
+        pub newkey: String,
+    } => |conn, input| {
+        let _: () = redis::cmd("RENAME")
+            .arg(&input.key)
+            .arg(&input.newkey)
+            .query_async(&mut conn)
+            .await
+            .tool_context("RENAME failed")?;
 
-/// Input for MGET command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct MgetInput {
-    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name to resolve connection from (uses default profile if not set)
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Keys to get
-    pub keys: Vec<String>,
-}
+        Ok(CallToolResult::text(format!(
+            "OK - renamed '{}' to '{}'",
+            input.key, input.newkey
+        )))
+    }
+);
 
-/// Build the mget tool
-pub fn mget(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_mget")
-        .description("Get the values of multiple keys in a single call.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<MgetInput>| async move {
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
+database_tool!(read_only, mget, "redis_mget",
+    "Get the values of multiple keys in a single call.",
+    {
+        /// Keys to get
+        pub keys: Vec<String>,
+    } => |conn, input| {
+        let mut cmd = redis::cmd("MGET");
+        for key in &input.keys {
+            cmd.arg(key);
+        }
 
-                let mut cmd = redis::cmd("MGET");
-                for key in &input.keys {
-                    cmd.arg(key);
-                }
+        let values: Vec<redis::Value> = cmd
+            .query_async(&mut conn)
+            .await
+            .tool_context("MGET failed")?;
 
-                let values: Vec<redis::Value> = cmd
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("MGET failed")?;
+        let output = input
+            .keys
+            .iter()
+            .zip(values.iter())
+            .map(|(k, v)| format!("{}: {}", k, format_value(v)))
+            .collect::<Vec<_>>()
+            .join("\n");
 
-                let output = input
-                    .keys
-                    .iter()
-                    .zip(values.iter())
-                    .map(|(k, v)| format!("{}: {}", k, format_value(v)))
-                    .collect::<Vec<_>>()
-                    .join("\n");
-
-                Ok(CallToolResult::text(output))
-            },
-        )
-        .build()
-}
+        Ok(CallToolResult::text(output))
+    }
+);
 
 /// A key-value pair for MSET
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct KeyValuePair {
     /// Key name
     pub key: String,
@@ -930,750 +530,379 @@ pub struct KeyValuePair {
     pub value: String,
 }
 
-/// Input for MSET command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct MsetInput {
-    /// Optional Redis URL (overrides profile)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name for connection resolution
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Key-value pairs to set
-    pub entries: Vec<KeyValuePair>,
-}
+database_tool!(write, mset, "redis_mset",
+    "Set multiple key-value pairs in a single atomic call.",
+    {
+        /// Key-value pairs to set
+        pub entries: Vec<KeyValuePair>,
+    } => |conn, input| {
+        let mut cmd = redis::cmd("MSET");
+        for entry in &input.entries {
+            cmd.arg(&entry.key).arg(&entry.value);
+        }
 
-/// Build the mset tool
-pub fn mset(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_mset")
-        .description("Set multiple key-value pairs in a single atomic call.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<MsetInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
+        let _: () = cmd
+            .query_async(&mut conn)
+            .await
+            .tool_context("MSET failed")?;
 
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
+        Ok(CallToolResult::text(format!(
+            "OK - set {} key(s)",
+            input.entries.len()
+        )))
+    }
+);
 
-                let mut cmd = redis::cmd("MSET");
-                for entry in &input.entries {
-                    cmd.arg(&entry.key).arg(&entry.value);
-                }
+database_tool!(write, persist, "redis_persist",
+    "Remove the expiry from a key, making it persistent.",
+    {
+        /// Key to remove expiry from
+        pub key: String,
+    } => |conn, input| {
+        let result: bool = redis::cmd("PERSIST")
+            .arg(&input.key)
+            .query_async(&mut conn)
+            .await
+            .tool_context("PERSIST failed")?;
 
-                let _: () = cmd
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("MSET failed")?;
+        if result {
+            Ok(CallToolResult::text(format!(
+                "OK - expiry removed from '{}'",
+                input.key
+            )))
+        } else {
+            Ok(CallToolResult::text(format!(
+                "Key '{}' does not exist or has no expiry",
+                input.key
+            )))
+        }
+    }
+);
 
+database_tool!(destructive, unlink, "redis_unlink",
+    "DANGEROUS: Asynchronously delete one or more keys (non-blocking version of DEL).",
+    {
+        /// Keys to unlink (async delete)
+        pub keys: Vec<String>,
+    } => |conn, input| {
+        let mut cmd = redis::cmd("UNLINK");
+        for key in &input.keys {
+            cmd.arg(key);
+        }
+
+        let count: i64 = cmd
+            .query_async(&mut conn)
+            .await
+            .tool_context("UNLINK failed")?;
+
+        Ok(CallToolResult::text(format!(
+            "Unlinked {} of {} key(s)",
+            count,
+            input.keys.len()
+        )))
+    }
+);
+
+database_tool!(write, copy, "redis_copy",
+    "Copy a key to a new key. Use replace=true to overwrite the destination.",
+    {
+        /// Source key
+        pub source: String,
+        /// Destination key
+        pub destination: String,
+        /// Replace destination key if it already exists
+        #[serde(default)]
+        pub replace: bool,
+    } => |conn, input| {
+        let mut cmd = redis::cmd("COPY");
+        cmd.arg(&input.source).arg(&input.destination);
+        if input.replace {
+            cmd.arg("REPLACE");
+        }
+
+        let result: bool = cmd
+            .query_async(&mut conn)
+            .await
+            .tool_context("COPY failed")?;
+
+        if result {
+            Ok(CallToolResult::text(format!(
+                "OK - copied '{}' to '{}'",
+                input.source, input.destination
+            )))
+        } else {
+            Ok(CallToolResult::text(format!(
+                "COPY failed: destination '{}' already exists (use replace=true to overwrite)",
+                input.destination
+            )))
+        }
+    }
+);
+
+database_tool!(read_only, dump, "redis_dump",
+    "Serialize a key's value using Redis internal format. Returns hex-encoded bytes \
+     for use with RESTORE.",
+    {
+        /// Key to dump
+        pub key: String,
+    } => |conn, input| {
+        let value: redis::Value = redis::cmd("DUMP")
+            .arg(&input.key)
+            .query_async(&mut conn)
+            .await
+            .tool_context("DUMP failed")?;
+
+        match value {
+            redis::Value::BulkString(bytes) => {
+                let hex: String = bytes.iter().map(|b| format!("{:02x}", b)).collect();
                 Ok(CallToolResult::text(format!(
-                    "OK - set {} key(s)",
-                    input.entries.len()
+                    "{}: {} bytes\n{}",
+                    input.key,
+                    bytes.len(),
+                    hex
                 )))
-            },
-        )
-        .build()
-}
+            }
+            redis::Value::Nil => Ok(CallToolResult::text(format!(
+                "(nil) - key '{}' not found",
+                input.key
+            ))),
+            _ => Ok(CallToolResult::text(format_value(&value))),
+        }
+    }
+);
 
-/// Input for PERSIST command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct PersistInput {
-    /// Optional Redis URL (overrides profile)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name for connection resolution
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Key to remove expiry from
-    pub key: String,
-}
+database_tool!(write, restore, "redis_restore",
+    "Restore a key from a serialized value (from DUMP). \
+     The serialized_value must be hex-encoded.",
+    {
+        /// Key to restore
+        pub key: String,
+        /// TTL in milliseconds (0 = no expiry)
+        pub ttl_ms: u64,
+        /// Hex-encoded serialized value from DUMP
+        pub serialized_value: String,
+    } => |conn, input| {
+        // Decode hex string to bytes
+        let bytes: Result<Vec<u8>, _> = (0..input.serialized_value.len())
+            .step_by(2)
+            .map(|i| {
+                u8::from_str_radix(
+                    &input.serialized_value[i..i.min(input.serialized_value.len()) + 2],
+                    16,
+                )
+            })
+            .collect();
 
-/// Build the persist tool
-pub fn persist(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_persist")
-        .description("Remove the expiry from a key, making it persistent.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<PersistInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
+        let bytes =
+            bytes.map_err(|_| tower_mcp::Error::tool("Invalid hex string in serialized_value"))?;
 
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
+        let _: () = redis::cmd("RESTORE")
+            .arg(&input.key)
+            .arg(input.ttl_ms)
+            .arg(bytes.as_slice())
+            .query_async(&mut conn)
+            .await
+            .tool_context("RESTORE failed")?;
 
-                let result: bool = redis::cmd("PERSIST")
-                    .arg(&input.key)
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("PERSIST failed")?;
+        Ok(CallToolResult::text(format!(
+            "OK - restored key '{}'",
+            input.key
+        )))
+    }
+);
 
-                if result {
-                    Ok(CallToolResult::text(format!(
-                        "OK - expiry removed from '{}'",
-                        input.key
-                    )))
-                } else {
-                    Ok(CallToolResult::text(format!(
-                        "Key '{}' does not exist or has no expiry",
-                        input.key
-                    )))
-                }
-            },
-        )
-        .build()
-}
+database_tool!(read_only, randomkey, "redis_randomkey",
+    "Return a random key from the database.",
+    {} => |conn, _input| {
+        let key: Option<String> = redis::cmd("RANDOMKEY")
+            .query_async(&mut conn)
+            .await
+            .tool_context("RANDOMKEY failed")?;
 
-/// Input for UNLINK command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct UnlinkInput {
-    /// Optional Redis URL (overrides profile)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name for connection resolution
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Keys to unlink (async delete)
-    pub keys: Vec<String>,
-}
+        match key {
+            Some(k) => Ok(CallToolResult::text(k)),
+            None => Ok(CallToolResult::text("(empty) - database has no keys")),
+        }
+    }
+);
 
-/// Build the unlink tool
-pub fn unlink(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_unlink")
-        .description(
-            "DANGEROUS: Asynchronously delete one or more keys (non-blocking version of DEL).",
-        )
-        .destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<UnlinkInput>| async move {
-                if !state.is_destructive_allowed() {
-                    return Err(McpError::tool(
-                        "Destructive operations require policy tier 'full'",
-                    ));
-                }
+database_tool!(read_only, touch, "redis_touch",
+    "Update the last access time of one or more keys without modifying them.",
+    {
+        /// Keys to touch (update last access time)
+        pub keys: Vec<String>,
+    } => |conn, input| {
+        let mut cmd = redis::cmd("TOUCH");
+        for key in &input.keys {
+            cmd.arg(key);
+        }
 
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
+        let count: i64 = cmd
+            .query_async(&mut conn)
+            .await
+            .tool_context("TOUCH failed")?;
 
-                let mut cmd = redis::cmd("UNLINK");
-                for key in &input.keys {
-                    cmd.arg(key);
-                }
-
-                let count: i64 = cmd
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("UNLINK failed")?;
-
-                Ok(CallToolResult::text(format!(
-                    "Unlinked {} of {} key(s)",
-                    count,
-                    input.keys.len()
-                )))
-            },
-        )
-        .build()
-}
-
-/// Input for COPY command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct CopyInput {
-    /// Optional Redis URL (overrides profile)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name for connection resolution
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Source key
-    pub source: String,
-    /// Destination key
-    pub destination: String,
-    /// Replace destination key if it already exists
-    #[serde(default)]
-    pub replace: bool,
-}
-
-/// Build the copy tool
-pub fn copy(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_copy")
-        .description("Copy a key to a new key. Use replace=true to overwrite the destination.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<CopyInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
-
-                let mut cmd = redis::cmd("COPY");
-                cmd.arg(&input.source).arg(&input.destination);
-                if input.replace {
-                    cmd.arg("REPLACE");
-                }
-
-                let result: bool = cmd
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("COPY failed")?;
-
-                if result {
-                    Ok(CallToolResult::text(format!(
-                        "OK - copied '{}' to '{}'",
-                        input.source, input.destination
-                    )))
-                } else {
-                    Ok(CallToolResult::text(format!(
-                        "COPY failed: destination '{}' already exists (use replace=true to overwrite)",
-                        input.destination
-                    )))
-                }
-            },
-        )
-        .build()
-}
-
-/// Input for DUMP command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct DumpInput {
-    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name to resolve connection from (uses default profile if not set)
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Key to dump
-    pub key: String,
-}
-
-/// Build the dump tool
-pub fn dump(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_dump")
-        .description(
-            "Serialize a key's value using Redis internal format. Returns hex-encoded bytes \
-             for use with RESTORE.",
-        )
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<DumpInput>| async move {
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
-
-                let value: redis::Value = redis::cmd("DUMP")
-                    .arg(&input.key)
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("DUMP failed")?;
-
-                match value {
-                    redis::Value::BulkString(bytes) => {
-                        let hex: String = bytes.iter().map(|b| format!("{:02x}", b)).collect();
-                        Ok(CallToolResult::text(format!(
-                            "{}: {} bytes\n{}",
-                            input.key,
-                            bytes.len(),
-                            hex
-                        )))
-                    }
-                    redis::Value::Nil => Ok(CallToolResult::text(format!(
-                        "(nil) - key '{}' not found",
-                        input.key
-                    ))),
-                    _ => Ok(CallToolResult::text(format_value(&value))),
-                }
-            },
-        )
-        .build()
-}
-
-/// Input for RESTORE command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct RestoreInput {
-    /// Optional Redis URL (overrides profile)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name for connection resolution
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Key to restore
-    pub key: String,
-    /// TTL in milliseconds (0 = no expiry)
-    pub ttl_ms: u64,
-    /// Hex-encoded serialized value from DUMP
-    pub serialized_value: String,
-}
-
-/// Build the restore tool
-pub fn restore(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_restore")
-        .description(
-            "Restore a key from a serialized value (from DUMP). \
-             The serialized_value must be hex-encoded.",
-        )
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<RestoreInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                // Decode hex string to bytes
-                let bytes: Result<Vec<u8>, _> = (0..input.serialized_value.len())
-                    .step_by(2)
-                    .map(|i| {
-                        u8::from_str_radix(
-                            &input.serialized_value[i..i.min(input.serialized_value.len()) + 2],
-                            16,
-                        )
-                    })
-                    .collect();
-
-                let bytes =
-                    bytes.map_err(|_| McpError::tool("Invalid hex string in serialized_value"))?;
-
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
-
-                let _: () = redis::cmd("RESTORE")
-                    .arg(&input.key)
-                    .arg(input.ttl_ms)
-                    .arg(bytes.as_slice())
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("RESTORE failed")?;
-
-                Ok(CallToolResult::text(format!(
-                    "OK - restored key '{}'",
-                    input.key
-                )))
-            },
-        )
-        .build()
-}
-
-/// Input for RANDOMKEY command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct RandomkeyInput {
-    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name to resolve connection from (uses default profile if not set)
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the randomkey tool
-pub fn randomkey(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_randomkey")
-        .description("Return a random key from the database.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<RandomkeyInput>| async move {
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
-
-                let key: Option<String> = redis::cmd("RANDOMKEY")
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("RANDOMKEY failed")?;
-
-                match key {
-                    Some(k) => Ok(CallToolResult::text(k)),
-                    None => Ok(CallToolResult::text("(empty) - database has no keys")),
-                }
-            },
-        )
-        .build()
-}
-
-/// Input for TOUCH command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct TouchInput {
-    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name to resolve connection from (uses default profile if not set)
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Keys to touch (update last access time)
-    pub keys: Vec<String>,
-}
-
-/// Build the touch tool
-pub fn touch(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_touch")
-        .description("Update the last access time of one or more keys without modifying them.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<TouchInput>| async move {
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
-
-                let mut cmd = redis::cmd("TOUCH");
-                for key in &input.keys {
-                    cmd.arg(key);
-                }
-
-                let count: i64 = cmd
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("TOUCH failed")?;
-
-                Ok(CallToolResult::text(format!(
-                    "Touched {} of {} key(s)",
-                    count,
-                    input.keys.len()
-                )))
-            },
-        )
-        .build()
-}
+        Ok(CallToolResult::text(format!(
+            "Touched {} of {} key(s)",
+            count,
+            input.keys.len()
+        )))
+    }
+);
 
 // --- P1 String Operations ---
 
-/// Input for INCR command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct IncrInput {
-    /// Optional Redis URL (overrides profile)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name for connection resolution
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Key to increment
-    pub key: String,
-}
+database_tool!(write, incr, "redis_incr",
+    "Increment the integer value of a key by 1. Creates the key with value 1 if it does not exist.",
+    {
+        /// Key to increment
+        pub key: String,
+    } => |conn, input| {
+        let value: i64 = redis::cmd("INCR")
+            .arg(&input.key)
+            .query_async(&mut conn)
+            .await
+            .tool_context("INCR failed")?;
 
-/// Build the incr tool
-pub fn incr(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_incr")
-        .description("Increment the integer value of a key by 1. Creates the key with value 1 if it does not exist.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<IncrInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
+        Ok(CallToolResult::text(format!(
+            "{}: {}",
+            input.key, value
+        )))
+    }
+);
 
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
+database_tool!(write, decr, "redis_decr",
+    "Decrement the integer value of a key by 1. Creates the key with value -1 if it does not exist.",
+    {
+        /// Key to decrement
+        pub key: String,
+    } => |conn, input| {
+        let value: i64 = redis::cmd("DECR")
+            .arg(&input.key)
+            .query_async(&mut conn)
+            .await
+            .tool_context("DECR failed")?;
 
-                let value: i64 = redis::cmd("INCR")
-                    .arg(&input.key)
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("INCR failed")?;
+        Ok(CallToolResult::text(format!(
+            "{}: {}",
+            input.key, value
+        )))
+    }
+);
 
-                Ok(CallToolResult::text(format!(
-                    "{}: {}",
-                    input.key, value
-                )))
-            },
-        )
-        .build()
-}
+database_tool!(write, append, "redis_append",
+    "Append a value to a key. Creates the key if it does not exist. Returns the new string length.",
+    {
+        /// Key to append to
+        pub key: String,
+        /// Value to append
+        pub value: String,
+    } => |conn, input| {
+        let length: i64 = redis::cmd("APPEND")
+            .arg(&input.key)
+            .arg(&input.value)
+            .query_async(&mut conn)
+            .await
+            .tool_context("APPEND failed")?;
 
-/// Input for DECR command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct DecrInput {
-    /// Optional Redis URL (overrides profile)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name for connection resolution
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Key to decrement
-    pub key: String,
-}
+        Ok(CallToolResult::text(format!(
+            "OK - '{}' new length: {}",
+            input.key, length
+        )))
+    }
+);
 
-/// Build the decr tool
-pub fn decr(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_decr")
-        .description("Decrement the integer value of a key by 1. Creates the key with value -1 if it does not exist.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<DecrInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
+database_tool!(read_only, strlen, "redis_strlen",
+    "Get the length of the string value stored at a key.",
+    {
+        /// Key to get string length of
+        pub key: String,
+    } => |conn, input| {
+        let length: i64 = redis::cmd("STRLEN")
+            .arg(&input.key)
+            .query_async(&mut conn)
+            .await
+            .tool_context("STRLEN failed")?;
 
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
+        Ok(CallToolResult::text(format!(
+            "{}: {} bytes",
+            input.key, length
+        )))
+    }
+);
 
-                let value: i64 = redis::cmd("DECR")
-                    .arg(&input.key)
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("DECR failed")?;
+database_tool!(read_only, getrange, "redis_getrange",
+    "Get a substring of the string value at a key by start and end offsets (inclusive).",
+    {
+        /// Key to get substring from
+        pub key: String,
+        /// Start offset (0-based, negative counts from end)
+        pub start: i64,
+        /// End offset (inclusive, negative counts from end)
+        pub end: i64,
+    } => |conn, input| {
+        let value: String = redis::cmd("GETRANGE")
+            .arg(&input.key)
+            .arg(input.start)
+            .arg(input.end)
+            .query_async(&mut conn)
+            .await
+            .tool_context("GETRANGE failed")?;
 
-                Ok(CallToolResult::text(format!(
-                    "{}: {}",
-                    input.key, value
-                )))
-            },
-        )
-        .build()
-}
+        Ok(CallToolResult::text(value))
+    }
+);
 
-/// Input for APPEND command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct AppendInput {
-    /// Optional Redis URL (overrides profile)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name for connection resolution
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Key to append to
-    pub key: String,
-    /// Value to append
-    pub value: String,
-}
+database_tool!(write, setrange, "redis_setrange",
+    "Overwrite part of a string value at the given byte offset. Returns the new string length.",
+    {
+        /// Key to overwrite substring in
+        pub key: String,
+        /// Byte offset to start overwriting at
+        pub offset: u64,
+        /// Value to write at the offset
+        pub value: String,
+    } => |conn, input| {
+        let length: i64 = redis::cmd("SETRANGE")
+            .arg(&input.key)
+            .arg(input.offset)
+            .arg(&input.value)
+            .query_async(&mut conn)
+            .await
+            .tool_context("SETRANGE failed")?;
 
-/// Build the append tool
-pub fn append(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_append")
-        .description("Append a value to a key. Creates the key if it does not exist. Returns the new string length.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<AppendInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
+        Ok(CallToolResult::text(format!(
+            "OK - '{}' new length: {}",
+            input.key, length
+        )))
+    }
+);
 
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
+database_tool!(write, setnx, "redis_setnx",
+    "Set a key only if it does not already exist. Returns whether the key was set.",
+    {
+        /// Key to set
+        pub key: String,
+        /// Value to set
+        pub value: String,
+    } => |conn, input| {
+        let was_set: bool = redis::cmd("SETNX")
+            .arg(&input.key)
+            .arg(&input.value)
+            .query_async(&mut conn)
+            .await
+            .tool_context("SETNX failed")?;
 
-                let length: i64 = redis::cmd("APPEND")
-                    .arg(&input.key)
-                    .arg(&input.value)
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("APPEND failed")?;
-
-                Ok(CallToolResult::text(format!(
-                    "OK - '{}' new length: {}",
-                    input.key, length
-                )))
-            },
-        )
-        .build()
-}
-
-/// Input for STRLEN command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct StrlenInput {
-    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name to resolve connection from (uses default profile if not set)
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Key to get string length of
-    pub key: String,
-}
-
-/// Build the strlen tool
-pub fn strlen(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_strlen")
-        .description("Get the length of the string value stored at a key.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<StrlenInput>| async move {
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
-
-                let length: i64 = redis::cmd("STRLEN")
-                    .arg(&input.key)
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("STRLEN failed")?;
-
-                Ok(CallToolResult::text(format!(
-                    "{}: {} bytes",
-                    input.key, length
-                )))
-            },
-        )
-        .build()
-}
-
-/// Input for GETRANGE command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetrangeInput {
-    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name to resolve connection from (uses default profile if not set)
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Key to get substring from
-    pub key: String,
-    /// Start offset (0-based, negative counts from end)
-    pub start: i64,
-    /// End offset (inclusive, negative counts from end)
-    pub end: i64,
-}
-
-/// Build the getrange tool
-pub fn getrange(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_getrange")
-        .description(
-            "Get a substring of the string value at a key by start and end offsets (inclusive).",
-        )
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<GetrangeInput>| async move {
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
-
-                let value: String = redis::cmd("GETRANGE")
-                    .arg(&input.key)
-                    .arg(input.start)
-                    .arg(input.end)
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("GETRANGE failed")?;
-
-                Ok(CallToolResult::text(value))
-            },
-        )
-        .build()
-}
-
-/// Input for SETRANGE command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct SetrangeInput {
-    /// Optional Redis URL (overrides profile)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name for connection resolution
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Key to overwrite substring in
-    pub key: String,
-    /// Byte offset to start overwriting at
-    pub offset: u64,
-    /// Value to write at the offset
-    pub value: String,
-}
-
-/// Build the setrange tool
-pub fn setrange(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_setrange")
-        .description("Overwrite part of a string value at the given byte offset. Returns the new string length.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<SetrangeInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
-
-                let length: i64 = redis::cmd("SETRANGE")
-                    .arg(&input.key)
-                    .arg(input.offset)
-                    .arg(&input.value)
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("SETRANGE failed")?;
-
-                Ok(CallToolResult::text(format!(
-                    "OK - '{}' new length: {}",
-                    input.key, length
-                )))
-            },
-        )
-        .build()
-}
-
-/// Input for SETNX command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct SetnxInput {
-    /// Optional Redis URL (overrides profile)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name for connection resolution
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Key to set
-    pub key: String,
-    /// Value to set
-    pub value: String,
-}
-
-/// Build the setnx tool
-pub fn setnx(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_setnx")
-        .description(
-            "Set a key only if it does not already exist. Returns whether the key was set.",
-        )
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<SetnxInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
-
-                let was_set: bool = redis::cmd("SETNX")
-                    .arg(&input.key)
-                    .arg(&input.value)
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("SETNX failed")?;
-
-                if was_set {
-                    Ok(CallToolResult::text(format!(
-                        "OK - set '{}' (key was new)",
-                        input.key
-                    )))
-                } else {
-                    Ok(CallToolResult::text(format!(
-                        "Key '{}' already exists, not set",
-                        input.key
-                    )))
-                }
-            },
-        )
-        .build()
-}
+        if was_set {
+            Ok(CallToolResult::text(format!(
+                "OK - set '{}' (key was new)",
+                input.key
+            )))
+        } else {
+            Ok(CallToolResult::text(format!(
+                "Key '{}' already exists, not set",
+                input.key
+            )))
+        }
+    }
+);

--- a/crates/redisctl-mcp/src/tools/redis/structures.rs
+++ b/crates/redisctl-mcp/src/tools/redis/structures.rs
@@ -4,432 +4,22 @@
 //! sunion, sinter, sdiff, zcard, zscore, zrank, zcount, zrangebyscore, llen, lindex)
 
 use std::collections::HashMap;
-use std::sync::Arc;
 
-use schemars::JsonSchema;
-use serde::Deserialize;
-use tower_mcp::extract::{Json, State};
-use tower_mcp::{CallToolResult, Error as McpError, McpRouter, ResultExt, Tool, ToolBuilder};
+use tower_mcp::{CallToolResult, ResultExt};
 
-use crate::state::AppState;
+use crate::tools::macros::{database_tool, mcp_module};
 
-/// All tool names registered by this sub-module.
-pub(super) const TOOL_NAMES: &[&str] = &[
-    "redis_hgetall",
-    "redis_lrange",
-    "redis_smembers",
-    "redis_zrange",
-    "redis_xinfo_stream",
-    "redis_xrange",
-    "redis_xlen",
-    "redis_pubsub_channels",
-    "redis_pubsub_numsub",
-    "redis_hset",
-    "redis_hdel",
-    "redis_lpush",
-    "redis_rpush",
-    "redis_lpop",
-    "redis_rpop",
-    "redis_sadd",
-    "redis_srem",
-    "redis_zadd",
-    "redis_zrem",
-    "redis_xadd",
-    "redis_xtrim",
-    "redis_hget",
-    "redis_hmget",
-    "redis_hlen",
-    "redis_hexists",
-    "redis_hkeys",
-    "redis_hvals",
-    "redis_hincrby",
-    "redis_scard",
-    "redis_sismember",
-    "redis_sunion",
-    "redis_sinter",
-    "redis_sdiff",
-    "redis_zcard",
-    "redis_zscore",
-    "redis_zrank",
-    "redis_zcount",
-    "redis_zrangebyscore",
-    "redis_llen",
-    "redis_lindex",
-];
-
-/// Build a sub-router containing all data structure Redis tools
-pub fn router(state: Arc<AppState>) -> McpRouter {
-    McpRouter::new()
-        .tool(hgetall(state.clone()))
-        .tool(lrange(state.clone()))
-        .tool(smembers(state.clone()))
-        .tool(zrange(state.clone()))
-        .tool(xinfo_stream(state.clone()))
-        .tool(xrange(state.clone()))
-        .tool(xlen(state.clone()))
-        .tool(pubsub_channels(state.clone()))
-        .tool(pubsub_numsub(state.clone()))
-        .tool(hset(state.clone()))
-        .tool(hdel(state.clone()))
-        .tool(lpush(state.clone()))
-        .tool(rpush(state.clone()))
-        .tool(lpop(state.clone()))
-        .tool(rpop(state.clone()))
-        .tool(sadd(state.clone()))
-        .tool(srem(state.clone()))
-        .tool(zadd(state.clone()))
-        .tool(zrem(state.clone()))
-        .tool(xadd(state.clone()))
-        .tool(xtrim(state.clone()))
-        .tool(hget(state.clone()))
-        .tool(hmget(state.clone()))
-        .tool(hlen(state.clone()))
-        .tool(hexists(state.clone()))
-        .tool(hkeys(state.clone()))
-        .tool(hvals(state.clone()))
-        .tool(hincrby(state.clone()))
-        .tool(scard(state.clone()))
-        .tool(sismember(state.clone()))
-        .tool(sunion(state.clone()))
-        .tool(sinter(state.clone()))
-        .tool(sdiff(state.clone()))
-        .tool(zcard(state.clone()))
-        .tool(zscore(state.clone()))
-        .tool(zrank(state.clone()))
-        .tool(zcount(state.clone()))
-        .tool(zrangebyscore(state.clone()))
-        .tool(llen(state.clone()))
-        .tool(lindex(state))
-}
-
-/// Input for HGETALL command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct HgetallInput {
-    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name to resolve connection from (uses default profile if not set)
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Hash key to get
-    pub key: String,
-}
-
-/// Build the hgetall tool
-pub fn hgetall(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_hgetall")
-        .description("Get all fields and values of a hash.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<HgetallInput>| async move {
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
-
-                let result: Vec<(String, String)> = redis::cmd("HGETALL")
-                    .arg(&input.key)
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("HGETALL failed")?;
-
-                if result.is_empty() {
-                    return Ok(CallToolResult::text(format!(
-                        "(empty hash or key '{}' not found)",
-                        input.key
-                    )));
-                }
-
-                let output = result
-                    .iter()
-                    .map(|(k, v)| format!("{}: {}", k, v))
-                    .collect::<Vec<_>>()
-                    .join("\n");
-
-                Ok(CallToolResult::text(format!(
-                    "Hash '{}' ({} fields):\n{}",
-                    input.key,
-                    result.len(),
-                    output
-                )))
-            },
-        )
-        .build()
-}
-
-/// Input for LRANGE command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct LrangeInput {
-    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name to resolve connection from (uses default profile if not set)
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// List key
-    pub key: String,
-    /// Start index (0-based)
-    #[serde(default)]
-    pub start: i64,
-    /// Stop index (-1 for all)
-    #[serde(default = "default_stop")]
-    pub stop: i64,
+/// A score-member pair for sorted set operations
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct ScoreMember {
+    /// Score value
+    pub score: f64,
+    /// Member value
+    pub member: String,
 }
 
 fn default_stop() -> i64 {
     -1
-}
-
-/// Build the lrange tool
-pub fn lrange(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_lrange")
-        .description("Get a range of elements from a list (start=0, stop=-1 for all).")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<LrangeInput>| async move {
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
-
-                let result: Vec<String> = redis::cmd("LRANGE")
-                    .arg(&input.key)
-                    .arg(input.start)
-                    .arg(input.stop)
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("LRANGE failed")?;
-
-                if result.is_empty() {
-                    return Ok(CallToolResult::text(format!(
-                        "(empty list or key '{}' not found)",
-                        input.key
-                    )));
-                }
-
-                let output = result
-                    .iter()
-                    .enumerate()
-                    .map(|(i, v)| format!("{}: {}", i, v))
-                    .collect::<Vec<_>>()
-                    .join("\n");
-
-                Ok(CallToolResult::text(format!(
-                    "List '{}' ({} elements):\n{}",
-                    input.key,
-                    result.len(),
-                    output
-                )))
-            },
-        )
-        .build()
-}
-
-/// Input for SMEMBERS command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct SmembersInput {
-    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name to resolve connection from (uses default profile if not set)
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Set key
-    pub key: String,
-}
-
-/// Build the smembers tool
-pub fn smembers(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_smembers")
-        .description("Get all members of a set.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<SmembersInput>| async move {
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
-
-                let result: Vec<String> = redis::cmd("SMEMBERS")
-                    .arg(&input.key)
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("SMEMBERS failed")?;
-
-                if result.is_empty() {
-                    return Ok(CallToolResult::text(format!(
-                        "(empty set or key '{}' not found)",
-                        input.key
-                    )));
-                }
-
-                Ok(CallToolResult::text(format!(
-                    "Set '{}' ({} members):\n{}",
-                    input.key,
-                    result.len(),
-                    result.join("\n")
-                )))
-            },
-        )
-        .build()
-}
-
-/// Input for ZRANGE command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ZrangeInput {
-    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name to resolve connection from (uses default profile if not set)
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Sorted set key
-    pub key: String,
-    /// Start index (0-based)
-    #[serde(default)]
-    pub start: i64,
-    /// Stop index (-1 for all)
-    #[serde(default = "default_stop")]
-    pub stop: i64,
-    /// Include scores in output
-    #[serde(default)]
-    pub withscores: bool,
-}
-
-/// Build the zrange tool
-pub fn zrange(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_zrange")
-        .description("Get a range of members from a sorted set by index.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<ZrangeInput>| async move {
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
-
-                if input.withscores {
-                    let result: Vec<(String, f64)> = redis::cmd("ZRANGE")
-                        .arg(&input.key)
-                        .arg(input.start)
-                        .arg(input.stop)
-                        .arg("WITHSCORES")
-                        .query_async(&mut conn)
-                        .await
-                        .tool_context("ZRANGE failed")?;
-
-                    if result.is_empty() {
-                        return Ok(CallToolResult::text(format!(
-                            "(empty sorted set or key '{}' not found)",
-                            input.key
-                        )));
-                    }
-
-                    let output = result
-                        .iter()
-                        .enumerate()
-                        .map(|(i, (member, score))| format!("{}: {} (score: {})", i, member, score))
-                        .collect::<Vec<_>>()
-                        .join("\n");
-
-                    Ok(CallToolResult::text(format!(
-                        "Sorted set '{}' ({} members):\n{}",
-                        input.key,
-                        result.len(),
-                        output
-                    )))
-                } else {
-                    let result: Vec<String> = redis::cmd("ZRANGE")
-                        .arg(&input.key)
-                        .arg(input.start)
-                        .arg(input.stop)
-                        .query_async(&mut conn)
-                        .await
-                        .tool_context("ZRANGE failed")?;
-
-                    if result.is_empty() {
-                        return Ok(CallToolResult::text(format!(
-                            "(empty sorted set or key '{}' not found)",
-                            input.key
-                        )));
-                    }
-
-                    let output = result
-                        .iter()
-                        .enumerate()
-                        .map(|(i, v)| format!("{}: {}", i, v))
-                        .collect::<Vec<_>>()
-                        .join("\n");
-
-                    Ok(CallToolResult::text(format!(
-                        "Sorted set '{}' ({} members):\n{}",
-                        input.key,
-                        result.len(),
-                        output
-                    )))
-                }
-            },
-        )
-        .build()
-}
-
-/// Input for XINFO STREAM command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct XinfoStreamInput {
-    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name to resolve connection from (uses default profile if not set)
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Stream key to inspect
-    pub key: String,
-}
-
-/// Build the xinfo_stream tool
-pub fn xinfo_stream(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_xinfo_stream")
-        .description("Get stream metadata including length, consumer groups, and entry details (XINFO STREAM).")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<XinfoStreamInput>| async move {
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
-
-                let result: redis::Value = redis::cmd("XINFO")
-                    .arg("STREAM")
-                    .arg(&input.key)
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("XINFO STREAM failed")?;
-
-                Ok(CallToolResult::text(format!(
-                    "Stream '{}':\n{}",
-                    input.key,
-                    super::format_value(&result)
-                )))
-            },
-        )
-        .build()
-}
-
-/// Input for XRANGE command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct XrangeInput {
-    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name to resolve connection from (uses default profile if not set)
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Stream key
-    pub key: String,
-    /// Start ID (default: "-" for beginning)
-    #[serde(default = "default_xrange_start")]
-    pub start: String,
-    /// End ID (default: "+" for end)
-    #[serde(default = "default_xrange_end")]
-    pub end: String,
-    /// Maximum number of entries to return
-    #[serde(default)]
-    pub count: Option<usize>,
 }
 
 fn default_xrange_start() -> String {
@@ -440,1867 +30,1341 @@ fn default_xrange_end() -> String {
     "+".to_string()
 }
 
-/// Build the xrange tool
-pub fn xrange(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_xrange")
-        .description("Get stream entries in a range. Use \"-\" to \"+\" for all entries.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<XrangeInput>| async move {
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
-
-                let mut cmd = redis::cmd("XRANGE");
-                cmd.arg(&input.key).arg(&input.start).arg(&input.end);
-
-                if let Some(count) = input.count {
-                    cmd.arg("COUNT").arg(count);
-                }
-
-                let result: redis::Value = cmd
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("XRANGE failed")?;
-
-                // Format stream entries
-                let formatted = match &result {
-                    redis::Value::Array(entries) if entries.is_empty() => {
-                        format!("(empty stream or key '{}' not found)", input.key)
-                    }
-                    redis::Value::Array(entries) => {
-                        let mut output =
-                            format!("Stream '{}' ({} entries):\n", input.key, entries.len());
-                        for entry in entries {
-                            output.push_str(&super::format_value(entry));
-                            output.push('\n');
-                        }
-                        output
-                    }
-                    _ => super::format_value(&result),
-                };
-
-                Ok(CallToolResult::text(formatted))
-            },
-        )
-        .build()
+mcp_module! {
+    hgetall => "redis_hgetall",
+    lrange => "redis_lrange",
+    smembers => "redis_smembers",
+    zrange => "redis_zrange",
+    xinfo_stream => "redis_xinfo_stream",
+    xrange => "redis_xrange",
+    xlen => "redis_xlen",
+    pubsub_channels => "redis_pubsub_channels",
+    pubsub_numsub => "redis_pubsub_numsub",
+    hset => "redis_hset",
+    hdel => "redis_hdel",
+    lpush => "redis_lpush",
+    rpush => "redis_rpush",
+    lpop => "redis_lpop",
+    rpop => "redis_rpop",
+    sadd => "redis_sadd",
+    srem => "redis_srem",
+    zadd => "redis_zadd",
+    zrem => "redis_zrem",
+    xadd => "redis_xadd",
+    xtrim => "redis_xtrim",
+    hget => "redis_hget",
+    hmget => "redis_hmget",
+    hlen => "redis_hlen",
+    hexists => "redis_hexists",
+    hkeys => "redis_hkeys",
+    hvals => "redis_hvals",
+    hincrby => "redis_hincrby",
+    scard => "redis_scard",
+    sismember => "redis_sismember",
+    sunion => "redis_sunion",
+    sinter => "redis_sinter",
+    sdiff => "redis_sdiff",
+    zcard => "redis_zcard",
+    zscore => "redis_zscore",
+    zrank => "redis_zrank",
+    zcount => "redis_zcount",
+    zrangebyscore => "redis_zrangebyscore",
+    llen => "redis_llen",
+    lindex => "redis_lindex",
 }
 
-/// Input for XLEN command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct XlenInput {
-    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name to resolve connection from (uses default profile if not set)
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Stream key
-    pub key: String,
-}
+// --- Read tools ---
 
-/// Build the xlen tool
-pub fn xlen(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_xlen")
-        .description("Get the number of entries in a stream.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<XlenInput>| async move {
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
+database_tool!(read_only, hgetall, "redis_hgetall",
+    "Get all fields and values of a hash.",
+    {
+        /// Hash key to get
+        pub key: String,
+    } => |conn, input| {
+        let result: Vec<(String, String)> = redis::cmd("HGETALL")
+            .arg(&input.key)
+            .query_async(&mut conn)
+            .await
+            .tool_context("HGETALL failed")?;
 
-                let len: i64 = redis::cmd("XLEN")
-                    .arg(&input.key)
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("XLEN failed")?;
+        if result.is_empty() {
+            return Ok(CallToolResult::text(format!(
+                "(empty hash or key '{}' not found)",
+                input.key
+            )));
+        }
 
-                Ok(CallToolResult::text(format!(
-                    "Stream '{}': {} entries",
-                    input.key, len
-                )))
-            },
-        )
-        .build()
-}
+        let output = result
+            .iter()
+            .map(|(k, v)| format!("{}: {}", k, v))
+            .collect::<Vec<_>>()
+            .join("\n");
 
-/// Input for PUBSUB CHANNELS command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct PubsubChannelsInput {
-    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name to resolve connection from (uses default profile if not set)
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Optional glob-style pattern to filter channels
-    #[serde(default)]
-    pub pattern: Option<String>,
-}
+        Ok(CallToolResult::text(format!(
+            "Hash '{}' ({} fields):\n{}",
+            input.key,
+            result.len(),
+            output
+        )))
+    }
+);
 
-/// Build the pubsub_channels tool
-pub fn pubsub_channels(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_pubsub_channels")
-        .description("List active pub/sub channels, optionally filtered by pattern.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<PubsubChannelsInput>| async move {
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
+database_tool!(read_only, lrange, "redis_lrange",
+    "Get a range of elements from a list (start=0, stop=-1 for all).",
+    {
+        /// List key
+        pub key: String,
+        /// Start index (0-based)
+        #[serde(default)]
+        pub start: i64,
+        /// Stop index (-1 for all)
+        #[serde(default = "default_stop")]
+        pub stop: i64,
+    } => |conn, input| {
+        let result: Vec<String> = redis::cmd("LRANGE")
+            .arg(&input.key)
+            .arg(input.start)
+            .arg(input.stop)
+            .query_async(&mut conn)
+            .await
+            .tool_context("LRANGE failed")?;
 
-                let mut cmd = redis::cmd("PUBSUB");
-                cmd.arg("CHANNELS");
+        if result.is_empty() {
+            return Ok(CallToolResult::text(format!(
+                "(empty list or key '{}' not found)",
+                input.key
+            )));
+        }
 
-                if let Some(ref pattern) = input.pattern {
-                    cmd.arg(pattern);
-                }
+        let output = result
+            .iter()
+            .enumerate()
+            .map(|(i, v)| format!("{}: {}", i, v))
+            .collect::<Vec<_>>()
+            .join("\n");
 
-                let channels: Vec<String> = cmd
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("PUBSUB CHANNELS failed")?;
+        Ok(CallToolResult::text(format!(
+            "List '{}' ({} elements):\n{}",
+            input.key,
+            result.len(),
+            output
+        )))
+    }
+);
 
-                if channels.is_empty() {
-                    return Ok(CallToolResult::text("No active pub/sub channels"));
-                }
+database_tool!(read_only, smembers, "redis_smembers",
+    "Get all members of a set.",
+    {
+        /// Set key
+        pub key: String,
+    } => |conn, input| {
+        let result: Vec<String> = redis::cmd("SMEMBERS")
+            .arg(&input.key)
+            .query_async(&mut conn)
+            .await
+            .tool_context("SMEMBERS failed")?;
 
-                Ok(CallToolResult::text(format!(
-                    "Active channels ({}):\n{}",
-                    channels.len(),
-                    channels.join("\n")
-                )))
-            },
-        )
-        .build()
-}
+        if result.is_empty() {
+            return Ok(CallToolResult::text(format!(
+                "(empty set or key '{}' not found)",
+                input.key
+            )));
+        }
 
-/// Input for PUBSUB NUMSUB command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct PubsubNumsubInput {
-    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name to resolve connection from (uses default profile if not set)
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Channel names to get subscriber counts for (omit for all)
-    #[serde(default)]
-    pub channels: Option<Vec<String>>,
-}
+        Ok(CallToolResult::text(format!(
+            "Set '{}' ({} members):\n{}",
+            input.key,
+            result.len(),
+            result.join("\n")
+        )))
+    }
+);
 
-/// Build the pubsub_numsub tool
-pub fn pubsub_numsub(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_pubsub_numsub")
-        .description("Get subscriber counts for pub/sub channels.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<PubsubNumsubInput>| async move {
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
+database_tool!(read_only, zrange, "redis_zrange",
+    "Get a range of members from a sorted set by index.",
+    {
+        /// Sorted set key
+        pub key: String,
+        /// Start index (0-based)
+        #[serde(default)]
+        pub start: i64,
+        /// Stop index (-1 for all)
+        #[serde(default = "default_stop")]
+        pub stop: i64,
+        /// Include scores in output
+        #[serde(default)]
+        pub withscores: bool,
+    } => |conn, input| {
+        if input.withscores {
+            let result: Vec<(String, f64)> = redis::cmd("ZRANGE")
+                .arg(&input.key)
+                .arg(input.start)
+                .arg(input.stop)
+                .arg("WITHSCORES")
+                .query_async(&mut conn)
+                .await
+                .tool_context("ZRANGE failed")?;
 
-                let mut cmd = redis::cmd("PUBSUB");
-                cmd.arg("NUMSUB");
-
-                if let Some(ref channels) = input.channels {
-                    for channel in channels {
-                        cmd.arg(channel);
-                    }
-                }
-
-                // PUBSUB NUMSUB returns alternating channel name + count
-                let result: Vec<redis::Value> = cmd
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("PUBSUB NUMSUB failed")?;
-
-                if result.is_empty() {
-                    return Ok(CallToolResult::text("No subscriber information available"));
-                }
-
-                let mut output = String::from("Channel subscriber counts:\n");
-                for pair in result.chunks(2) {
-                    if pair.len() == 2 {
-                        let channel = super::format_value(&pair[0]);
-                        let count = super::format_value(&pair[1]);
-                        output.push_str(&format!("  {}: {} subscribers\n", channel, count));
-                    }
-                }
-
-                Ok(CallToolResult::text(output))
-            },
-        )
-        .build()
-}
-
-// --- Write tools ---
-
-/// Input for HSET command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct HsetInput {
-    /// Optional Redis URL (overrides profile)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name for connection resolution
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Hash key
-    pub key: String,
-    /// Field-value pairs to set
-    pub fields: HashMap<String, String>,
-}
-
-/// Build the hset tool
-pub fn hset(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_hset")
-        .description("Set one or more field-value pairs in a hash. Creates the hash if needed.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<HsetInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
-
-                let mut cmd = redis::cmd("HSET");
-                cmd.arg(&input.key);
-                for (field, value) in &input.fields {
-                    cmd.arg(field).arg(value);
-                }
-
-                let added: i64 = cmd
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("HSET failed")?;
-
-                Ok(CallToolResult::text(format!(
-                    "OK - {} field(s) added to hash '{}' ({} field(s) set total)",
-                    added,
-                    input.key,
-                    input.fields.len()
-                )))
-            },
-        )
-        .build()
-}
-
-/// Input for HDEL command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct HdelInput {
-    /// Optional Redis URL (overrides profile)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name for connection resolution
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Hash key
-    pub key: String,
-    /// Fields to delete
-    pub fields: Vec<String>,
-}
-
-/// Build the hdel tool
-pub fn hdel(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_hdel")
-        .description("Delete one or more fields from a hash.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<HdelInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
-
-                let mut cmd = redis::cmd("HDEL");
-                cmd.arg(&input.key);
-                for field in &input.fields {
-                    cmd.arg(field);
-                }
-
-                let removed: i64 = cmd
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("HDEL failed")?;
-
-                Ok(CallToolResult::text(format!(
-                    "Deleted {} of {} field(s) from hash '{}'",
-                    removed,
-                    input.fields.len(),
+            if result.is_empty() {
+                return Ok(CallToolResult::text(format!(
+                    "(empty sorted set or key '{}' not found)",
                     input.key
-                )))
-            },
-        )
-        .build()
-}
+                )));
+            }
 
-/// Input for LPUSH command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct LpushInput {
-    /// Optional Redis URL (overrides profile)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name for connection resolution
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// List key
-    pub key: String,
-    /// Elements to push to the head of the list
-    pub elements: Vec<String>,
-}
+            let output = result
+                .iter()
+                .enumerate()
+                .map(|(i, (member, score))| format!("{}: {} (score: {})", i, member, score))
+                .collect::<Vec<_>>()
+                .join("\n");
 
-/// Build the lpush tool
-pub fn lpush(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_lpush")
-        .description("Push elements to the head (left) of a list. Creates the list if needed.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<LpushInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
+            Ok(CallToolResult::text(format!(
+                "Sorted set '{}' ({} members):\n{}",
+                input.key,
+                result.len(),
+                output
+            )))
+        } else {
+            let result: Vec<String> = redis::cmd("ZRANGE")
+                .arg(&input.key)
+                .arg(input.start)
+                .arg(input.stop)
+                .query_async(&mut conn)
+                .await
+                .tool_context("ZRANGE failed")?;
 
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
-
-                let mut cmd = redis::cmd("LPUSH");
-                cmd.arg(&input.key);
-                for elem in &input.elements {
-                    cmd.arg(elem);
-                }
-
-                let length: i64 = cmd
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("LPUSH failed")?;
-
-                Ok(CallToolResult::text(format!(
-                    "OK - pushed {} element(s) to '{}', new length: {}",
-                    input.elements.len(),
-                    input.key,
-                    length
-                )))
-            },
-        )
-        .build()
-}
-
-/// Input for RPUSH command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct RpushInput {
-    /// Optional Redis URL (overrides profile)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name for connection resolution
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// List key
-    pub key: String,
-    /// Elements to push to the tail of the list
-    pub elements: Vec<String>,
-}
-
-/// Build the rpush tool
-pub fn rpush(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_rpush")
-        .description("Push elements to the tail (right) of a list. Creates the list if needed.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<RpushInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
-
-                let mut cmd = redis::cmd("RPUSH");
-                cmd.arg(&input.key);
-                for elem in &input.elements {
-                    cmd.arg(elem);
-                }
-
-                let length: i64 = cmd
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("RPUSH failed")?;
-
-                Ok(CallToolResult::text(format!(
-                    "OK - pushed {} element(s) to '{}', new length: {}",
-                    input.elements.len(),
-                    input.key,
-                    length
-                )))
-            },
-        )
-        .build()
-}
-
-/// Input for LPOP command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct LpopInput {
-    /// Optional Redis URL (overrides profile)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name for connection resolution
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// List key
-    pub key: String,
-    /// Number of elements to pop (default: 1)
-    #[serde(default)]
-    pub count: Option<u64>,
-}
-
-/// Build the lpop tool
-pub fn lpop(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_lpop")
-        .description("Pop elements from the head (left) of a list.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<LpopInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
-
-                let mut cmd = redis::cmd("LPOP");
-                cmd.arg(&input.key);
-                if let Some(count) = input.count {
-                    cmd.arg(count);
-                }
-
-                let result: redis::Value = cmd
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("LPOP failed")?;
-
-                Ok(CallToolResult::text(format!(
-                    "LPOP '{}': {}",
-                    input.key,
-                    super::format_value(&result)
-                )))
-            },
-        )
-        .build()
-}
-
-/// Input for RPOP command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct RpopInput {
-    /// Optional Redis URL (overrides profile)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name for connection resolution
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// List key
-    pub key: String,
-    /// Number of elements to pop (default: 1)
-    #[serde(default)]
-    pub count: Option<u64>,
-}
-
-/// Build the rpop tool
-pub fn rpop(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_rpop")
-        .description("Pop elements from the tail (right) of a list.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<RpopInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
-
-                let mut cmd = redis::cmd("RPOP");
-                cmd.arg(&input.key);
-                if let Some(count) = input.count {
-                    cmd.arg(count);
-                }
-
-                let result: redis::Value = cmd
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("RPOP failed")?;
-
-                Ok(CallToolResult::text(format!(
-                    "RPOP '{}': {}",
-                    input.key,
-                    super::format_value(&result)
-                )))
-            },
-        )
-        .build()
-}
-
-/// Input for SADD command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct SaddInput {
-    /// Optional Redis URL (overrides profile)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name for connection resolution
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Set key
-    pub key: String,
-    /// Members to add to the set
-    pub members: Vec<String>,
-}
-
-/// Build the sadd tool
-pub fn sadd(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_sadd")
-        .description("Add one or more members to a set. Creates the set if needed.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<SaddInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
-
-                let mut cmd = redis::cmd("SADD");
-                cmd.arg(&input.key);
-                for member in &input.members {
-                    cmd.arg(member);
-                }
-
-                let added: i64 = cmd
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("SADD failed")?;
-
-                Ok(CallToolResult::text(format!(
-                    "OK - added {} of {} member(s) to set '{}'",
-                    added,
-                    input.members.len(),
+            if result.is_empty() {
+                return Ok(CallToolResult::text(format!(
+                    "(empty sorted set or key '{}' not found)",
                     input.key
-                )))
-            },
-        )
-        .build()
-}
+                )));
+            }
 
-/// Input for SREM command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct SremInput {
-    /// Optional Redis URL (overrides profile)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name for connection resolution
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Set key
-    pub key: String,
-    /// Members to remove from the set
-    pub members: Vec<String>,
-}
+            let output = result
+                .iter()
+                .enumerate()
+                .map(|(i, v)| format!("{}: {}", i, v))
+                .collect::<Vec<_>>()
+                .join("\n");
 
-/// Build the srem tool
-pub fn srem(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_srem")
-        .description("Remove one or more members from a set.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<SremInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
+            Ok(CallToolResult::text(format!(
+                "Sorted set '{}' ({} members):\n{}",
+                input.key,
+                result.len(),
+                output
+            )))
+        }
+    }
+);
+
+database_tool!(read_only, xinfo_stream, "redis_xinfo_stream",
+    "Get stream metadata including length, consumer groups, and entry details (XINFO STREAM).",
+    {
+        /// Stream key to inspect
+        pub key: String,
+    } => |conn, input| {
+        let result: redis::Value = redis::cmd("XINFO")
+            .arg("STREAM")
+            .arg(&input.key)
+            .query_async(&mut conn)
+            .await
+            .tool_context("XINFO STREAM failed")?;
+
+        Ok(CallToolResult::text(format!(
+            "Stream '{}':\n{}",
+            input.key,
+            super::format_value(&result)
+        )))
+    }
+);
+
+database_tool!(read_only, xrange, "redis_xrange",
+    "Get stream entries in a range. Use \"-\" to \"+\" for all entries.",
+    {
+        /// Stream key
+        pub key: String,
+        /// Start ID (default: "-" for beginning)
+        #[serde(default = "default_xrange_start")]
+        pub start: String,
+        /// End ID (default: "+" for end)
+        #[serde(default = "default_xrange_end")]
+        pub end: String,
+        /// Maximum number of entries to return
+        #[serde(default)]
+        pub count: Option<usize>,
+    } => |conn, input| {
+        let mut cmd = redis::cmd("XRANGE");
+        cmd.arg(&input.key).arg(&input.start).arg(&input.end);
+
+        if let Some(count) = input.count {
+            cmd.arg("COUNT").arg(count);
+        }
+
+        let result: redis::Value = cmd
+            .query_async(&mut conn)
+            .await
+            .tool_context("XRANGE failed")?;
+
+        // Format stream entries
+        let formatted = match &result {
+            redis::Value::Array(entries) if entries.is_empty() => {
+                format!("(empty stream or key '{}' not found)", input.key)
+            }
+            redis::Value::Array(entries) => {
+                let mut output =
+                    format!("Stream '{}' ({} entries):\n", input.key, entries.len());
+                for entry in entries {
+                    output.push_str(&super::format_value(entry));
+                    output.push('\n');
                 }
+                output
+            }
+            _ => super::format_value(&result),
+        };
 
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
+        Ok(CallToolResult::text(formatted))
+    }
+);
 
-                let mut cmd = redis::cmd("SREM");
-                cmd.arg(&input.key);
-                for member in &input.members {
-                    cmd.arg(member);
-                }
+database_tool!(read_only, xlen, "redis_xlen",
+    "Get the number of entries in a stream.",
+    {
+        /// Stream key
+        pub key: String,
+    } => |conn, input| {
+        let len: i64 = redis::cmd("XLEN")
+            .arg(&input.key)
+            .query_async(&mut conn)
+            .await
+            .tool_context("XLEN failed")?;
 
-                let removed: i64 = cmd
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("SREM failed")?;
+        Ok(CallToolResult::text(format!(
+            "Stream '{}': {} entries",
+            input.key, len
+        )))
+    }
+);
 
-                Ok(CallToolResult::text(format!(
-                    "Removed {} of {} member(s) from set '{}'",
-                    removed,
-                    input.members.len(),
-                    input.key
-                )))
-            },
-        )
-        .build()
-}
+database_tool!(read_only, pubsub_channels, "redis_pubsub_channels",
+    "List active pub/sub channels, optionally filtered by pattern.",
+    {
+        /// Optional glob-style pattern to filter channels
+        #[serde(default)]
+        pub pattern: Option<String>,
+    } => |conn, input| {
+        let mut cmd = redis::cmd("PUBSUB");
+        cmd.arg("CHANNELS");
 
-/// A score-member pair for sorted set operations
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ScoreMember {
-    /// Score value
-    pub score: f64,
-    /// Member value
-    pub member: String,
-}
+        if let Some(ref pattern) = input.pattern {
+            cmd.arg(pattern);
+        }
 
-/// Input for ZADD command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ZaddInput {
-    /// Optional Redis URL (overrides profile)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name for connection resolution
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Sorted set key
-    pub key: String,
-    /// Score-member pairs to add
-    pub members: Vec<ScoreMember>,
-    /// Only add new elements, do not update existing ones
-    #[serde(default)]
-    pub nx: bool,
-    /// Only update existing elements, do not add new ones
-    #[serde(default)]
-    pub xx: bool,
-    /// Only update elements whose new score is greater than current score
-    #[serde(default)]
-    pub gt: bool,
-    /// Only update elements whose new score is less than current score
-    #[serde(default)]
-    pub lt: bool,
-    /// Return the number of elements changed (added + updated) instead of only added
-    #[serde(default)]
-    pub ch: bool,
-}
+        let channels: Vec<String> = cmd
+            .query_async(&mut conn)
+            .await
+            .tool_context("PUBSUB CHANNELS failed")?;
 
-/// Build the zadd tool
-pub fn zadd(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_zadd")
-        .description(
-            "Add members with scores to a sorted set. Creates the set if needed. \
-             Supports NX, XX, GT, LT, and CH flags.",
-        )
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<ZaddInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
+        if channels.is_empty() {
+            return Ok(CallToolResult::text("No active pub/sub channels"));
+        }
 
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
+        Ok(CallToolResult::text(format!(
+            "Active channels ({}):\n{}",
+            channels.len(),
+            channels.join("\n")
+        )))
+    }
+);
 
-                let mut cmd = redis::cmd("ZADD");
-                cmd.arg(&input.key);
+database_tool!(read_only, pubsub_numsub, "redis_pubsub_numsub",
+    "Get subscriber counts for pub/sub channels.",
+    {
+        /// Channel names to get subscriber counts for (omit for all)
+        #[serde(default)]
+        pub channels: Option<Vec<String>>,
+    } => |conn, input| {
+        let mut cmd = redis::cmd("PUBSUB");
+        cmd.arg("NUMSUB");
 
-                if input.nx {
-                    cmd.arg("NX");
-                }
-                if input.xx {
-                    cmd.arg("XX");
-                }
-                if input.gt {
-                    cmd.arg("GT");
-                }
-                if input.lt {
-                    cmd.arg("LT");
-                }
-                if input.ch {
-                    cmd.arg("CH");
-                }
+        if let Some(ref channels) = input.channels {
+            for channel in channels {
+                cmd.arg(channel);
+            }
+        }
 
-                for sm in &input.members {
-                    cmd.arg(sm.score).arg(&sm.member);
-                }
+        // PUBSUB NUMSUB returns alternating channel name + count
+        let result: Vec<redis::Value> = cmd
+            .query_async(&mut conn)
+            .await
+            .tool_context("PUBSUB NUMSUB failed")?;
 
-                let count: i64 = cmd
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("ZADD failed")?;
+        if result.is_empty() {
+            return Ok(CallToolResult::text("No subscriber information available"));
+        }
 
-                let verb = if input.ch { "changed" } else { "added" };
-                Ok(CallToolResult::text(format!(
-                    "OK - {} {} member(s) in sorted set '{}'",
-                    count, verb, input.key
-                )))
-            },
-        )
-        .build()
-}
+        let mut output = String::from("Channel subscriber counts:\n");
+        for pair in result.chunks(2) {
+            if pair.len() == 2 {
+                let channel = super::format_value(&pair[0]);
+                let count = super::format_value(&pair[1]);
+                output.push_str(&format!("  {}: {} subscribers\n", channel, count));
+            }
+        }
 
-/// Input for ZREM command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ZremInput {
-    /// Optional Redis URL (overrides profile)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name for connection resolution
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Sorted set key
-    pub key: String,
-    /// Members to remove
-    pub members: Vec<String>,
-}
-
-/// Build the zrem tool
-pub fn zrem(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_zrem")
-        .description("Remove one or more members from a sorted set.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<ZremInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
-
-                let mut cmd = redis::cmd("ZREM");
-                cmd.arg(&input.key);
-                for member in &input.members {
-                    cmd.arg(member);
-                }
-
-                let removed: i64 = cmd
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("ZREM failed")?;
-
-                Ok(CallToolResult::text(format!(
-                    "Removed {} of {} member(s) from sorted set '{}'",
-                    removed,
-                    input.members.len(),
-                    input.key
-                )))
-            },
-        )
-        .build()
-}
-
-/// Input for XADD command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct XaddInput {
-    /// Optional Redis URL (overrides profile)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name for connection resolution
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Stream key
-    pub key: String,
-    /// Entry ID (default: "*" for auto-generated)
-    #[serde(default)]
-    pub id: Option<String>,
-    /// Field-value pairs for the stream entry
-    pub fields: HashMap<String, String>,
-    /// Do not create stream if it does not exist
-    #[serde(default)]
-    pub nomkstream: bool,
-    /// Cap stream to a maximum length
-    #[serde(default)]
-    pub maxlen: Option<u64>,
-    /// Cap stream entries older than this ID
-    #[serde(default)]
-    pub minid: Option<String>,
-    /// Use approximate trimming (~) for better performance
-    #[serde(default)]
-    pub approximate: bool,
-}
-
-/// Build the xadd tool
-pub fn xadd(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_xadd")
-        .description(
-            "Append an entry to a stream. Supports NOMKSTREAM, MAXLEN, and MINID trimming.",
-        )
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<XaddInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
-
-                let mut cmd = redis::cmd("XADD");
-                cmd.arg(&input.key);
-
-                if input.nomkstream {
-                    cmd.arg("NOMKSTREAM");
-                }
-
-                if let Some(maxlen) = input.maxlen {
-                    cmd.arg("MAXLEN");
-                    if input.approximate {
-                        cmd.arg("~");
-                    }
-                    cmd.arg(maxlen);
-                } else if let Some(ref minid) = input.minid {
-                    cmd.arg("MINID");
-                    if input.approximate {
-                        cmd.arg("~");
-                    }
-                    cmd.arg(minid);
-                }
-
-                let id = input.id.as_deref().unwrap_or("*");
-                cmd.arg(id);
-
-                for (field, value) in &input.fields {
-                    cmd.arg(field).arg(value);
-                }
-
-                let entry_id: String = cmd
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("XADD failed")?;
-
-                Ok(CallToolResult::text(format!(
-                    "OK - added entry {} to stream '{}'",
-                    entry_id, input.key
-                )))
-            },
-        )
-        .build()
-}
-
-/// Input for XTRIM command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct XtrimInput {
-    /// Optional Redis URL (overrides profile)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name for connection resolution
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Stream key
-    pub key: String,
-    /// Trimming strategy: "MAXLEN" or "MINID"
-    pub strategy: String,
-    /// Threshold value (count for MAXLEN, ID for MINID)
-    pub threshold: String,
-    /// Use approximate trimming (~) for better performance
-    #[serde(default)]
-    pub approximate: bool,
-}
-
-/// Build the xtrim tool
-pub fn xtrim(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_xtrim")
-        .description(
-            "Trim a stream by length (MAXLEN) or minimum ID (MINID). \
-             Use approximate=true for better performance.",
-        )
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<XtrimInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
-
-                let mut cmd = redis::cmd("XTRIM");
-                cmd.arg(&input.key);
-                cmd.arg(&input.strategy);
-
-                if input.approximate {
-                    cmd.arg("~");
-                }
-                cmd.arg(&input.threshold);
-
-                let trimmed: i64 = cmd
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("XTRIM failed")?;
-
-                Ok(CallToolResult::text(format!(
-                    "OK - trimmed {} entries from stream '{}'",
-                    trimmed, input.key
-                )))
-            },
-        )
-        .build()
-}
+        Ok(CallToolResult::text(output))
+    }
+);
 
 // --- P1 Hash read tools ---
 
-/// Input for HGET command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct HgetInput {
-    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name to resolve connection from (uses default profile if not set)
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Hash key
-    pub key: String,
-    /// Field to get
-    pub field: String,
-}
+database_tool!(read_only, hget, "redis_hget",
+    "Get the value of a single field in a hash.",
+    {
+        /// Hash key
+        pub key: String,
+        /// Field to get
+        pub field: String,
+    } => |conn, input| {
+        let value: Option<String> = redis::cmd("HGET")
+            .arg(&input.key)
+            .arg(&input.field)
+            .query_async(&mut conn)
+            .await
+            .tool_context("HGET failed")?;
 
-/// Build the hget tool
-pub fn hget(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_hget")
-        .description("Get the value of a single field in a hash.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<HgetInput>| async move {
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
+        match value {
+            Some(v) => Ok(CallToolResult::text(v)),
+            None => Ok(CallToolResult::text(format!(
+                "(nil) - field '{}' not found in '{}'",
+                input.field, input.key
+            ))),
+        }
+    }
+);
 
-                let value: Option<String> = redis::cmd("HGET")
-                    .arg(&input.key)
-                    .arg(&input.field)
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("HGET failed")?;
+database_tool!(read_only, hmget, "redis_hmget",
+    "Get the values of multiple fields in a hash.",
+    {
+        /// Hash key
+        pub key: String,
+        /// Fields to get
+        pub fields: Vec<String>,
+    } => |conn, input| {
+        let mut cmd = redis::cmd("HMGET");
+        cmd.arg(&input.key);
+        for field in &input.fields {
+            cmd.arg(field);
+        }
 
-                match value {
-                    Some(v) => Ok(CallToolResult::text(v)),
-                    None => Ok(CallToolResult::text(format!(
-                        "(nil) - field '{}' not found in '{}'",
-                        input.field, input.key
-                    ))),
-                }
-            },
-        )
-        .build()
-}
+        let values: Vec<redis::Value> = cmd
+            .query_async(&mut conn)
+            .await
+            .tool_context("HMGET failed")?;
 
-/// Input for HMGET command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct HmgetInput {
-    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name to resolve connection from (uses default profile if not set)
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Hash key
-    pub key: String,
-    /// Fields to get
-    pub fields: Vec<String>,
-}
+        let output = input
+            .fields
+            .iter()
+            .zip(values.iter())
+            .map(|(f, v)| format!("{}: {}", f, super::format_value(v)))
+            .collect::<Vec<_>>()
+            .join("\n");
 
-/// Build the hmget tool
-pub fn hmget(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_hmget")
-        .description("Get the values of multiple fields in a hash.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<HmgetInput>| async move {
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
+        Ok(CallToolResult::text(output))
+    }
+);
 
-                let mut cmd = redis::cmd("HMGET");
-                cmd.arg(&input.key);
-                for field in &input.fields {
-                    cmd.arg(field);
-                }
+database_tool!(read_only, hlen, "redis_hlen",
+    "Get the number of fields in a hash.",
+    {
+        /// Hash key
+        pub key: String,
+    } => |conn, input| {
+        let count: i64 = redis::cmd("HLEN")
+            .arg(&input.key)
+            .query_async(&mut conn)
+            .await
+            .tool_context("HLEN failed")?;
 
-                let values: Vec<redis::Value> = cmd
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("HMGET failed")?;
+        Ok(CallToolResult::text(format!(
+            "{}: {} fields",
+            input.key, count
+        )))
+    }
+);
 
-                let output = input
-                    .fields
-                    .iter()
-                    .zip(values.iter())
-                    .map(|(f, v)| format!("{}: {}", f, super::format_value(v)))
-                    .collect::<Vec<_>>()
-                    .join("\n");
+database_tool!(read_only, hexists, "redis_hexists",
+    "Check if a field exists in a hash.",
+    {
+        /// Hash key
+        pub key: String,
+        /// Field to check
+        pub field: String,
+    } => |conn, input| {
+        let exists: bool = redis::cmd("HEXISTS")
+            .arg(&input.key)
+            .arg(&input.field)
+            .query_async(&mut conn)
+            .await
+            .tool_context("HEXISTS failed")?;
 
-                Ok(CallToolResult::text(output))
-            },
-        )
-        .build()
-}
+        Ok(CallToolResult::text(format!(
+            "{}.{}: {}",
+            input.key,
+            input.field,
+            if exists { "exists" } else { "does not exist" }
+        )))
+    }
+);
 
-/// Input for HLEN command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct HlenInput {
-    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name to resolve connection from (uses default profile if not set)
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Hash key
-    pub key: String,
-}
+database_tool!(read_only, hkeys, "redis_hkeys",
+    "Get all field names in a hash.",
+    {
+        /// Hash key
+        pub key: String,
+    } => |conn, input| {
+        let fields: Vec<String> = redis::cmd("HKEYS")
+            .arg(&input.key)
+            .query_async(&mut conn)
+            .await
+            .tool_context("HKEYS failed")?;
 
-/// Build the hlen tool
-pub fn hlen(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_hlen")
-        .description("Get the number of fields in a hash.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<HlenInput>| async move {
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
+        if fields.is_empty() {
+            return Ok(CallToolResult::text(format!(
+                "(empty hash or key '{}' not found)",
+                input.key
+            )));
+        }
 
-                let count: i64 = redis::cmd("HLEN")
-                    .arg(&input.key)
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("HLEN failed")?;
+        Ok(CallToolResult::text(format!(
+            "Hash '{}' ({} fields):\n{}",
+            input.key,
+            fields.len(),
+            fields.join("\n")
+        )))
+    }
+);
 
-                Ok(CallToolResult::text(format!(
-                    "{}: {} fields",
-                    input.key, count
-                )))
-            },
-        )
-        .build()
-}
+database_tool!(read_only, hvals, "redis_hvals",
+    "Get all values in a hash.",
+    {
+        /// Hash key
+        pub key: String,
+    } => |conn, input| {
+        let values: Vec<String> = redis::cmd("HVALS")
+            .arg(&input.key)
+            .query_async(&mut conn)
+            .await
+            .tool_context("HVALS failed")?;
 
-/// Input for HEXISTS command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct HexistsInput {
-    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name to resolve connection from (uses default profile if not set)
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Hash key
-    pub key: String,
-    /// Field to check
-    pub field: String,
-}
+        if values.is_empty() {
+            return Ok(CallToolResult::text(format!(
+                "(empty hash or key '{}' not found)",
+                input.key
+            )));
+        }
 
-/// Build the hexists tool
-pub fn hexists(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_hexists")
-        .description("Check if a field exists in a hash.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<HexistsInput>| async move {
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
-
-                let exists: bool = redis::cmd("HEXISTS")
-                    .arg(&input.key)
-                    .arg(&input.field)
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("HEXISTS failed")?;
-
-                Ok(CallToolResult::text(format!(
-                    "{}.{}: {}",
-                    input.key,
-                    input.field,
-                    if exists { "exists" } else { "does not exist" }
-                )))
-            },
-        )
-        .build()
-}
-
-/// Input for HKEYS command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct HkeysInput {
-    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name to resolve connection from (uses default profile if not set)
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Hash key
-    pub key: String,
-}
-
-/// Build the hkeys tool
-pub fn hkeys(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_hkeys")
-        .description("Get all field names in a hash.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<HkeysInput>| async move {
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
-
-                let fields: Vec<String> = redis::cmd("HKEYS")
-                    .arg(&input.key)
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("HKEYS failed")?;
-
-                if fields.is_empty() {
-                    return Ok(CallToolResult::text(format!(
-                        "(empty hash or key '{}' not found)",
-                        input.key
-                    )));
-                }
-
-                Ok(CallToolResult::text(format!(
-                    "Hash '{}' ({} fields):\n{}",
-                    input.key,
-                    fields.len(),
-                    fields.join("\n")
-                )))
-            },
-        )
-        .build()
-}
-
-/// Input for HVALS command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct HvalsInput {
-    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name to resolve connection from (uses default profile if not set)
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Hash key
-    pub key: String,
-}
-
-/// Build the hvals tool
-pub fn hvals(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_hvals")
-        .description("Get all values in a hash.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<HvalsInput>| async move {
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
-
-                let values: Vec<String> = redis::cmd("HVALS")
-                    .arg(&input.key)
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("HVALS failed")?;
-
-                if values.is_empty() {
-                    return Ok(CallToolResult::text(format!(
-                        "(empty hash or key '{}' not found)",
-                        input.key
-                    )));
-                }
-
-                Ok(CallToolResult::text(format!(
-                    "Hash '{}' ({} values):\n{}",
-                    input.key,
-                    values.len(),
-                    values.join("\n")
-                )))
-            },
-        )
-        .build()
-}
-
-/// Input for HINCRBY command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct HincrbyInput {
-    /// Optional Redis URL (overrides profile)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name for connection resolution
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Hash key
-    pub key: String,
-    /// Field to increment
-    pub field: String,
-    /// Increment value (can be negative)
-    pub increment: i64,
-}
-
-/// Build the hincrby tool
-pub fn hincrby(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_hincrby")
-        .description("Increment the integer value of a hash field by the given amount.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<HincrbyInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
-
-                let value: i64 = redis::cmd("HINCRBY")
-                    .arg(&input.key)
-                    .arg(&input.field)
-                    .arg(input.increment)
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("HINCRBY failed")?;
-
-                Ok(CallToolResult::text(format!(
-                    "{}.{}: {}",
-                    input.key, input.field, value
-                )))
-            },
-        )
-        .build()
-}
+        Ok(CallToolResult::text(format!(
+            "Hash '{}' ({} values):\n{}",
+            input.key,
+            values.len(),
+            values.join("\n")
+        )))
+    }
+);
 
 // --- P1 Set read tools ---
 
-/// Input for SCARD command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ScardInput {
-    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name to resolve connection from (uses default profile if not set)
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Set key
-    pub key: String,
-}
+database_tool!(read_only, scard, "redis_scard",
+    "Get the number of members in a set (cardinality).",
+    {
+        /// Set key
+        pub key: String,
+    } => |conn, input| {
+        let count: i64 = redis::cmd("SCARD")
+            .arg(&input.key)
+            .query_async(&mut conn)
+            .await
+            .tool_context("SCARD failed")?;
 
-/// Build the scard tool
-pub fn scard(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_scard")
-        .description("Get the number of members in a set (cardinality).")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<ScardInput>| async move {
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
+        Ok(CallToolResult::text(format!(
+            "{}: {} members",
+            input.key, count
+        )))
+    }
+);
 
-                let count: i64 = redis::cmd("SCARD")
-                    .arg(&input.key)
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("SCARD failed")?;
+database_tool!(read_only, sismember, "redis_sismember",
+    "Check if a value is a member of a set.",
+    {
+        /// Set key
+        pub key: String,
+        /// Member to check
+        pub member: String,
+    } => |conn, input| {
+        let is_member: bool = redis::cmd("SISMEMBER")
+            .arg(&input.key)
+            .arg(&input.member)
+            .query_async(&mut conn)
+            .await
+            .tool_context("SISMEMBER failed")?;
 
-                Ok(CallToolResult::text(format!(
-                    "{}: {} members",
-                    input.key, count
-                )))
-            },
-        )
-        .build()
-}
+        Ok(CallToolResult::text(format!(
+            "'{}' {} a member of '{}'",
+            input.member,
+            if is_member { "is" } else { "is not" },
+            input.key
+        )))
+    }
+);
 
-/// Input for SISMEMBER command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct SismemberInput {
-    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name to resolve connection from (uses default profile if not set)
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Set key
-    pub key: String,
-    /// Member to check
-    pub member: String,
-}
+database_tool!(read_only, sunion, "redis_sunion",
+    "Return the union of multiple sets.",
+    {
+        /// Set keys to compute union of
+        pub keys: Vec<String>,
+    } => |conn, input| {
+        let mut cmd = redis::cmd("SUNION");
+        for key in &input.keys {
+            cmd.arg(key);
+        }
 
-/// Build the sismember tool
-pub fn sismember(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_sismember")
-        .description("Check if a value is a member of a set.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<SismemberInput>| async move {
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
+        let members: Vec<String> = cmd
+            .query_async(&mut conn)
+            .await
+            .tool_context("SUNION failed")?;
 
-                let is_member: bool = redis::cmd("SISMEMBER")
-                    .arg(&input.key)
-                    .arg(&input.member)
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("SISMEMBER failed")?;
+        if members.is_empty() {
+            return Ok(CallToolResult::text("(empty set)"));
+        }
 
-                Ok(CallToolResult::text(format!(
-                    "'{}' {} a member of '{}'",
-                    input.member,
-                    if is_member { "is" } else { "is not" },
-                    input.key
-                )))
-            },
-        )
-        .build()
-}
+        Ok(CallToolResult::text(format!(
+            "Union ({} members):\n{}",
+            members.len(),
+            members.join("\n")
+        )))
+    }
+);
 
-/// Input for SUNION command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct SunionInput {
-    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name to resolve connection from (uses default profile if not set)
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Set keys to compute union of
-    pub keys: Vec<String>,
-}
+database_tool!(read_only, sinter, "redis_sinter",
+    "Return the intersection of multiple sets.",
+    {
+        /// Set keys to compute intersection of
+        pub keys: Vec<String>,
+    } => |conn, input| {
+        let mut cmd = redis::cmd("SINTER");
+        for key in &input.keys {
+            cmd.arg(key);
+        }
 
-/// Build the sunion tool
-pub fn sunion(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_sunion")
-        .description("Return the union of multiple sets.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<SunionInput>| async move {
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
+        let members: Vec<String> = cmd
+            .query_async(&mut conn)
+            .await
+            .tool_context("SINTER failed")?;
 
-                let mut cmd = redis::cmd("SUNION");
-                for key in &input.keys {
-                    cmd.arg(key);
-                }
+        if members.is_empty() {
+            return Ok(CallToolResult::text("(empty set)"));
+        }
 
-                let members: Vec<String> = cmd
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("SUNION failed")?;
+        Ok(CallToolResult::text(format!(
+            "Intersection ({} members):\n{}",
+            members.len(),
+            members.join("\n")
+        )))
+    }
+);
 
-                if members.is_empty() {
-                    return Ok(CallToolResult::text("(empty set)"));
-                }
+database_tool!(read_only, sdiff, "redis_sdiff",
+    "Return the difference between the first set and all subsequent sets.",
+    {
+        /// Set keys (first set minus all subsequent sets)
+        pub keys: Vec<String>,
+    } => |conn, input| {
+        let mut cmd = redis::cmd("SDIFF");
+        for key in &input.keys {
+            cmd.arg(key);
+        }
 
-                Ok(CallToolResult::text(format!(
-                    "Union ({} members):\n{}",
-                    members.len(),
-                    members.join("\n")
-                )))
-            },
-        )
-        .build()
-}
+        let members: Vec<String> = cmd
+            .query_async(&mut conn)
+            .await
+            .tool_context("SDIFF failed")?;
 
-/// Input for SINTER command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct SinterInput {
-    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name to resolve connection from (uses default profile if not set)
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Set keys to compute intersection of
-    pub keys: Vec<String>,
-}
+        if members.is_empty() {
+            return Ok(CallToolResult::text("(empty set)"));
+        }
 
-/// Build the sinter tool
-pub fn sinter(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_sinter")
-        .description("Return the intersection of multiple sets.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<SinterInput>| async move {
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
-
-                let mut cmd = redis::cmd("SINTER");
-                for key in &input.keys {
-                    cmd.arg(key);
-                }
-
-                let members: Vec<String> = cmd
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("SINTER failed")?;
-
-                if members.is_empty() {
-                    return Ok(CallToolResult::text("(empty set)"));
-                }
-
-                Ok(CallToolResult::text(format!(
-                    "Intersection ({} members):\n{}",
-                    members.len(),
-                    members.join("\n")
-                )))
-            },
-        )
-        .build()
-}
-
-/// Input for SDIFF command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct SdiffInput {
-    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name to resolve connection from (uses default profile if not set)
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Set keys (first set minus all subsequent sets)
-    pub keys: Vec<String>,
-}
-
-/// Build the sdiff tool
-pub fn sdiff(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_sdiff")
-        .description("Return the difference between the first set and all subsequent sets.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<SdiffInput>| async move {
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
-
-                let mut cmd = redis::cmd("SDIFF");
-                for key in &input.keys {
-                    cmd.arg(key);
-                }
-
-                let members: Vec<String> = cmd
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("SDIFF failed")?;
-
-                if members.is_empty() {
-                    return Ok(CallToolResult::text("(empty set)"));
-                }
-
-                Ok(CallToolResult::text(format!(
-                    "Difference ({} members):\n{}",
-                    members.len(),
-                    members.join("\n")
-                )))
-            },
-        )
-        .build()
-}
+        Ok(CallToolResult::text(format!(
+            "Difference ({} members):\n{}",
+            members.len(),
+            members.join("\n")
+        )))
+    }
+);
 
 // --- P1 Sorted Set read tools ---
 
-/// Input for ZCARD command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ZcardInput {
-    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name to resolve connection from (uses default profile if not set)
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Sorted set key
-    pub key: String,
-}
+database_tool!(read_only, zcard, "redis_zcard",
+    "Get the number of members in a sorted set (cardinality).",
+    {
+        /// Sorted set key
+        pub key: String,
+    } => |conn, input| {
+        let count: i64 = redis::cmd("ZCARD")
+            .arg(&input.key)
+            .query_async(&mut conn)
+            .await
+            .tool_context("ZCARD failed")?;
 
-/// Build the zcard tool
-pub fn zcard(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_zcard")
-        .description("Get the number of members in a sorted set (cardinality).")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<ZcardInput>| async move {
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
+        Ok(CallToolResult::text(format!(
+            "{}: {} members",
+            input.key, count
+        )))
+    }
+);
 
-                let count: i64 = redis::cmd("ZCARD")
-                    .arg(&input.key)
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("ZCARD failed")?;
+database_tool!(read_only, zscore, "redis_zscore",
+    "Get the score of a member in a sorted set.",
+    {
+        /// Sorted set key
+        pub key: String,
+        /// Member to get score for
+        pub member: String,
+    } => |conn, input| {
+        let score: Option<f64> = redis::cmd("ZSCORE")
+            .arg(&input.key)
+            .arg(&input.member)
+            .query_async(&mut conn)
+            .await
+            .tool_context("ZSCORE failed")?;
 
-                Ok(CallToolResult::text(format!(
-                    "{}: {} members",
-                    input.key, count
-                )))
-            },
-        )
-        .build()
-}
+        match score {
+            Some(s) => Ok(CallToolResult::text(format!(
+                "{}.{}: {}",
+                input.key, input.member, s
+            ))),
+            None => Ok(CallToolResult::text(format!(
+                "(nil) - '{}' not found in '{}'",
+                input.member, input.key
+            ))),
+        }
+    }
+);
 
-/// Input for ZSCORE command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ZscoreInput {
-    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name to resolve connection from (uses default profile if not set)
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Sorted set key
-    pub key: String,
-    /// Member to get score for
-    pub member: String,
-}
+database_tool!(read_only, zrank, "redis_zrank",
+    "Get the rank (0-based index) of a member in a sorted set, ordered low to high.",
+    {
+        /// Sorted set key
+        pub key: String,
+        /// Member to get rank for
+        pub member: String,
+    } => |conn, input| {
+        let rank: Option<i64> = redis::cmd("ZRANK")
+            .arg(&input.key)
+            .arg(&input.member)
+            .query_async(&mut conn)
+            .await
+            .tool_context("ZRANK failed")?;
 
-/// Build the zscore tool
-pub fn zscore(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_zscore")
-        .description("Get the score of a member in a sorted set.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<ZscoreInput>| async move {
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
+        match rank {
+            Some(r) => Ok(CallToolResult::text(format!(
+                "{}.{}: rank {}",
+                input.key, input.member, r
+            ))),
+            None => Ok(CallToolResult::text(format!(
+                "(nil) - '{}' not found in '{}'",
+                input.member, input.key
+            ))),
+        }
+    }
+);
 
-                let score: Option<f64> = redis::cmd("ZSCORE")
-                    .arg(&input.key)
-                    .arg(&input.member)
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("ZSCORE failed")?;
+database_tool!(read_only, zcount, "redis_zcount",
+    "Count members in a sorted set with scores between min and max (inclusive). Use \"-inf\"/\"+inf\" for unbounded.",
+    {
+        /// Sorted set key
+        pub key: String,
+        /// Minimum score (use "-inf" for no lower bound)
+        pub min: String,
+        /// Maximum score (use "+inf" for no upper bound)
+        pub max: String,
+    } => |conn, input| {
+        let count: i64 = redis::cmd("ZCOUNT")
+            .arg(&input.key)
+            .arg(&input.min)
+            .arg(&input.max)
+            .query_async(&mut conn)
+            .await
+            .tool_context("ZCOUNT failed")?;
 
-                match score {
-                    Some(s) => Ok(CallToolResult::text(format!(
-                        "{}.{}: {}",
-                        input.key, input.member, s
-                    ))),
-                    None => Ok(CallToolResult::text(format!(
-                        "(nil) - '{}' not found in '{}'",
-                        input.member, input.key
-                    ))),
-                }
-            },
-        )
-        .build()
-}
+        Ok(CallToolResult::text(format!(
+            "{}: {} members in score range [{}, {}]",
+            input.key, count, input.min, input.max
+        )))
+    }
+);
 
-/// Input for ZRANK command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ZrankInput {
-    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name to resolve connection from (uses default profile if not set)
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Sorted set key
-    pub key: String,
-    /// Member to get rank for
-    pub member: String,
-}
+database_tool!(read_only, zrangebyscore, "redis_zrangebyscore",
+    "Get members from a sorted set with scores in the given range. Use \"-inf\"/\"+inf\" for unbounded.",
+    {
+        /// Sorted set key
+        pub key: String,
+        /// Minimum score (use "-inf" for no lower bound)
+        pub min: String,
+        /// Maximum score (use "+inf" for no upper bound)
+        pub max: String,
+        /// Include scores in output
+        #[serde(default)]
+        pub withscores: bool,
+        /// Offset for pagination (requires count)
+        #[serde(default)]
+        pub offset: Option<i64>,
+        /// Maximum number of results (requires offset)
+        #[serde(default)]
+        pub count: Option<i64>,
+    } => |conn, input| {
+        let mut cmd = redis::cmd("ZRANGEBYSCORE");
+        cmd.arg(&input.key).arg(&input.min).arg(&input.max);
 
-/// Build the zrank tool
-pub fn zrank(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_zrank")
-        .description(
-            "Get the rank (0-based index) of a member in a sorted set, ordered low to high.",
-        )
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<ZrankInput>| async move {
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
+        if input.withscores {
+            cmd.arg("WITHSCORES");
+        }
 
-                let rank: Option<i64> = redis::cmd("ZRANK")
-                    .arg(&input.key)
-                    .arg(&input.member)
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("ZRANK failed")?;
+        if let (Some(offset), Some(count)) = (input.offset, input.count) {
+            cmd.arg("LIMIT").arg(offset).arg(count);
+        }
 
-                match rank {
-                    Some(r) => Ok(CallToolResult::text(format!(
-                        "{}.{}: rank {}",
-                        input.key, input.member, r
-                    ))),
-                    None => Ok(CallToolResult::text(format!(
-                        "(nil) - '{}' not found in '{}'",
-                        input.member, input.key
-                    ))),
-                }
-            },
-        )
-        .build()
-}
+        if input.withscores {
+            let result: Vec<(String, f64)> = cmd
+                .query_async(&mut conn)
+                .await
+                .tool_context("ZRANGEBYSCORE failed")?;
 
-/// Input for ZCOUNT command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ZcountInput {
-    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name to resolve connection from (uses default profile if not set)
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Sorted set key
-    pub key: String,
-    /// Minimum score (use "-inf" for no lower bound)
-    pub min: String,
-    /// Maximum score (use "+inf" for no upper bound)
-    pub max: String,
-}
+            if result.is_empty() {
+                return Ok(CallToolResult::text(format!(
+                    "No members in '{}' with scores in [{}, {}]",
+                    input.key, input.min, input.max
+                )));
+            }
 
-/// Build the zcount tool
-pub fn zcount(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_zcount")
-        .description("Count members in a sorted set with scores between min and max (inclusive). Use \"-inf\"/\"+inf\" for unbounded.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<ZcountInput>| async move {
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
+            let output = result
+                .iter()
+                .map(|(member, score)| format!("{} (score: {})", member, score))
+                .collect::<Vec<_>>()
+                .join("\n");
 
-                let count: i64 = redis::cmd("ZCOUNT")
-                    .arg(&input.key)
-                    .arg(&input.min)
-                    .arg(&input.max)
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("ZCOUNT failed")?;
+            Ok(CallToolResult::text(format!(
+                "'{}' ({} members in [{}, {}]):\n{}",
+                input.key,
+                result.len(),
+                input.min,
+                input.max,
+                output
+            )))
+        } else {
+            let result: Vec<String> = cmd
+                .query_async(&mut conn)
+                .await
+                .tool_context("ZRANGEBYSCORE failed")?;
 
-                Ok(CallToolResult::text(format!(
-                    "{}: {} members in score range [{}, {}]",
-                    input.key, count, input.min, input.max
-                )))
-            },
-        )
-        .build()
-}
+            if result.is_empty() {
+                return Ok(CallToolResult::text(format!(
+                    "No members in '{}' with scores in [{}, {}]",
+                    input.key, input.min, input.max
+                )));
+            }
 
-/// Input for ZRANGEBYSCORE command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ZrangebyscoreInput {
-    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name to resolve connection from (uses default profile if not set)
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Sorted set key
-    pub key: String,
-    /// Minimum score (use "-inf" for no lower bound)
-    pub min: String,
-    /// Maximum score (use "+inf" for no upper bound)
-    pub max: String,
-    /// Include scores in output
-    #[serde(default)]
-    pub withscores: bool,
-    /// Offset for pagination (requires count)
-    #[serde(default)]
-    pub offset: Option<i64>,
-    /// Maximum number of results (requires offset)
-    #[serde(default)]
-    pub count: Option<i64>,
-}
-
-/// Build the zrangebyscore tool
-pub fn zrangebyscore(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_zrangebyscore")
-        .description("Get members from a sorted set with scores in the given range. Use \"-inf\"/\"+inf\" for unbounded.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<ZrangebyscoreInput>| async move {
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
-
-                let mut cmd = redis::cmd("ZRANGEBYSCORE");
-                cmd.arg(&input.key).arg(&input.min).arg(&input.max);
-
-                if input.withscores {
-                    cmd.arg("WITHSCORES");
-                }
-
-                if let (Some(offset), Some(count)) = (input.offset, input.count) {
-                    cmd.arg("LIMIT").arg(offset).arg(count);
-                }
-
-                if input.withscores {
-                    let result: Vec<(String, f64)> = cmd
-                        .query_async(&mut conn)
-                        .await
-                        .tool_context("ZRANGEBYSCORE failed")?;
-
-                    if result.is_empty() {
-                        return Ok(CallToolResult::text(format!(
-                            "No members in '{}' with scores in [{}, {}]",
-                            input.key, input.min, input.max
-                        )));
-                    }
-
-                    let output = result
-                        .iter()
-                        .map(|(member, score)| format!("{} (score: {})", member, score))
-                        .collect::<Vec<_>>()
-                        .join("\n");
-
-                    Ok(CallToolResult::text(format!(
-                        "'{}' ({} members in [{}, {}]):\n{}",
-                        input.key,
-                        result.len(),
-                        input.min,
-                        input.max,
-                        output
-                    )))
-                } else {
-                    let result: Vec<String> = cmd
-                        .query_async(&mut conn)
-                        .await
-                        .tool_context("ZRANGEBYSCORE failed")?;
-
-                    if result.is_empty() {
-                        return Ok(CallToolResult::text(format!(
-                            "No members in '{}' with scores in [{}, {}]",
-                            input.key, input.min, input.max
-                        )));
-                    }
-
-                    Ok(CallToolResult::text(format!(
-                        "'{}' ({} members in [{}, {}]):\n{}",
-                        input.key,
-                        result.len(),
-                        input.min,
-                        input.max,
-                        result.join("\n")
-                    )))
-                }
-            },
-        )
-        .build()
-}
+            Ok(CallToolResult::text(format!(
+                "'{}' ({} members in [{}, {}]):\n{}",
+                input.key,
+                result.len(),
+                input.min,
+                input.max,
+                result.join("\n")
+            )))
+        }
+    }
+);
 
 // --- P1 List read tools ---
 
-/// Input for LLEN command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct LlenInput {
-    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name to resolve connection from (uses default profile if not set)
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// List key
-    pub key: String,
-}
+database_tool!(read_only, llen, "redis_llen",
+    "Get the length of a list.",
+    {
+        /// List key
+        pub key: String,
+    } => |conn, input| {
+        let length: i64 = redis::cmd("LLEN")
+            .arg(&input.key)
+            .query_async(&mut conn)
+            .await
+            .tool_context("LLEN failed")?;
 
-/// Build the llen tool
-pub fn llen(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_llen")
-        .description("Get the length of a list.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<LlenInput>| async move {
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
+        Ok(CallToolResult::text(format!(
+            "{}: {} elements",
+            input.key, length
+        )))
+    }
+);
 
-                let length: i64 = redis::cmd("LLEN")
-                    .arg(&input.key)
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("LLEN failed")?;
+database_tool!(read_only, lindex, "redis_lindex",
+    "Get an element from a list by its index (0-based, negative counts from end).",
+    {
+        /// List key
+        pub key: String,
+        /// Index (0-based, negative counts from end)
+        pub index: i64,
+    } => |conn, input| {
+        let value: Option<String> = redis::cmd("LINDEX")
+            .arg(&input.key)
+            .arg(input.index)
+            .query_async(&mut conn)
+            .await
+            .tool_context("LINDEX failed")?;
 
-                Ok(CallToolResult::text(format!(
-                    "{}: {} elements",
-                    input.key, length
-                )))
-            },
-        )
-        .build()
-}
+        match value {
+            Some(v) => Ok(CallToolResult::text(v)),
+            None => Ok(CallToolResult::text(format!(
+                "(nil) - index {} out of range or key '{}' not found",
+                input.index, input.key
+            ))),
+        }
+    }
+);
 
-/// Input for LINDEX command
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct LindexInput {
-    /// Optional Redis URL (overrides profile, uses configured URL if not provided)
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Optional profile name to resolve connection from (uses default profile if not set)
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// List key
-    pub key: String,
-    /// Index (0-based, negative counts from end)
-    pub index: i64,
-}
+// --- Write tools ---
 
-/// Build the lindex tool
-pub fn lindex(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("redis_lindex")
-        .description("Get an element from a list by its index (0-based, negative counts from end).")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<LindexInput>| async move {
-                let mut conn =
-                    super::get_connection(input.url, input.profile.as_deref(), &state).await?;
+database_tool!(write, hset, "redis_hset",
+    "Set one or more field-value pairs in a hash. Creates the hash if needed.",
+    {
+        /// Hash key
+        pub key: String,
+        /// Field-value pairs to set
+        pub fields: HashMap<String, String>,
+    } => |conn, input| {
+        let mut cmd = redis::cmd("HSET");
+        cmd.arg(&input.key);
+        for (field, value) in &input.fields {
+            cmd.arg(field).arg(value);
+        }
 
-                let value: Option<String> = redis::cmd("LINDEX")
-                    .arg(&input.key)
-                    .arg(input.index)
-                    .query_async(&mut conn)
-                    .await
-                    .tool_context("LINDEX failed")?;
+        let added: i64 = cmd
+            .query_async(&mut conn)
+            .await
+            .tool_context("HSET failed")?;
 
-                match value {
-                    Some(v) => Ok(CallToolResult::text(v)),
-                    None => Ok(CallToolResult::text(format!(
-                        "(nil) - index {} out of range or key '{}' not found",
-                        input.index, input.key
-                    ))),
-                }
-            },
-        )
-        .build()
-}
+        Ok(CallToolResult::text(format!(
+            "OK - {} field(s) added to hash '{}' ({} field(s) set total)",
+            added,
+            input.key,
+            input.fields.len()
+        )))
+    }
+);
+
+database_tool!(write, hdel, "redis_hdel",
+    "Delete one or more fields from a hash.",
+    {
+        /// Hash key
+        pub key: String,
+        /// Fields to delete
+        pub fields: Vec<String>,
+    } => |conn, input| {
+        let mut cmd = redis::cmd("HDEL");
+        cmd.arg(&input.key);
+        for field in &input.fields {
+            cmd.arg(field);
+        }
+
+        let removed: i64 = cmd
+            .query_async(&mut conn)
+            .await
+            .tool_context("HDEL failed")?;
+
+        Ok(CallToolResult::text(format!(
+            "Deleted {} of {} field(s) from hash '{}'",
+            removed,
+            input.fields.len(),
+            input.key
+        )))
+    }
+);
+
+database_tool!(write, lpush, "redis_lpush",
+    "Push elements to the head (left) of a list. Creates the list if needed.",
+    {
+        /// List key
+        pub key: String,
+        /// Elements to push to the head of the list
+        pub elements: Vec<String>,
+    } => |conn, input| {
+        let mut cmd = redis::cmd("LPUSH");
+        cmd.arg(&input.key);
+        for elem in &input.elements {
+            cmd.arg(elem);
+        }
+
+        let length: i64 = cmd
+            .query_async(&mut conn)
+            .await
+            .tool_context("LPUSH failed")?;
+
+        Ok(CallToolResult::text(format!(
+            "OK - pushed {} element(s) to '{}', new length: {}",
+            input.elements.len(),
+            input.key,
+            length
+        )))
+    }
+);
+
+database_tool!(write, rpush, "redis_rpush",
+    "Push elements to the tail (right) of a list. Creates the list if needed.",
+    {
+        /// List key
+        pub key: String,
+        /// Elements to push to the tail of the list
+        pub elements: Vec<String>,
+    } => |conn, input| {
+        let mut cmd = redis::cmd("RPUSH");
+        cmd.arg(&input.key);
+        for elem in &input.elements {
+            cmd.arg(elem);
+        }
+
+        let length: i64 = cmd
+            .query_async(&mut conn)
+            .await
+            .tool_context("RPUSH failed")?;
+
+        Ok(CallToolResult::text(format!(
+            "OK - pushed {} element(s) to '{}', new length: {}",
+            input.elements.len(),
+            input.key,
+            length
+        )))
+    }
+);
+
+database_tool!(write, lpop, "redis_lpop",
+    "Pop elements from the head (left) of a list.",
+    {
+        /// List key
+        pub key: String,
+        /// Number of elements to pop (default: 1)
+        #[serde(default)]
+        pub count: Option<u64>,
+    } => |conn, input| {
+        let mut cmd = redis::cmd("LPOP");
+        cmd.arg(&input.key);
+        if let Some(count) = input.count {
+            cmd.arg(count);
+        }
+
+        let result: redis::Value = cmd
+            .query_async(&mut conn)
+            .await
+            .tool_context("LPOP failed")?;
+
+        Ok(CallToolResult::text(format!(
+            "LPOP '{}': {}",
+            input.key,
+            super::format_value(&result)
+        )))
+    }
+);
+
+database_tool!(write, rpop, "redis_rpop",
+    "Pop elements from the tail (right) of a list.",
+    {
+        /// List key
+        pub key: String,
+        /// Number of elements to pop (default: 1)
+        #[serde(default)]
+        pub count: Option<u64>,
+    } => |conn, input| {
+        let mut cmd = redis::cmd("RPOP");
+        cmd.arg(&input.key);
+        if let Some(count) = input.count {
+            cmd.arg(count);
+        }
+
+        let result: redis::Value = cmd
+            .query_async(&mut conn)
+            .await
+            .tool_context("RPOP failed")?;
+
+        Ok(CallToolResult::text(format!(
+            "RPOP '{}': {}",
+            input.key,
+            super::format_value(&result)
+        )))
+    }
+);
+
+database_tool!(write, sadd, "redis_sadd",
+    "Add one or more members to a set. Creates the set if needed.",
+    {
+        /// Set key
+        pub key: String,
+        /// Members to add to the set
+        pub members: Vec<String>,
+    } => |conn, input| {
+        let mut cmd = redis::cmd("SADD");
+        cmd.arg(&input.key);
+        for member in &input.members {
+            cmd.arg(member);
+        }
+
+        let added: i64 = cmd
+            .query_async(&mut conn)
+            .await
+            .tool_context("SADD failed")?;
+
+        Ok(CallToolResult::text(format!(
+            "OK - added {} of {} member(s) to set '{}'",
+            added,
+            input.members.len(),
+            input.key
+        )))
+    }
+);
+
+database_tool!(write, srem, "redis_srem",
+    "Remove one or more members from a set.",
+    {
+        /// Set key
+        pub key: String,
+        /// Members to remove from the set
+        pub members: Vec<String>,
+    } => |conn, input| {
+        let mut cmd = redis::cmd("SREM");
+        cmd.arg(&input.key);
+        for member in &input.members {
+            cmd.arg(member);
+        }
+
+        let removed: i64 = cmd
+            .query_async(&mut conn)
+            .await
+            .tool_context("SREM failed")?;
+
+        Ok(CallToolResult::text(format!(
+            "Removed {} of {} member(s) from set '{}'",
+            removed,
+            input.members.len(),
+            input.key
+        )))
+    }
+);
+
+database_tool!(write, zadd, "redis_zadd",
+    "Add members with scores to a sorted set. Creates the set if needed. \
+     Supports NX, XX, GT, LT, and CH flags.",
+    {
+        /// Sorted set key
+        pub key: String,
+        /// Score-member pairs to add
+        pub members: Vec<ScoreMember>,
+        /// Only add new elements, do not update existing ones
+        #[serde(default)]
+        pub nx: bool,
+        /// Only update existing elements, do not add new ones
+        #[serde(default)]
+        pub xx: bool,
+        /// Only update elements whose new score is greater than current score
+        #[serde(default)]
+        pub gt: bool,
+        /// Only update elements whose new score is less than current score
+        #[serde(default)]
+        pub lt: bool,
+        /// Return the number of elements changed (added + updated) instead of only added
+        #[serde(default)]
+        pub ch: bool,
+    } => |conn, input| {
+        let mut cmd = redis::cmd("ZADD");
+        cmd.arg(&input.key);
+
+        if input.nx {
+            cmd.arg("NX");
+        }
+        if input.xx {
+            cmd.arg("XX");
+        }
+        if input.gt {
+            cmd.arg("GT");
+        }
+        if input.lt {
+            cmd.arg("LT");
+        }
+        if input.ch {
+            cmd.arg("CH");
+        }
+
+        for sm in &input.members {
+            cmd.arg(sm.score).arg(&sm.member);
+        }
+
+        let count: i64 = cmd
+            .query_async(&mut conn)
+            .await
+            .tool_context("ZADD failed")?;
+
+        let verb = if input.ch { "changed" } else { "added" };
+        Ok(CallToolResult::text(format!(
+            "OK - {} {} member(s) in sorted set '{}'",
+            count, verb, input.key
+        )))
+    }
+);
+
+database_tool!(write, zrem, "redis_zrem",
+    "Remove one or more members from a sorted set.",
+    {
+        /// Sorted set key
+        pub key: String,
+        /// Members to remove
+        pub members: Vec<String>,
+    } => |conn, input| {
+        let mut cmd = redis::cmd("ZREM");
+        cmd.arg(&input.key);
+        for member in &input.members {
+            cmd.arg(member);
+        }
+
+        let removed: i64 = cmd
+            .query_async(&mut conn)
+            .await
+            .tool_context("ZREM failed")?;
+
+        Ok(CallToolResult::text(format!(
+            "Removed {} of {} member(s) from sorted set '{}'",
+            removed,
+            input.members.len(),
+            input.key
+        )))
+    }
+);
+
+database_tool!(write, xadd, "redis_xadd",
+    "Append an entry to a stream. Supports NOMKSTREAM, MAXLEN, and MINID trimming.",
+    {
+        /// Stream key
+        pub key: String,
+        /// Entry ID (default: "*" for auto-generated)
+        #[serde(default)]
+        pub id: Option<String>,
+        /// Field-value pairs for the stream entry
+        pub fields: HashMap<String, String>,
+        /// Do not create stream if it does not exist
+        #[serde(default)]
+        pub nomkstream: bool,
+        /// Cap stream to a maximum length
+        #[serde(default)]
+        pub maxlen: Option<u64>,
+        /// Cap stream entries older than this ID
+        #[serde(default)]
+        pub minid: Option<String>,
+        /// Use approximate trimming (~) for better performance
+        #[serde(default)]
+        pub approximate: bool,
+    } => |conn, input| {
+        let mut cmd = redis::cmd("XADD");
+        cmd.arg(&input.key);
+
+        if input.nomkstream {
+            cmd.arg("NOMKSTREAM");
+        }
+
+        if let Some(maxlen) = input.maxlen {
+            cmd.arg("MAXLEN");
+            if input.approximate {
+                cmd.arg("~");
+            }
+            cmd.arg(maxlen);
+        } else if let Some(ref minid) = input.minid {
+            cmd.arg("MINID");
+            if input.approximate {
+                cmd.arg("~");
+            }
+            cmd.arg(minid);
+        }
+
+        let id = input.id.as_deref().unwrap_or("*");
+        cmd.arg(id);
+
+        for (field, value) in &input.fields {
+            cmd.arg(field).arg(value);
+        }
+
+        let entry_id: String = cmd
+            .query_async(&mut conn)
+            .await
+            .tool_context("XADD failed")?;
+
+        Ok(CallToolResult::text(format!(
+            "OK - added entry {} to stream '{}'",
+            entry_id, input.key
+        )))
+    }
+);
+
+database_tool!(write, xtrim, "redis_xtrim",
+    "Trim a stream by length (MAXLEN) or minimum ID (MINID). \
+     Use approximate=true for better performance.",
+    {
+        /// Stream key
+        pub key: String,
+        /// Trimming strategy: "MAXLEN" or "MINID"
+        pub strategy: String,
+        /// Threshold value (count for MAXLEN, ID for MINID)
+        pub threshold: String,
+        /// Use approximate trimming (~) for better performance
+        #[serde(default)]
+        pub approximate: bool,
+    } => |conn, input| {
+        let mut cmd = redis::cmd("XTRIM");
+        cmd.arg(&input.key);
+        cmd.arg(&input.strategy);
+
+        if input.approximate {
+            cmd.arg("~");
+        }
+        cmd.arg(&input.threshold);
+
+        let trimmed: i64 = cmd
+            .query_async(&mut conn)
+            .await
+            .tool_context("XTRIM failed")?;
+
+        Ok(CallToolResult::text(format!(
+            "OK - trimmed {} entries from stream '{}'",
+            trimmed, input.key
+        )))
+    }
+);
+
+database_tool!(write, hincrby, "redis_hincrby",
+    "Increment the integer value of a hash field by the given amount.",
+    {
+        /// Hash key
+        pub key: String,
+        /// Field to increment
+        pub field: String,
+        /// Increment value (can be negative)
+        pub increment: i64,
+    } => |conn, input| {
+        let value: i64 = redis::cmd("HINCRBY")
+            .arg(&input.key)
+            .arg(&input.field)
+            .arg(input.increment)
+            .query_async(&mut conn)
+            .await
+            .tool_context("HINCRBY failed")?;
+
+        Ok(CallToolResult::text(format!(
+            "{}.{}: {}",
+            input.key, input.field, value
+        )))
+    }
+);


### PR DESCRIPTION
## Summary

- Convert keys.rs (31 tools), structures.rs (40 tools), and diagnostics.rs (4 tools) to `database_tool!` and `mcp_module!` macros
- Completes the database tool group: all 89 database tools now use the declarative pattern
- Net reduction: -1824 lines (4435 removed, 2611 added)

| File | Before | After | Reduction |
|---|---|---|---|
| keys.rs (31 tools) | 1679 | 908 | 46% |
| structures.rs (40 tools) | 2306 | 1370 | 41% |
| diagnostics.rs (4 tools) | 597 | 480 | 20% |

Continues #791

## Test plan

- [x] `cargo clippy -p redisctl-mcp --all-features -- -D warnings` clean
- [x] `cargo check -p redisctl-mcp --no-default-features` compiles
- [x] All 95 lib tests pass
- [x] `cargo fmt --all -- --check` clean