### PR TITLE
refactor(mcp): convert cloud tools to declarative macros

### DIFF
--- a/crates/redisctl-mcp/src/tools/cloud/account.rs
+++ b/crates/redisctl-mcp/src/tools/cloud/account.rs
@@ -1,7 +1,5 @@
 //! Account, ACL, task, cloud account (BYOC), and user tools for Redis Cloud
 
-use std::sync::Arc;
-
 use redis_cloud::acl::{
     AclRedisRuleCreateRequest, AclRedisRuleUpdateRequest, AclRoleCreateRequest,
     AclRoleDatabaseSpec, AclRoleRedisRuleSpec, AclRoleUpdateRequest, AclUserCreateRequest,
@@ -13,658 +11,13 @@ use redis_cloud::{
     AccountHandler, AclHandler, CloudAccountHandler, CostReportCreateRequest, CostReportHandler,
     TaskHandler, UserHandler,
 };
-use schemars::JsonSchema;
-use serde::Deserialize;
-use tower_mcp::extract::{Json, State};
-use tower_mcp::{CallToolResult, Error as McpError, McpRouter, ResultExt, Tool, ToolBuilder};
+use tower_mcp::{CallToolResult, ResultExt};
 
-use crate::state::AppState;
+use crate::tools::macros::{cloud_tool, mcp_module};
 use crate::tools::wrap_list;
 
-// ============================================================================
-// Account tools
-// ============================================================================
-
-/// Input for getting current account
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetAccountInput {
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the get_account tool
-pub fn get_account(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_account")
-        .description("Get current account information.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<GetAccountInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = AccountHandler::new(client);
-                let account = handler
-                    .get_current_account()
-                    .await
-                    .tool_context("Failed to get account")?;
-
-                CallToolResult::from_serialize(&account)
-            },
-        )
-        .build()
-}
-
-/// Input for getting account system logs
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetSystemLogsInput {
-    /// Number of entries to skip (for pagination)
-    #[serde(default)]
-    pub offset: Option<i32>,
-    /// Maximum number of entries to return
-    #[serde(default)]
-    pub limit: Option<i32>,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the get_system_logs tool
-pub fn get_system_logs(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_system_logs")
-        .description("Get system audit logs.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<GetSystemLogsInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = AccountHandler::new(client);
-                let logs = handler
-                    .get_account_system_logs(input.offset, input.limit)
-                    .await
-                    .tool_context("Failed to get system logs")?;
-
-                CallToolResult::from_serialize(&logs)
-            },
-        )
-        .build()
-}
-
-/// Input for getting account session logs
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetSessionLogsInput {
-    /// Number of entries to skip (for pagination)
-    #[serde(default)]
-    pub offset: Option<i32>,
-    /// Maximum number of entries to return
-    #[serde(default)]
-    pub limit: Option<i32>,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the get_session_logs tool
-pub fn get_session_logs(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_session_logs")
-        .description("Get session activity logs.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetSessionLogsInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = AccountHandler::new(client);
-                let logs = handler
-                    .get_account_session_logs(input.offset, input.limit)
-                    .await
-                    .tool_context("Failed to get session logs")?;
-
-                CallToolResult::from_serialize(&logs)
-            },
-        )
-        .build()
-}
-
-/// Input for getting supported regions
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetRegionsInput {
-    /// Optional cloud provider filter (e.g., "AWS", "GCP", "Azure")
-    #[serde(default)]
-    pub provider: Option<String>,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the get_regions tool
-pub fn get_regions(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_regions")
-        .description("Get supported cloud regions. Optionally filter by provider.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<GetRegionsInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = AccountHandler::new(client);
-                let regions = handler
-                    .get_supported_regions(input.provider)
-                    .await
-                    .tool_context("Failed to get regions")?;
-
-                CallToolResult::from_serialize(&regions)
-            },
-        )
-        .build()
-}
-
-/// Input for getting database modules
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetModulesInput {
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the get_modules tool
-pub fn get_modules(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_modules")
-        .description("Get supported database modules.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<GetModulesInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = AccountHandler::new(client);
-                let modules = handler
-                    .get_supported_database_modules()
-                    .await
-                    .tool_context("Failed to get modules")?;
-
-                CallToolResult::from_serialize(&modules)
-            },
-        )
-        .build()
-}
-
-// ============================================================================
-// Account Users tools
-// ============================================================================
-
-/// Input for listing account users
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ListAccountUsersInput {
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the list_account_users tool
-pub fn list_account_users(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("list_account_users")
-        .description("List all account users (team members with console access).")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<ListAccountUsersInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = UserHandler::new(client);
-                let users = handler
-                    .get_all_users()
-                    .await
-                    .tool_context("Failed to list users")?;
-
-                CallToolResult::from_serialize(&users)
-            },
-        )
-        .build()
-}
-
-/// Input for getting a specific account user
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetAccountUserInput {
-    /// Account user ID
-    pub user_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the get_account_user tool
-pub fn get_account_user(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_account_user")
-        .description("Get an account user by ID.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetAccountUserInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = UserHandler::new(client);
-                let user = handler
-                    .get_user_by_id(input.user_id)
-                    .await
-                    .tool_context("Failed to get account user")?;
-
-                CallToolResult::from_serialize(&user)
-            },
-        )
-        .build()
-}
-
-/// Input for updating an account user
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct UpdateAccountUserInput {
-    /// Account user ID to update
-    pub user_id: i32,
-    /// Updated name for the user
-    pub name: String,
-    /// Updated role (e.g., "owner", "member", "viewer")
-    #[serde(default)]
-    pub role: Option<String>,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the update_account_user tool
-pub fn update_account_user(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("update_account_user")
-        .description("Update an account user's name or role.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<UpdateAccountUserInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations require policy tier 'read-write' or 'full'",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = UserHandler::new(client);
-                let request = AccountUserUpdateRequest {
-                    user_id: None,
-                    name: input.name,
-                    role: input.role,
-                    command_type: None,
-                };
-                let result = handler
-                    .update_user(input.user_id, &request)
-                    .await
-                    .tool_context("Failed to update account user")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// Input for deleting an account user
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct DeleteAccountUserInput {
-    /// Account user ID to delete
-    pub user_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the delete_account_user tool
-pub fn delete_account_user(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("delete_account_user")
-        .description("DANGEROUS: Delete an account user. The user will lose all access.")
-        .destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<DeleteAccountUserInput>| async move {
-                if !state.is_destructive_allowed() {
-                    return Err(McpError::tool(
-                        "Destructive operations require policy tier 'full'",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = UserHandler::new(client);
-                let result = handler
-                    .delete_user_by_id(input.user_id)
-                    .await
-                    .tool_context("Failed to delete account user")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-// ============================================================================
-// ACL tools (database-level access control)
-// ============================================================================
-
-/// Input for listing ACL users
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ListAclUsersInput {
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the list_acl_users tool
-pub fn list_acl_users(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("list_acl_users")
-        .description("List all ACL users.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<ListAclUsersInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = AclHandler::new(client);
-                let users = handler
-                    .get_all_acl_users()
-                    .await
-                    .tool_context("Failed to list ACL users")?;
-
-                CallToolResult::from_serialize(&users)
-            },
-        )
-        .build()
-}
-
-/// Input for getting a specific ACL user
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetAclUserInput {
-    /// ACL user ID
-    pub user_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the get_acl_user tool
-pub fn get_acl_user(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_acl_user")
-        .description("Get an ACL user by ID.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<GetAclUserInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = AclHandler::new(client);
-                let user = handler
-                    .get_user_by_id(input.user_id)
-                    .await
-                    .tool_context("Failed to get ACL user")?;
-
-                CallToolResult::from_serialize(&user)
-            },
-        )
-        .build()
-}
-
-/// Input for listing ACL roles
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ListAclRolesInput {
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the list_acl_roles tool
-pub fn list_acl_roles(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("list_acl_roles")
-        .description("List all ACL roles.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<ListAclRolesInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = AclHandler::new(client);
-                let roles = handler
-                    .get_roles()
-                    .await
-                    .tool_context("Failed to list ACL roles")?;
-
-                CallToolResult::from_serialize(&roles)
-            },
-        )
-        .build()
-}
-
-/// Input for listing Redis rules
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ListRedisRulesInput {
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the list_redis_rules tool
-pub fn list_redis_rules(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("list_redis_rules")
-        .description("List all Redis ACL rules.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<ListRedisRulesInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = AclHandler::new(client);
-                let rules = handler
-                    .get_all_redis_rules()
-                    .await
-                    .tool_context("Failed to list Redis rules")?;
-
-                CallToolResult::from_serialize(&rules)
-            },
-        )
-        .build()
-}
-
-// ============================================================================
-// ACL write operations (require write permission)
-// ============================================================================
-
-/// Input for creating an ACL user
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct CreateAclUserInput {
-    /// Access control user name
-    pub name: String,
-    /// Name of the database access role to assign. Use list_acl_roles to get available roles.
-    pub role: String,
-    /// Database password for the user
-    pub password: String,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the create_acl_user tool
-pub fn create_acl_user(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("create_acl_user")
-        .description("Create a new ACL user with a database access role.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<CreateAclUserInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = AclHandler::new(client);
-                let request = AclUserCreateRequest {
-                    name: input.name,
-                    role: input.role,
-                    password: input.password,
-                    command_type: None,
-                };
-                let result = handler
-                    .create_user(&request)
-                    .await
-                    .tool_context("Failed to create ACL user")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// Input for updating an ACL user
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct UpdateAclUserInput {
-    /// ACL user ID to update
-    pub user_id: i32,
-    /// New database access role name (optional)
-    #[serde(default)]
-    pub role: Option<String>,
-    /// New database password (optional)
-    #[serde(default)]
-    pub password: Option<String>,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the update_acl_user tool
-pub fn update_acl_user(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("update_acl_user")
-        .description("Update an ACL user's role or password.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<UpdateAclUserInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = AclHandler::new(client);
-                let request = AclUserUpdateRequest {
-                    user_id: None,
-                    role: input.role,
-                    password: input.password,
-                    command_type: None,
-                };
-                let result = handler
-                    .update_acl_user(input.user_id, &request)
-                    .await
-                    .tool_context("Failed to update ACL user")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// Input for deleting an ACL user
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct DeleteAclUserInput {
-    /// ACL user ID to delete
-    pub user_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the delete_acl_user tool
-pub fn delete_acl_user(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("delete_acl_user")
-        .description("DANGEROUS: Delete an ACL user. Active sessions will be terminated.")
-        .destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<DeleteAclUserInput>| async move {
-                if !state.is_destructive_allowed() {
-                    return Err(McpError::tool(
-                        "Destructive operations require policy tier 'full'",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = AclHandler::new(client);
-                let result = handler
-                    .delete_user(input.user_id)
-                    .await
-                    .tool_context("Failed to delete ACL user")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
 /// Database specification for ACL role assignment
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct DatabaseSpec {
     /// Subscription ID for the database
     pub subscription_id: i32,
@@ -676,576 +29,12 @@ pub struct DatabaseSpec {
 }
 
 /// Redis rule specification for role creation/update
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct RedisRuleSpec {
     /// Redis ACL rule name. Use list_redis_rules to get available rules.
     pub rule_name: String,
     /// List of databases where this rule applies
     pub databases: Vec<DatabaseSpec>,
-}
-
-/// Input for creating an ACL role
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct CreateAclRoleInput {
-    /// Database access role name
-    pub name: String,
-    /// List of Redis ACL rules to assign to this role
-    pub redis_rules: Vec<RedisRuleSpec>,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the create_acl_role tool
-pub fn create_acl_role(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("create_acl_role")
-        .description("Create a new ACL role with Redis rules and database associations.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<CreateAclRoleInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = AclHandler::new(client);
-                let request = AclRoleCreateRequest {
-                    name: input.name,
-                    redis_rules: input
-                        .redis_rules
-                        .into_iter()
-                        .map(|r| AclRoleRedisRuleSpec {
-                            rule_name: r.rule_name,
-                            databases: r
-                                .databases
-                                .into_iter()
-                                .map(|d| AclRoleDatabaseSpec {
-                                    subscription_id: d.subscription_id,
-                                    database_id: d.database_id,
-                                    regions: d.regions,
-                                })
-                                .collect(),
-                        })
-                        .collect(),
-                    command_type: None,
-                };
-                let result = handler
-                    .create_role(&request)
-                    .await
-                    .tool_context("Failed to create ACL role")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// Input for updating an ACL role
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct UpdateAclRoleInput {
-    /// ACL role ID to update
-    pub role_id: i32,
-    /// New role name (optional)
-    #[serde(default)]
-    pub name: Option<String>,
-    /// New list of Redis ACL rules (optional)
-    #[serde(default)]
-    pub redis_rules: Option<Vec<RedisRuleSpec>>,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the update_acl_role tool
-pub fn update_acl_role(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("update_acl_role")
-        .description("Update an ACL role's name or Redis rule assignments.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<UpdateAclRoleInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = AclHandler::new(client);
-                let request = AclRoleUpdateRequest {
-                    name: input.name,
-                    redis_rules: input.redis_rules.map(|rules| {
-                        rules
-                            .into_iter()
-                            .map(|r| AclRoleRedisRuleSpec {
-                                rule_name: r.rule_name,
-                                databases: r
-                                    .databases
-                                    .into_iter()
-                                    .map(|d| AclRoleDatabaseSpec {
-                                        subscription_id: d.subscription_id,
-                                        database_id: d.database_id,
-                                        regions: d.regions,
-                                    })
-                                    .collect(),
-                            })
-                            .collect()
-                    }),
-                    role_id: None,
-                    command_type: None,
-                };
-                let result = handler
-                    .update_role(input.role_id, &request)
-                    .await
-                    .tool_context("Failed to update ACL role")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// Input for deleting an ACL role
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct DeleteAclRoleInput {
-    /// ACL role ID to delete
-    pub role_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the delete_acl_role tool
-pub fn delete_acl_role(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("delete_acl_role")
-        .description("DANGEROUS: Delete an ACL role. Assigned users will lose their permissions.")
-        .destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<DeleteAclRoleInput>| async move {
-                if !state.is_destructive_allowed() {
-                    return Err(McpError::tool(
-                        "Destructive operations require policy tier 'full'",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = AclHandler::new(client);
-                let result = handler
-                    .delete_acl_role(input.role_id)
-                    .await
-                    .tool_context("Failed to delete ACL role")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// Input for creating a Redis ACL rule
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct CreateRedisRuleInput {
-    /// Redis ACL rule name
-    pub name: String,
-    /// Redis ACL rule pattern (e.g., "+@all ~*" or "+@read ~cache:*")
-    pub redis_rule: String,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the create_redis_rule tool
-pub fn create_redis_rule(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("create_redis_rule")
-        .description("Create a new Redis ACL rule defining command permissions.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<CreateRedisRuleInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = AclHandler::new(client);
-                let request = AclRedisRuleCreateRequest {
-                    name: input.name,
-                    redis_rule: input.redis_rule,
-                    command_type: None,
-                };
-                let result = handler
-                    .create_redis_rule(&request)
-                    .await
-                    .tool_context("Failed to create Redis rule")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// Input for updating a Redis ACL rule
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct UpdateRedisRuleInput {
-    /// Redis ACL rule ID to update
-    pub rule_id: i32,
-    /// New rule name
-    pub name: String,
-    /// New Redis ACL rule pattern
-    pub redis_rule: String,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the update_redis_rule tool
-pub fn update_redis_rule(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("update_redis_rule")
-        .description("Update a Redis ACL rule's name or pattern.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<UpdateRedisRuleInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = AclHandler::new(client);
-                let request = AclRedisRuleUpdateRequest {
-                    redis_rule_id: None,
-                    name: input.name,
-                    redis_rule: input.redis_rule,
-                    command_type: None,
-                };
-                let result = handler
-                    .update_redis_rule(input.rule_id, &request)
-                    .await
-                    .tool_context("Failed to update Redis rule")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// Input for deleting a Redis ACL rule
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct DeleteRedisRuleInput {
-    /// Redis ACL rule ID to delete
-    pub rule_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the delete_redis_rule tool
-pub fn delete_redis_rule(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("delete_redis_rule")
-        .description("DANGEROUS: Delete a Redis ACL rule. Roles using it will lose those permissions.")
-        .destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<DeleteRedisRuleInput>| async move {
-                if !state.is_destructive_allowed() {
-                    return Err(McpError::tool(
-                        "Destructive operations require policy tier 'full'",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = AclHandler::new(client);
-                let result = handler
-                    .delete_redis_rule(input.rule_id)
-                    .await
-                    .tool_context("Failed to delete Redis rule")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-// ============================================================================
-// Cost report tools
-// ============================================================================
-
-/// Input for generating a cost report
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GenerateCostReportInput {
-    /// Start date in YYYY-MM-DD format
-    pub start_date: String,
-    /// End date in YYYY-MM-DD format (max 40 days from start_date)
-    pub end_date: String,
-    /// Output format: "csv" or "json" (default: "csv")
-    #[serde(default)]
-    pub format: Option<String>,
-    /// Filter by subscription IDs
-    #[serde(default)]
-    pub subscription_ids: Option<Vec<i32>>,
-    /// Filter by database IDs
-    #[serde(default)]
-    pub database_ids: Option<Vec<i32>>,
-    /// Filter by subscription type: "pro" or "essentials"
-    #[serde(default)]
-    pub subscription_type: Option<String>,
-    /// Filter by cloud regions
-    #[serde(default)]
-    pub regions: Option<Vec<String>>,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the generate_cost_report tool
-pub fn generate_cost_report(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("generate_cost_report")
-        .description("Generate a FOCUS cost report for the specified date range.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GenerateCostReportInput>| async move {
-                use redis_cloud::{CostReportFormat, SubscriptionType};
-
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = CostReportHandler::new(client);
-                let format = input.format.as_deref().map(|f| match f {
-                    "json" => CostReportFormat::Json,
-                    _ => CostReportFormat::Csv,
-                });
-                let subscription_type = input.subscription_type.as_deref().map(|t| match t {
-                    "essentials" => SubscriptionType::Essentials,
-                    _ => SubscriptionType::Pro,
-                });
-                let request = CostReportCreateRequest {
-                    start_date: input.start_date,
-                    end_date: input.end_date,
-                    format,
-                    subscription_ids: input.subscription_ids,
-                    database_ids: input.database_ids,
-                    subscription_type,
-                    regions: input.regions,
-                    tags: None,
-                };
-                let result = handler
-                    .generate_cost_report(request)
-                    .await
-                    .tool_context("Failed to generate cost report")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// Input for downloading a cost report
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct DownloadCostReportInput {
-    /// Cost report ID from a completed generation task
-    pub cost_report_id: String,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the download_cost_report tool
-pub fn download_cost_report(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("download_cost_report")
-        .description("Download a previously generated cost report by ID.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<DownloadCostReportInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = CostReportHandler::new(client);
-                let bytes = handler
-                    .download_cost_report(&input.cost_report_id)
-                    .await
-                    .tool_context("Failed to download cost report")?;
-
-                let content = String::from_utf8(bytes).unwrap_or_else(|e| {
-                    format!("<binary data, {} bytes>", e.into_bytes().len())
-                });
-                CallToolResult::from_serialize(&content)
-            },
-        )
-        .build()
-}
-
-// ============================================================================
-// Payment method tools
-// ============================================================================
-
-/// Input for listing payment methods
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ListPaymentMethodsInput {
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the list_payment_methods tool
-pub fn list_payment_methods(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("list_payment_methods")
-        .description("List all payment methods.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<ListPaymentMethodsInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = AccountHandler::new(client);
-                let methods = handler
-                    .get_account_payment_methods()
-                    .await
-                    .tool_context("Failed to list payment methods")?;
-
-                CallToolResult::from_serialize(&methods)
-            },
-        )
-        .build()
-}
-
-// ============================================================================
-// Task tools
-// ============================================================================
-
-/// Input for listing tasks
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ListTasksInput {
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the list_tasks tool
-pub fn list_tasks(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("list_tasks")
-        .description("List all async tasks.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<ListTasksInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = TaskHandler::new(client);
-                let tasks = handler
-                    .get_all_tasks()
-                    .await
-                    .tool_context("Failed to list tasks")?;
-
-                wrap_list("tasks", &tasks)
-            },
-        )
-        .build()
-}
-
-/// Input for getting a specific task
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetTaskInput {
-    /// Task ID
-    pub task_id: String,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the get_task tool
-pub fn get_task(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_task")
-        .description("Get task status by ID.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<GetTaskInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = TaskHandler::new(client);
-                let task = handler
-                    .get_task_by_id(input.task_id)
-                    .await
-                    .tool_context("Failed to get task")?;
-
-                CallToolResult::from_serialize(&task)
-            },
-        )
-        .build()
-}
-
-/// Input for waiting on a cloud task
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct WaitForCloudTaskInput {
-    /// Task ID to wait for
-    pub task_id: String,
-    /// Maximum time to wait in seconds (default: 300)
-    #[serde(default = "default_task_timeout")]
-    pub timeout_seconds: u64,
-    /// Polling interval in seconds (default: 5)
-    #[serde(default = "default_task_interval")]
-    pub interval_seconds: u64,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
 }
 
 fn default_task_timeout() -> u64 {
@@ -1256,391 +45,808 @@ fn default_task_interval() -> u64 {
     5
 }
 
-/// Build the wait_for_cloud_task tool
-pub fn wait_for_cloud_task(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("wait_for_cloud_task")
-        .description("Poll an async task until it reaches a terminal state. Useful for multi-step workflows.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<WaitForCloudTaskInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = TaskHandler::new(client);
-                let deadline =
-                    tokio::time::Instant::now() + std::time::Duration::from_secs(input.timeout_seconds);
-                let interval = std::time::Duration::from_secs(input.interval_seconds);
-
-                loop {
-                    let task = handler
-                        .get_task_by_id(input.task_id.clone())
-                        .await
-                        .tool_context("Failed to get task status")?;
-
-                    // Check for terminal states
-                    if let Some(ref status) = task.status {
-                        let s = status.to_lowercase();
-                        if matches!(
-                            s.as_str(),
-                            "completed"
-                                | "failed"
-                                | "error"
-                                | "success"
-                                | "cancelled"
-                                | "aborted"
-                        ) {
-                            return CallToolResult::from_serialize(&task);
-                        }
-                    }
-
-                    // Check timeout
-                    if tokio::time::Instant::now() >= deadline {
-                        return CallToolResult::from_serialize(&serde_json::json!({
-                            "timeout": true,
-                            "message": format!(
-                                "Task {} did not complete within {} seconds",
-                                input.task_id, input.timeout_seconds
-                            ),
-                            "last_status": task,
-                        }));
-                    }
-
-                    tokio::time::sleep(interval).await;
-                }
-            },
-        )
-        .build()
+mcp_module! {
+    get_account => "get_account",
+    get_system_logs => "get_system_logs",
+    get_session_logs => "get_session_logs",
+    get_regions => "get_regions",
+    get_modules => "get_modules",
+    list_account_users => "list_account_users",
+    get_account_user => "get_account_user",
+    update_account_user => "update_account_user",
+    delete_account_user => "delete_account_user",
+    list_acl_users => "list_acl_users",
+    get_acl_user => "get_acl_user",
+    list_acl_roles => "list_acl_roles",
+    list_redis_rules => "list_redis_rules",
+    create_acl_user => "create_acl_user",
+    update_acl_user => "update_acl_user",
+    delete_acl_user => "delete_acl_user",
+    create_acl_role => "create_acl_role",
+    update_acl_role => "update_acl_role",
+    delete_acl_role => "delete_acl_role",
+    create_redis_rule => "create_redis_rule",
+    update_redis_rule => "update_redis_rule",
+    delete_redis_rule => "delete_redis_rule",
+    generate_cost_report => "generate_cost_report",
+    download_cost_report => "download_cost_report",
+    list_payment_methods => "list_payment_methods",
+    list_tasks => "list_tasks",
+    get_task => "get_task",
+    wait_for_cloud_task => "wait_for_cloud_task",
+    list_cloud_accounts => "list_cloud_accounts",
+    get_cloud_account => "get_cloud_account",
+    create_cloud_account => "create_cloud_account",
+    update_cloud_account => "update_cloud_account",
+    delete_cloud_account => "delete_cloud_account",
 }
+
+// ============================================================================
+// Account tools
+// ============================================================================
+
+cloud_tool!(read_only, get_account, "get_account",
+    "Get current account information.",
+    {} => |client, _input| {
+        let handler = AccountHandler::new(client);
+        let account = handler
+            .get_current_account()
+            .await
+            .tool_context("Failed to get account")?;
+
+        CallToolResult::from_serialize(&account)
+    }
+);
+
+cloud_tool!(read_only, get_system_logs, "get_system_logs",
+    "Get system audit logs.",
+    {
+        /// Number of entries to skip (for pagination)
+        #[serde(default)]
+        pub offset: Option<i32>,
+        /// Maximum number of entries to return
+        #[serde(default)]
+        pub limit: Option<i32>,
+    } => |client, input| {
+        let handler = AccountHandler::new(client);
+        let logs = handler
+            .get_account_system_logs(input.offset, input.limit)
+            .await
+            .tool_context("Failed to get system logs")?;
+
+        CallToolResult::from_serialize(&logs)
+    }
+);
+
+cloud_tool!(read_only, get_session_logs, "get_session_logs",
+    "Get session activity logs.",
+    {
+        /// Number of entries to skip (for pagination)
+        #[serde(default)]
+        pub offset: Option<i32>,
+        /// Maximum number of entries to return
+        #[serde(default)]
+        pub limit: Option<i32>,
+    } => |client, input| {
+        let handler = AccountHandler::new(client);
+        let logs = handler
+            .get_account_session_logs(input.offset, input.limit)
+            .await
+            .tool_context("Failed to get session logs")?;
+
+        CallToolResult::from_serialize(&logs)
+    }
+);
+
+cloud_tool!(read_only, get_regions, "get_regions",
+    "Get supported cloud regions. Optionally filter by provider.",
+    {
+        /// Optional cloud provider filter (e.g., "AWS", "GCP", "Azure")
+        #[serde(default)]
+        pub provider: Option<String>,
+    } => |client, input| {
+        let handler = AccountHandler::new(client);
+        let regions = handler
+            .get_supported_regions(input.provider)
+            .await
+            .tool_context("Failed to get regions")?;
+
+        CallToolResult::from_serialize(&regions)
+    }
+);
+
+cloud_tool!(read_only, get_modules, "get_modules",
+    "Get supported database modules.",
+    {} => |client, _input| {
+        let handler = AccountHandler::new(client);
+        let modules = handler
+            .get_supported_database_modules()
+            .await
+            .tool_context("Failed to get modules")?;
+
+        CallToolResult::from_serialize(&modules)
+    }
+);
+
+// ============================================================================
+// Account Users tools
+// ============================================================================
+
+cloud_tool!(read_only, list_account_users, "list_account_users",
+    "List all account users (team members with console access).",
+    {} => |client, _input| {
+        let handler = UserHandler::new(client);
+        let users = handler
+            .get_all_users()
+            .await
+            .tool_context("Failed to list users")?;
+
+        CallToolResult::from_serialize(&users)
+    }
+);
+
+cloud_tool!(read_only, get_account_user, "get_account_user",
+    "Get an account user by ID.",
+    {
+        /// Account user ID
+        pub user_id: i32,
+    } => |client, input| {
+        let handler = UserHandler::new(client);
+        let user = handler
+            .get_user_by_id(input.user_id)
+            .await
+            .tool_context("Failed to get account user")?;
+
+        CallToolResult::from_serialize(&user)
+    }
+);
+
+cloud_tool!(write, update_account_user, "update_account_user",
+    "Update an account user's name or role.",
+    {
+        /// Account user ID to update
+        pub user_id: i32,
+        /// Updated name for the user
+        pub name: String,
+        /// Updated role (e.g., "owner", "member", "viewer")
+        #[serde(default)]
+        pub role: Option<String>,
+    } => |client, input| {
+        let handler = UserHandler::new(client);
+        let request = AccountUserUpdateRequest {
+            user_id: None,
+            name: input.name,
+            role: input.role,
+            command_type: None,
+        };
+        let result = handler
+            .update_user(input.user_id, &request)
+            .await
+            .tool_context("Failed to update account user")?;
+
+        CallToolResult::from_serialize(&result)
+    }
+);
+
+cloud_tool!(destructive, delete_account_user, "delete_account_user",
+    "DANGEROUS: Delete an account user. The user will lose all access.",
+    {
+        /// Account user ID to delete
+        pub user_id: i32,
+    } => |client, input| {
+        let handler = UserHandler::new(client);
+        let result = handler
+            .delete_user_by_id(input.user_id)
+            .await
+            .tool_context("Failed to delete account user")?;
+
+        CallToolResult::from_serialize(&result)
+    }
+);
+
+// ============================================================================
+// ACL tools (database-level access control)
+// ============================================================================
+
+cloud_tool!(read_only, list_acl_users, "list_acl_users",
+    "List all ACL users.",
+    {} => |client, _input| {
+        let handler = AclHandler::new(client);
+        let users = handler
+            .get_all_acl_users()
+            .await
+            .tool_context("Failed to list ACL users")?;
+
+        CallToolResult::from_serialize(&users)
+    }
+);
+
+cloud_tool!(read_only, get_acl_user, "get_acl_user",
+    "Get an ACL user by ID.",
+    {
+        /// ACL user ID
+        pub user_id: i32,
+    } => |client, input| {
+        let handler = AclHandler::new(client);
+        let user = handler
+            .get_user_by_id(input.user_id)
+            .await
+            .tool_context("Failed to get ACL user")?;
+
+        CallToolResult::from_serialize(&user)
+    }
+);
+
+cloud_tool!(read_only, list_acl_roles, "list_acl_roles",
+    "List all ACL roles.",
+    {} => |client, _input| {
+        let handler = AclHandler::new(client);
+        let roles = handler
+            .get_roles()
+            .await
+            .tool_context("Failed to list ACL roles")?;
+
+        CallToolResult::from_serialize(&roles)
+    }
+);
+
+cloud_tool!(read_only, list_redis_rules, "list_redis_rules",
+    "List all Redis ACL rules.",
+    {} => |client, _input| {
+        let handler = AclHandler::new(client);
+        let rules = handler
+            .get_all_redis_rules()
+            .await
+            .tool_context("Failed to list Redis rules")?;
+
+        CallToolResult::from_serialize(&rules)
+    }
+);
+
+// ============================================================================
+// ACL write operations (require write permission)
+// ============================================================================
+
+cloud_tool!(write, create_acl_user, "create_acl_user",
+    "Create a new ACL user with a database access role.",
+    {
+        /// Access control user name
+        pub name: String,
+        /// Name of the database access role to assign. Use list_acl_roles to get available roles.
+        pub role: String,
+        /// Database password for the user
+        pub password: String,
+    } => |client, input| {
+        let handler = AclHandler::new(client);
+        let request = AclUserCreateRequest {
+            name: input.name,
+            role: input.role,
+            password: input.password,
+            command_type: None,
+        };
+        let result = handler
+            .create_user(&request)
+            .await
+            .tool_context("Failed to create ACL user")?;
+
+        CallToolResult::from_serialize(&result)
+    }
+);
+
+cloud_tool!(write, update_acl_user, "update_acl_user",
+    "Update an ACL user's role or password.",
+    {
+        /// ACL user ID to update
+        pub user_id: i32,
+        /// New database access role name (optional)
+        #[serde(default)]
+        pub role: Option<String>,
+        /// New database password (optional)
+        #[serde(default)]
+        pub password: Option<String>,
+    } => |client, input| {
+        let handler = AclHandler::new(client);
+        let request = AclUserUpdateRequest {
+            user_id: None,
+            role: input.role,
+            password: input.password,
+            command_type: None,
+        };
+        let result = handler
+            .update_acl_user(input.user_id, &request)
+            .await
+            .tool_context("Failed to update ACL user")?;
+
+        CallToolResult::from_serialize(&result)
+    }
+);
+
+cloud_tool!(destructive, delete_acl_user, "delete_acl_user",
+    "DANGEROUS: Delete an ACL user. Active sessions will be terminated.",
+    {
+        /// ACL user ID to delete
+        pub user_id: i32,
+    } => |client, input| {
+        let handler = AclHandler::new(client);
+        let result = handler
+            .delete_user(input.user_id)
+            .await
+            .tool_context("Failed to delete ACL user")?;
+
+        CallToolResult::from_serialize(&result)
+    }
+);
+
+cloud_tool!(write, create_acl_role, "create_acl_role",
+    "Create a new ACL role with Redis rules and database associations.",
+    {
+        /// Database access role name
+        pub name: String,
+        /// List of Redis ACL rules to assign to this role
+        pub redis_rules: Vec<RedisRuleSpec>,
+    } => |client, input| {
+        let handler = AclHandler::new(client);
+        let request = AclRoleCreateRequest {
+            name: input.name,
+            redis_rules: input
+                .redis_rules
+                .into_iter()
+                .map(|r| AclRoleRedisRuleSpec {
+                    rule_name: r.rule_name,
+                    databases: r
+                        .databases
+                        .into_iter()
+                        .map(|d| AclRoleDatabaseSpec {
+                            subscription_id: d.subscription_id,
+                            database_id: d.database_id,
+                            regions: d.regions,
+                        })
+                        .collect(),
+                })
+                .collect(),
+            command_type: None,
+        };
+        let result = handler
+            .create_role(&request)
+            .await
+            .tool_context("Failed to create ACL role")?;
+
+        CallToolResult::from_serialize(&result)
+    }
+);
+
+cloud_tool!(write, update_acl_role, "update_acl_role",
+    "Update an ACL role's name or Redis rule assignments.",
+    {
+        /// ACL role ID to update
+        pub role_id: i32,
+        /// New role name (optional)
+        #[serde(default)]
+        pub name: Option<String>,
+        /// New list of Redis ACL rules (optional)
+        #[serde(default)]
+        pub redis_rules: Option<Vec<RedisRuleSpec>>,
+    } => |client, input| {
+        let handler = AclHandler::new(client);
+        let request = AclRoleUpdateRequest {
+            name: input.name,
+            redis_rules: input.redis_rules.map(|rules| {
+                rules
+                    .into_iter()
+                    .map(|r| AclRoleRedisRuleSpec {
+                        rule_name: r.rule_name,
+                        databases: r
+                            .databases
+                            .into_iter()
+                            .map(|d| AclRoleDatabaseSpec {
+                                subscription_id: d.subscription_id,
+                                database_id: d.database_id,
+                                regions: d.regions,
+                            })
+                            .collect(),
+                    })
+                    .collect()
+            }),
+            role_id: None,
+            command_type: None,
+        };
+        let result = handler
+            .update_role(input.role_id, &request)
+            .await
+            .tool_context("Failed to update ACL role")?;
+
+        CallToolResult::from_serialize(&result)
+    }
+);
+
+cloud_tool!(destructive, delete_acl_role, "delete_acl_role",
+    "DANGEROUS: Delete an ACL role. Assigned users will lose their permissions.",
+    {
+        /// ACL role ID to delete
+        pub role_id: i32,
+    } => |client, input| {
+        let handler = AclHandler::new(client);
+        let result = handler
+            .delete_acl_role(input.role_id)
+            .await
+            .tool_context("Failed to delete ACL role")?;
+
+        CallToolResult::from_serialize(&result)
+    }
+);
+
+cloud_tool!(write, create_redis_rule, "create_redis_rule",
+    "Create a new Redis ACL rule defining command permissions.",
+    {
+        /// Redis ACL rule name
+        pub name: String,
+        /// Redis ACL rule pattern (e.g., "+@all ~*" or "+@read ~cache:*")
+        pub redis_rule: String,
+    } => |client, input| {
+        let handler = AclHandler::new(client);
+        let request = AclRedisRuleCreateRequest {
+            name: input.name,
+            redis_rule: input.redis_rule,
+            command_type: None,
+        };
+        let result = handler
+            .create_redis_rule(&request)
+            .await
+            .tool_context("Failed to create Redis rule")?;
+
+        CallToolResult::from_serialize(&result)
+    }
+);
+
+cloud_tool!(write, update_redis_rule, "update_redis_rule",
+    "Update a Redis ACL rule's name or pattern.",
+    {
+        /// Redis ACL rule ID to update
+        pub rule_id: i32,
+        /// New rule name
+        pub name: String,
+        /// New Redis ACL rule pattern
+        pub redis_rule: String,
+    } => |client, input| {
+        let handler = AclHandler::new(client);
+        let request = AclRedisRuleUpdateRequest {
+            redis_rule_id: None,
+            name: input.name,
+            redis_rule: input.redis_rule,
+            command_type: None,
+        };
+        let result = handler
+            .update_redis_rule(input.rule_id, &request)
+            .await
+            .tool_context("Failed to update Redis rule")?;
+
+        CallToolResult::from_serialize(&result)
+    }
+);
+
+cloud_tool!(destructive, delete_redis_rule, "delete_redis_rule",
+    "DANGEROUS: Delete a Redis ACL rule. Roles using it will lose those permissions.",
+    {
+        /// Redis ACL rule ID to delete
+        pub rule_id: i32,
+    } => |client, input| {
+        let handler = AclHandler::new(client);
+        let result = handler
+            .delete_redis_rule(input.rule_id)
+            .await
+            .tool_context("Failed to delete Redis rule")?;
+
+        CallToolResult::from_serialize(&result)
+    }
+);
+
+// ============================================================================
+// Cost report tools
+// ============================================================================
+
+cloud_tool!(write, generate_cost_report, "generate_cost_report",
+    "Generate a FOCUS cost report for the specified date range.",
+    {
+        /// Start date in YYYY-MM-DD format
+        pub start_date: String,
+        /// End date in YYYY-MM-DD format (max 40 days from start_date)
+        pub end_date: String,
+        /// Output format: "csv" or "json" (default: "csv")
+        #[serde(default)]
+        pub format: Option<String>,
+        /// Filter by subscription IDs
+        #[serde(default)]
+        pub subscription_ids: Option<Vec<i32>>,
+        /// Filter by database IDs
+        #[serde(default)]
+        pub database_ids: Option<Vec<i32>>,
+        /// Filter by subscription type: "pro" or "essentials"
+        #[serde(default)]
+        pub subscription_type: Option<String>,
+        /// Filter by cloud regions
+        #[serde(default)]
+        pub regions: Option<Vec<String>>,
+    } => |client, input| {
+        use redis_cloud::{CostReportFormat, SubscriptionType};
+
+        let handler = CostReportHandler::new(client);
+        let format = input.format.as_deref().map(|f| match f {
+            "json" => CostReportFormat::Json,
+            _ => CostReportFormat::Csv,
+        });
+        let subscription_type = input.subscription_type.as_deref().map(|t| match t {
+            "essentials" => SubscriptionType::Essentials,
+            _ => SubscriptionType::Pro,
+        });
+        let request = CostReportCreateRequest {
+            start_date: input.start_date,
+            end_date: input.end_date,
+            format,
+            subscription_ids: input.subscription_ids,
+            database_ids: input.database_ids,
+            subscription_type,
+            regions: input.regions,
+            tags: None,
+        };
+        let result = handler
+            .generate_cost_report(request)
+            .await
+            .tool_context("Failed to generate cost report")?;
+
+        CallToolResult::from_serialize(&result)
+    }
+);
+
+cloud_tool!(read_only, download_cost_report, "download_cost_report",
+    "Download a previously generated cost report by ID.",
+    {
+        /// Cost report ID from a completed generation task
+        pub cost_report_id: String,
+    } => |client, input| {
+        let handler = CostReportHandler::new(client);
+        let bytes = handler
+            .download_cost_report(&input.cost_report_id)
+            .await
+            .tool_context("Failed to download cost report")?;
+
+        let content = String::from_utf8(bytes).unwrap_or_else(|e| {
+            format!("<binary data, {} bytes>", e.into_bytes().len())
+        });
+        CallToolResult::from_serialize(&content)
+    }
+);
+
+// ============================================================================
+// Payment method tools
+// ============================================================================
+
+cloud_tool!(read_only, list_payment_methods, "list_payment_methods",
+    "List all payment methods.",
+    {} => |client, _input| {
+        let handler = AccountHandler::new(client);
+        let methods = handler
+            .get_account_payment_methods()
+            .await
+            .tool_context("Failed to list payment methods")?;
+
+        CallToolResult::from_serialize(&methods)
+    }
+);
+
+// ============================================================================
+// Task tools
+// ============================================================================
+
+cloud_tool!(read_only, list_tasks, "list_tasks",
+    "List all async tasks.",
+    {} => |client, _input| {
+        let handler = TaskHandler::new(client);
+        let tasks = handler
+            .get_all_tasks()
+            .await
+            .tool_context("Failed to list tasks")?;
+
+        wrap_list("tasks", &tasks)
+    }
+);
+
+cloud_tool!(read_only, get_task, "get_task",
+    "Get task status by ID.",
+    {
+        /// Task ID
+        pub task_id: String,
+    } => |client, input| {
+        let handler = TaskHandler::new(client);
+        let task = handler
+            .get_task_by_id(input.task_id)
+            .await
+            .tool_context("Failed to get task")?;
+
+        CallToolResult::from_serialize(&task)
+    }
+);
+
+cloud_tool!(read_only, wait_for_cloud_task, "wait_for_cloud_task",
+    "Poll an async task until it reaches a terminal state. Useful for multi-step workflows.",
+    {
+        /// Task ID to wait for
+        pub task_id: String,
+        /// Maximum time to wait in seconds (default: 300)
+        #[serde(default = "default_task_timeout")]
+        pub timeout_seconds: u64,
+        /// Polling interval in seconds (default: 5)
+        #[serde(default = "default_task_interval")]
+        pub interval_seconds: u64,
+    } => |client, input| {
+        let handler = TaskHandler::new(client);
+        let deadline =
+            tokio::time::Instant::now() + std::time::Duration::from_secs(input.timeout_seconds);
+        let interval = std::time::Duration::from_secs(input.interval_seconds);
+
+        loop {
+            let task = handler
+                .get_task_by_id(input.task_id.clone())
+                .await
+                .tool_context("Failed to get task status")?;
+
+            // Check for terminal states
+            if let Some(ref status) = task.status {
+                let s = status.to_lowercase();
+                if matches!(
+                    s.as_str(),
+                    "completed"
+                        | "failed"
+                        | "error"
+                        | "success"
+                        | "cancelled"
+                        | "aborted"
+                ) {
+                    return CallToolResult::from_serialize(&task);
+                }
+            }
+
+            // Check timeout
+            if tokio::time::Instant::now() >= deadline {
+                return CallToolResult::from_serialize(&serde_json::json!({
+                    "timeout": true,
+                    "message": format!(
+                        "Task {} did not complete within {} seconds",
+                        input.task_id, input.timeout_seconds
+                    ),
+                    "last_status": task,
+                }));
+            }
+
+            tokio::time::sleep(interval).await;
+        }
+    }
+);
 
 // ============================================================================
 // Cloud Account (BYOC) tools
 // ============================================================================
 
-/// Input for listing cloud accounts
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ListCloudAccountsInput {
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+cloud_tool!(read_only, list_cloud_accounts, "list_cloud_accounts",
+    "List all cloud provider accounts (BYOC).",
+    {} => |client, _input| {
+        let handler = CloudAccountHandler::new(client);
+        let result = handler
+            .get_cloud_accounts()
+            .await
+            .tool_context("Failed to list cloud accounts")?;
 
-/// Build the list_cloud_accounts tool
-pub fn list_cloud_accounts(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("list_cloud_accounts")
-        .description("List all cloud provider accounts (BYOC).")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<ListCloudAccountsInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
+        let accounts = result.cloud_accounts.unwrap_or_default();
+        wrap_list("cloud_accounts", &accounts)
+    }
+);
 
-                let handler = CloudAccountHandler::new(client);
-                let result = handler
-                    .get_cloud_accounts()
-                    .await
-                    .tool_context("Failed to list cloud accounts")?;
+cloud_tool!(read_only, get_cloud_account, "get_cloud_account",
+    "Get a cloud provider account (BYOC) by ID.",
+    {
+        /// Cloud account ID
+        pub cloud_account_id: i32,
+    } => |client, input| {
+        let handler = CloudAccountHandler::new(client);
+        let account = handler
+            .get_cloud_account_by_id(input.cloud_account_id)
+            .await
+            .tool_context("Failed to get cloud account")?;
 
-                let accounts = result.cloud_accounts.unwrap_or_default();
-                wrap_list("cloud_accounts", &accounts)
-            },
-        )
-        .build()
-}
+        CallToolResult::from_serialize(&account)
+    }
+);
 
-/// Input for getting a cloud account by ID
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetCloudAccountInput {
-    /// Cloud account ID
-    pub cloud_account_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+cloud_tool!(write, create_cloud_account, "create_cloud_account",
+    "Create a new cloud provider account (BYOC).",
+    {
+        /// Cloud account display name
+        pub name: String,
+        /// Cloud provider (e.g., "AWS", "GCP", "Azure"). Defaults to "AWS" if not specified.
+        #[serde(default)]
+        pub provider: Option<String>,
+        /// Cloud provider access key
+        pub access_key_id: String,
+        /// Cloud provider secret key
+        pub access_secret_key: String,
+        /// Cloud provider management console username
+        pub console_username: String,
+        /// Cloud provider management console password
+        pub console_password: String,
+        /// Cloud provider management console login URL
+        pub sign_in_login_url: String,
+    } => |client, input| {
+        let handler = CloudAccountHandler::new(client);
+        let request = CloudAccountCreateRequest {
+            name: input.name,
+            provider: input.provider,
+            access_key_id: input.access_key_id,
+            access_secret_key: input.access_secret_key,
+            console_username: input.console_username,
+            console_password: input.console_password,
+            sign_in_login_url: input.sign_in_login_url,
+            command_type: None,
+        };
+        let result = handler
+            .create_cloud_account(&request)
+            .await
+            .tool_context("Failed to create cloud account")?;
 
-/// Build the get_cloud_account tool
-pub fn get_cloud_account(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_cloud_account")
-        .description("Get a cloud provider account (BYOC) by ID.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetCloudAccountInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
+        CallToolResult::from_serialize(&result)
+    }
+);
 
-                let handler = CloudAccountHandler::new(client);
-                let account = handler
-                    .get_cloud_account_by_id(input.cloud_account_id)
-                    .await
-                    .tool_context("Failed to get cloud account")?;
+cloud_tool!(write, update_cloud_account, "update_cloud_account",
+    "Update a cloud provider account (BYOC) configuration.",
+    {
+        /// Cloud account ID to update
+        pub cloud_account_id: i32,
+        /// New display name (optional)
+        #[serde(default)]
+        pub name: Option<String>,
+        /// Cloud provider access key
+        pub access_key_id: String,
+        /// Cloud provider secret key
+        pub access_secret_key: String,
+        /// Cloud provider management console username
+        pub console_username: String,
+        /// Cloud provider management console password
+        pub console_password: String,
+        /// Cloud provider management console login URL (optional)
+        #[serde(default)]
+        pub sign_in_login_url: Option<String>,
+    } => |client, input| {
+        let handler = CloudAccountHandler::new(client);
+        let request = CloudAccountUpdateRequest {
+            name: input.name,
+            cloud_account_id: None,
+            access_key_id: input.access_key_id,
+            access_secret_key: input.access_secret_key,
+            console_username: input.console_username,
+            console_password: input.console_password,
+            sign_in_login_url: input.sign_in_login_url,
+            command_type: None,
+        };
+        let result = handler
+            .update_cloud_account(input.cloud_account_id, &request)
+            .await
+            .tool_context("Failed to update cloud account")?;
 
-                CallToolResult::from_serialize(&account)
-            },
-        )
-        .build()
-}
+        CallToolResult::from_serialize(&result)
+    }
+);
 
-/// Input for creating a cloud account
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct CreateCloudAccountInput {
-    /// Cloud account display name
-    pub name: String,
-    /// Cloud provider (e.g., "AWS", "GCP", "Azure"). Defaults to "AWS" if not specified.
-    #[serde(default)]
-    pub provider: Option<String>,
-    /// Cloud provider access key
-    pub access_key_id: String,
-    /// Cloud provider secret key
-    pub access_secret_key: String,
-    /// Cloud provider management console username
-    pub console_username: String,
-    /// Cloud provider management console password
-    pub console_password: String,
-    /// Cloud provider management console login URL
-    pub sign_in_login_url: String,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+cloud_tool!(destructive, delete_cloud_account, "delete_cloud_account",
+    "DANGEROUS: Delete a cloud provider account (BYOC).",
+    {
+        /// Cloud account ID to delete
+        pub cloud_account_id: i32,
+    } => |client, input| {
+        let handler = CloudAccountHandler::new(client);
+        let result = handler
+            .delete_cloud_account(input.cloud_account_id)
+            .await
+            .tool_context("Failed to delete cloud account")?;
 
-/// Build the create_cloud_account tool
-pub fn create_cloud_account(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("create_cloud_account")
-        .description("Create a new cloud provider account (BYOC).")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<CreateCloudAccountInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = CloudAccountHandler::new(client);
-                let request = CloudAccountCreateRequest {
-                    name: input.name,
-                    provider: input.provider,
-                    access_key_id: input.access_key_id,
-                    access_secret_key: input.access_secret_key,
-                    console_username: input.console_username,
-                    console_password: input.console_password,
-                    sign_in_login_url: input.sign_in_login_url,
-                    command_type: None,
-                };
-                let result = handler
-                    .create_cloud_account(&request)
-                    .await
-                    .tool_context("Failed to create cloud account")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// Input for updating a cloud account
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct UpdateCloudAccountInput {
-    /// Cloud account ID to update
-    pub cloud_account_id: i32,
-    /// New display name (optional)
-    #[serde(default)]
-    pub name: Option<String>,
-    /// Cloud provider access key
-    pub access_key_id: String,
-    /// Cloud provider secret key
-    pub access_secret_key: String,
-    /// Cloud provider management console username
-    pub console_username: String,
-    /// Cloud provider management console password
-    pub console_password: String,
-    /// Cloud provider management console login URL (optional)
-    #[serde(default)]
-    pub sign_in_login_url: Option<String>,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the update_cloud_account tool
-pub fn update_cloud_account(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("update_cloud_account")
-        .description("Update a cloud provider account (BYOC) configuration.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<UpdateCloudAccountInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = CloudAccountHandler::new(client);
-                let request = CloudAccountUpdateRequest {
-                    name: input.name,
-                    cloud_account_id: None,
-                    access_key_id: input.access_key_id,
-                    access_secret_key: input.access_secret_key,
-                    console_username: input.console_username,
-                    console_password: input.console_password,
-                    sign_in_login_url: input.sign_in_login_url,
-                    command_type: None,
-                };
-                let result = handler
-                    .update_cloud_account(input.cloud_account_id, &request)
-                    .await
-                    .tool_context("Failed to update cloud account")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// Input for deleting a cloud account
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct DeleteCloudAccountInput {
-    /// Cloud account ID to delete
-    pub cloud_account_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the delete_cloud_account tool
-pub fn delete_cloud_account(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("delete_cloud_account")
-        .description("DANGEROUS: Delete a cloud provider account (BYOC).")
-        .destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<DeleteCloudAccountInput>| async move {
-                if !state.is_destructive_allowed() {
-                    return Err(McpError::tool(
-                        "Destructive operations require policy tier 'full'",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = CloudAccountHandler::new(client);
-                let result = handler
-                    .delete_cloud_account(input.cloud_account_id)
-                    .await
-                    .tool_context("Failed to delete cloud account")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// All tool names registered by this sub-module.
-pub(super) const TOOL_NAMES: &[&str] = &[
-    "get_account",
-    "get_system_logs",
-    "get_session_logs",
-    "get_regions",
-    "get_modules",
-    "list_account_users",
-    "get_account_user",
-    "update_account_user",
-    "delete_account_user",
-    "list_acl_users",
-    "get_acl_user",
-    "list_acl_roles",
-    "list_redis_rules",
-    "create_acl_user",
-    "update_acl_user",
-    "delete_acl_user",
-    "create_acl_role",
-    "update_acl_role",
-    "delete_acl_role",
-    "create_redis_rule",
-    "update_redis_rule",
-    "delete_redis_rule",
-    "generate_cost_report",
-    "download_cost_report",
-    "list_payment_methods",
-    "list_tasks",
-    "get_task",
-    "wait_for_cloud_task",
-    "list_cloud_accounts",
-    "get_cloud_account",
-    "create_cloud_account",
-    "update_cloud_account",
-    "delete_cloud_account",
-];
-
-/// Build an MCP sub-router containing account, ACL, cloud account, and task tools
-pub fn router(state: Arc<AppState>) -> McpRouter {
-    McpRouter::new()
-        // Account & Configuration
-        .tool(get_account(state.clone()))
-        .tool(get_regions(state.clone()))
-        .tool(get_modules(state.clone()))
-        .tool(list_account_users(state.clone()))
-        .tool(get_account_user(state.clone()))
-        .tool(update_account_user(state.clone()))
-        .tool(delete_account_user(state.clone()))
-        .tool(list_acl_users(state.clone()))
-        .tool(get_acl_user(state.clone()))
-        .tool(list_acl_roles(state.clone()))
-        .tool(list_redis_rules(state.clone()))
-        .tool(list_payment_methods(state.clone()))
-        // ACL Write Operations
-        .tool(create_acl_user(state.clone()))
-        .tool(update_acl_user(state.clone()))
-        .tool(delete_acl_user(state.clone()))
-        .tool(create_acl_role(state.clone()))
-        .tool(update_acl_role(state.clone()))
-        .tool(delete_acl_role(state.clone()))
-        .tool(create_redis_rule(state.clone()))
-        .tool(update_redis_rule(state.clone()))
-        .tool(delete_redis_rule(state.clone()))
-        // Cloud Accounts (BYOC)
-        .tool(list_cloud_accounts(state.clone()))
-        .tool(get_cloud_account(state.clone()))
-        .tool(create_cloud_account(state.clone()))
-        .tool(update_cloud_account(state.clone()))
-        .tool(delete_cloud_account(state.clone()))
-        // Cost Reports
-        .tool(generate_cost_report(state.clone()))
-        .tool(download_cost_report(state.clone()))
-        // Logs
-        .tool(get_system_logs(state.clone()))
-        .tool(get_session_logs(state.clone()))
-        // Tasks
-        .tool(list_tasks(state.clone()))
-        .tool(get_task(state.clone()))
-        .tool(wait_for_cloud_task(state.clone()))
-}
+        CallToolResult::from_serialize(&result)
+    }
+);

--- a/crates/redisctl-mcp/src/tools/cloud/fixed.rs
+++ b/crates/redisctl-mcp/src/tools/cloud/fixed.rs
@@ -1,7 +1,5 @@
 //! Fixed/Essentials tier subscription and database tools for Redis Cloud
 
-use std::sync::Arc;
-
 use redis_cloud::fixed::databases::{
     DatabaseTagCreateRequest, DatabaseTagUpdateRequest, DatabaseTagsUpdateRequest,
     FixedDatabaseBackupRequest, FixedDatabaseCreateRequest, FixedDatabaseHandler,
@@ -12,1172 +10,9 @@ use redis_cloud::fixed::subscriptions::{
 };
 use schemars::JsonSchema;
 use serde::Deserialize;
-use tower_mcp::extract::{Json, State};
-use tower_mcp::{CallToolResult, Error as McpError, McpRouter, ResultExt, Tool, ToolBuilder};
+use tower_mcp::{CallToolResult, ResultExt};
 
-use crate::state::AppState;
-
-// ============================================================================
-// Fixed/Essentials Subscription tools
-// ============================================================================
-
-/// Input for listing fixed subscriptions
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ListFixedSubscriptionsInput {
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the list_fixed_subscriptions tool
-pub fn list_fixed_subscriptions(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("list_fixed_subscriptions")
-        .description("List all Fixed/Essentials subscriptions.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<ListFixedSubscriptionsInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = FixedSubscriptionHandler::new(client);
-                let subscriptions = handler
-                    .list()
-                    .await
-                    .tool_context("Failed to list fixed subscriptions")?;
-
-                CallToolResult::from_serialize(&subscriptions)
-            },
-        )
-        .build()
-}
-
-/// Input for getting a specific fixed subscription
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetFixedSubscriptionInput {
-    /// Fixed subscription ID
-    pub subscription_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the get_fixed_subscription tool
-pub fn get_fixed_subscription(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_fixed_subscription")
-        .description("Get subscription details by ID.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetFixedSubscriptionInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = FixedSubscriptionHandler::new(client);
-                let subscription = handler
-                    .get_by_id(input.subscription_id)
-                    .await
-                    .tool_context("Failed to get fixed subscription")?;
-
-                CallToolResult::from_serialize(&subscription)
-            },
-        )
-        .build()
-}
-
-/// Input for creating a fixed subscription
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct CreateFixedSubscriptionInput {
-    /// New subscription name
-    pub name: String,
-    /// Essentials plan ID (use list_fixed_plans to find available plans)
-    pub plan_id: i32,
-    /// Payment method: "credit-card" or "marketplace"
-    #[serde(default)]
-    pub payment_method: Option<String>,
-    /// Payment method ID (required when payment_method is "credit-card")
-    #[serde(default)]
-    pub payment_method_id: Option<i32>,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the create_fixed_subscription tool
-pub fn create_fixed_subscription(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("create_fixed_subscription")
-        .description(
-            "Create a new Fixed/Essentials subscription. \
-             Prerequisites: 1) list_fixed_plans -- choose a plan by size, region, and price. \
-             2) list_payment_methods -- verify a payment method exists.",
-        )
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<CreateFixedSubscriptionInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let request = FixedSubscriptionCreateRequest {
-                    name: input.name,
-                    plan_id: input.plan_id,
-                    payment_method: input.payment_method,
-                    payment_method_id: input.payment_method_id,
-                    command_type: None,
-                };
-
-                let handler = FixedSubscriptionHandler::new(client);
-                let result = handler
-                    .create(&request)
-                    .await
-                    .tool_context("Failed to create fixed subscription")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// Input for updating a fixed subscription
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct UpdateFixedSubscriptionInput {
-    /// Fixed subscription ID to update
-    pub subscription_id: i32,
-    /// Updated subscription name
-    #[serde(default)]
-    pub name: Option<String>,
-    /// New plan ID
-    #[serde(default)]
-    pub plan_id: Option<i32>,
-    /// Payment method: "credit-card" or "marketplace"
-    #[serde(default)]
-    pub payment_method: Option<String>,
-    /// Payment method ID
-    #[serde(default)]
-    pub payment_method_id: Option<i32>,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the update_fixed_subscription tool
-pub fn update_fixed_subscription(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("update_fixed_subscription")
-        .description("Update a Fixed/Essentials subscription.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<UpdateFixedSubscriptionInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let request = FixedSubscriptionUpdateRequest {
-                    subscription_id: None,
-                    name: input.name,
-                    plan_id: input.plan_id,
-                    payment_method: input.payment_method,
-                    payment_method_id: input.payment_method_id,
-                    command_type: None,
-                };
-
-                let handler = FixedSubscriptionHandler::new(client);
-                let result = handler
-                    .update(input.subscription_id, &request)
-                    .await
-                    .tool_context("Failed to update fixed subscription")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// Input for deleting a fixed subscription
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct DeleteFixedSubscriptionInput {
-    /// Fixed subscription ID to delete
-    pub subscription_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the delete_fixed_subscription tool
-pub fn delete_fixed_subscription(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("delete_fixed_subscription")
-        .description(
-            "DANGEROUS: Delete a Fixed/Essentials subscription. \
-             All databases must be deleted first.",
-        )
-        .destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<DeleteFixedSubscriptionInput>| async move {
-                if !state.is_destructive_allowed() {
-                    return Err(McpError::tool(
-                        "Destructive operations require policy tier 'full'",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = FixedSubscriptionHandler::new(client);
-                let result = handler
-                    .delete_by_id(input.subscription_id)
-                    .await
-                    .tool_context("Failed to delete fixed subscription")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// Input for listing fixed plans
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ListFixedPlansInput {
-    /// Cloud provider filter (e.g., "AWS", "GCP", "Azure")
-    #[serde(default)]
-    pub provider: Option<String>,
-    /// Filter by Redis Flex plans
-    #[serde(default)]
-    pub redis_flex: Option<bool>,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the list_fixed_plans tool
-pub fn list_fixed_plans(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("list_fixed_plans")
-        .description("List available Fixed/Essentials plans.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<ListFixedPlansInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = FixedSubscriptionHandler::new(client);
-                let plans = handler
-                    .list_plans(input.provider, input.redis_flex)
-                    .await
-                    .tool_context("Failed to list fixed plans")?;
-
-                CallToolResult::from_serialize(&plans)
-            },
-        )
-        .build()
-}
-
-/// Input for getting fixed plans by subscription
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetFixedPlansBySubscriptionInput {
-    /// Fixed subscription ID
-    pub subscription_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the get_fixed_plans_by_subscription tool
-pub fn get_fixed_plans_by_subscription(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_fixed_plans_by_subscription")
-        .description("Get compatible plans for a subscription.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetFixedPlansBySubscriptionInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = FixedSubscriptionHandler::new(client);
-                let plans = handler
-                    .get_plans_by_subscription_id(input.subscription_id)
-                    .await
-                    .tool_context("Failed to get fixed plans by subscription")?;
-
-                CallToolResult::from_serialize(&plans)
-            },
-        )
-        .build()
-}
-
-/// Input for getting a specific fixed plan
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetFixedPlanInput {
-    /// Plan ID
-    pub plan_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the get_fixed_plan tool
-pub fn get_fixed_plan(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_fixed_plan")
-        .description("Get plan details by ID.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<GetFixedPlanInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = FixedSubscriptionHandler::new(client);
-                let plan = handler
-                    .get_plan_by_id(input.plan_id)
-                    .await
-                    .tool_context("Failed to get fixed plan")?;
-
-                CallToolResult::from_serialize(&plan)
-            },
-        )
-        .build()
-}
-
-/// Input for getting fixed Redis versions
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetFixedRedisVersionsInput {
-    /// Fixed subscription ID
-    pub subscription_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the get_fixed_redis_versions tool
-pub fn get_fixed_redis_versions(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_fixed_redis_versions")
-        .description("Get available Redis versions for a subscription.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetFixedRedisVersionsInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = FixedSubscriptionHandler::new(client);
-                let versions = handler
-                    .get_redis_versions(input.subscription_id)
-                    .await
-                    .tool_context("Failed to get fixed Redis versions")?;
-
-                CallToolResult::from_serialize(&versions)
-            },
-        )
-        .build()
-}
-
-// ============================================================================
-// Fixed/Essentials Database tools
-// ============================================================================
-
-/// Input for listing fixed databases
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ListFixedDatabasesInput {
-    /// Fixed subscription ID
-    pub subscription_id: i32,
-    /// Number of entries to skip (for pagination)
-    #[serde(default)]
-    pub offset: Option<i32>,
-    /// Maximum number of entries to return
-    #[serde(default)]
-    pub limit: Option<i32>,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the list_fixed_databases tool
-pub fn list_fixed_databases(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("list_fixed_databases")
-        .description("List databases in a subscription.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<ListFixedDatabasesInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = FixedDatabaseHandler::new(client);
-                let databases = handler
-                    .list(input.subscription_id, input.offset, input.limit)
-                    .await
-                    .tool_context("Failed to list fixed databases")?;
-
-                CallToolResult::from_serialize(&databases)
-            },
-        )
-        .build()
-}
-
-/// Input for getting a specific fixed database
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetFixedDatabaseInput {
-    /// Fixed subscription ID
-    pub subscription_id: i32,
-    /// Database ID
-    pub database_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the get_fixed_database tool
-pub fn get_fixed_database(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_fixed_database")
-        .description("Get database details by ID.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetFixedDatabaseInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = FixedDatabaseHandler::new(client);
-                let database = handler
-                    .get_by_id(input.subscription_id, input.database_id)
-                    .await
-                    .tool_context("Failed to get fixed database")?;
-
-                CallToolResult::from_serialize(&database)
-            },
-        )
-        .build()
-}
-
-/// Input for creating a fixed database
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct CreateFixedDatabaseInput {
-    /// Fixed subscription ID
-    pub subscription_id: i32,
-    /// Database name (max 40 chars, letters, digits, and hyphens only)
-    pub name: String,
-    /// Database protocol: "stack" (default) or "redis" (for Redis Flex)
-    #[serde(default)]
-    pub protocol: Option<String>,
-    /// Total memory in GB including replication overhead (Pay-as-you-go only)
-    #[serde(default)]
-    pub memory_limit_in_gb: Option<f64>,
-    /// Maximum dataset size in GB (Pay-as-you-go only)
-    #[serde(default)]
-    pub dataset_size_in_gb: Option<f64>,
-    /// Support Redis OSS Cluster API (Pay-as-you-go only)
-    #[serde(default)]
-    pub support_oss_cluster_api: Option<bool>,
-    /// Redis database version
-    #[serde(default)]
-    pub redis_version: Option<String>,
-    /// Data persistence mode (e.g., "none", "aof-every-1-second", "snapshot-every-1-hour")
-    #[serde(default)]
-    pub data_persistence: Option<String>,
-    /// Data eviction policy
-    #[serde(default)]
-    pub data_eviction_policy: Option<String>,
-    /// Enable replication for high availability
-    #[serde(default)]
-    pub replication: Option<bool>,
-    /// Enable TLS for connections
-    #[serde(default)]
-    pub enable_tls: Option<bool>,
-    /// Database password (random generated if not set)
-    #[serde(default)]
-    pub password: Option<String>,
-    /// List of source IP addresses or subnet masks to allow
-    #[serde(default)]
-    pub source_ips: Option<Vec<String>>,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the create_fixed_database tool
-pub fn create_fixed_database(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("create_fixed_database")
-        .description(
-            "Create a database in a Fixed/Essentials subscription. \
-             Prerequisites: 1) get_fixed_subscription -- verify the subscription exists and is active. \
-             2) get_fixed_plans_by_subscription -- check compatible plans. \
-             3) get_fixed_redis_versions -- pick a supported Redis version.",
-        )
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<CreateFixedDatabaseInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let request = FixedDatabaseCreateRequest {
-                    subscription_id: None,
-                    name: input.name,
-                    protocol: input.protocol,
-                    memory_limit_in_gb: input.memory_limit_in_gb,
-                    dataset_size_in_gb: input.dataset_size_in_gb,
-                    support_oss_cluster_api: input.support_oss_cluster_api,
-                    redis_version: input.redis_version,
-                    resp_version: None,
-                    use_external_endpoint_for_oss_cluster_api: None,
-                    enable_database_clustering: None,
-                    number_of_shards: None,
-                    data_persistence: input.data_persistence,
-                    data_eviction_policy: input.data_eviction_policy,
-                    replication: input.replication,
-                    periodic_backup_path: None,
-                    source_ips: input.source_ips,
-                    regex_rules: None,
-                    replica_of: None,
-                    replica: None,
-                    client_ssl_certificate: None,
-                    client_tls_certificates: None,
-                    enable_tls: input.enable_tls,
-                    password: input.password,
-                    alerts: None,
-                    modules: None,
-                    command_type: None,
-                };
-
-                let handler = FixedDatabaseHandler::new(client);
-                let result = handler
-                    .create(input.subscription_id, &request)
-                    .await
-                    .tool_context("Failed to create fixed database")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// Input for updating a fixed database
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct UpdateFixedDatabaseInput {
-    /// Fixed subscription ID
-    pub subscription_id: i32,
-    /// Database ID to update
-    pub database_id: i32,
-    /// Updated database name
-    #[serde(default)]
-    pub name: Option<String>,
-    /// Total memory in GB including replication overhead (Pay-as-you-go only)
-    #[serde(default)]
-    pub memory_limit_in_gb: Option<f64>,
-    /// Data persistence mode
-    #[serde(default)]
-    pub data_persistence: Option<String>,
-    /// Data eviction policy
-    #[serde(default)]
-    pub data_eviction_policy: Option<String>,
-    /// Enable or disable replication
-    #[serde(default)]
-    pub replication: Option<bool>,
-    /// Enable or disable TLS
-    #[serde(default)]
-    pub enable_tls: Option<bool>,
-    /// Updated database password
-    #[serde(default)]
-    pub password: Option<String>,
-    /// List of source IP addresses or subnet masks to allow
-    #[serde(default)]
-    pub source_ips: Option<Vec<String>>,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the update_fixed_database tool
-pub fn update_fixed_database(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("update_fixed_database")
-        .description("Update a database in a Fixed/Essentials subscription.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<UpdateFixedDatabaseInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let request = FixedDatabaseUpdateRequest {
-                    subscription_id: None,
-                    database_id: None,
-                    name: input.name,
-                    memory_limit_in_gb: input.memory_limit_in_gb,
-                    dataset_size_in_gb: None,
-                    support_oss_cluster_api: None,
-                    resp_version: None,
-                    use_external_endpoint_for_oss_cluster_api: None,
-                    enable_database_clustering: None,
-                    number_of_shards: None,
-                    data_persistence: input.data_persistence,
-                    data_eviction_policy: input.data_eviction_policy,
-                    replication: input.replication,
-                    periodic_backup_path: None,
-                    source_ips: input.source_ips,
-                    replica_of: None,
-                    replica: None,
-                    regex_rules: None,
-                    client_ssl_certificate: None,
-                    client_tls_certificates: None,
-                    enable_tls: input.enable_tls,
-                    password: input.password,
-                    enable_default_user: None,
-                    alerts: None,
-                    command_type: None,
-                };
-
-                let handler = FixedDatabaseHandler::new(client);
-                let result = handler
-                    .update(input.subscription_id, input.database_id, &request)
-                    .await
-                    .tool_context("Failed to update fixed database")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// Input for deleting a fixed database
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct DeleteFixedDatabaseInput {
-    /// Fixed subscription ID
-    pub subscription_id: i32,
-    /// Database ID to delete
-    pub database_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the delete_fixed_database tool
-pub fn delete_fixed_database(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("delete_fixed_database")
-        .description("DANGEROUS: Delete a Fixed/Essentials database and all its data.")
-        .destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<DeleteFixedDatabaseInput>| async move {
-                if !state.is_destructive_allowed() {
-                    return Err(McpError::tool(
-                        "Destructive operations require policy tier 'full'",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = FixedDatabaseHandler::new(client);
-                let result = handler
-                    .delete_by_id(input.subscription_id, input.database_id)
-                    .await
-                    .tool_context("Failed to delete fixed database")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-// ============================================================================
-// Fixed/Essentials Database operations tools
-// ============================================================================
-
-/// Input for getting fixed database backup status
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetFixedDatabaseBackupStatusInput {
-    /// Fixed subscription ID
-    pub subscription_id: i32,
-    /// Database ID
-    pub database_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the get_fixed_database_backup_status tool
-pub fn get_fixed_database_backup_status(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_fixed_database_backup_status")
-        .description("Get latest backup status for a database.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetFixedDatabaseBackupStatusInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = FixedDatabaseHandler::new(client);
-                let status = handler
-                    .get_backup_status(input.subscription_id, input.database_id)
-                    .await
-                    .tool_context("Failed to get fixed database backup status")?;
-
-                CallToolResult::from_serialize(&status)
-            },
-        )
-        .build()
-}
-
-/// Input for backing up a fixed database
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct BackupFixedDatabaseInput {
-    /// Fixed subscription ID
-    pub subscription_id: i32,
-    /// Database ID
-    pub database_id: i32,
-    /// Custom backup path (overrides the configured periodicBackupPath)
-    #[serde(default)]
-    pub adhoc_backup_path: Option<String>,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the backup_fixed_database tool
-pub fn backup_fixed_database(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("backup_fixed_database")
-        .description("Trigger a manual backup of a database.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<BackupFixedDatabaseInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let request = FixedDatabaseBackupRequest {
-                    subscription_id: None,
-                    database_id: None,
-                    adhoc_backup_path: input.adhoc_backup_path,
-                    command_type: None,
-                };
-
-                let handler = FixedDatabaseHandler::new(client);
-                let result = handler
-                    .backup(input.subscription_id, input.database_id, &request)
-                    .await
-                    .tool_context("Failed to backup fixed database")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// Input for getting fixed database import status
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetFixedDatabaseImportStatusInput {
-    /// Fixed subscription ID
-    pub subscription_id: i32,
-    /// Database ID
-    pub database_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the get_fixed_database_import_status tool
-pub fn get_fixed_database_import_status(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_fixed_database_import_status")
-        .description("Get latest import status for a database.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetFixedDatabaseImportStatusInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = FixedDatabaseHandler::new(client);
-                let status = handler
-                    .get_import_status(input.subscription_id, input.database_id)
-                    .await
-                    .tool_context("Failed to get fixed database import status")?;
-
-                CallToolResult::from_serialize(&status)
-            },
-        )
-        .build()
-}
-
-/// Input for importing data into a fixed database
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ImportFixedDatabaseInput {
-    /// Fixed subscription ID
-    pub subscription_id: i32,
-    /// Database ID
-    pub database_id: i32,
-    /// Source type: "http", "redis", "ftp", "aws-s3", "azure-blob-storage", "google-blob-storage"
-    pub source_type: String,
-    /// One or more URIs to import from
-    pub import_from_uri: Vec<String>,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the import_fixed_database tool
-pub fn import_fixed_database(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("import_fixed_database")
-        .description(
-            "Import data into a database from an external source. \
-             WARNING: This will overwrite existing data.",
-        )
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<ImportFixedDatabaseInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let request = FixedDatabaseImportRequest {
-                    subscription_id: None,
-                    database_id: None,
-                    source_type: input.source_type,
-                    import_from_uri: input.import_from_uri,
-                    command_type: None,
-                };
-
-                let handler = FixedDatabaseHandler::new(client);
-                let result = handler
-                    .import(input.subscription_id, input.database_id, &request)
-                    .await
-                    .tool_context("Failed to import fixed database")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// Input for getting fixed database slow log
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetFixedDatabaseSlowLogInput {
-    /// Fixed subscription ID
-    pub subscription_id: i32,
-    /// Database ID
-    pub database_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the get_fixed_database_slow_log tool
-pub fn get_fixed_database_slow_log(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_fixed_database_slow_log")
-        .description("Get slow log entries for a database.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetFixedDatabaseSlowLogInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = FixedDatabaseHandler::new(client);
-                let log = handler
-                    .get_slow_log(input.subscription_id, input.database_id)
-                    .await
-                    .tool_context("Failed to get fixed database slow log")?;
-
-                CallToolResult::from_serialize(&log)
-            },
-        )
-        .build()
-}
-
-// ============================================================================
-// Fixed/Essentials Database tag tools
-// ============================================================================
-
-/// Input for getting fixed database tags
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetFixedDatabaseTagsInput {
-    /// Fixed subscription ID
-    pub subscription_id: i32,
-    /// Database ID
-    pub database_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the get_fixed_database_tags tool
-pub fn get_fixed_database_tags(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_fixed_database_tags")
-        .description("Get tags for a database.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetFixedDatabaseTagsInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = FixedDatabaseHandler::new(client);
-                let tags = handler
-                    .get_tags(input.subscription_id, input.database_id)
-                    .await
-                    .tool_context("Failed to get fixed database tags")?;
-
-                CallToolResult::from_serialize(&tags)
-            },
-        )
-        .build()
-}
-
-/// Input for creating a fixed database tag
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct CreateFixedDatabaseTagInput {
-    /// Fixed subscription ID
-    pub subscription_id: i32,
-    /// Database ID
-    pub database_id: i32,
-    /// Tag key
-    pub key: String,
-    /// Tag value
-    pub value: String,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the create_fixed_database_tag tool
-pub fn create_fixed_database_tag(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("create_fixed_database_tag")
-        .description("Create a tag on a database.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<CreateFixedDatabaseTagInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let request = DatabaseTagCreateRequest {
-                    key: input.key,
-                    value: input.value,
-                    subscription_id: None,
-                    database_id: None,
-                    command_type: None,
-                };
-
-                let handler = FixedDatabaseHandler::new(client);
-                let tag = handler
-                    .create_tag(input.subscription_id, input.database_id, &request)
-                    .await
-                    .tool_context("Failed to create fixed database tag")?;
-
-                CallToolResult::from_serialize(&tag)
-            },
-        )
-        .build()
-}
-
-/// Input for updating a fixed database tag
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct UpdateFixedDatabaseTagInput {
-    /// Fixed subscription ID
-    pub subscription_id: i32,
-    /// Database ID
-    pub database_id: i32,
-    /// Tag key to update
-    pub tag_key: String,
-    /// New tag value
-    pub value: String,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the update_fixed_database_tag tool
-pub fn update_fixed_database_tag(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("update_fixed_database_tag")
-        .description("Update a tag value on a database.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<UpdateFixedDatabaseTagInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let request = DatabaseTagUpdateRequest {
-                    subscription_id: None,
-                    database_id: None,
-                    key: None,
-                    value: input.value,
-                    command_type: None,
-                };
-
-                let handler = FixedDatabaseHandler::new(client);
-                let tag = handler
-                    .update_tag(
-                        input.subscription_id,
-                        input.database_id,
-                        input.tag_key,
-                        &request,
-                    )
-                    .await
-                    .tool_context("Failed to update fixed database tag")?;
-
-                CallToolResult::from_serialize(&tag)
-            },
-        )
-        .build()
-}
-
-/// Input for deleting a fixed database tag
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct DeleteFixedDatabaseTagInput {
-    /// Fixed subscription ID
-    pub subscription_id: i32,
-    /// Database ID
-    pub database_id: i32,
-    /// Tag key to delete
-    pub tag_key: String,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the delete_fixed_database_tag tool
-pub fn delete_fixed_database_tag(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("delete_fixed_database_tag")
-        .description("DANGEROUS: Delete a tag from a database.")
-        .destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<DeleteFixedDatabaseTagInput>| async move {
-                if !state.is_destructive_allowed() {
-                    return Err(McpError::tool(
-                        "Destructive operations require policy tier 'full'",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = FixedDatabaseHandler::new(client);
-                let result = handler
-                    .delete_tag(input.subscription_id, input.database_id, input.tag_key)
-                    .await
-                    .tool_context("Failed to delete fixed database tag")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
+use crate::tools::macros::{cloud_tool, mcp_module};
 
 /// Input for a tag key-value pair
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -1188,268 +23,761 @@ pub struct FixedTagInput {
     pub value: String,
 }
 
-/// Input for updating all fixed database tags
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct UpdateFixedDatabaseTagsInput {
-    /// Fixed subscription ID
-    pub subscription_id: i32,
-    /// Database ID
-    pub database_id: i32,
-    /// Tags to set on the database (replaces all existing tags)
-    pub tags: Vec<FixedTagInput>,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
+mcp_module! {
+    list_fixed_subscriptions => "list_fixed_subscriptions",
+    get_fixed_subscription => "get_fixed_subscription",
+    create_fixed_subscription => "create_fixed_subscription",
+    update_fixed_subscription => "update_fixed_subscription",
+    delete_fixed_subscription => "delete_fixed_subscription",
+    list_fixed_plans => "list_fixed_plans",
+    get_fixed_plans_by_subscription => "get_fixed_plans_by_subscription",
+    get_fixed_plan => "get_fixed_plan",
+    get_fixed_redis_versions => "get_fixed_redis_versions",
+    list_fixed_databases => "list_fixed_databases",
+    get_fixed_database => "get_fixed_database",
+    create_fixed_database => "create_fixed_database",
+    update_fixed_database => "update_fixed_database",
+    delete_fixed_database => "delete_fixed_database",
+    get_fixed_database_backup_status => "get_fixed_database_backup_status",
+    backup_fixed_database => "backup_fixed_database",
+    get_fixed_database_import_status => "get_fixed_database_import_status",
+    import_fixed_database => "import_fixed_database",
+    get_fixed_database_slow_log => "get_fixed_database_slow_log",
+    get_fixed_database_tags => "get_fixed_database_tags",
+    create_fixed_database_tag => "create_fixed_database_tag",
+    update_fixed_database_tag => "update_fixed_database_tag",
+    delete_fixed_database_tag => "delete_fixed_database_tag",
+    update_fixed_database_tags => "update_fixed_database_tags",
+    get_fixed_database_upgrade_versions => "get_fixed_database_upgrade_versions",
+    get_fixed_database_upgrade_status => "get_fixed_database_upgrade_status",
+    upgrade_fixed_database_redis_version => "upgrade_fixed_database_redis_version",
 }
 
-/// Build the update_fixed_database_tags tool
-pub fn update_fixed_database_tags(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("update_fixed_database_tags")
-        .description("Update all tags on a database (replaces existing tags).")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<UpdateFixedDatabaseTagsInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
+// ============================================================================
+// Fixed/Essentials Subscription tools
+// ============================================================================
 
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
+cloud_tool!(read_only, list_fixed_subscriptions, "list_fixed_subscriptions",
+    "List all Fixed/Essentials subscriptions.",
+    {} => |client, _input| {
+        let handler = FixedSubscriptionHandler::new(client);
+        let subscriptions = handler
+            .list()
+            .await
+            .tool_context("Failed to list fixed subscriptions")?;
 
-                let tags = input
-                    .tags
-                    .into_iter()
-                    .map(|t| Tag {
-                        key: t.key,
-                        value: t.value,
-                        command_type: None,
-                    })
-                    .collect();
+        CallToolResult::from_serialize(&subscriptions)
+    }
+);
 
-                let request = DatabaseTagsUpdateRequest {
-                    subscription_id: None,
-                    database_id: None,
-                    tags,
-                    command_type: None,
-                };
+cloud_tool!(read_only, get_fixed_subscription, "get_fixed_subscription",
+    "Get subscription details by ID.",
+    {
+        /// Fixed subscription ID
+        pub subscription_id: i32,
+    } => |client, input| {
+        let handler = FixedSubscriptionHandler::new(client);
+        let subscription = handler
+            .get_by_id(input.subscription_id)
+            .await
+            .tool_context("Failed to get fixed subscription")?;
 
-                let handler = FixedDatabaseHandler::new(client);
-                let result = handler
-                    .update_tags(input.subscription_id, input.database_id, &request)
-                    .await
-                    .tool_context("Failed to update fixed database tags")?;
+        CallToolResult::from_serialize(&subscription)
+    }
+);
 
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
+cloud_tool!(write, create_fixed_subscription, "create_fixed_subscription",
+    "Create a new Fixed/Essentials subscription. \
+     Prerequisites: 1) list_fixed_plans -- choose a plan by size, region, and price. \
+     2) list_payment_methods -- verify a payment method exists.",
+    {
+        /// New subscription name
+        pub name: String,
+        /// Essentials plan ID (use list_fixed_plans to find available plans)
+        pub plan_id: i32,
+        /// Payment method: "credit-card" or "marketplace"
+        #[serde(default)]
+        pub payment_method: Option<String>,
+        /// Payment method ID (required when payment_method is "credit-card")
+        #[serde(default)]
+        pub payment_method_id: Option<i32>,
+    } => |client, input| {
+        let request = FixedSubscriptionCreateRequest {
+            name: input.name,
+            plan_id: input.plan_id,
+            payment_method: input.payment_method,
+            payment_method_id: input.payment_method_id,
+            command_type: None,
+        };
+
+        let handler = FixedSubscriptionHandler::new(client);
+        let result = handler
+            .create(&request)
+            .await
+            .tool_context("Failed to create fixed subscription")?;
+
+        CallToolResult::from_serialize(&result)
+    }
+);
+
+cloud_tool!(write, update_fixed_subscription, "update_fixed_subscription",
+    "Update a Fixed/Essentials subscription.",
+    {
+        /// Fixed subscription ID to update
+        pub subscription_id: i32,
+        /// Updated subscription name
+        #[serde(default)]
+        pub name: Option<String>,
+        /// New plan ID
+        #[serde(default)]
+        pub plan_id: Option<i32>,
+        /// Payment method: "credit-card" or "marketplace"
+        #[serde(default)]
+        pub payment_method: Option<String>,
+        /// Payment method ID
+        #[serde(default)]
+        pub payment_method_id: Option<i32>,
+    } => |client, input| {
+        let request = FixedSubscriptionUpdateRequest {
+            subscription_id: None,
+            name: input.name,
+            plan_id: input.plan_id,
+            payment_method: input.payment_method,
+            payment_method_id: input.payment_method_id,
+            command_type: None,
+        };
+
+        let handler = FixedSubscriptionHandler::new(client);
+        let result = handler
+            .update(input.subscription_id, &request)
+            .await
+            .tool_context("Failed to update fixed subscription")?;
+
+        CallToolResult::from_serialize(&result)
+    }
+);
+
+cloud_tool!(destructive, delete_fixed_subscription, "delete_fixed_subscription",
+    "DANGEROUS: Delete a Fixed/Essentials subscription. \
+     All databases must be deleted first.",
+    {
+        /// Fixed subscription ID to delete
+        pub subscription_id: i32,
+    } => |client, input| {
+        let handler = FixedSubscriptionHandler::new(client);
+        let result = handler
+            .delete_by_id(input.subscription_id)
+            .await
+            .tool_context("Failed to delete fixed subscription")?;
+
+        CallToolResult::from_serialize(&result)
+    }
+);
+
+cloud_tool!(read_only, list_fixed_plans, "list_fixed_plans",
+    "List available Fixed/Essentials plans.",
+    {
+        /// Cloud provider filter (e.g., "AWS", "GCP", "Azure")
+        #[serde(default)]
+        pub provider: Option<String>,
+        /// Filter by Redis Flex plans
+        #[serde(default)]
+        pub redis_flex: Option<bool>,
+    } => |client, input| {
+        let handler = FixedSubscriptionHandler::new(client);
+        let plans = handler
+            .list_plans(input.provider, input.redis_flex)
+            .await
+            .tool_context("Failed to list fixed plans")?;
+
+        CallToolResult::from_serialize(&plans)
+    }
+);
+
+cloud_tool!(read_only, get_fixed_plans_by_subscription, "get_fixed_plans_by_subscription",
+    "Get compatible plans for a subscription.",
+    {
+        /// Fixed subscription ID
+        pub subscription_id: i32,
+    } => |client, input| {
+        let handler = FixedSubscriptionHandler::new(client);
+        let plans = handler
+            .get_plans_by_subscription_id(input.subscription_id)
+            .await
+            .tool_context("Failed to get fixed plans by subscription")?;
+
+        CallToolResult::from_serialize(&plans)
+    }
+);
+
+cloud_tool!(read_only, get_fixed_plan, "get_fixed_plan",
+    "Get plan details by ID.",
+    {
+        /// Plan ID
+        pub plan_id: i32,
+    } => |client, input| {
+        let handler = FixedSubscriptionHandler::new(client);
+        let plan = handler
+            .get_plan_by_id(input.plan_id)
+            .await
+            .tool_context("Failed to get fixed plan")?;
+
+        CallToolResult::from_serialize(&plan)
+    }
+);
+
+cloud_tool!(read_only, get_fixed_redis_versions, "get_fixed_redis_versions",
+    "Get available Redis versions for a subscription.",
+    {
+        /// Fixed subscription ID
+        pub subscription_id: i32,
+    } => |client, input| {
+        let handler = FixedSubscriptionHandler::new(client);
+        let versions = handler
+            .get_redis_versions(input.subscription_id)
+            .await
+            .tool_context("Failed to get fixed Redis versions")?;
+
+        CallToolResult::from_serialize(&versions)
+    }
+);
+
+// ============================================================================
+// Fixed/Essentials Database tools
+// ============================================================================
+
+cloud_tool!(read_only, list_fixed_databases, "list_fixed_databases",
+    "List databases in a subscription.",
+    {
+        /// Fixed subscription ID
+        pub subscription_id: i32,
+        /// Number of entries to skip (for pagination)
+        #[serde(default)]
+        pub offset: Option<i32>,
+        /// Maximum number of entries to return
+        #[serde(default)]
+        pub limit: Option<i32>,
+    } => |client, input| {
+        let handler = FixedDatabaseHandler::new(client);
+        let databases = handler
+            .list(input.subscription_id, input.offset, input.limit)
+            .await
+            .tool_context("Failed to list fixed databases")?;
+
+        CallToolResult::from_serialize(&databases)
+    }
+);
+
+cloud_tool!(read_only, get_fixed_database, "get_fixed_database",
+    "Get database details by ID.",
+    {
+        /// Fixed subscription ID
+        pub subscription_id: i32,
+        /// Database ID
+        pub database_id: i32,
+    } => |client, input| {
+        let handler = FixedDatabaseHandler::new(client);
+        let database = handler
+            .get_by_id(input.subscription_id, input.database_id)
+            .await
+            .tool_context("Failed to get fixed database")?;
+
+        CallToolResult::from_serialize(&database)
+    }
+);
+
+cloud_tool!(write, create_fixed_database, "create_fixed_database",
+    "Create a database in a Fixed/Essentials subscription. \
+     Prerequisites: 1) get_fixed_subscription -- verify the subscription exists and is active. \
+     2) get_fixed_plans_by_subscription -- check compatible plans. \
+     3) get_fixed_redis_versions -- pick a supported Redis version.",
+    {
+        /// Fixed subscription ID
+        pub subscription_id: i32,
+        /// Database name (max 40 chars, letters, digits, and hyphens only)
+        pub name: String,
+        /// Database protocol: "stack" (default) or "redis" (for Redis Flex)
+        #[serde(default)]
+        pub protocol: Option<String>,
+        /// Total memory in GB including replication overhead (Pay-as-you-go only)
+        #[serde(default)]
+        pub memory_limit_in_gb: Option<f64>,
+        /// Maximum dataset size in GB (Pay-as-you-go only)
+        #[serde(default)]
+        pub dataset_size_in_gb: Option<f64>,
+        /// Support Redis OSS Cluster API (Pay-as-you-go only)
+        #[serde(default)]
+        pub support_oss_cluster_api: Option<bool>,
+        /// Redis database version
+        #[serde(default)]
+        pub redis_version: Option<String>,
+        /// Data persistence mode (e.g., "none", "aof-every-1-second", "snapshot-every-1-hour")
+        #[serde(default)]
+        pub data_persistence: Option<String>,
+        /// Data eviction policy
+        #[serde(default)]
+        pub data_eviction_policy: Option<String>,
+        /// Enable replication for high availability
+        #[serde(default)]
+        pub replication: Option<bool>,
+        /// Enable TLS for connections
+        #[serde(default)]
+        pub enable_tls: Option<bool>,
+        /// Database password (random generated if not set)
+        #[serde(default)]
+        pub password: Option<String>,
+        /// List of source IP addresses or subnet masks to allow
+        #[serde(default)]
+        pub source_ips: Option<Vec<String>>,
+    } => |client, input| {
+        let request = FixedDatabaseCreateRequest {
+            subscription_id: None,
+            name: input.name,
+            protocol: input.protocol,
+            memory_limit_in_gb: input.memory_limit_in_gb,
+            dataset_size_in_gb: input.dataset_size_in_gb,
+            support_oss_cluster_api: input.support_oss_cluster_api,
+            redis_version: input.redis_version,
+            resp_version: None,
+            use_external_endpoint_for_oss_cluster_api: None,
+            enable_database_clustering: None,
+            number_of_shards: None,
+            data_persistence: input.data_persistence,
+            data_eviction_policy: input.data_eviction_policy,
+            replication: input.replication,
+            periodic_backup_path: None,
+            source_ips: input.source_ips,
+            regex_rules: None,
+            replica_of: None,
+            replica: None,
+            client_ssl_certificate: None,
+            client_tls_certificates: None,
+            enable_tls: input.enable_tls,
+            password: input.password,
+            alerts: None,
+            modules: None,
+            command_type: None,
+        };
+
+        let handler = FixedDatabaseHandler::new(client);
+        let result = handler
+            .create(input.subscription_id, &request)
+            .await
+            .tool_context("Failed to create fixed database")?;
+
+        CallToolResult::from_serialize(&result)
+    }
+);
+
+cloud_tool!(write, update_fixed_database, "update_fixed_database",
+    "Update a database in a Fixed/Essentials subscription.",
+    {
+        /// Fixed subscription ID
+        pub subscription_id: i32,
+        /// Database ID to update
+        pub database_id: i32,
+        /// Updated database name
+        #[serde(default)]
+        pub name: Option<String>,
+        /// Total memory in GB including replication overhead (Pay-as-you-go only)
+        #[serde(default)]
+        pub memory_limit_in_gb: Option<f64>,
+        /// Data persistence mode
+        #[serde(default)]
+        pub data_persistence: Option<String>,
+        /// Data eviction policy
+        #[serde(default)]
+        pub data_eviction_policy: Option<String>,
+        /// Enable or disable replication
+        #[serde(default)]
+        pub replication: Option<bool>,
+        /// Enable or disable TLS
+        #[serde(default)]
+        pub enable_tls: Option<bool>,
+        /// Updated database password
+        #[serde(default)]
+        pub password: Option<String>,
+        /// List of source IP addresses or subnet masks to allow
+        #[serde(default)]
+        pub source_ips: Option<Vec<String>>,
+    } => |client, input| {
+        let request = FixedDatabaseUpdateRequest {
+            subscription_id: None,
+            database_id: None,
+            name: input.name,
+            memory_limit_in_gb: input.memory_limit_in_gb,
+            dataset_size_in_gb: None,
+            support_oss_cluster_api: None,
+            resp_version: None,
+            use_external_endpoint_for_oss_cluster_api: None,
+            enable_database_clustering: None,
+            number_of_shards: None,
+            data_persistence: input.data_persistence,
+            data_eviction_policy: input.data_eviction_policy,
+            replication: input.replication,
+            periodic_backup_path: None,
+            source_ips: input.source_ips,
+            replica_of: None,
+            replica: None,
+            regex_rules: None,
+            client_ssl_certificate: None,
+            client_tls_certificates: None,
+            enable_tls: input.enable_tls,
+            password: input.password,
+            enable_default_user: None,
+            alerts: None,
+            command_type: None,
+        };
+
+        let handler = FixedDatabaseHandler::new(client);
+        let result = handler
+            .update(input.subscription_id, input.database_id, &request)
+            .await
+            .tool_context("Failed to update fixed database")?;
+
+        CallToolResult::from_serialize(&result)
+    }
+);
+
+cloud_tool!(destructive, delete_fixed_database, "delete_fixed_database",
+    "DANGEROUS: Delete a Fixed/Essentials database and all its data.",
+    {
+        /// Fixed subscription ID
+        pub subscription_id: i32,
+        /// Database ID to delete
+        pub database_id: i32,
+    } => |client, input| {
+        let handler = FixedDatabaseHandler::new(client);
+        let result = handler
+            .delete_by_id(input.subscription_id, input.database_id)
+            .await
+            .tool_context("Failed to delete fixed database")?;
+
+        CallToolResult::from_serialize(&result)
+    }
+);
+
+// ============================================================================
+// Fixed/Essentials Database operations tools
+// ============================================================================
+
+cloud_tool!(read_only, get_fixed_database_backup_status, "get_fixed_database_backup_status",
+    "Get latest backup status for a database.",
+    {
+        /// Fixed subscription ID
+        pub subscription_id: i32,
+        /// Database ID
+        pub database_id: i32,
+    } => |client, input| {
+        let handler = FixedDatabaseHandler::new(client);
+        let status = handler
+            .get_backup_status(input.subscription_id, input.database_id)
+            .await
+            .tool_context("Failed to get fixed database backup status")?;
+
+        CallToolResult::from_serialize(&status)
+    }
+);
+
+cloud_tool!(write, backup_fixed_database, "backup_fixed_database",
+    "Trigger a manual backup of a database.",
+    {
+        /// Fixed subscription ID
+        pub subscription_id: i32,
+        /// Database ID
+        pub database_id: i32,
+        /// Custom backup path (overrides the configured periodicBackupPath)
+        #[serde(default)]
+        pub adhoc_backup_path: Option<String>,
+    } => |client, input| {
+        let request = FixedDatabaseBackupRequest {
+            subscription_id: None,
+            database_id: None,
+            adhoc_backup_path: input.adhoc_backup_path,
+            command_type: None,
+        };
+
+        let handler = FixedDatabaseHandler::new(client);
+        let result = handler
+            .backup(input.subscription_id, input.database_id, &request)
+            .await
+            .tool_context("Failed to backup fixed database")?;
+
+        CallToolResult::from_serialize(&result)
+    }
+);
+
+cloud_tool!(read_only, get_fixed_database_import_status, "get_fixed_database_import_status",
+    "Get latest import status for a database.",
+    {
+        /// Fixed subscription ID
+        pub subscription_id: i32,
+        /// Database ID
+        pub database_id: i32,
+    } => |client, input| {
+        let handler = FixedDatabaseHandler::new(client);
+        let status = handler
+            .get_import_status(input.subscription_id, input.database_id)
+            .await
+            .tool_context("Failed to get fixed database import status")?;
+
+        CallToolResult::from_serialize(&status)
+    }
+);
+
+cloud_tool!(write, import_fixed_database, "import_fixed_database",
+    "Import data into a database from an external source. \
+     WARNING: This will overwrite existing data.",
+    {
+        /// Fixed subscription ID
+        pub subscription_id: i32,
+        /// Database ID
+        pub database_id: i32,
+        /// Source type: "http", "redis", "ftp", "aws-s3", "azure-blob-storage", "google-blob-storage"
+        pub source_type: String,
+        /// One or more URIs to import from
+        pub import_from_uri: Vec<String>,
+    } => |client, input| {
+        let request = FixedDatabaseImportRequest {
+            subscription_id: None,
+            database_id: None,
+            source_type: input.source_type,
+            import_from_uri: input.import_from_uri,
+            command_type: None,
+        };
+
+        let handler = FixedDatabaseHandler::new(client);
+        let result = handler
+            .import(input.subscription_id, input.database_id, &request)
+            .await
+            .tool_context("Failed to import fixed database")?;
+
+        CallToolResult::from_serialize(&result)
+    }
+);
+
+cloud_tool!(read_only, get_fixed_database_slow_log, "get_fixed_database_slow_log",
+    "Get slow log entries for a database.",
+    {
+        /// Fixed subscription ID
+        pub subscription_id: i32,
+        /// Database ID
+        pub database_id: i32,
+    } => |client, input| {
+        let handler = FixedDatabaseHandler::new(client);
+        let log = handler
+            .get_slow_log(input.subscription_id, input.database_id)
+            .await
+            .tool_context("Failed to get fixed database slow log")?;
+
+        CallToolResult::from_serialize(&log)
+    }
+);
+
+// ============================================================================
+// Fixed/Essentials Database tag tools
+// ============================================================================
+
+cloud_tool!(read_only, get_fixed_database_tags, "get_fixed_database_tags",
+    "Get tags for a database.",
+    {
+        /// Fixed subscription ID
+        pub subscription_id: i32,
+        /// Database ID
+        pub database_id: i32,
+    } => |client, input| {
+        let handler = FixedDatabaseHandler::new(client);
+        let tags = handler
+            .get_tags(input.subscription_id, input.database_id)
+            .await
+            .tool_context("Failed to get fixed database tags")?;
+
+        CallToolResult::from_serialize(&tags)
+    }
+);
+
+cloud_tool!(write, create_fixed_database_tag, "create_fixed_database_tag",
+    "Create a tag on a database.",
+    {
+        /// Fixed subscription ID
+        pub subscription_id: i32,
+        /// Database ID
+        pub database_id: i32,
+        /// Tag key
+        pub key: String,
+        /// Tag value
+        pub value: String,
+    } => |client, input| {
+        let request = DatabaseTagCreateRequest {
+            key: input.key,
+            value: input.value,
+            subscription_id: None,
+            database_id: None,
+            command_type: None,
+        };
+
+        let handler = FixedDatabaseHandler::new(client);
+        let tag = handler
+            .create_tag(input.subscription_id, input.database_id, &request)
+            .await
+            .tool_context("Failed to create fixed database tag")?;
+
+        CallToolResult::from_serialize(&tag)
+    }
+);
+
+cloud_tool!(write, update_fixed_database_tag, "update_fixed_database_tag",
+    "Update a tag value on a database.",
+    {
+        /// Fixed subscription ID
+        pub subscription_id: i32,
+        /// Database ID
+        pub database_id: i32,
+        /// Tag key to update
+        pub tag_key: String,
+        /// New tag value
+        pub value: String,
+    } => |client, input| {
+        let request = DatabaseTagUpdateRequest {
+            subscription_id: None,
+            database_id: None,
+            key: None,
+            value: input.value,
+            command_type: None,
+        };
+
+        let handler = FixedDatabaseHandler::new(client);
+        let tag = handler
+            .update_tag(
+                input.subscription_id,
+                input.database_id,
+                input.tag_key,
+                &request,
+            )
+            .await
+            .tool_context("Failed to update fixed database tag")?;
+
+        CallToolResult::from_serialize(&tag)
+    }
+);
+
+cloud_tool!(destructive, delete_fixed_database_tag, "delete_fixed_database_tag",
+    "DANGEROUS: Delete a tag from a database.",
+    {
+        /// Fixed subscription ID
+        pub subscription_id: i32,
+        /// Database ID
+        pub database_id: i32,
+        /// Tag key to delete
+        pub tag_key: String,
+    } => |client, input| {
+        let handler = FixedDatabaseHandler::new(client);
+        let result = handler
+            .delete_tag(input.subscription_id, input.database_id, input.tag_key)
+            .await
+            .tool_context("Failed to delete fixed database tag")?;
+
+        CallToolResult::from_serialize(&result)
+    }
+);
+
+cloud_tool!(write, update_fixed_database_tags, "update_fixed_database_tags",
+    "Update all tags on a database (replaces existing tags).",
+    {
+        /// Fixed subscription ID
+        pub subscription_id: i32,
+        /// Database ID
+        pub database_id: i32,
+        /// Tags to set on the database (replaces all existing tags)
+        pub tags: Vec<FixedTagInput>,
+    } => |client, input| {
+        let tags = input
+            .tags
+            .into_iter()
+            .map(|t| Tag {
+                key: t.key,
+                value: t.value,
+                command_type: None,
+            })
+            .collect();
+
+        let request = DatabaseTagsUpdateRequest {
+            subscription_id: None,
+            database_id: None,
+            tags,
+            command_type: None,
+        };
+
+        let handler = FixedDatabaseHandler::new(client);
+        let result = handler
+            .update_tags(input.subscription_id, input.database_id, &request)
+            .await
+            .tool_context("Failed to update fixed database tags")?;
+
+        CallToolResult::from_serialize(&result)
+    }
+);
 
 // ============================================================================
 // Fixed/Essentials Database upgrade tools
 // ============================================================================
 
-/// Input for getting fixed database available upgrade versions
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetFixedDatabaseUpgradeVersionsInput {
-    /// Fixed subscription ID
-    pub subscription_id: i32,
-    /// Database ID
-    pub database_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+cloud_tool!(read_only, get_fixed_database_upgrade_versions, "get_fixed_database_upgrade_versions",
+    "Get available upgrade target Redis versions for a database.",
+    {
+        /// Fixed subscription ID
+        pub subscription_id: i32,
+        /// Database ID
+        pub database_id: i32,
+    } => |client, input| {
+        let handler = FixedDatabaseHandler::new(client);
+        let versions = handler
+            .get_available_target_versions(input.subscription_id, input.database_id)
+            .await
+            .tool_context("Failed to get fixed database upgrade versions")?;
 
-/// Build the get_fixed_database_upgrade_versions tool
-pub fn get_fixed_database_upgrade_versions(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_fixed_database_upgrade_versions")
-        .description("Get available upgrade target Redis versions for a database.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetFixedDatabaseUpgradeVersionsInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
+        CallToolResult::from_serialize(&versions)
+    }
+);
 
-                let handler = FixedDatabaseHandler::new(client);
-                let versions = handler
-                    .get_available_target_versions(input.subscription_id, input.database_id)
-                    .await
-                    .tool_context("Failed to get fixed database upgrade versions")?;
+cloud_tool!(read_only, get_fixed_database_upgrade_status, "get_fixed_database_upgrade_status",
+    "Get latest Redis version upgrade status for a database.",
+    {
+        /// Fixed subscription ID
+        pub subscription_id: i32,
+        /// Database ID
+        pub database_id: i32,
+    } => |client, input| {
+        let handler = FixedDatabaseHandler::new(client);
+        let status = handler
+            .get_upgrade_status(input.subscription_id, input.database_id)
+            .await
+            .tool_context("Failed to get fixed database upgrade status")?;
 
-                CallToolResult::from_serialize(&versions)
-            },
-        )
-        .build()
-}
+        CallToolResult::from_serialize(&status)
+    }
+);
 
-/// Input for getting fixed database upgrade status
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetFixedDatabaseUpgradeStatusInput {
-    /// Fixed subscription ID
-    pub subscription_id: i32,
-    /// Database ID
-    pub database_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+cloud_tool!(write, upgrade_fixed_database_redis_version, "upgrade_fixed_database_redis_version",
+    "Upgrade the Redis version of a database.",
+    {
+        /// Fixed subscription ID
+        pub subscription_id: i32,
+        /// Database ID
+        pub database_id: i32,
+        /// Target Redis version to upgrade to (use get_fixed_database_upgrade_versions to see available versions)
+        pub target_version: String,
+    } => |client, input| {
+        let handler = FixedDatabaseHandler::new(client);
+        let result = handler
+            .upgrade_redis_version(
+                input.subscription_id,
+                input.database_id,
+                &input.target_version,
+            )
+            .await
+            .tool_context("Failed to upgrade fixed database Redis version")?;
 
-/// Build the get_fixed_database_upgrade_status tool
-pub fn get_fixed_database_upgrade_status(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_fixed_database_upgrade_status")
-        .description("Get latest Redis version upgrade status for a database.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetFixedDatabaseUpgradeStatusInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = FixedDatabaseHandler::new(client);
-                let status = handler
-                    .get_upgrade_status(input.subscription_id, input.database_id)
-                    .await
-                    .tool_context("Failed to get fixed database upgrade status")?;
-
-                CallToolResult::from_serialize(&status)
-            },
-        )
-        .build()
-}
-
-/// Input for upgrading a fixed database Redis version
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct UpgradeFixedDatabaseRedisVersionInput {
-    /// Fixed subscription ID
-    pub subscription_id: i32,
-    /// Database ID
-    pub database_id: i32,
-    /// Target Redis version to upgrade to (use get_fixed_database_upgrade_versions to see available versions)
-    pub target_version: String,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the upgrade_fixed_database_redis_version tool
-pub fn upgrade_fixed_database_redis_version(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("upgrade_fixed_database_redis_version")
-        .description("Upgrade the Redis version of a database.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<UpgradeFixedDatabaseRedisVersionInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = FixedDatabaseHandler::new(client);
-                let result = handler
-                    .upgrade_redis_version(
-                        input.subscription_id,
-                        input.database_id,
-                        &input.target_version,
-                    )
-                    .await
-                    .tool_context("Failed to upgrade fixed database Redis version")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-// ============================================================================
-// Instructions & Router
-// ============================================================================
-
-/// All tool names registered by this sub-module.
-pub(super) const TOOL_NAMES: &[&str] = &[
-    "list_fixed_subscriptions",
-    "get_fixed_subscription",
-    "create_fixed_subscription",
-    "update_fixed_subscription",
-    "delete_fixed_subscription",
-    "list_fixed_plans",
-    "get_fixed_plans_by_subscription",
-    "get_fixed_plan",
-    "get_fixed_redis_versions",
-    "list_fixed_databases",
-    "get_fixed_database",
-    "create_fixed_database",
-    "update_fixed_database",
-    "delete_fixed_database",
-    "get_fixed_database_backup_status",
-    "backup_fixed_database",
-    "get_fixed_database_import_status",
-    "import_fixed_database",
-    "get_fixed_database_slow_log",
-    "get_fixed_database_tags",
-    "create_fixed_database_tag",
-    "update_fixed_database_tag",
-    "delete_fixed_database_tag",
-    "update_fixed_database_tags",
-    "get_fixed_database_upgrade_versions",
-    "get_fixed_database_upgrade_status",
-    "upgrade_fixed_database_redis_version",
-];
-
-/// Build an MCP sub-router containing all Fixed/Essentials tools
-pub fn router(state: Arc<AppState>) -> McpRouter {
-    McpRouter::new()
-        // Fixed Subscription read tools
-        .tool(list_fixed_subscriptions(state.clone()))
-        .tool(get_fixed_subscription(state.clone()))
-        .tool(list_fixed_plans(state.clone()))
-        .tool(get_fixed_plans_by_subscription(state.clone()))
-        .tool(get_fixed_plan(state.clone()))
-        .tool(get_fixed_redis_versions(state.clone()))
-        // Fixed Database read tools
-        .tool(list_fixed_databases(state.clone()))
-        .tool(get_fixed_database(state.clone()))
-        .tool(get_fixed_database_backup_status(state.clone()))
-        .tool(get_fixed_database_import_status(state.clone()))
-        .tool(get_fixed_database_slow_log(state.clone()))
-        .tool(get_fixed_database_tags(state.clone()))
-        .tool(get_fixed_database_upgrade_versions(state.clone()))
-        .tool(get_fixed_database_upgrade_status(state.clone()))
-        // Fixed Subscription write tools
-        .tool(create_fixed_subscription(state.clone()))
-        .tool(update_fixed_subscription(state.clone()))
-        .tool(delete_fixed_subscription(state.clone()))
-        // Fixed Database write tools
-        .tool(create_fixed_database(state.clone()))
-        .tool(update_fixed_database(state.clone()))
-        .tool(delete_fixed_database(state.clone()))
-        .tool(backup_fixed_database(state.clone()))
-        .tool(import_fixed_database(state.clone()))
-        // Fixed Database tag write tools
-        .tool(create_fixed_database_tag(state.clone()))
-        .tool(update_fixed_database_tag(state.clone()))
-        .tool(delete_fixed_database_tag(state.clone()))
-        .tool(update_fixed_database_tags(state.clone()))
-        // Fixed Database upgrade write tool
-        .tool(upgrade_fixed_database_redis_version(state))
-}
+        CallToolResult::from_serialize(&result)
+    }
+);

--- a/crates/redisctl-mcp/src/tools/cloud/networking.rs
+++ b/crates/redisctl-mcp/src/tools/cloud/networking.rs
@@ -2,8 +2,6 @@
 //!
 //! VPC Peering, Transit Gateway, Private Service Connect (PSC), and PrivateLink tools.
 
-use std::sync::Arc;
-
 use redis_cloud::connectivity::psc::PscEndpointUpdateRequest;
 use redis_cloud::connectivity::transit_gateway::TgwAttachmentRequest;
 use redis_cloud::connectivity::vpc_peering::VpcPeeringCreateRequest;
@@ -11,2097 +9,1137 @@ use redis_cloud::{
     PrincipalType, PrivateLinkAddPrincipalRequest, PrivateLinkCreateRequest, PrivateLinkHandler,
     PscHandler, TransitGatewayHandler, VpcPeeringHandler,
 };
-use schemars::JsonSchema;
-use serde::Deserialize;
-use tower_mcp::extract::{Json, State};
-use tower_mcp::{
-    CallToolResult, Error as McpError, McpRouter, ResultExt, Tool, ToolBuilder, ToolError,
-};
+use tower_mcp::{CallToolResult, ResultExt, ToolError};
 
-use crate::state::AppState;
+use crate::tools::macros::{cloud_tool, mcp_module};
+
+mcp_module! {
+    get_vpc_peering => "get_vpc_peering",
+    create_vpc_peering => "create_vpc_peering",
+    update_vpc_peering => "update_vpc_peering",
+    delete_vpc_peering => "delete_vpc_peering",
+    get_aa_vpc_peering => "get_aa_vpc_peering",
+    create_aa_vpc_peering => "create_aa_vpc_peering",
+    update_aa_vpc_peering => "update_aa_vpc_peering",
+    delete_aa_vpc_peering => "delete_aa_vpc_peering",
+    get_tgw_attachments => "get_tgw_attachments",
+    get_tgw_invitations => "get_tgw_invitations",
+    accept_tgw_invitation => "accept_tgw_invitation",
+    reject_tgw_invitation => "reject_tgw_invitation",
+    create_tgw_attachment => "create_tgw_attachment",
+    update_tgw_attachment_cidrs => "update_tgw_attachment_cidrs",
+    delete_tgw_attachment => "delete_tgw_attachment",
+    get_aa_tgw_attachments => "get_aa_tgw_attachments",
+    get_aa_tgw_invitations => "get_aa_tgw_invitations",
+    accept_aa_tgw_invitation => "accept_aa_tgw_invitation",
+    reject_aa_tgw_invitation => "reject_aa_tgw_invitation",
+    create_aa_tgw_attachment => "create_aa_tgw_attachment",
+    update_aa_tgw_attachment_cidrs => "update_aa_tgw_attachment_cidrs",
+    delete_aa_tgw_attachment => "delete_aa_tgw_attachment",
+    get_psc_service => "get_psc_service",
+    create_psc_service => "create_psc_service",
+    delete_psc_service => "delete_psc_service",
+    get_psc_endpoints => "get_psc_endpoints",
+    create_psc_endpoint => "create_psc_endpoint",
+    update_psc_endpoint => "update_psc_endpoint",
+    delete_psc_endpoint => "delete_psc_endpoint",
+    get_psc_creation_script => "get_psc_creation_script",
+    get_psc_deletion_script => "get_psc_deletion_script",
+    get_aa_psc_service => "get_aa_psc_service",
+    create_aa_psc_service => "create_aa_psc_service",
+    delete_aa_psc_service => "delete_aa_psc_service",
+    get_aa_psc_endpoints => "get_aa_psc_endpoints",
+    create_aa_psc_endpoint => "create_aa_psc_endpoint",
+    update_aa_psc_endpoint => "update_aa_psc_endpoint",
+    delete_aa_psc_endpoint => "delete_aa_psc_endpoint",
+    get_aa_psc_creation_script => "get_aa_psc_creation_script",
+    get_aa_psc_deletion_script => "get_aa_psc_deletion_script",
+    get_private_link => "get_private_link",
+    create_private_link => "create_private_link",
+    delete_private_link => "delete_private_link",
+    add_private_link_principals => "add_private_link_principals",
+    remove_private_link_principals => "remove_private_link_principals",
+    get_private_link_endpoint_script => "get_private_link_endpoint_script",
+    get_aa_private_link => "get_aa_private_link",
+    create_aa_private_link => "create_aa_private_link",
+    add_aa_private_link_principals => "add_aa_private_link_principals",
+    remove_aa_private_link_principals => "remove_aa_private_link_principals",
+    get_aa_private_link_endpoint_script => "get_aa_private_link_endpoint_script",
+}
 
 // ============================================================================
 // VPC Peering tools
 // ============================================================================
 
-/// Input for getting VPC peering details
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetVpcPeeringInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+cloud_tool!(read_only, get_vpc_peering, "get_vpc_peering",
+    "Get VPC peering details.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+    } => |client, input| {
+        let handler = VpcPeeringHandler::new(client);
+        let result = handler
+            .get(input.subscription_id)
+            .await
+            .tool_context("Failed to get VPC peering")?;
 
-/// Build the get_vpc_peering tool
-pub fn get_vpc_peering(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_vpc_peering")
-        .description("Get VPC peering details.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<GetVpcPeeringInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
+        CallToolResult::from_serialize(&result)
+    }
+);
 
-                let handler = VpcPeeringHandler::new(client);
-                let result = handler
-                    .get(input.subscription_id)
-                    .await
-                    .tool_context("Failed to get VPC peering")?;
+cloud_tool!(write, create_vpc_peering, "create_vpc_peering",
+    "Create a VPC peering connection.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// Cloud provider (AWS, GCP, Azure)
+        #[serde(default)]
+        pub provider: Option<String>,
+        /// AWS VPC ID
+        #[serde(default)]
+        pub vpc_id: Option<String>,
+        /// AWS region
+        #[serde(default)]
+        pub aws_region: Option<String>,
+        /// AWS account ID
+        #[serde(default)]
+        pub aws_account_id: Option<String>,
+        /// VPC CIDR block
+        #[serde(default)]
+        pub vpc_cidr: Option<String>,
+        /// Multiple VPC CIDR blocks
+        #[serde(default)]
+        pub vpc_cidrs: Option<Vec<String>>,
+        /// GCP project ID (for GCP peering)
+        #[serde(default)]
+        pub gcp_project_id: Option<String>,
+        /// GCP network name (for GCP peering)
+        #[serde(default)]
+        pub network_name: Option<String>,
+    } => |client, input| {
+        let request = VpcPeeringCreateRequest {
+            provider: input.provider,
+            vpc_id: input.vpc_id,
+            aws_region: input.aws_region,
+            aws_account_id: input.aws_account_id,
+            vpc_cidr: input.vpc_cidr,
+            vpc_cidrs: input.vpc_cidrs,
+            gcp_project_id: input.gcp_project_id,
+            network_name: input.network_name,
+            ..Default::default()
+        };
 
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
+        let handler = VpcPeeringHandler::new(client);
+        let result = handler
+            .create(input.subscription_id, &request)
+            .await
+            .tool_context("Failed to create VPC peering")?;
 
-/// Input for creating a VPC peering
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct CreateVpcPeeringInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Cloud provider (AWS, GCP, Azure)
-    #[serde(default)]
-    pub provider: Option<String>,
-    /// AWS VPC ID
-    #[serde(default)]
-    pub vpc_id: Option<String>,
-    /// AWS region
-    #[serde(default)]
-    pub aws_region: Option<String>,
-    /// AWS account ID
-    #[serde(default)]
-    pub aws_account_id: Option<String>,
-    /// VPC CIDR block
-    #[serde(default)]
-    pub vpc_cidr: Option<String>,
-    /// Multiple VPC CIDR blocks
-    #[serde(default)]
-    pub vpc_cidrs: Option<Vec<String>>,
-    /// GCP project ID (for GCP peering)
-    #[serde(default)]
-    pub gcp_project_id: Option<String>,
-    /// GCP network name (for GCP peering)
-    #[serde(default)]
-    pub network_name: Option<String>,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+        CallToolResult::from_serialize(&result)
+    }
+);
 
-/// Build the create_vpc_peering tool
-pub fn create_vpc_peering(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("create_vpc_peering")
-        .description("Create a VPC peering connection.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<CreateVpcPeeringInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
+cloud_tool!(write, update_vpc_peering, "update_vpc_peering",
+    "Update a VPC peering connection.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// VPC Peering ID
+        pub peering_id: i32,
+        /// Cloud provider (AWS, GCP, Azure)
+        #[serde(default)]
+        pub provider: Option<String>,
+        /// AWS VPC ID
+        #[serde(default)]
+        pub vpc_id: Option<String>,
+        /// AWS region
+        #[serde(default)]
+        pub aws_region: Option<String>,
+        /// AWS account ID
+        #[serde(default)]
+        pub aws_account_id: Option<String>,
+        /// VPC CIDR block
+        #[serde(default)]
+        pub vpc_cidr: Option<String>,
+        /// Multiple VPC CIDR blocks
+        #[serde(default)]
+        pub vpc_cidrs: Option<Vec<String>>,
+        /// GCP project ID (for GCP peering)
+        #[serde(default)]
+        pub gcp_project_id: Option<String>,
+        /// GCP network name (for GCP peering)
+        #[serde(default)]
+        pub network_name: Option<String>,
+    } => |client, input| {
+        let request = VpcPeeringCreateRequest {
+            provider: input.provider,
+            vpc_id: input.vpc_id,
+            aws_region: input.aws_region,
+            aws_account_id: input.aws_account_id,
+            vpc_cidr: input.vpc_cidr,
+            vpc_cidrs: input.vpc_cidrs,
+            gcp_project_id: input.gcp_project_id,
+            network_name: input.network_name,
+            ..Default::default()
+        };
 
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
+        let handler = VpcPeeringHandler::new(client);
+        let result = handler
+            .update(input.subscription_id, input.peering_id, &request)
+            .await
+            .tool_context("Failed to update VPC peering")?;
 
-                let request = VpcPeeringCreateRequest {
-                    provider: input.provider,
-                    vpc_id: input.vpc_id,
-                    aws_region: input.aws_region,
-                    aws_account_id: input.aws_account_id,
-                    vpc_cidr: input.vpc_cidr,
-                    vpc_cidrs: input.vpc_cidrs,
-                    gcp_project_id: input.gcp_project_id,
-                    network_name: input.network_name,
-                    ..Default::default()
-                };
+        CallToolResult::from_serialize(&result)
+    }
+);
 
-                let handler = VpcPeeringHandler::new(client);
-                let result = handler
-                    .create(input.subscription_id, &request)
-                    .await
-                    .tool_context("Failed to create VPC peering")?;
+cloud_tool!(destructive, delete_vpc_peering, "delete_vpc_peering",
+    "DANGEROUS: Delete a VPC peering connection. Causes connectivity loss.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// VPC Peering ID
+        pub peering_id: i32,
+    } => |client, input| {
+        let handler = VpcPeeringHandler::new(client);
+        let result = handler
+            .delete(input.subscription_id, input.peering_id)
+            .await
+            .tool_context("Failed to delete VPC peering")?;
 
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// Input for updating a VPC peering
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct UpdateVpcPeeringInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// VPC Peering ID
-    pub peering_id: i32,
-    /// Cloud provider (AWS, GCP, Azure)
-    #[serde(default)]
-    pub provider: Option<String>,
-    /// AWS VPC ID
-    #[serde(default)]
-    pub vpc_id: Option<String>,
-    /// AWS region
-    #[serde(default)]
-    pub aws_region: Option<String>,
-    /// AWS account ID
-    #[serde(default)]
-    pub aws_account_id: Option<String>,
-    /// VPC CIDR block
-    #[serde(default)]
-    pub vpc_cidr: Option<String>,
-    /// Multiple VPC CIDR blocks
-    #[serde(default)]
-    pub vpc_cidrs: Option<Vec<String>>,
-    /// GCP project ID (for GCP peering)
-    #[serde(default)]
-    pub gcp_project_id: Option<String>,
-    /// GCP network name (for GCP peering)
-    #[serde(default)]
-    pub network_name: Option<String>,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the update_vpc_peering tool
-pub fn update_vpc_peering(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("update_vpc_peering")
-        .description("Update a VPC peering connection.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<UpdateVpcPeeringInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let request = VpcPeeringCreateRequest {
-                    provider: input.provider,
-                    vpc_id: input.vpc_id,
-                    aws_region: input.aws_region,
-                    aws_account_id: input.aws_account_id,
-                    vpc_cidr: input.vpc_cidr,
-                    vpc_cidrs: input.vpc_cidrs,
-                    gcp_project_id: input.gcp_project_id,
-                    network_name: input.network_name,
-                    ..Default::default()
-                };
-
-                let handler = VpcPeeringHandler::new(client);
-                let result = handler
-                    .update(input.subscription_id, input.peering_id, &request)
-                    .await
-                    .tool_context("Failed to update VPC peering")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// Input for deleting a VPC peering
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct DeleteVpcPeeringInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// VPC Peering ID
-    pub peering_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the delete_vpc_peering tool
-pub fn delete_vpc_peering(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("delete_vpc_peering")
-        .description("DANGEROUS: Delete a VPC peering connection. Causes connectivity loss.")
-        .destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<DeleteVpcPeeringInput>| async move {
-                if !state.is_destructive_allowed() {
-                    return Err(McpError::tool(
-                        "Destructive operations require policy tier 'full'",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = VpcPeeringHandler::new(client);
-                let result = handler
-                    .delete(input.subscription_id, input.peering_id)
-                    .await
-                    .tool_context("Failed to delete VPC peering")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
+        CallToolResult::from_serialize(&result)
+    }
+);
 
 // ============================================================================
 // Active-Active VPC Peering tools
 // ============================================================================
 
-/// Input for getting Active-Active VPC peering details
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetAaVpcPeeringInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+cloud_tool!(read_only, get_aa_vpc_peering, "get_aa_vpc_peering",
+    "Get Active-Active VPC peering details.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+    } => |client, input| {
+        let handler = VpcPeeringHandler::new(client);
+        let result = handler
+            .get_active_active(input.subscription_id)
+            .await
+            .tool_context("Failed to get AA VPC peering")?;
 
-/// Build the get_aa_vpc_peering tool
-pub fn get_aa_vpc_peering(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_aa_vpc_peering")
-        .description("Get Active-Active VPC peering details.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetAaVpcPeeringInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
+        CallToolResult::from_serialize(&result)
+    }
+);
 
-                let handler = VpcPeeringHandler::new(client);
-                let result = handler
-                    .get_active_active(input.subscription_id)
-                    .await
-                    .tool_context("Failed to get AA VPC peering")?;
+cloud_tool!(write, create_aa_vpc_peering, "create_aa_vpc_peering",
+    "Create an Active-Active VPC peering connection.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// Cloud provider (AWS, GCP, Azure)
+        #[serde(default)]
+        pub provider: Option<String>,
+        /// AWS VPC ID
+        #[serde(default)]
+        pub vpc_id: Option<String>,
+        /// AWS region
+        #[serde(default)]
+        pub aws_region: Option<String>,
+        /// AWS account ID
+        #[serde(default)]
+        pub aws_account_id: Option<String>,
+        /// VPC CIDR block
+        #[serde(default)]
+        pub vpc_cidr: Option<String>,
+        /// Multiple VPC CIDR blocks
+        #[serde(default)]
+        pub vpc_cidrs: Option<Vec<String>>,
+        /// GCP project ID (for GCP peering)
+        #[serde(default)]
+        pub gcp_project_id: Option<String>,
+        /// GCP network name (for GCP peering)
+        #[serde(default)]
+        pub network_name: Option<String>,
+    } => |client, input| {
+        let request = VpcPeeringCreateRequest {
+            provider: input.provider,
+            vpc_id: input.vpc_id,
+            aws_region: input.aws_region,
+            aws_account_id: input.aws_account_id,
+            vpc_cidr: input.vpc_cidr,
+            vpc_cidrs: input.vpc_cidrs,
+            gcp_project_id: input.gcp_project_id,
+            network_name: input.network_name,
+            ..Default::default()
+        };
 
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
+        let handler = VpcPeeringHandler::new(client);
+        let result = handler
+            .create_active_active(input.subscription_id, &request)
+            .await
+            .tool_context("Failed to create AA VPC peering")?;
 
-/// Input for creating an Active-Active VPC peering
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct CreateAaVpcPeeringInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Cloud provider (AWS, GCP, Azure)
-    #[serde(default)]
-    pub provider: Option<String>,
-    /// AWS VPC ID
-    #[serde(default)]
-    pub vpc_id: Option<String>,
-    /// AWS region
-    #[serde(default)]
-    pub aws_region: Option<String>,
-    /// AWS account ID
-    #[serde(default)]
-    pub aws_account_id: Option<String>,
-    /// VPC CIDR block
-    #[serde(default)]
-    pub vpc_cidr: Option<String>,
-    /// Multiple VPC CIDR blocks
-    #[serde(default)]
-    pub vpc_cidrs: Option<Vec<String>>,
-    /// GCP project ID (for GCP peering)
-    #[serde(default)]
-    pub gcp_project_id: Option<String>,
-    /// GCP network name (for GCP peering)
-    #[serde(default)]
-    pub network_name: Option<String>,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+        CallToolResult::from_serialize(&result)
+    }
+);
 
-/// Build the create_aa_vpc_peering tool
-pub fn create_aa_vpc_peering(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("create_aa_vpc_peering")
-        .description("Create an Active-Active VPC peering connection.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<CreateAaVpcPeeringInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
+cloud_tool!(write, update_aa_vpc_peering, "update_aa_vpc_peering",
+    "Update an Active-Active VPC peering connection.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// VPC Peering ID
+        pub peering_id: i32,
+        /// Cloud provider (AWS, GCP, Azure)
+        #[serde(default)]
+        pub provider: Option<String>,
+        /// AWS VPC ID
+        #[serde(default)]
+        pub vpc_id: Option<String>,
+        /// AWS region
+        #[serde(default)]
+        pub aws_region: Option<String>,
+        /// AWS account ID
+        #[serde(default)]
+        pub aws_account_id: Option<String>,
+        /// VPC CIDR block
+        #[serde(default)]
+        pub vpc_cidr: Option<String>,
+        /// Multiple VPC CIDR blocks
+        #[serde(default)]
+        pub vpc_cidrs: Option<Vec<String>>,
+        /// GCP project ID (for GCP peering)
+        #[serde(default)]
+        pub gcp_project_id: Option<String>,
+        /// GCP network name (for GCP peering)
+        #[serde(default)]
+        pub network_name: Option<String>,
+    } => |client, input| {
+        let request = VpcPeeringCreateRequest {
+            provider: input.provider,
+            vpc_id: input.vpc_id,
+            aws_region: input.aws_region,
+            aws_account_id: input.aws_account_id,
+            vpc_cidr: input.vpc_cidr,
+            vpc_cidrs: input.vpc_cidrs,
+            gcp_project_id: input.gcp_project_id,
+            network_name: input.network_name,
+            ..Default::default()
+        };
 
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
+        let handler = VpcPeeringHandler::new(client);
+        let result = handler
+            .update_active_active(input.subscription_id, input.peering_id, &request)
+            .await
+            .tool_context("Failed to update AA VPC peering")?;
 
-                let request = VpcPeeringCreateRequest {
-                    provider: input.provider,
-                    vpc_id: input.vpc_id,
-                    aws_region: input.aws_region,
-                    aws_account_id: input.aws_account_id,
-                    vpc_cidr: input.vpc_cidr,
-                    vpc_cidrs: input.vpc_cidrs,
-                    gcp_project_id: input.gcp_project_id,
-                    network_name: input.network_name,
-                    ..Default::default()
-                };
+        CallToolResult::from_serialize(&result)
+    }
+);
 
-                let handler = VpcPeeringHandler::new(client);
-                let result = handler
-                    .create_active_active(input.subscription_id, &request)
-                    .await
-                    .tool_context("Failed to create AA VPC peering")?;
+cloud_tool!(destructive, delete_aa_vpc_peering, "delete_aa_vpc_peering",
+    "DANGEROUS: Delete an Active-Active VPC peering connection. Causes connectivity loss.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// VPC Peering ID
+        pub peering_id: i32,
+    } => |client, input| {
+        let handler = VpcPeeringHandler::new(client);
+        let result = handler
+            .delete_active_active(input.subscription_id, input.peering_id)
+            .await
+            .tool_context("Failed to delete AA VPC peering")?;
 
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// Input for updating an Active-Active VPC peering
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct UpdateAaVpcPeeringInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// VPC Peering ID
-    pub peering_id: i32,
-    /// Cloud provider (AWS, GCP, Azure)
-    #[serde(default)]
-    pub provider: Option<String>,
-    /// AWS VPC ID
-    #[serde(default)]
-    pub vpc_id: Option<String>,
-    /// AWS region
-    #[serde(default)]
-    pub aws_region: Option<String>,
-    /// AWS account ID
-    #[serde(default)]
-    pub aws_account_id: Option<String>,
-    /// VPC CIDR block
-    #[serde(default)]
-    pub vpc_cidr: Option<String>,
-    /// Multiple VPC CIDR blocks
-    #[serde(default)]
-    pub vpc_cidrs: Option<Vec<String>>,
-    /// GCP project ID (for GCP peering)
-    #[serde(default)]
-    pub gcp_project_id: Option<String>,
-    /// GCP network name (for GCP peering)
-    #[serde(default)]
-    pub network_name: Option<String>,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the update_aa_vpc_peering tool
-pub fn update_aa_vpc_peering(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("update_aa_vpc_peering")
-        .description("Update an Active-Active VPC peering connection.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<UpdateAaVpcPeeringInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let request = VpcPeeringCreateRequest {
-                    provider: input.provider,
-                    vpc_id: input.vpc_id,
-                    aws_region: input.aws_region,
-                    aws_account_id: input.aws_account_id,
-                    vpc_cidr: input.vpc_cidr,
-                    vpc_cidrs: input.vpc_cidrs,
-                    gcp_project_id: input.gcp_project_id,
-                    network_name: input.network_name,
-                    ..Default::default()
-                };
-
-                let handler = VpcPeeringHandler::new(client);
-                let result = handler
-                    .update_active_active(input.subscription_id, input.peering_id, &request)
-                    .await
-                    .tool_context("Failed to update AA VPC peering")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// Input for deleting an Active-Active VPC peering
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct DeleteAaVpcPeeringInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// VPC Peering ID
-    pub peering_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the delete_aa_vpc_peering tool
-pub fn delete_aa_vpc_peering(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("delete_aa_vpc_peering")
-        .description("DANGEROUS: Delete an Active-Active VPC peering connection. Causes connectivity loss.")
-        .destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<DeleteAaVpcPeeringInput>| async move {
-                if !state.is_destructive_allowed() {
-                    return Err(McpError::tool(
-                        "Destructive operations require policy tier 'full'",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = VpcPeeringHandler::new(client);
-                let result = handler
-                    .delete_active_active(input.subscription_id, input.peering_id)
-                    .await
-                    .tool_context("Failed to delete AA VPC peering")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
+        CallToolResult::from_serialize(&result)
+    }
+);
 
 // ============================================================================
 // Transit Gateway tools
 // ============================================================================
 
-/// Input for getting Transit Gateway attachments
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetTgwAttachmentsInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+cloud_tool!(read_only, get_tgw_attachments, "get_tgw_attachments",
+    "Get Transit Gateway attachments.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+    } => |client, input| {
+        let handler = TransitGatewayHandler::new(client);
+        let result = handler
+            .get_attachments(input.subscription_id)
+            .await
+            .tool_context("Failed to get TGW attachments")?;
 
-/// Build the get_tgw_attachments tool
-pub fn get_tgw_attachments(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_tgw_attachments")
-        .description("Get Transit Gateway attachments.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetTgwAttachmentsInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
+        CallToolResult::from_serialize(&result)
+    }
+);
 
-                let handler = TransitGatewayHandler::new(client);
-                let result = handler
-                    .get_attachments(input.subscription_id)
-                    .await
-                    .tool_context("Failed to get TGW attachments")?;
+cloud_tool!(read_only, get_tgw_invitations, "get_tgw_invitations",
+    "Get Transit Gateway shared invitations.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+    } => |client, input| {
+        let handler = TransitGatewayHandler::new(client);
+        let result = handler
+            .get_shared_invitations(input.subscription_id)
+            .await
+            .tool_context("Failed to get TGW invitations")?;
 
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
+        CallToolResult::from_serialize(&result)
+    }
+);
 
-/// Input for getting Transit Gateway invitations
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetTgwInvitationsInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+cloud_tool!(write, accept_tgw_invitation, "accept_tgw_invitation",
+    "Accept a Transit Gateway resource share invitation.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// Invitation ID
+        pub invitation_id: String,
+    } => |client, input| {
+        let handler = TransitGatewayHandler::new(client);
+        let result = handler
+            .accept_resource_share(input.subscription_id, input.invitation_id)
+            .await
+            .tool_context("Failed to accept TGW invitation")?;
 
-/// Build the get_tgw_invitations tool
-pub fn get_tgw_invitations(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_tgw_invitations")
-        .description("Get Transit Gateway shared invitations.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetTgwInvitationsInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
+        CallToolResult::from_serialize(&result)
+    }
+);
 
-                let handler = TransitGatewayHandler::new(client);
-                let result = handler
-                    .get_shared_invitations(input.subscription_id)
-                    .await
-                    .tool_context("Failed to get TGW invitations")?;
+cloud_tool!(write, reject_tgw_invitation, "reject_tgw_invitation",
+    "Reject a Transit Gateway resource share invitation.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// Invitation ID
+        pub invitation_id: String,
+    } => |client, input| {
+        let handler = TransitGatewayHandler::new(client);
+        let result = handler
+            .reject_resource_share(input.subscription_id, input.invitation_id)
+            .await
+            .tool_context("Failed to reject TGW invitation")?;
 
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
+        CallToolResult::from_serialize(&result)
+    }
+);
 
-/// Input for accepting a Transit Gateway invitation
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct AcceptTgwInvitationInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Invitation ID
-    pub invitation_id: String,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+cloud_tool!(write, create_tgw_attachment, "create_tgw_attachment",
+    "Create a Transit Gateway attachment.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// AWS account ID
+        #[serde(default)]
+        pub aws_account_id: Option<String>,
+        /// Transit Gateway ID
+        #[serde(default)]
+        pub tgw_id: Option<String>,
+        /// CIDR blocks to route through the TGW
+        #[serde(default)]
+        pub cidrs: Option<Vec<String>>,
+    } => |client, input| {
+        let request = TgwAttachmentRequest {
+            aws_account_id: input.aws_account_id,
+            tgw_id: input.tgw_id,
+            cidrs: input.cidrs,
+        };
 
-/// Build the accept_tgw_invitation tool
-pub fn accept_tgw_invitation(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("accept_tgw_invitation")
-        .description("Accept a Transit Gateway resource share invitation.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<AcceptTgwInvitationInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
+        let handler = TransitGatewayHandler::new(client);
+        let result = handler
+            .create_attachment(input.subscription_id, &request)
+            .await
+            .tool_context("Failed to create TGW attachment")?;
 
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
+        CallToolResult::from_serialize(&result)
+    }
+);
 
-                let handler = TransitGatewayHandler::new(client);
-                let result = handler
-                    .accept_resource_share(input.subscription_id, input.invitation_id)
-                    .await
-                    .tool_context("Failed to accept TGW invitation")?;
+cloud_tool!(write, update_tgw_attachment_cidrs, "update_tgw_attachment_cidrs",
+    "Update CIDRs for a Transit Gateway attachment.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// Attachment ID
+        pub attachment_id: String,
+        /// AWS account ID
+        #[serde(default)]
+        pub aws_account_id: Option<String>,
+        /// Transit Gateway ID
+        #[serde(default)]
+        pub tgw_id: Option<String>,
+        /// CIDR blocks to route through the TGW
+        #[serde(default)]
+        pub cidrs: Option<Vec<String>>,
+    } => |client, input| {
+        let request = TgwAttachmentRequest {
+            aws_account_id: input.aws_account_id,
+            tgw_id: input.tgw_id,
+            cidrs: input.cidrs,
+        };
 
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
+        let handler = TransitGatewayHandler::new(client);
+        let result = handler
+            .update_attachment_cidrs(input.subscription_id, input.attachment_id, &request)
+            .await
+            .tool_context("Failed to update TGW attachment CIDRs")?;
 
-/// Input for rejecting a Transit Gateway invitation
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct RejectTgwInvitationInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Invitation ID
-    pub invitation_id: String,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+        CallToolResult::from_serialize(&result)
+    }
+);
 
-/// Build the reject_tgw_invitation tool
-pub fn reject_tgw_invitation(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("reject_tgw_invitation")
-        .description("Reject a Transit Gateway resource share invitation.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<RejectTgwInvitationInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
+cloud_tool!(destructive, delete_tgw_attachment, "delete_tgw_attachment",
+    "DANGEROUS: Delete a Transit Gateway attachment. Causes connectivity loss.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// Attachment ID
+        pub attachment_id: String,
+    } => |client, input| {
+        let handler = TransitGatewayHandler::new(client);
+        let result = handler
+            .delete_attachment(input.subscription_id, input.attachment_id)
+            .await
+            .tool_context("Failed to delete TGW attachment")?;
 
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = TransitGatewayHandler::new(client);
-                let result = handler
-                    .reject_resource_share(input.subscription_id, input.invitation_id)
-                    .await
-                    .tool_context("Failed to reject TGW invitation")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// Input for creating a Transit Gateway attachment
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct CreateTgwAttachmentInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// AWS account ID
-    #[serde(default)]
-    pub aws_account_id: Option<String>,
-    /// Transit Gateway ID
-    #[serde(default)]
-    pub tgw_id: Option<String>,
-    /// CIDR blocks to route through the TGW
-    #[serde(default)]
-    pub cidrs: Option<Vec<String>>,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the create_tgw_attachment tool
-pub fn create_tgw_attachment(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("create_tgw_attachment")
-        .description("Create a Transit Gateway attachment.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<CreateTgwAttachmentInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let request = TgwAttachmentRequest {
-                    aws_account_id: input.aws_account_id,
-                    tgw_id: input.tgw_id,
-                    cidrs: input.cidrs,
-                };
-
-                let handler = TransitGatewayHandler::new(client);
-                let result = handler
-                    .create_attachment(input.subscription_id, &request)
-                    .await
-                    .tool_context("Failed to create TGW attachment")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// Input for updating Transit Gateway attachment CIDRs
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct UpdateTgwAttachmentCidrsInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Attachment ID
-    pub attachment_id: String,
-    /// AWS account ID
-    #[serde(default)]
-    pub aws_account_id: Option<String>,
-    /// Transit Gateway ID
-    #[serde(default)]
-    pub tgw_id: Option<String>,
-    /// CIDR blocks to route through the TGW
-    #[serde(default)]
-    pub cidrs: Option<Vec<String>>,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the update_tgw_attachment_cidrs tool
-pub fn update_tgw_attachment_cidrs(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("update_tgw_attachment_cidrs")
-        .description("Update CIDRs for a Transit Gateway attachment.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<UpdateTgwAttachmentCidrsInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let request = TgwAttachmentRequest {
-                    aws_account_id: input.aws_account_id,
-                    tgw_id: input.tgw_id,
-                    cidrs: input.cidrs,
-                };
-
-                let handler = TransitGatewayHandler::new(client);
-                let result = handler
-                    .update_attachment_cidrs(input.subscription_id, input.attachment_id, &request)
-                    .await
-                    .tool_context("Failed to update TGW attachment CIDRs")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// Input for deleting a Transit Gateway attachment
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct DeleteTgwAttachmentInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Attachment ID
-    pub attachment_id: String,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the delete_tgw_attachment tool
-pub fn delete_tgw_attachment(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("delete_tgw_attachment")
-        .description("DANGEROUS: Delete a Transit Gateway attachment. Causes connectivity loss.")
-        .destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<DeleteTgwAttachmentInput>| async move {
-                if !state.is_destructive_allowed() {
-                    return Err(McpError::tool(
-                        "Destructive operations require policy tier 'full'",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = TransitGatewayHandler::new(client);
-                let result = handler
-                    .delete_attachment(input.subscription_id, input.attachment_id)
-                    .await
-                    .tool_context("Failed to delete TGW attachment")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
+        CallToolResult::from_serialize(&result)
+    }
+);
 
 // ============================================================================
 // Active-Active Transit Gateway tools
 // ============================================================================
 
-/// Input for getting Active-Active Transit Gateway attachments
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetAaTgwAttachmentsInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+cloud_tool!(read_only, get_aa_tgw_attachments, "get_aa_tgw_attachments",
+    "Get Active-Active Transit Gateway attachments.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+    } => |client, input| {
+        let handler = TransitGatewayHandler::new(client);
+        let result = handler
+            .get_attachments_active_active(input.subscription_id)
+            .await
+            .tool_context("Failed to get AA TGW attachments")?;
 
-/// Build the get_aa_tgw_attachments tool
-pub fn get_aa_tgw_attachments(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_aa_tgw_attachments")
-        .description("Get Active-Active Transit Gateway attachments.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetAaTgwAttachmentsInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
+        CallToolResult::from_serialize(&result)
+    }
+);
 
-                let handler = TransitGatewayHandler::new(client);
-                let result = handler
-                    .get_attachments_active_active(input.subscription_id)
-                    .await
-                    .tool_context("Failed to get AA TGW attachments")?;
+cloud_tool!(read_only, get_aa_tgw_invitations, "get_aa_tgw_invitations",
+    "Get Active-Active Transit Gateway shared invitations.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+    } => |client, input| {
+        let handler = TransitGatewayHandler::new(client);
+        let result = handler
+            .get_shared_invitations_active_active(input.subscription_id)
+            .await
+            .tool_context("Failed to get AA TGW invitations")?;
 
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
+        CallToolResult::from_serialize(&result)
+    }
+);
 
-/// Input for getting Active-Active Transit Gateway invitations
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetAaTgwInvitationsInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+cloud_tool!(write, accept_aa_tgw_invitation, "accept_aa_tgw_invitation",
+    "Accept an Active-Active Transit Gateway resource share invitation.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// Region ID
+        pub region_id: i32,
+        /// Invitation ID
+        pub invitation_id: String,
+    } => |client, input| {
+        let handler = TransitGatewayHandler::new(client);
+        let result = handler
+            .accept_resource_share_active_active(
+                input.subscription_id,
+                input.region_id,
+                input.invitation_id,
+            )
+            .await
+            .tool_context("Failed to accept AA TGW invitation")?;
 
-/// Build the get_aa_tgw_invitations tool
-pub fn get_aa_tgw_invitations(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_aa_tgw_invitations")
-        .description("Get Active-Active Transit Gateway shared invitations.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetAaTgwInvitationsInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
+        CallToolResult::from_serialize(&result)
+    }
+);
 
-                let handler = TransitGatewayHandler::new(client);
-                let result = handler
-                    .get_shared_invitations_active_active(input.subscription_id)
-                    .await
-                    .tool_context("Failed to get AA TGW invitations")?;
+cloud_tool!(write, reject_aa_tgw_invitation, "reject_aa_tgw_invitation",
+    "Reject an Active-Active Transit Gateway resource share invitation.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// Region ID
+        pub region_id: i32,
+        /// Invitation ID
+        pub invitation_id: String,
+    } => |client, input| {
+        let handler = TransitGatewayHandler::new(client);
+        let result = handler
+            .reject_resource_share_active_active(
+                input.subscription_id,
+                input.region_id,
+                input.invitation_id,
+            )
+            .await
+            .tool_context("Failed to reject AA TGW invitation")?;
 
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
+        CallToolResult::from_serialize(&result)
+    }
+);
 
-/// Input for accepting an Active-Active Transit Gateway invitation
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct AcceptAaTgwInvitationInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Region ID
-    pub region_id: i32,
-    /// Invitation ID
-    pub invitation_id: String,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+cloud_tool!(write, create_aa_tgw_attachment, "create_aa_tgw_attachment",
+    "Create an Active-Active Transit Gateway attachment.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// Region ID
+        pub region_id: i32,
+        /// AWS account ID
+        #[serde(default)]
+        pub aws_account_id: Option<String>,
+        /// Transit Gateway ID
+        #[serde(default)]
+        pub tgw_id: Option<String>,
+        /// CIDR blocks to route through the TGW
+        #[serde(default)]
+        pub cidrs: Option<Vec<String>>,
+    } => |client, input| {
+        let request = TgwAttachmentRequest {
+            aws_account_id: input.aws_account_id,
+            tgw_id: input.tgw_id,
+            cidrs: input.cidrs,
+        };
 
-/// Build the accept_aa_tgw_invitation tool
-pub fn accept_aa_tgw_invitation(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("accept_aa_tgw_invitation")
-        .description("Accept an Active-Active Transit Gateway resource share invitation.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<AcceptAaTgwInvitationInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
+        let handler = TransitGatewayHandler::new(client);
+        let result = handler
+            .create_attachment_active_active(
+                input.subscription_id,
+                input.region_id,
+                &request,
+            )
+            .await
+            .tool_context("Failed to create AA TGW attachment")?;
 
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
+        CallToolResult::from_serialize(&result)
+    }
+);
 
-                let handler = TransitGatewayHandler::new(client);
-                let result = handler
-                    .accept_resource_share_active_active(
-                        input.subscription_id,
-                        input.region_id,
-                        input.invitation_id,
-                    )
-                    .await
-                    .tool_context("Failed to accept AA TGW invitation")?;
+cloud_tool!(write, update_aa_tgw_attachment_cidrs, "update_aa_tgw_attachment_cidrs",
+    "Update CIDRs for an Active-Active Transit Gateway attachment.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// Region ID
+        pub region_id: i32,
+        /// Attachment ID
+        pub attachment_id: String,
+        /// AWS account ID
+        #[serde(default)]
+        pub aws_account_id: Option<String>,
+        /// Transit Gateway ID
+        #[serde(default)]
+        pub tgw_id: Option<String>,
+        /// CIDR blocks to route through the TGW
+        #[serde(default)]
+        pub cidrs: Option<Vec<String>>,
+    } => |client, input| {
+        let request = TgwAttachmentRequest {
+            aws_account_id: input.aws_account_id,
+            tgw_id: input.tgw_id,
+            cidrs: input.cidrs,
+        };
 
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
+        let handler = TransitGatewayHandler::new(client);
+        let result = handler
+            .update_attachment_cidrs_active_active(
+                input.subscription_id,
+                input.region_id,
+                input.attachment_id,
+                &request,
+            )
+            .await
+            .tool_context("Failed to update AA TGW attachment CIDRs")?;
 
-/// Input for rejecting an Active-Active Transit Gateway invitation
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct RejectAaTgwInvitationInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Region ID
-    pub region_id: i32,
-    /// Invitation ID
-    pub invitation_id: String,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+        CallToolResult::from_serialize(&result)
+    }
+);
 
-/// Build the reject_aa_tgw_invitation tool
-pub fn reject_aa_tgw_invitation(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("reject_aa_tgw_invitation")
-        .description("Reject an Active-Active Transit Gateway resource share invitation.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<RejectAaTgwInvitationInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
+cloud_tool!(destructive, delete_aa_tgw_attachment, "delete_aa_tgw_attachment",
+    "DANGEROUS: Delete an Active-Active Transit Gateway attachment. Causes connectivity loss.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// Region ID
+        pub region_id: i32,
+        /// Attachment ID
+        pub attachment_id: String,
+    } => |client, input| {
+        let handler = TransitGatewayHandler::new(client);
+        let result = handler
+            .delete_attachment_active_active(
+                input.subscription_id,
+                input.region_id,
+                input.attachment_id,
+            )
+            .await
+            .tool_context("Failed to delete AA TGW attachment")?;
 
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = TransitGatewayHandler::new(client);
-                let result = handler
-                    .reject_resource_share_active_active(
-                        input.subscription_id,
-                        input.region_id,
-                        input.invitation_id,
-                    )
-                    .await
-                    .tool_context("Failed to reject AA TGW invitation")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// Input for creating an Active-Active Transit Gateway attachment
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct CreateAaTgwAttachmentInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Region ID
-    pub region_id: i32,
-    /// AWS account ID
-    #[serde(default)]
-    pub aws_account_id: Option<String>,
-    /// Transit Gateway ID
-    #[serde(default)]
-    pub tgw_id: Option<String>,
-    /// CIDR blocks to route through the TGW
-    #[serde(default)]
-    pub cidrs: Option<Vec<String>>,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the create_aa_tgw_attachment tool
-pub fn create_aa_tgw_attachment(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("create_aa_tgw_attachment")
-        .description("Create an Active-Active Transit Gateway attachment.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<CreateAaTgwAttachmentInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let request = TgwAttachmentRequest {
-                    aws_account_id: input.aws_account_id,
-                    tgw_id: input.tgw_id,
-                    cidrs: input.cidrs,
-                };
-
-                let handler = TransitGatewayHandler::new(client);
-                let result = handler
-                    .create_attachment_active_active(
-                        input.subscription_id,
-                        input.region_id,
-                        &request,
-                    )
-                    .await
-                    .tool_context("Failed to create AA TGW attachment")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// Input for updating Active-Active Transit Gateway attachment CIDRs
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct UpdateAaTgwAttachmentCidrsInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Region ID
-    pub region_id: i32,
-    /// Attachment ID
-    pub attachment_id: String,
-    /// AWS account ID
-    #[serde(default)]
-    pub aws_account_id: Option<String>,
-    /// Transit Gateway ID
-    #[serde(default)]
-    pub tgw_id: Option<String>,
-    /// CIDR blocks to route through the TGW
-    #[serde(default)]
-    pub cidrs: Option<Vec<String>>,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the update_aa_tgw_attachment_cidrs tool
-pub fn update_aa_tgw_attachment_cidrs(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("update_aa_tgw_attachment_cidrs")
-        .description("Update CIDRs for an Active-Active Transit Gateway attachment.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<UpdateAaTgwAttachmentCidrsInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let request = TgwAttachmentRequest {
-                    aws_account_id: input.aws_account_id,
-                    tgw_id: input.tgw_id,
-                    cidrs: input.cidrs,
-                };
-
-                let handler = TransitGatewayHandler::new(client);
-                let result = handler
-                    .update_attachment_cidrs_active_active(
-                        input.subscription_id,
-                        input.region_id,
-                        input.attachment_id,
-                        &request,
-                    )
-                    .await
-                    .tool_context("Failed to update AA TGW attachment CIDRs")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// Input for deleting an Active-Active Transit Gateway attachment
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct DeleteAaTgwAttachmentInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Region ID
-    pub region_id: i32,
-    /// Attachment ID
-    pub attachment_id: String,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the delete_aa_tgw_attachment tool
-pub fn delete_aa_tgw_attachment(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("delete_aa_tgw_attachment")
-        .description("DANGEROUS: Delete an Active-Active Transit Gateway attachment. Causes connectivity loss.")
-        .destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<DeleteAaTgwAttachmentInput>| async move {
-                if !state.is_destructive_allowed() {
-                    return Err(McpError::tool(
-                        "Destructive operations require policy tier 'full'",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = TransitGatewayHandler::new(client);
-                let result = handler
-                    .delete_attachment_active_active(
-                        input.subscription_id,
-                        input.region_id,
-                        input.attachment_id,
-                    )
-                    .await
-                    .tool_context("Failed to delete AA TGW attachment")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
+        CallToolResult::from_serialize(&result)
+    }
+);
 
 // ============================================================================
 // Private Service Connect (PSC) tools
 // ============================================================================
 
-/// Input for getting PSC service
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetPscServiceInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+cloud_tool!(read_only, get_psc_service, "get_psc_service",
+    "Get Private Service Connect (PSC) service.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+    } => |client, input| {
+        let handler = PscHandler::new(client);
+        let result = handler
+            .get_service(input.subscription_id)
+            .await
+            .tool_context("Failed to get PSC service")?;
 
-/// Build the get_psc_service tool
-pub fn get_psc_service(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_psc_service")
-        .description("Get Private Service Connect (PSC) service.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<GetPscServiceInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
+        CallToolResult::from_serialize(&result)
+    }
+);
 
-                let handler = PscHandler::new(client);
-                let result = handler
-                    .get_service(input.subscription_id)
-                    .await
-                    .tool_context("Failed to get PSC service")?;
+cloud_tool!(write, create_psc_service, "create_psc_service",
+    "Create a Private Service Connect (PSC) service.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+    } => |client, input| {
+        let handler = PscHandler::new(client);
+        let result = handler
+            .create_service(input.subscription_id)
+            .await
+            .tool_context("Failed to create PSC service")?;
 
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
+        CallToolResult::from_serialize(&result)
+    }
+);
 
-/// Input for creating PSC service
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct CreatePscServiceInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+cloud_tool!(destructive, delete_psc_service, "delete_psc_service",
+    "DANGEROUS: Delete a PSC service. Disconnects all endpoints.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+    } => |client, input| {
+        let handler = PscHandler::new(client);
+        let result = handler
+            .delete_service(input.subscription_id)
+            .await
+            .tool_context("Failed to delete PSC service")?;
 
-/// Build the create_psc_service tool
-pub fn create_psc_service(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("create_psc_service")
-        .description("Create a Private Service Connect (PSC) service.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<CreatePscServiceInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
+        CallToolResult::from_serialize(&result)
+    }
+);
 
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
+cloud_tool!(read_only, get_psc_endpoints, "get_psc_endpoints",
+    "Get Private Service Connect (PSC) endpoints.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+    } => |client, input| {
+        let handler = PscHandler::new(client);
+        let result = handler
+            .get_endpoints(input.subscription_id)
+            .await
+            .tool_context("Failed to get PSC endpoints")?;
 
-                let handler = PscHandler::new(client);
-                let result = handler
-                    .create_service(input.subscription_id)
-                    .await
-                    .tool_context("Failed to create PSC service")?;
+        CallToolResult::from_serialize(&result)
+    }
+);
 
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
+cloud_tool!(write, create_psc_endpoint, "create_psc_endpoint",
+    "Create a Private Service Connect (PSC) endpoint.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// PSC service ID (used internally by the request)
+        pub psc_service_id: i32,
+        /// Endpoint ID (used internally by the request)
+        pub endpoint_id: i32,
+        /// Google Cloud project ID
+        #[serde(default)]
+        pub gcp_project_id: Option<String>,
+        /// Name of the Google Cloud VPC that hosts your application
+        #[serde(default)]
+        pub gcp_vpc_name: Option<String>,
+        /// Name of your VPC's subnet of IP address ranges
+        #[serde(default)]
+        pub gcp_vpc_subnet_name: Option<String>,
+        /// Prefix used to create PSC endpoints in the consumer application VPC
+        #[serde(default)]
+        pub endpoint_connection_name: Option<String>,
+    } => |client, input| {
+        let request = PscEndpointUpdateRequest {
+            subscription_id: input.subscription_id,
+            psc_service_id: input.psc_service_id,
+            endpoint_id: input.endpoint_id,
+            gcp_project_id: input.gcp_project_id,
+            gcp_vpc_name: input.gcp_vpc_name,
+            gcp_vpc_subnet_name: input.gcp_vpc_subnet_name,
+            endpoint_connection_name: input.endpoint_connection_name,
+        };
 
-/// Input for deleting PSC service
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct DeletePscServiceInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+        let handler = PscHandler::new(client);
+        let result = handler
+            .create_endpoint(input.subscription_id, &request)
+            .await
+            .tool_context("Failed to create PSC endpoint")?;
 
-/// Build the delete_psc_service tool
-pub fn delete_psc_service(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("delete_psc_service")
-        .description("DANGEROUS: Delete a PSC service. Disconnects all endpoints.")
-        .destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<DeletePscServiceInput>| async move {
-                if !state.is_destructive_allowed() {
-                    return Err(McpError::tool(
-                        "Destructive operations require policy tier 'full'",
-                    ));
-                }
+        CallToolResult::from_serialize(&result)
+    }
+);
 
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
+cloud_tool!(write, update_psc_endpoint, "update_psc_endpoint",
+    "Update a Private Service Connect (PSC) endpoint.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// Endpoint ID
+        pub endpoint_id: i32,
+        /// PSC service ID
+        pub psc_service_id: i32,
+        /// Google Cloud project ID
+        #[serde(default)]
+        pub gcp_project_id: Option<String>,
+        /// Name of the Google Cloud VPC that hosts your application
+        #[serde(default)]
+        pub gcp_vpc_name: Option<String>,
+        /// Name of your VPC's subnet of IP address ranges
+        #[serde(default)]
+        pub gcp_vpc_subnet_name: Option<String>,
+        /// Prefix used to create PSC endpoints in the consumer application VPC
+        #[serde(default)]
+        pub endpoint_connection_name: Option<String>,
+    } => |client, input| {
+        let request = PscEndpointUpdateRequest {
+            subscription_id: input.subscription_id,
+            psc_service_id: input.psc_service_id,
+            endpoint_id: input.endpoint_id,
+            gcp_project_id: input.gcp_project_id,
+            gcp_vpc_name: input.gcp_vpc_name,
+            gcp_vpc_subnet_name: input.gcp_vpc_subnet_name,
+            endpoint_connection_name: input.endpoint_connection_name,
+        };
 
-                let handler = PscHandler::new(client);
-                let result = handler
-                    .delete_service(input.subscription_id)
-                    .await
-                    .tool_context("Failed to delete PSC service")?;
+        let handler = PscHandler::new(client);
+        let result = handler
+            .update_endpoint(input.subscription_id, input.endpoint_id, &request)
+            .await
+            .tool_context("Failed to update PSC endpoint")?;
 
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
+        CallToolResult::from_serialize(&result)
+    }
+);
 
-/// Input for getting PSC endpoints
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetPscEndpointsInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+cloud_tool!(destructive, delete_psc_endpoint, "delete_psc_endpoint",
+    "DANGEROUS: Delete a PSC endpoint. Causes connectivity loss.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// Endpoint ID
+        pub endpoint_id: i32,
+    } => |client, input| {
+        let handler = PscHandler::new(client);
+        let result = handler
+            .delete_endpoint(input.subscription_id, input.endpoint_id)
+            .await
+            .tool_context("Failed to delete PSC endpoint")?;
 
-/// Build the get_psc_endpoints tool
-pub fn get_psc_endpoints(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_psc_endpoints")
-        .description("Get Private Service Connect (PSC) endpoints.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetPscEndpointsInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
+        CallToolResult::from_serialize(&result)
+    }
+);
 
-                let handler = PscHandler::new(client);
-                let result = handler
-                    .get_endpoints(input.subscription_id)
-                    .await
-                    .tool_context("Failed to get PSC endpoints")?;
+cloud_tool!(read_only, get_psc_creation_script, "get_psc_creation_script",
+    "Get the creation script for a PSC endpoint.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// Endpoint ID
+        pub endpoint_id: i32,
+    } => |client, input| {
+        let handler = PscHandler::new(client);
+        let result = handler
+            .get_endpoint_creation_script(input.subscription_id, input.endpoint_id)
+            .await
+            .tool_context("Failed to get PSC creation script")?;
 
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
+        Ok(CallToolResult::text(result))
+    }
+);
 
-/// Input for creating a PSC endpoint
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct CreatePscEndpointInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// PSC service ID (used internally by the request)
-    pub psc_service_id: i32,
-    /// Endpoint ID (used internally by the request)
-    pub endpoint_id: i32,
-    /// Google Cloud project ID
-    #[serde(default)]
-    pub gcp_project_id: Option<String>,
-    /// Name of the Google Cloud VPC that hosts your application
-    #[serde(default)]
-    pub gcp_vpc_name: Option<String>,
-    /// Name of your VPC's subnet of IP address ranges
-    #[serde(default)]
-    pub gcp_vpc_subnet_name: Option<String>,
-    /// Prefix used to create PSC endpoints in the consumer application VPC
-    #[serde(default)]
-    pub endpoint_connection_name: Option<String>,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+cloud_tool!(read_only, get_psc_deletion_script, "get_psc_deletion_script",
+    "Get the deletion script for a PSC endpoint.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// Endpoint ID
+        pub endpoint_id: i32,
+    } => |client, input| {
+        let handler = PscHandler::new(client);
+        let result = handler
+            .get_endpoint_deletion_script(input.subscription_id, input.endpoint_id)
+            .await
+            .tool_context("Failed to get PSC deletion script")?;
 
-/// Build the create_psc_endpoint tool
-pub fn create_psc_endpoint(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("create_psc_endpoint")
-        .description("Create a Private Service Connect (PSC) endpoint.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<CreatePscEndpointInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let request = PscEndpointUpdateRequest {
-                    subscription_id: input.subscription_id,
-                    psc_service_id: input.psc_service_id,
-                    endpoint_id: input.endpoint_id,
-                    gcp_project_id: input.gcp_project_id,
-                    gcp_vpc_name: input.gcp_vpc_name,
-                    gcp_vpc_subnet_name: input.gcp_vpc_subnet_name,
-                    endpoint_connection_name: input.endpoint_connection_name,
-                };
-
-                let handler = PscHandler::new(client);
-                let result = handler
-                    .create_endpoint(input.subscription_id, &request)
-                    .await
-                    .tool_context("Failed to create PSC endpoint")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// Input for updating a PSC endpoint
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct UpdatePscEndpointInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Endpoint ID
-    pub endpoint_id: i32,
-    /// PSC service ID
-    pub psc_service_id: i32,
-    /// Google Cloud project ID
-    #[serde(default)]
-    pub gcp_project_id: Option<String>,
-    /// Name of the Google Cloud VPC that hosts your application
-    #[serde(default)]
-    pub gcp_vpc_name: Option<String>,
-    /// Name of your VPC's subnet of IP address ranges
-    #[serde(default)]
-    pub gcp_vpc_subnet_name: Option<String>,
-    /// Prefix used to create PSC endpoints in the consumer application VPC
-    #[serde(default)]
-    pub endpoint_connection_name: Option<String>,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the update_psc_endpoint tool
-pub fn update_psc_endpoint(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("update_psc_endpoint")
-        .description("Update a Private Service Connect (PSC) endpoint.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<UpdatePscEndpointInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let request = PscEndpointUpdateRequest {
-                    subscription_id: input.subscription_id,
-                    psc_service_id: input.psc_service_id,
-                    endpoint_id: input.endpoint_id,
-                    gcp_project_id: input.gcp_project_id,
-                    gcp_vpc_name: input.gcp_vpc_name,
-                    gcp_vpc_subnet_name: input.gcp_vpc_subnet_name,
-                    endpoint_connection_name: input.endpoint_connection_name,
-                };
-
-                let handler = PscHandler::new(client);
-                let result = handler
-                    .update_endpoint(input.subscription_id, input.endpoint_id, &request)
-                    .await
-                    .tool_context("Failed to update PSC endpoint")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// Input for deleting a PSC endpoint
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct DeletePscEndpointInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Endpoint ID
-    pub endpoint_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the delete_psc_endpoint tool
-pub fn delete_psc_endpoint(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("delete_psc_endpoint")
-        .description("DANGEROUS: Delete a PSC endpoint. Causes connectivity loss.")
-        .destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<DeletePscEndpointInput>| async move {
-                if !state.is_destructive_allowed() {
-                    return Err(McpError::tool(
-                        "Destructive operations require policy tier 'full'",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = PscHandler::new(client);
-                let result = handler
-                    .delete_endpoint(input.subscription_id, input.endpoint_id)
-                    .await
-                    .tool_context("Failed to delete PSC endpoint")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// Input for getting PSC creation script
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetPscCreationScriptInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Endpoint ID
-    pub endpoint_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the get_psc_creation_script tool
-pub fn get_psc_creation_script(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_psc_creation_script")
-        .description("Get the creation script for a PSC endpoint.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetPscCreationScriptInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = PscHandler::new(client);
-                let result = handler
-                    .get_endpoint_creation_script(input.subscription_id, input.endpoint_id)
-                    .await
-                    .tool_context("Failed to get PSC creation script")?;
-
-                Ok(CallToolResult::text(result))
-            },
-        )
-        .build()
-}
-
-/// Input for getting PSC deletion script
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetPscDeletionScriptInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Endpoint ID
-    pub endpoint_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the get_psc_deletion_script tool
-pub fn get_psc_deletion_script(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_psc_deletion_script")
-        .description("Get the deletion script for a PSC endpoint.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetPscDeletionScriptInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = PscHandler::new(client);
-                let result = handler
-                    .get_endpoint_deletion_script(input.subscription_id, input.endpoint_id)
-                    .await
-                    .tool_context("Failed to get PSC deletion script")?;
-
-                Ok(CallToolResult::text(result))
-            },
-        )
-        .build()
-}
+        Ok(CallToolResult::text(result))
+    }
+);
 
 // ============================================================================
 // Active-Active PSC tools
 // ============================================================================
 
-/// Input for getting Active-Active PSC service
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetAaPscServiceInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+cloud_tool!(read_only, get_aa_psc_service, "get_aa_psc_service",
+    "Get Active-Active PSC service.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+    } => |client, input| {
+        let handler = PscHandler::new(client);
+        let result = handler
+            .get_service_active_active(input.subscription_id)
+            .await
+            .tool_context("Failed to get AA PSC service")?;
 
-/// Build the get_aa_psc_service tool
-pub fn get_aa_psc_service(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_aa_psc_service")
-        .description("Get Active-Active PSC service.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetAaPscServiceInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
+        CallToolResult::from_serialize(&result)
+    }
+);
 
-                let handler = PscHandler::new(client);
-                let result = handler
-                    .get_service_active_active(input.subscription_id)
-                    .await
-                    .tool_context("Failed to get AA PSC service")?;
+cloud_tool!(write, create_aa_psc_service, "create_aa_psc_service",
+    "Create an Active-Active PSC service.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+    } => |client, input| {
+        let handler = PscHandler::new(client);
+        let result = handler
+            .create_service_active_active(input.subscription_id)
+            .await
+            .tool_context("Failed to create AA PSC service")?;
 
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
+        CallToolResult::from_serialize(&result)
+    }
+);
 
-/// Input for creating Active-Active PSC service
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct CreateAaPscServiceInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+cloud_tool!(destructive, delete_aa_psc_service, "delete_aa_psc_service",
+    "DANGEROUS: Delete an Active-Active PSC service. Disconnects all endpoints.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+    } => |client, input| {
+        let handler = PscHandler::new(client);
+        let result = handler
+            .delete_service_active_active(input.subscription_id)
+            .await
+            .tool_context("Failed to delete AA PSC service")?;
 
-/// Build the create_aa_psc_service tool
-pub fn create_aa_psc_service(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("create_aa_psc_service")
-        .description("Create an Active-Active PSC service.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<CreateAaPscServiceInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
+        CallToolResult::from_serialize(&result)
+    }
+);
 
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
+cloud_tool!(read_only, get_aa_psc_endpoints, "get_aa_psc_endpoints",
+    "Get Active-Active PSC endpoints.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+    } => |client, input| {
+        let handler = PscHandler::new(client);
+        let result = handler
+            .get_endpoints_active_active(input.subscription_id)
+            .await
+            .tool_context("Failed to get AA PSC endpoints")?;
 
-                let handler = PscHandler::new(client);
-                let result = handler
-                    .create_service_active_active(input.subscription_id)
-                    .await
-                    .tool_context("Failed to create AA PSC service")?;
+        CallToolResult::from_serialize(&result)
+    }
+);
 
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
+cloud_tool!(write, create_aa_psc_endpoint, "create_aa_psc_endpoint",
+    "Create an Active-Active PSC endpoint.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// PSC service ID
+        pub psc_service_id: i32,
+        /// Endpoint ID
+        pub endpoint_id: i32,
+        /// Google Cloud project ID
+        #[serde(default)]
+        pub gcp_project_id: Option<String>,
+        /// Name of the Google Cloud VPC that hosts your application
+        #[serde(default)]
+        pub gcp_vpc_name: Option<String>,
+        /// Name of your VPC's subnet of IP address ranges
+        #[serde(default)]
+        pub gcp_vpc_subnet_name: Option<String>,
+        /// Prefix used to create PSC endpoints in the consumer application VPC
+        #[serde(default)]
+        pub endpoint_connection_name: Option<String>,
+    } => |client, input| {
+        let request = PscEndpointUpdateRequest {
+            subscription_id: input.subscription_id,
+            psc_service_id: input.psc_service_id,
+            endpoint_id: input.endpoint_id,
+            gcp_project_id: input.gcp_project_id,
+            gcp_vpc_name: input.gcp_vpc_name,
+            gcp_vpc_subnet_name: input.gcp_vpc_subnet_name,
+            endpoint_connection_name: input.endpoint_connection_name,
+        };
 
-/// Input for deleting Active-Active PSC service
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct DeleteAaPscServiceInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+        let handler = PscHandler::new(client);
+        let result = handler
+            .create_endpoint_active_active(input.subscription_id, &request)
+            .await
+            .tool_context("Failed to create AA PSC endpoint")?;
 
-/// Build the delete_aa_psc_service tool
-pub fn delete_aa_psc_service(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("delete_aa_psc_service")
-        .description("DANGEROUS: Delete an Active-Active PSC service. Disconnects all endpoints.")
-        .destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<DeleteAaPscServiceInput>| async move {
-                if !state.is_destructive_allowed() {
-                    return Err(McpError::tool(
-                        "Destructive operations require policy tier 'full'",
-                    ));
-                }
+        CallToolResult::from_serialize(&result)
+    }
+);
 
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
+cloud_tool!(write, update_aa_psc_endpoint, "update_aa_psc_endpoint",
+    "Update an Active-Active PSC endpoint.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// Region ID
+        pub region_id: i32,
+        /// Endpoint ID
+        pub endpoint_id: i32,
+        /// PSC service ID
+        pub psc_service_id: i32,
+        /// Google Cloud project ID
+        #[serde(default)]
+        pub gcp_project_id: Option<String>,
+        /// Name of the Google Cloud VPC that hosts your application
+        #[serde(default)]
+        pub gcp_vpc_name: Option<String>,
+        /// Name of your VPC's subnet of IP address ranges
+        #[serde(default)]
+        pub gcp_vpc_subnet_name: Option<String>,
+        /// Prefix used to create PSC endpoints in the consumer application VPC
+        #[serde(default)]
+        pub endpoint_connection_name: Option<String>,
+    } => |client, input| {
+        let request = PscEndpointUpdateRequest {
+            subscription_id: input.subscription_id,
+            psc_service_id: input.psc_service_id,
+            endpoint_id: input.endpoint_id,
+            gcp_project_id: input.gcp_project_id,
+            gcp_vpc_name: input.gcp_vpc_name,
+            gcp_vpc_subnet_name: input.gcp_vpc_subnet_name,
+            endpoint_connection_name: input.endpoint_connection_name,
+        };
 
-                let handler = PscHandler::new(client);
-                let result = handler
-                    .delete_service_active_active(input.subscription_id)
-                    .await
-                    .tool_context("Failed to delete AA PSC service")?;
+        let handler = PscHandler::new(client);
+        let result = handler
+            .update_endpoint_active_active(
+                input.subscription_id,
+                input.region_id,
+                input.endpoint_id,
+                &request,
+            )
+            .await
+            .tool_context("Failed to update AA PSC endpoint")?;
 
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
+        CallToolResult::from_serialize(&result)
+    }
+);
 
-/// Input for getting Active-Active PSC endpoints
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetAaPscEndpointsInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+cloud_tool!(destructive, delete_aa_psc_endpoint, "delete_aa_psc_endpoint",
+    "DANGEROUS: Delete an Active-Active PSC endpoint. Causes connectivity loss.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// Region ID
+        pub region_id: i32,
+        /// Endpoint ID
+        pub endpoint_id: i32,
+    } => |client, input| {
+        let handler = PscHandler::new(client);
+        let result = handler
+            .delete_endpoint_active_active(
+                input.subscription_id,
+                input.region_id,
+                input.endpoint_id,
+            )
+            .await
+            .tool_context("Failed to delete AA PSC endpoint")?;
 
-/// Build the get_aa_psc_endpoints tool
-pub fn get_aa_psc_endpoints(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_aa_psc_endpoints")
-        .description("Get Active-Active PSC endpoints.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetAaPscEndpointsInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
+        CallToolResult::from_serialize(&result)
+    }
+);
 
-                let handler = PscHandler::new(client);
-                let result = handler
-                    .get_endpoints_active_active(input.subscription_id)
-                    .await
-                    .tool_context("Failed to get AA PSC endpoints")?;
+cloud_tool!(read_only, get_aa_psc_creation_script, "get_aa_psc_creation_script",
+    "Get the creation script for an Active-Active PSC endpoint.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// Region ID
+        pub region_id: i32,
+        /// PSC service ID
+        pub psc_service_id: i32,
+        /// Endpoint ID
+        pub endpoint_id: i32,
+    } => |client, input| {
+        let handler = PscHandler::new(client);
+        let result = handler
+            .get_endpoint_creation_script_active_active(
+                input.subscription_id,
+                input.region_id,
+                input.psc_service_id,
+                input.endpoint_id,
+            )
+            .await
+            .tool_context("Failed to get AA PSC creation script")?;
 
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
+        Ok(CallToolResult::text(result))
+    }
+);
 
-/// Input for creating an Active-Active PSC endpoint
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct CreateAaPscEndpointInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// PSC service ID
-    pub psc_service_id: i32,
-    /// Endpoint ID
-    pub endpoint_id: i32,
-    /// Google Cloud project ID
-    #[serde(default)]
-    pub gcp_project_id: Option<String>,
-    /// Name of the Google Cloud VPC that hosts your application
-    #[serde(default)]
-    pub gcp_vpc_name: Option<String>,
-    /// Name of your VPC's subnet of IP address ranges
-    #[serde(default)]
-    pub gcp_vpc_subnet_name: Option<String>,
-    /// Prefix used to create PSC endpoints in the consumer application VPC
-    #[serde(default)]
-    pub endpoint_connection_name: Option<String>,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+cloud_tool!(read_only, get_aa_psc_deletion_script, "get_aa_psc_deletion_script",
+    "Get the deletion script for an Active-Active PSC endpoint.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// Region ID
+        pub region_id: i32,
+        /// PSC service ID
+        pub psc_service_id: i32,
+        /// Endpoint ID
+        pub endpoint_id: i32,
+    } => |client, input| {
+        let handler = PscHandler::new(client);
+        let result = handler
+            .get_endpoint_deletion_script_active_active(
+                input.subscription_id,
+                input.region_id,
+                input.psc_service_id,
+                input.endpoint_id,
+            )
+            .await
+            .tool_context("Failed to get AA PSC deletion script")?;
 
-/// Build the create_aa_psc_endpoint tool
-pub fn create_aa_psc_endpoint(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("create_aa_psc_endpoint")
-        .description("Create an Active-Active PSC endpoint.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<CreateAaPscEndpointInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let request = PscEndpointUpdateRequest {
-                    subscription_id: input.subscription_id,
-                    psc_service_id: input.psc_service_id,
-                    endpoint_id: input.endpoint_id,
-                    gcp_project_id: input.gcp_project_id,
-                    gcp_vpc_name: input.gcp_vpc_name,
-                    gcp_vpc_subnet_name: input.gcp_vpc_subnet_name,
-                    endpoint_connection_name: input.endpoint_connection_name,
-                };
-
-                let handler = PscHandler::new(client);
-                let result = handler
-                    .create_endpoint_active_active(input.subscription_id, &request)
-                    .await
-                    .tool_context("Failed to create AA PSC endpoint")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// Input for updating an Active-Active PSC endpoint
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct UpdateAaPscEndpointInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Region ID
-    pub region_id: i32,
-    /// Endpoint ID
-    pub endpoint_id: i32,
-    /// PSC service ID
-    pub psc_service_id: i32,
-    /// Google Cloud project ID
-    #[serde(default)]
-    pub gcp_project_id: Option<String>,
-    /// Name of the Google Cloud VPC that hosts your application
-    #[serde(default)]
-    pub gcp_vpc_name: Option<String>,
-    /// Name of your VPC's subnet of IP address ranges
-    #[serde(default)]
-    pub gcp_vpc_subnet_name: Option<String>,
-    /// Prefix used to create PSC endpoints in the consumer application VPC
-    #[serde(default)]
-    pub endpoint_connection_name: Option<String>,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the update_aa_psc_endpoint tool
-pub fn update_aa_psc_endpoint(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("update_aa_psc_endpoint")
-        .description("Update an Active-Active PSC endpoint.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<UpdateAaPscEndpointInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let request = PscEndpointUpdateRequest {
-                    subscription_id: input.subscription_id,
-                    psc_service_id: input.psc_service_id,
-                    endpoint_id: input.endpoint_id,
-                    gcp_project_id: input.gcp_project_id,
-                    gcp_vpc_name: input.gcp_vpc_name,
-                    gcp_vpc_subnet_name: input.gcp_vpc_subnet_name,
-                    endpoint_connection_name: input.endpoint_connection_name,
-                };
-
-                let handler = PscHandler::new(client);
-                let result = handler
-                    .update_endpoint_active_active(
-                        input.subscription_id,
-                        input.region_id,
-                        input.endpoint_id,
-                        &request,
-                    )
-                    .await
-                    .tool_context("Failed to update AA PSC endpoint")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// Input for deleting an Active-Active PSC endpoint
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct DeleteAaPscEndpointInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Region ID
-    pub region_id: i32,
-    /// Endpoint ID
-    pub endpoint_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the delete_aa_psc_endpoint tool
-pub fn delete_aa_psc_endpoint(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("delete_aa_psc_endpoint")
-        .description("DANGEROUS: Delete an Active-Active PSC endpoint. Causes connectivity loss.")
-        .destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<DeleteAaPscEndpointInput>| async move {
-                if !state.is_destructive_allowed() {
-                    return Err(McpError::tool(
-                        "Destructive operations require policy tier 'full'",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = PscHandler::new(client);
-                let result = handler
-                    .delete_endpoint_active_active(
-                        input.subscription_id,
-                        input.region_id,
-                        input.endpoint_id,
-                    )
-                    .await
-                    .tool_context("Failed to delete AA PSC endpoint")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// Input for getting Active-Active PSC creation script
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetAaPscCreationScriptInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Region ID
-    pub region_id: i32,
-    /// PSC service ID
-    pub psc_service_id: i32,
-    /// Endpoint ID
-    pub endpoint_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the get_aa_psc_creation_script tool
-pub fn get_aa_psc_creation_script(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_aa_psc_creation_script")
-        .description("Get the creation script for an Active-Active PSC endpoint.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetAaPscCreationScriptInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = PscHandler::new(client);
-                let result = handler
-                    .get_endpoint_creation_script_active_active(
-                        input.subscription_id,
-                        input.region_id,
-                        input.psc_service_id,
-                        input.endpoint_id,
-                    )
-                    .await
-                    .tool_context("Failed to get AA PSC creation script")?;
-
-                Ok(CallToolResult::text(result))
-            },
-        )
-        .build()
-}
-
-/// Input for getting Active-Active PSC deletion script
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetAaPscDeletionScriptInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Region ID
-    pub region_id: i32,
-    /// PSC service ID
-    pub psc_service_id: i32,
-    /// Endpoint ID
-    pub endpoint_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the get_aa_psc_deletion_script tool
-pub fn get_aa_psc_deletion_script(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_aa_psc_deletion_script")
-        .description("Get the deletion script for an Active-Active PSC endpoint.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetAaPscDeletionScriptInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = PscHandler::new(client);
-                let result = handler
-                    .get_endpoint_deletion_script_active_active(
-                        input.subscription_id,
-                        input.region_id,
-                        input.psc_service_id,
-                        input.endpoint_id,
-                    )
-                    .await
-                    .tool_context("Failed to get AA PSC deletion script")?;
-
-                Ok(CallToolResult::text(result))
-            },
-        )
-        .build()
-}
+        Ok(CallToolResult::text(result))
+    }
+);
 
 // ============================================================================
 // PrivateLink tools
 // ============================================================================
-
-/// Input for getting PrivateLink configuration
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetPrivateLinkInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the get_private_link tool
-pub fn get_private_link(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_private_link")
-        .description("Get AWS PrivateLink configuration.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetPrivateLinkInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = PrivateLinkHandler::new(client);
-                let result = handler
-                    .get(input.subscription_id)
-                    .await
-                    .tool_context("Failed to get PrivateLink")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// Input for creating a PrivateLink
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct CreatePrivateLinkInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Share name for the PrivateLink service (max 64 characters)
-    pub share_name: String,
-    /// AWS principal (account ID, role ARN, etc.)
-    pub principal: String,
-    /// Principal type: aws_account, organization, organization_unit, iam_role, iam_user, service_principal
-    pub principal_type: String,
-    /// Optional alias for the PrivateLink
-    #[serde(default)]
-    pub alias: Option<String>,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
 
 fn parse_principal_type(s: &str) -> Result<PrincipalType, ToolError> {
     match s.to_lowercase().as_str() {
@@ -2118,636 +1156,310 @@ fn parse_principal_type(s: &str) -> Result<PrincipalType, ToolError> {
     }
 }
 
-/// Build the create_private_link tool
-pub fn create_private_link(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("create_private_link")
-        .description("Create an AWS PrivateLink configuration.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<CreatePrivateLinkInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
+cloud_tool!(read_only, get_private_link, "get_private_link",
+    "Get AWS PrivateLink configuration.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+    } => |client, input| {
+        let handler = PrivateLinkHandler::new(client);
+        let result = handler
+            .get(input.subscription_id)
+            .await
+            .tool_context("Failed to get PrivateLink")?;
 
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
+        CallToolResult::from_serialize(&result)
+    }
+);
 
-                let principal_type = parse_principal_type(&input.principal_type)?;
+cloud_tool!(write, create_private_link, "create_private_link",
+    "Create an AWS PrivateLink configuration.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// Share name for the PrivateLink service (max 64 characters)
+        pub share_name: String,
+        /// AWS principal (account ID, role ARN, etc.)
+        pub principal: String,
+        /// Principal type: aws_account, organization, organization_unit, iam_role, iam_user, service_principal
+        pub principal_type: String,
+        /// Optional alias for the PrivateLink
+        #[serde(default)]
+        pub alias: Option<String>,
+    } => |client, input| {
+        let principal_type = parse_principal_type(&input.principal_type)?;
 
-                let request = PrivateLinkCreateRequest {
-                    share_name: input.share_name,
-                    principal: input.principal,
-                    principal_type,
-                    alias: input.alias,
-                };
+        let request = PrivateLinkCreateRequest {
+            share_name: input.share_name,
+            principal: input.principal,
+            principal_type,
+            alias: input.alias,
+        };
 
-                let handler = PrivateLinkHandler::new(client);
-                let result = handler
-                    .create(input.subscription_id, &request)
-                    .await
-                    .tool_context("Failed to create PrivateLink")?;
+        let handler = PrivateLinkHandler::new(client);
+        let result = handler
+            .create(input.subscription_id, &request)
+            .await
+            .tool_context("Failed to create PrivateLink")?;
 
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
+        CallToolResult::from_serialize(&result)
+    }
+);
 
-/// Input for deleting a PrivateLink
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct DeletePrivateLinkInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+cloud_tool!(destructive, delete_private_link, "delete_private_link",
+    "DANGEROUS: Delete an AWS PrivateLink configuration. Causes connectivity loss.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+    } => |client, input| {
+        let handler = PrivateLinkHandler::new(client);
+        let result = handler
+            .delete(input.subscription_id)
+            .await
+            .tool_context("Failed to delete PrivateLink")?;
 
-/// Build the delete_private_link tool
-pub fn delete_private_link(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("delete_private_link")
-        .description("DANGEROUS: Delete an AWS PrivateLink configuration. Causes connectivity loss.")
-        .destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<DeletePrivateLinkInput>| async move {
-                if !state.is_destructive_allowed() {
-                    return Err(McpError::tool(
-                        "Destructive operations require policy tier 'full'",
-                    ));
-                }
+        CallToolResult::from_serialize(&result)
+    }
+);
 
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
+cloud_tool!(write, add_private_link_principals, "add_private_link_principals",
+    "Add AWS principals to a PrivateLink access list.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// AWS principal (account ID, role ARN, etc.)
+        pub principal: String,
+        /// Principal type: aws_account, organization, organization_unit, iam_role, iam_user, service_principal
+        #[serde(default)]
+        pub principal_type: Option<String>,
+        /// Optional alias for the principal
+        #[serde(default)]
+        pub alias: Option<String>,
+    } => |client, input| {
+        let principal_type = input
+            .principal_type
+            .map(|pt| parse_principal_type(&pt))
+            .transpose()?;
 
-                let handler = PrivateLinkHandler::new(client);
-                let result = handler
-                    .delete(input.subscription_id)
-                    .await
-                    .tool_context("Failed to delete PrivateLink")?;
+        let request = PrivateLinkAddPrincipalRequest {
+            principal: input.principal,
+            principal_type,
+            alias: input.alias,
+        };
 
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
+        let handler = PrivateLinkHandler::new(client);
+        let result = handler
+            .add_principals(input.subscription_id, &request)
+            .await
+            .tool_context("Failed to add PrivateLink principals")?;
 
-/// Input for adding principals to PrivateLink
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct AddPrivateLinkPrincipalsInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// AWS principal (account ID, role ARN, etc.)
-    pub principal: String,
-    /// Principal type: aws_account, organization, organization_unit, iam_role, iam_user, service_principal
-    #[serde(default)]
-    pub principal_type: Option<String>,
-    /// Optional alias for the principal
-    #[serde(default)]
-    pub alias: Option<String>,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+        CallToolResult::from_serialize(&result)
+    }
+);
 
-/// Build the add_private_link_principals tool
-pub fn add_private_link_principals(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("add_private_link_principals")
-        .description("Add AWS principals to a PrivateLink access list.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<AddPrivateLinkPrincipalsInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
+cloud_tool!(write, remove_private_link_principals, "remove_private_link_principals",
+    "Remove AWS principals from a PrivateLink access list.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// AWS principal (account ID, role ARN, etc.) to remove
+        pub principal: String,
+        /// Principal type: aws_account, organization, organization_unit, iam_role, iam_user, service_principal
+        #[serde(default)]
+        pub principal_type: Option<String>,
+        /// Alias of the principal
+        #[serde(default)]
+        pub alias: Option<String>,
+    } => |client, input| {
+        let principal_type = input
+            .principal_type
+            .map(|pt| parse_principal_type(&pt))
+            .transpose()?;
 
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
+        let request =
+            redis_cloud::connectivity::private_link::PrivateLinkRemovePrincipalRequest {
+                principal: input.principal,
+                principal_type,
+                alias: input.alias,
+            };
 
-                let principal_type = input
-                    .principal_type
-                    .map(|pt| parse_principal_type(&pt))
-                    .transpose()?;
+        let handler = PrivateLinkHandler::new(client);
+        let result = handler
+            .remove_principals(input.subscription_id, &request)
+            .await
+            .tool_context("Failed to remove PrivateLink principals")?;
 
-                let request = PrivateLinkAddPrincipalRequest {
-                    principal: input.principal,
-                    principal_type,
-                    alias: input.alias,
-                };
+        CallToolResult::from_serialize(&result)
+    }
+);
 
-                let handler = PrivateLinkHandler::new(client);
-                let result = handler
-                    .add_principals(input.subscription_id, &request)
-                    .await
-                    .tool_context("Failed to add PrivateLink principals")?;
+cloud_tool!(read_only, get_private_link_endpoint_script, "get_private_link_endpoint_script",
+    "Get the endpoint creation script for an AWS PrivateLink.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+    } => |client, input| {
+        let handler = PrivateLinkHandler::new(client);
+        let result = handler
+            .get_endpoint_script(input.subscription_id)
+            .await
+            .tool_context("Failed to get PrivateLink endpoint script")?;
 
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// Input for removing principals from PrivateLink
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct RemovePrivateLinkPrincipalsInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// AWS principal (account ID, role ARN, etc.) to remove
-    pub principal: String,
-    /// Principal type: aws_account, organization, organization_unit, iam_role, iam_user, service_principal
-    #[serde(default)]
-    pub principal_type: Option<String>,
-    /// Alias of the principal
-    #[serde(default)]
-    pub alias: Option<String>,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the remove_private_link_principals tool
-pub fn remove_private_link_principals(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("remove_private_link_principals")
-        .description("Remove AWS principals from a PrivateLink access list.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<RemovePrivateLinkPrincipalsInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let principal_type = input
-                    .principal_type
-                    .map(|pt| parse_principal_type(&pt))
-                    .transpose()?;
-
-                let request =
-                    redis_cloud::connectivity::private_link::PrivateLinkRemovePrincipalRequest {
-                        principal: input.principal,
-                        principal_type,
-                        alias: input.alias,
-                    };
-
-                let handler = PrivateLinkHandler::new(client);
-                let result = handler
-                    .remove_principals(input.subscription_id, &request)
-                    .await
-                    .tool_context("Failed to remove PrivateLink principals")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// Input for getting PrivateLink endpoint script
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetPrivateLinkEndpointScriptInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the get_private_link_endpoint_script tool
-pub fn get_private_link_endpoint_script(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_private_link_endpoint_script")
-        .description("Get the endpoint creation script for an AWS PrivateLink.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetPrivateLinkEndpointScriptInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = PrivateLinkHandler::new(client);
-                let result = handler
-                    .get_endpoint_script(input.subscription_id)
-                    .await
-                    .tool_context("Failed to get PrivateLink endpoint script")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
+        CallToolResult::from_serialize(&result)
+    }
+);
 
 // ============================================================================
 // Active-Active PrivateLink tools
 // ============================================================================
 
-/// Input for getting Active-Active PrivateLink configuration
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetAaPrivateLinkInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Region ID
-    pub region_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+cloud_tool!(read_only, get_aa_private_link, "get_aa_private_link",
+    "Get Active-Active AWS PrivateLink configuration.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// Region ID
+        pub region_id: i32,
+    } => |client, input| {
+        let handler = PrivateLinkHandler::new(client);
+        let result = handler
+            .get_active_active(input.subscription_id, input.region_id)
+            .await
+            .tool_context("Failed to get AA PrivateLink")?;
 
-/// Build the get_aa_private_link tool
-pub fn get_aa_private_link(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_aa_private_link")
-        .description("Get Active-Active AWS PrivateLink configuration.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetAaPrivateLinkInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
+        CallToolResult::from_serialize(&result)
+    }
+);
 
-                let handler = PrivateLinkHandler::new(client);
-                let result = handler
-                    .get_active_active(input.subscription_id, input.region_id)
-                    .await
-                    .tool_context("Failed to get AA PrivateLink")?;
+cloud_tool!(write, create_aa_private_link, "create_aa_private_link",
+    "Create an Active-Active AWS PrivateLink configuration.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// Region ID
+        pub region_id: i32,
+        /// Share name for the PrivateLink service (max 64 characters)
+        pub share_name: String,
+        /// AWS principal (account ID, role ARN, etc.)
+        pub principal: String,
+        /// Principal type: aws_account, organization, organization_unit, iam_role, iam_user, service_principal
+        pub principal_type: String,
+        /// Optional alias for the PrivateLink
+        #[serde(default)]
+        pub alias: Option<String>,
+    } => |client, input| {
+        let principal_type = parse_principal_type(&input.principal_type)?;
 
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
+        let request = PrivateLinkCreateRequest {
+            share_name: input.share_name,
+            principal: input.principal,
+            principal_type,
+            alias: input.alias,
+        };
 
-/// Input for creating an Active-Active PrivateLink
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct CreateAaPrivateLinkInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Region ID
-    pub region_id: i32,
-    /// Share name for the PrivateLink service (max 64 characters)
-    pub share_name: String,
-    /// AWS principal (account ID, role ARN, etc.)
-    pub principal: String,
-    /// Principal type: aws_account, organization, organization_unit, iam_role, iam_user, service_principal
-    pub principal_type: String,
-    /// Optional alias for the PrivateLink
-    #[serde(default)]
-    pub alias: Option<String>,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+        let handler = PrivateLinkHandler::new(client);
+        let result = handler
+            .create_active_active(input.subscription_id, input.region_id, &request)
+            .await
+            .tool_context("Failed to create AA PrivateLink")?;
 
-/// Build the create_aa_private_link tool
-pub fn create_aa_private_link(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("create_aa_private_link")
-        .description("Create an Active-Active AWS PrivateLink configuration.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<CreateAaPrivateLinkInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
+        CallToolResult::from_serialize(&result)
+    }
+);
 
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
+cloud_tool!(write, add_aa_private_link_principals, "add_aa_private_link_principals",
+    "Add AWS principals to an Active-Active PrivateLink access list.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// Region ID
+        pub region_id: i32,
+        /// AWS principal (account ID, role ARN, etc.)
+        pub principal: String,
+        /// Principal type: aws_account, organization, organization_unit, iam_role, iam_user, service_principal
+        #[serde(default)]
+        pub principal_type: Option<String>,
+        /// Optional alias for the principal
+        #[serde(default)]
+        pub alias: Option<String>,
+    } => |client, input| {
+        let principal_type = input
+            .principal_type
+            .map(|pt| parse_principal_type(&pt))
+            .transpose()?;
 
-                let principal_type = parse_principal_type(&input.principal_type)?;
+        let request = PrivateLinkAddPrincipalRequest {
+            principal: input.principal,
+            principal_type,
+            alias: input.alias,
+        };
 
-                let request = PrivateLinkCreateRequest {
-                    share_name: input.share_name,
-                    principal: input.principal,
-                    principal_type,
-                    alias: input.alias,
-                };
+        let handler = PrivateLinkHandler::new(client);
+        let result = handler
+            .add_principals_active_active(input.subscription_id, input.region_id, &request)
+            .await
+            .tool_context("Failed to add AA PrivateLink principals")?;
 
-                let handler = PrivateLinkHandler::new(client);
-                let result = handler
-                    .create_active_active(input.subscription_id, input.region_id, &request)
-                    .await
-                    .tool_context("Failed to create AA PrivateLink")?;
+        CallToolResult::from_serialize(&result)
+    }
+);
 
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
+cloud_tool!(write, remove_aa_private_link_principals, "remove_aa_private_link_principals",
+    "Remove AWS principals from an Active-Active PrivateLink access list.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// Region ID
+        pub region_id: i32,
+        /// AWS principal (account ID, role ARN, etc.) to remove
+        pub principal: String,
+        /// Principal type: aws_account, organization, organization_unit, iam_role, iam_user, service_principal
+        #[serde(default)]
+        pub principal_type: Option<String>,
+        /// Alias of the principal
+        #[serde(default)]
+        pub alias: Option<String>,
+    } => |client, input| {
+        let principal_type = input
+            .principal_type
+            .map(|pt| parse_principal_type(&pt))
+            .transpose()?;
 
-/// Input for adding principals to Active-Active PrivateLink
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct AddAaPrivateLinkPrincipalsInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Region ID
-    pub region_id: i32,
-    /// AWS principal (account ID, role ARN, etc.)
-    pub principal: String,
-    /// Principal type: aws_account, organization, organization_unit, iam_role, iam_user, service_principal
-    #[serde(default)]
-    pub principal_type: Option<String>,
-    /// Optional alias for the principal
-    #[serde(default)]
-    pub alias: Option<String>,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+        let request =
+            redis_cloud::connectivity::private_link::PrivateLinkRemovePrincipalRequest {
+                principal: input.principal,
+                principal_type,
+                alias: input.alias,
+            };
 
-/// Build the add_aa_private_link_principals tool
-pub fn add_aa_private_link_principals(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("add_aa_private_link_principals")
-        .description("Add AWS principals to an Active-Active PrivateLink access list.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<AddAaPrivateLinkPrincipalsInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
+        let handler = PrivateLinkHandler::new(client);
+        let result = handler
+            .remove_principals_active_active(
+                input.subscription_id,
+                input.region_id,
+                &request,
+            )
+            .await
+            .tool_context("Failed to remove AA PrivateLink principals")?;
 
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
+        CallToolResult::from_serialize(&result)
+    }
+);
 
-                let principal_type = input
-                    .principal_type
-                    .map(|pt| parse_principal_type(&pt))
-                    .transpose()?;
+cloud_tool!(read_only, get_aa_private_link_endpoint_script, "get_aa_private_link_endpoint_script",
+    "Get the endpoint creation script for an Active-Active AWS PrivateLink.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// Region ID
+        pub region_id: i32,
+    } => |client, input| {
+        let handler = PrivateLinkHandler::new(client);
+        let result = handler
+            .get_endpoint_script_active_active(input.subscription_id, input.region_id)
+            .await
+            .tool_context("Failed to get AA PrivateLink endpoint script")?;
 
-                let request = PrivateLinkAddPrincipalRequest {
-                    principal: input.principal,
-                    principal_type,
-                    alias: input.alias,
-                };
-
-                let handler = PrivateLinkHandler::new(client);
-                let result = handler
-                    .add_principals_active_active(input.subscription_id, input.region_id, &request)
-                    .await
-                    .tool_context("Failed to add AA PrivateLink principals")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// Input for removing principals from Active-Active PrivateLink
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct RemoveAaPrivateLinkPrincipalsInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Region ID
-    pub region_id: i32,
-    /// AWS principal (account ID, role ARN, etc.) to remove
-    pub principal: String,
-    /// Principal type: aws_account, organization, organization_unit, iam_role, iam_user, service_principal
-    #[serde(default)]
-    pub principal_type: Option<String>,
-    /// Alias of the principal
-    #[serde(default)]
-    pub alias: Option<String>,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the remove_aa_private_link_principals tool
-pub fn remove_aa_private_link_principals(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("remove_aa_private_link_principals")
-        .description("Remove AWS principals from an Active-Active PrivateLink access list.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<RemoveAaPrivateLinkPrincipalsInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let principal_type = input
-                    .principal_type
-                    .map(|pt| parse_principal_type(&pt))
-                    .transpose()?;
-
-                let request =
-                    redis_cloud::connectivity::private_link::PrivateLinkRemovePrincipalRequest {
-                        principal: input.principal,
-                        principal_type,
-                        alias: input.alias,
-                    };
-
-                let handler = PrivateLinkHandler::new(client);
-                let result = handler
-                    .remove_principals_active_active(
-                        input.subscription_id,
-                        input.region_id,
-                        &request,
-                    )
-                    .await
-                    .tool_context("Failed to remove AA PrivateLink principals")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// Input for getting Active-Active PrivateLink endpoint script
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetAaPrivateLinkEndpointScriptInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Region ID
-    pub region_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the get_aa_private_link_endpoint_script tool
-pub fn get_aa_private_link_endpoint_script(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_aa_private_link_endpoint_script")
-        .description("Get the endpoint creation script for an Active-Active AWS PrivateLink.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetAaPrivateLinkEndpointScriptInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = PrivateLinkHandler::new(client);
-                let result = handler
-                    .get_endpoint_script_active_active(input.subscription_id, input.region_id)
-                    .await
-                    .tool_context("Failed to get AA PrivateLink endpoint script")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-// ============================================================================
-// Instructions and Router
-// ============================================================================
-
-/// All tool names registered by this sub-module.
-pub(super) const TOOL_NAMES: &[&str] = &[
-    "get_vpc_peering",
-    "create_vpc_peering",
-    "update_vpc_peering",
-    "delete_vpc_peering",
-    "get_aa_vpc_peering",
-    "create_aa_vpc_peering",
-    "update_aa_vpc_peering",
-    "delete_aa_vpc_peering",
-    "get_tgw_attachments",
-    "get_tgw_invitations",
-    "accept_tgw_invitation",
-    "reject_tgw_invitation",
-    "create_tgw_attachment",
-    "update_tgw_attachment_cidrs",
-    "delete_tgw_attachment",
-    "get_aa_tgw_attachments",
-    "get_aa_tgw_invitations",
-    "accept_aa_tgw_invitation",
-    "reject_aa_tgw_invitation",
-    "create_aa_tgw_attachment",
-    "update_aa_tgw_attachment_cidrs",
-    "delete_aa_tgw_attachment",
-    "get_psc_service",
-    "create_psc_service",
-    "delete_psc_service",
-    "get_psc_endpoints",
-    "create_psc_endpoint",
-    "update_psc_endpoint",
-    "delete_psc_endpoint",
-    "get_psc_creation_script",
-    "get_psc_deletion_script",
-    "get_aa_psc_service",
-    "create_aa_psc_service",
-    "delete_aa_psc_service",
-    "get_aa_psc_endpoints",
-    "create_aa_psc_endpoint",
-    "update_aa_psc_endpoint",
-    "delete_aa_psc_endpoint",
-    "get_aa_psc_creation_script",
-    "get_aa_psc_deletion_script",
-    "get_private_link",
-    "create_private_link",
-    "delete_private_link",
-    "add_private_link_principals",
-    "remove_private_link_principals",
-    "get_private_link_endpoint_script",
-    "get_aa_private_link",
-    "create_aa_private_link",
-    "add_aa_private_link_principals",
-    "remove_aa_private_link_principals",
-    "get_aa_private_link_endpoint_script",
-];
-
-/// Build an MCP sub-router containing all networking tools
-pub fn router(state: Arc<AppState>) -> McpRouter {
-    McpRouter::new()
-        // VPC Peering
-        .tool(get_vpc_peering(state.clone()))
-        .tool(create_vpc_peering(state.clone()))
-        .tool(update_vpc_peering(state.clone()))
-        .tool(delete_vpc_peering(state.clone()))
-        .tool(get_aa_vpc_peering(state.clone()))
-        .tool(create_aa_vpc_peering(state.clone()))
-        .tool(update_aa_vpc_peering(state.clone()))
-        .tool(delete_aa_vpc_peering(state.clone()))
-        // Transit Gateway
-        .tool(get_tgw_attachments(state.clone()))
-        .tool(get_tgw_invitations(state.clone()))
-        .tool(accept_tgw_invitation(state.clone()))
-        .tool(reject_tgw_invitation(state.clone()))
-        .tool(create_tgw_attachment(state.clone()))
-        .tool(update_tgw_attachment_cidrs(state.clone()))
-        .tool(delete_tgw_attachment(state.clone()))
-        .tool(get_aa_tgw_attachments(state.clone()))
-        .tool(get_aa_tgw_invitations(state.clone()))
-        .tool(accept_aa_tgw_invitation(state.clone()))
-        .tool(reject_aa_tgw_invitation(state.clone()))
-        .tool(create_aa_tgw_attachment(state.clone()))
-        .tool(update_aa_tgw_attachment_cidrs(state.clone()))
-        .tool(delete_aa_tgw_attachment(state.clone()))
-        // PSC
-        .tool(get_psc_service(state.clone()))
-        .tool(create_psc_service(state.clone()))
-        .tool(delete_psc_service(state.clone()))
-        .tool(get_psc_endpoints(state.clone()))
-        .tool(create_psc_endpoint(state.clone()))
-        .tool(update_psc_endpoint(state.clone()))
-        .tool(delete_psc_endpoint(state.clone()))
-        .tool(get_psc_creation_script(state.clone()))
-        .tool(get_psc_deletion_script(state.clone()))
-        .tool(get_aa_psc_service(state.clone()))
-        .tool(create_aa_psc_service(state.clone()))
-        .tool(delete_aa_psc_service(state.clone()))
-        .tool(get_aa_psc_endpoints(state.clone()))
-        .tool(create_aa_psc_endpoint(state.clone()))
-        .tool(update_aa_psc_endpoint(state.clone()))
-        .tool(delete_aa_psc_endpoint(state.clone()))
-        .tool(get_aa_psc_creation_script(state.clone()))
-        .tool(get_aa_psc_deletion_script(state.clone()))
-        // PrivateLink
-        .tool(get_private_link(state.clone()))
-        .tool(create_private_link(state.clone()))
-        .tool(delete_private_link(state.clone()))
-        .tool(add_private_link_principals(state.clone()))
-        .tool(remove_private_link_principals(state.clone()))
-        .tool(get_private_link_endpoint_script(state.clone()))
-        .tool(get_aa_private_link(state.clone()))
-        .tool(create_aa_private_link(state.clone()))
-        .tool(add_aa_private_link_principals(state.clone()))
-        .tool(remove_aa_private_link_principals(state.clone()))
-        .tool(get_aa_private_link_endpoint_script(state.clone()))
-}
+        CallToolResult::from_serialize(&result)
+    }
+);

--- a/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs
+++ b/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs
@@ -1,6 +1,5 @@
 //! Subscription and database tools for Redis Cloud
 
-use std::sync::Arc;
 use std::time::Duration;
 
 use redis_cloud::databases::DatabaseCreateRequest;
@@ -10,324 +9,12 @@ use redisctl_core::cloud::{
     delete_subscription_and_wait, flush_database_and_wait, import_database_and_wait,
     update_database_and_wait,
 };
-use schemars::JsonSchema;
-use serde::Deserialize;
-use tower_mcp::extract::{Json, State};
-use tower_mcp::{CallToolResult, Error as McpError, McpRouter, ResultExt, Tool, ToolBuilder};
+use tower_mcp::{CallToolResult, ResultExt};
 
-use crate::state::AppState;
-
-/// Input for listing subscriptions
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ListSubscriptionsInput {
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the list_subscriptions tool
-pub fn list_subscriptions(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("list_subscriptions")
-        .description("List all subscriptions.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<ListSubscriptionsInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = SubscriptionHandler::new(client);
-                let account_subs = handler
-                    .get_all_subscriptions()
-                    .await
-                    .tool_context("Failed to list subscriptions")?;
-
-                CallToolResult::from_serialize(&account_subs)
-            },
-        )
-        .build()
-}
-
-/// Input for getting a specific subscription
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetSubscriptionInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the get_subscription tool
-pub fn get_subscription(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_subscription")
-        .description("Get subscription details by ID.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<GetSubscriptionInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = SubscriptionHandler::new(client);
-                let subscription = handler
-                    .get_subscription_by_id(input.subscription_id)
-                    .await
-                    .tool_context("Failed to get subscription")?;
-
-                CallToolResult::from_serialize(&subscription)
-            },
-        )
-        .build()
-}
-
-/// Input for listing databases
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ListDatabasesInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the list_databases tool
-pub fn list_databases(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("list_databases")
-        .description("List all databases in a subscription.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<ListDatabasesInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = DatabaseHandler::new(client);
-                let databases = handler
-                    .get_subscription_databases(input.subscription_id, None, None)
-                    .await
-                    .tool_context("Failed to list databases")?;
-
-                CallToolResult::from_serialize(&databases)
-            },
-        )
-        .build()
-}
-
-/// Input for getting a specific database
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetDatabaseInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Database ID
-    pub database_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the get_database tool
-pub fn get_database(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_database")
-        .description("Get database details by ID.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<GetDatabaseInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = DatabaseHandler::new(client);
-                let database = handler
-                    .get_subscription_database_by_id(input.subscription_id, input.database_id)
-                    .await
-                    .tool_context("Failed to get database")?;
-
-                CallToolResult::from_serialize(&database)
-            },
-        )
-        .build()
-}
+use crate::tools::macros::{cloud_tool, mcp_module};
 
 // ============================================================================
-// Database operations tools
-// ============================================================================
-
-/// Input for getting database backup status
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetBackupStatusInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Database ID
-    pub database_id: i32,
-    /// Optional region name for Active-Active databases
-    #[serde(default)]
-    pub region_name: Option<String>,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the get_backup_status tool
-pub fn get_backup_status(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_backup_status")
-        .description("Get backup status and history for a database.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetBackupStatusInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = DatabaseHandler::new(client);
-                let status = handler
-                    .get_database_backup_status(
-                        input.subscription_id,
-                        input.database_id,
-                        input.region_name,
-                    )
-                    .await
-                    .tool_context("Failed to get backup status")?;
-
-                CallToolResult::from_serialize(&status)
-            },
-        )
-        .build()
-}
-
-/// Input for getting slow log
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetSlowLogInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Database ID
-    pub database_id: i32,
-    /// Optional region name for Active-Active databases
-    #[serde(default)]
-    pub region_name: Option<String>,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the get_slow_log tool
-pub fn get_slow_log(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_slow_log")
-        .description("Get slow log entries for a database.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<GetSlowLogInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = DatabaseHandler::new(client);
-                let log = handler
-                    .get_slow_log(input.subscription_id, input.database_id, input.region_name)
-                    .await
-                    .tool_context("Failed to get slow log")?;
-
-                CallToolResult::from_serialize(&log)
-            },
-        )
-        .build()
-}
-
-/// Input for getting database tags
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetTagsInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Database ID
-    pub database_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the get_tags tool
-pub fn get_tags(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_database_tags")
-        .description("Get tags for a database.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<GetTagsInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = DatabaseHandler::new(client);
-                let tags = handler
-                    .get_tags(input.subscription_id, input.database_id)
-                    .await
-                    .tool_context("Failed to get tags")?;
-
-                CallToolResult::from_serialize(&tags)
-            },
-        )
-        .build()
-}
-
-/// Input for getting database certificate
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetCertificateInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Database ID
-    pub database_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the get_database_certificate tool
-pub fn get_database_certificate(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_database_certificate")
-        .description(
-            "Get the TLS/SSL certificate for a database in PEM format.",
-        )
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetCertificateInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = DatabaseHandler::new(client);
-                let cert = handler
-                    .get_subscription_database_certificate(
-                        input.subscription_id,
-                        input.database_id,
-                    )
-                    .await
-                    .tool_context("Failed to get certificate")?;
-
-                CallToolResult::from_serialize(&cert)
-            },
-        )
-        .build()
-}
-
-// ============================================================================
-// Write operations (require write permission)
+// Helper functions for serde defaults
 // ============================================================================
 
 fn default_replication() -> bool {
@@ -342,559 +29,12 @@ fn default_timeout() -> u64 {
     600
 }
 
-/// Input for creating a database
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct CreateDatabaseInput {
-    /// Subscription ID to create the database in
-    pub subscription_id: i32,
-    /// Database name
-    pub name: String,
-    /// Memory limit in GB (e.g., 1.0, 2.5, 10.0)
-    pub memory_limit_in_gb: f64,
-    /// Enable replication for high availability (default: true)
-    #[serde(default = "default_replication")]
-    pub replication: bool,
-    /// Protocol: "redis" (RESP2), "stack" (RESP2 with modules), or "memcached"
-    #[serde(default = "default_protocol")]
-    pub protocol: String,
-    /// Data persistence: "none", "aof-every-1-second", "aof-every-write", "snapshot-every-1-hour", etc.
-    #[serde(default)]
-    pub data_persistence: Option<String>,
-    /// Timeout in seconds to wait for database creation (default: 600)
-    #[serde(default = "default_timeout")]
-    pub timeout_seconds: u64,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the create_database tool
-pub fn create_database(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("create_database")
-        .description(
-            "Create a new database in a Pro subscription and wait for it to be ready. \
-             Prerequisites: 1) get_subscription -- verify the target subscription exists and is active. \
-             2) get_modules -- validate desired modules. \
-             3) get_redis_versions -- pick a supported Redis version.",
-        )
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<CreateDatabaseInput>| async move {
-                // Check write permission
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                // Build the request using Layer 1's TypedBuilder
-                let request = match (input.protocol.as_str(), input.data_persistence.as_ref()) {
-                    ("redis", None) => DatabaseCreateRequest::builder()
-                        .name(&input.name)
-                        .memory_limit_in_gb(input.memory_limit_in_gb)
-                        .replication(input.replication)
-                        .build(),
-                    ("redis", Some(persistence)) => DatabaseCreateRequest::builder()
-                        .name(&input.name)
-                        .memory_limit_in_gb(input.memory_limit_in_gb)
-                        .replication(input.replication)
-                        .data_persistence(persistence)
-                        .build(),
-                    (protocol, None) => DatabaseCreateRequest::builder()
-                        .name(&input.name)
-                        .memory_limit_in_gb(input.memory_limit_in_gb)
-                        .replication(input.replication)
-                        .protocol(protocol)
-                        .build(),
-                    (protocol, Some(persistence)) => DatabaseCreateRequest::builder()
-                        .name(&input.name)
-                        .memory_limit_in_gb(input.memory_limit_in_gb)
-                        .replication(input.replication)
-                        .protocol(protocol)
-                        .data_persistence(persistence)
-                        .build(),
-                };
-
-                // Use Layer 2 workflow - no progress callback needed for MCP
-                let database = create_database_and_wait(
-                    &client,
-                    input.subscription_id,
-                    &request,
-                    Duration::from_secs(input.timeout_seconds),
-                    None, // MCP doesn't need progress callbacks
-                )
-                .await
-                .tool_context("Failed to create database")?;
-
-                CallToolResult::from_serialize(&database)
-            },
-        )
-        .build()
-}
-
-/// Input for updating a database
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct UpdateDatabaseInput {
-    /// Subscription ID containing the database
-    pub subscription_id: i32,
-    /// Database ID to update
-    pub database_id: i32,
-    /// New database name (optional)
-    #[serde(default)]
-    pub name: Option<String>,
-    /// New memory limit in GB (optional)
-    #[serde(default)]
-    pub memory_limit_in_gb: Option<f64>,
-    /// Change replication setting (optional)
-    #[serde(default)]
-    pub replication: Option<bool>,
-    /// Change data persistence (optional)
-    #[serde(default)]
-    pub data_persistence: Option<String>,
-    /// Change eviction policy (optional)
-    #[serde(default)]
-    pub data_eviction_policy: Option<String>,
-    /// Timeout in seconds (default: 600)
-    #[serde(default = "default_timeout")]
-    pub timeout_seconds: u64,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the update_database tool
-pub fn update_database(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("update_database")
-        .description(
-            "Update a database configuration.",
-        )
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<UpdateDatabaseInput>| async move {
-                use redis_cloud::databases::DatabaseUpdateRequest;
-
-                // Check write permission
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                // Build the update request
-                let mut request = DatabaseUpdateRequest::builder().build();
-                request.name = input.name;
-                request.memory_limit_in_gb = input.memory_limit_in_gb;
-                request.replication = input.replication;
-                request.data_persistence = input.data_persistence;
-                request.data_eviction_policy = input.data_eviction_policy;
-
-                // Validate at least one field is set
-                if request.name.is_none()
-                    && request.memory_limit_in_gb.is_none()
-                    && request.replication.is_none()
-                    && request.data_persistence.is_none()
-                    && request.data_eviction_policy.is_none()
-                {
-                    return Err(McpError::tool(
-                        "At least one update field is required",
-                    ));
-                }
-
-                // Use Layer 2 workflow
-                let database = update_database_and_wait(
-                    &client,
-                    input.subscription_id,
-                    input.database_id,
-                    &request,
-                    Duration::from_secs(input.timeout_seconds),
-                    None,
-                )
-                .await
-                .tool_context("Failed to update database")?;
-
-                CallToolResult::from_serialize(&database)
-            },
-        )
-        .build()
-}
-
-/// Input for deleting a database
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct DeleteDatabaseInput {
-    /// Subscription ID containing the database
-    pub subscription_id: i32,
-    /// Database ID to delete
-    pub database_id: i32,
-    /// Timeout in seconds (default: 600)
-    #[serde(default = "default_timeout")]
-    pub timeout_seconds: u64,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the delete_database tool
-pub fn delete_database(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("delete_database")
-        .description(
-            "DANGEROUS: Delete a database and all its data.",
-        )
-        .destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<DeleteDatabaseInput>| async move {
-                // Check destructive permission
-                if !state.is_destructive_allowed() {
-                    return Err(McpError::tool(
-                        "Destructive operations require policy tier 'full'",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                // Use Layer 2 workflow
-                delete_database_and_wait(
-                    &client,
-                    input.subscription_id,
-                    input.database_id,
-                    Duration::from_secs(input.timeout_seconds),
-                    None,
-                )
-                .await
-                .tool_context("Failed to delete database")?;
-
-                CallToolResult::from_serialize(&serde_json::json!({
-                    "message": "Database deleted successfully",
-                    "subscription_id": input.subscription_id,
-                    "database_id": input.database_id
-                }))
-            },
-        )
-        .build()
-}
-
-/// Input for backing up a database
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct BackupDatabaseInput {
-    /// Subscription ID containing the database
-    pub subscription_id: i32,
-    /// Database ID to backup
-    pub database_id: i32,
-    /// Region name (required for Active-Active databases)
-    #[serde(default)]
-    pub region_name: Option<String>,
-    /// Timeout in seconds (default: 600)
-    #[serde(default = "default_timeout")]
-    pub timeout_seconds: u64,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the backup_database tool
-pub fn backup_database(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("backup_database")
-        .description(
-            "Trigger a manual backup of a database.",
-        )
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<BackupDatabaseInput>| async move {
-                // Check write permission
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                // Use Layer 2 workflow
-                backup_database_and_wait(
-                    &client,
-                    input.subscription_id,
-                    input.database_id,
-                    input.region_name.as_deref(),
-                    Duration::from_secs(input.timeout_seconds),
-                    None,
-                )
-                .await
-                .tool_context("Failed to backup database")?;
-
-                CallToolResult::from_serialize(&serde_json::json!({
-                    "message": "Backup completed successfully",
-                    "subscription_id": input.subscription_id,
-                    "database_id": input.database_id
-                }))
-            },
-        )
-        .build()
-}
-
 fn default_import_timeout() -> u64 {
     1800 // Imports can take longer
 }
 
-/// Input for importing data into a database
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ImportDatabaseInput {
-    /// Subscription ID containing the database
-    pub subscription_id: i32,
-    /// Database ID to import into
-    pub database_id: i32,
-    /// Source type: "http", "redis", "ftp", "aws-s3", "azure-blob-storage", "google-blob-storage"
-    pub source_type: String,
-    /// URI to import from
-    pub import_from_uri: String,
-    /// Timeout in seconds (default: 1800 for imports)
-    #[serde(default = "default_import_timeout")]
-    pub timeout_seconds: u64,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the import_database tool
-pub fn import_database(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("import_database")
-        .description(
-            "Import data into a database from an external source. WARNING: This will overwrite existing data.",
-        )
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<ImportDatabaseInput>| async move {
-                use redis_cloud::databases::DatabaseImportRequest;
-
-                // Check write permission
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                // Build the import request
-                let request = DatabaseImportRequest::builder()
-                    .source_type(&input.source_type)
-                    .import_from_uri(vec![input.import_from_uri.clone()])
-                    .build();
-
-                // Use Layer 2 workflow
-                import_database_and_wait(
-                    &client,
-                    input.subscription_id,
-                    input.database_id,
-                    &request,
-                    Duration::from_secs(input.timeout_seconds),
-                    None,
-                )
-                .await
-                .tool_context("Failed to import database")?;
-
-                CallToolResult::from_serialize(&serde_json::json!({
-                    "message": "Import completed successfully",
-                    "subscription_id": input.subscription_id,
-                    "database_id": input.database_id
-                }))
-            },
-        )
-        .build()
-}
-
-/// Input for deleting a subscription
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct DeleteSubscriptionInput {
-    /// Subscription ID to delete
-    pub subscription_id: i32,
-    /// Timeout in seconds (default: 600)
-    #[serde(default = "default_timeout")]
-    pub timeout_seconds: u64,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the delete_subscription tool
-pub fn delete_subscription(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("delete_subscription")
-        .description(
-            "DANGEROUS: Delete a subscription. All databases must be deleted first.",
-        )
-        .destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<DeleteSubscriptionInput>| async move {
-                // Check destructive permission
-                if !state.is_destructive_allowed() {
-                    return Err(McpError::tool(
-                        "Destructive operations require policy tier 'full'",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                // Use Layer 2 workflow
-                delete_subscription_and_wait(
-                    &client,
-                    input.subscription_id,
-                    Duration::from_secs(input.timeout_seconds),
-                    None,
-                )
-                .await
-                .tool_context("Failed to delete subscription")?;
-
-                CallToolResult::from_serialize(&serde_json::json!({
-                    "message": "Subscription deleted successfully",
-                    "subscription_id": input.subscription_id
-                }))
-            },
-        )
-        .build()
-}
-
 fn default_flush_timeout() -> u64 {
     300
-}
-
-/// Input for flushing a database
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct FlushDatabaseInput {
-    /// Subscription ID containing the database
-    pub subscription_id: i32,
-    /// Database ID to flush
-    pub database_id: i32,
-    /// Timeout in seconds (default: 300)
-    #[serde(default = "default_flush_timeout")]
-    pub timeout_seconds: u64,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the flush_database tool
-pub fn flush_database(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("flush_database")
-        .description("DANGEROUS: Removes all data from a database.")
-        .destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<FlushDatabaseInput>| async move {
-                // Check destructive permission
-                if !state.is_destructive_allowed() {
-                    return Err(McpError::tool(
-                        "Destructive operations require policy tier 'full'",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                // Use Layer 2 workflow
-                flush_database_and_wait(
-                    &client,
-                    input.subscription_id,
-                    input.database_id,
-                    Duration::from_secs(input.timeout_seconds),
-                    None,
-                )
-                .await
-                .tool_context("Failed to flush database")?;
-
-                CallToolResult::from_serialize(&serde_json::json!({
-                    "message": "Database flushed successfully",
-                    "subscription_id": input.subscription_id,
-                    "database_id": input.database_id
-                }))
-            },
-        )
-        .build()
-}
-
-/// Input for flushing an Active-Active (CRDB) database
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct FlushCrdbDatabaseInput {
-    /// Subscription ID containing the database
-    pub subscription_id: i32,
-    /// Database ID to flush
-    pub database_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the flush_crdb_database tool
-pub fn flush_crdb_database(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("flush_crdb_database")
-        .description(
-            "DANGEROUS: Removes all data from an Active-Active (CRDB) database. \
-             Use this instead of regular flush for Active-Active databases.",
-        )
-        .destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<FlushCrdbDatabaseInput>| async move {
-                if !state.is_destructive_allowed() {
-                    return Err(McpError::tool(
-                        "Destructive operations require policy tier 'full'",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = DatabaseHandler::new(client);
-                let request = redis_cloud::databases::CrdbFlushRequest {
-                    subscription_id: None,
-                    database_id: None,
-                    command_type: None,
-                };
-                let result = handler
-                    .flush_crdb(input.subscription_id, input.database_id, &request)
-                    .await
-                    .tool_context("Failed to flush CRDB database")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
 }
 
 fn default_cloud_account_id() -> i32 {
@@ -905,377 +45,12 @@ fn default_subscription_timeout() -> u64 {
     1800 // Subscriptions can take a while
 }
 
-/// Input for creating a subscription
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct CreateSubscriptionInput {
-    /// Subscription name
-    pub name: String,
-    /// Cloud provider: "AWS", "GCP", or "Azure"
-    pub cloud_provider: String,
-    /// Cloud region (e.g., "us-east-1" for AWS, "us-central1" for GCP)
-    pub region: String,
-    /// Cloud account ID (use list_cloud_accounts to find available accounts, or use 1 for internal account)
-    #[serde(default = "default_cloud_account_id")]
-    pub cloud_account_id: i32,
-    /// Database name for the initial database
-    pub database_name: String,
-    /// Memory limit in GB for the initial database
-    pub memory_limit_in_gb: f64,
-    /// Database protocol: "redis" (default), "stack", or "memcached"
-    #[serde(default = "default_protocol")]
-    pub protocol: String,
-    /// Enable replication for high availability (default: true)
-    #[serde(default = "default_replication")]
-    pub replication: bool,
-    /// Timeout in seconds (default: 1800 - subscriptions take longer)
-    #[serde(default = "default_subscription_timeout")]
-    pub timeout_seconds: u64,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the create_subscription tool
-pub fn create_subscription(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("create_subscription")
-        .description(
-            "Create a new Pro subscription with an initial database. \
-             Prerequisites: 1) list_payment_methods -- verify a payment method exists. \
-             2) get_regions -- validate the target cloud provider and region. \
-             3) get_modules -- confirm desired database modules are available. \
-             4) get_redis_versions -- pick a supported Redis version.",
-        )
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<CreateSubscriptionInput>| async move {
-                use redis_cloud::flexible::subscriptions::{
-                    SubscriptionCreateRequest, SubscriptionDatabaseSpec, SubscriptionRegionSpec,
-                    SubscriptionSpec,
-                };
-                use redisctl_core::cloud::create_subscription_and_wait;
-
-                // Check write permission
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                // Build the subscription request
-                let request = SubscriptionCreateRequest::builder()
-                    .name(&input.name)
-                    .cloud_providers(vec![SubscriptionSpec {
-                        provider: Some(input.cloud_provider.clone()),
-                        cloud_account_id: Some(input.cloud_account_id),
-                        regions: vec![SubscriptionRegionSpec {
-                            region: input.region.clone(),
-                            multiple_availability_zones: None,
-                            preferred_availability_zones: None,
-                            networking: None,
-                        }],
-                    }])
-                    .databases(vec![SubscriptionDatabaseSpec {
-                        name: input.database_name.clone(),
-                        protocol: input.protocol.clone(),
-                        memory_limit_in_gb: Some(input.memory_limit_in_gb),
-                        dataset_size_in_gb: None,
-                        support_oss_cluster_api: None,
-                        data_persistence: None,
-                        replication: Some(input.replication),
-                        throughput_measurement: None,
-                        local_throughput_measurement: None,
-                        modules: None,
-                        quantity: None,
-                        average_item_size_in_bytes: None,
-                        resp_version: None,
-                        redis_version: None,
-                        sharding_type: None,
-                        query_performance_factor: None,
-                    }])
-                    .build();
-
-                // Use Layer 2 workflow
-                let subscription = create_subscription_and_wait(
-                    &client,
-                    &request,
-                    Duration::from_secs(input.timeout_seconds),
-                    None,
-                )
-                .await
-                .tool_context("Failed to create subscription")?;
-
-                CallToolResult::from_serialize(&subscription)
-            },
-        )
-        .build()
-}
-
-/// Input for updating a subscription
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct UpdateSubscriptionInput {
-    /// Subscription ID to update
-    pub subscription_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the update_subscription tool
-pub fn update_subscription(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("update_subscription")
-        .description(
-            "Update a subscription.",
-        )
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<UpdateSubscriptionInput>| async move {
-                use redis_cloud::flexible::subscriptions::BaseSubscriptionUpdateRequest;
-
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let request = BaseSubscriptionUpdateRequest {
-                    subscription_id: None,
-                    command_type: None,
-                };
-
-                let handler = SubscriptionHandler::new(client);
-                let result = handler
-                    .update_subscription(input.subscription_id, &request)
-                    .await
-                    .tool_context("Failed to update subscription")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// Input for getting subscription pricing
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetSubscriptionPricingInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the get_subscription_pricing tool
-pub fn get_subscription_pricing(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_subscription_pricing")
-        .description(
-            "Get pricing details for a subscription.",
-        )
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetSubscriptionPricingInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = SubscriptionHandler::new(client);
-                let pricing = handler
-                    .get_subscription_pricing(input.subscription_id)
-                    .await
-                    .tool_context("Failed to get subscription pricing")?;
-
-                CallToolResult::from_serialize(&pricing)
-            },
-        )
-        .build()
-}
-
-/// Input for getting available Redis versions
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetRedisVersionsInput {
-    /// Optional subscription ID to filter versions
-    #[serde(default)]
-    pub subscription_id: Option<i32>,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the get_redis_versions tool
-pub fn get_redis_versions(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_redis_versions")
-        .description(
-            "Get available Redis versions. Optionally filter by subscription ID.",
-        )
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetRedisVersionsInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = SubscriptionHandler::new(client);
-                let versions = handler
-                    .get_redis_versions(input.subscription_id)
-                    .await
-                    .tool_context("Failed to get Redis versions")?;
-
-                CallToolResult::from_serialize(&versions)
-            },
-        )
-        .build()
-}
-
-/// Input for getting subscription CIDR allowlist
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetSubscriptionCidrAllowlistInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the get_subscription_cidr_allowlist tool
-pub fn get_subscription_cidr_allowlist(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_subscription_cidr_allowlist")
-        .description("Get the CIDR allowlist for a subscription.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetSubscriptionCidrAllowlistInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = SubscriptionHandler::new(client);
-                let allowlist = handler
-                    .get_cidr_allowlist(input.subscription_id)
-                    .await
-                    .tool_context("Failed to get subscription CIDR allowlist")?;
-
-                CallToolResult::from_serialize(&allowlist)
-            },
-        )
-        .build()
-}
-
-/// Input for updating subscription CIDR allowlist
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct UpdateSubscriptionCidrAllowlistInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// List of CIDR IP ranges to allow (e.g., ["192.168.1.0/24", "10.0.0.0/8"])
-    #[serde(default)]
-    pub cidr_ips: Option<Vec<String>>,
-    /// List of security group IDs to allow (AWS only)
-    #[serde(default)]
-    pub security_group_ids: Option<Vec<String>>,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the update_subscription_cidr_allowlist tool
-pub fn update_subscription_cidr_allowlist(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("update_subscription_cidr_allowlist")
-        .description("Update the CIDR allowlist for a subscription.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<UpdateSubscriptionCidrAllowlistInput>| async move {
-                use redis_cloud::flexible::subscriptions::CidrAllowlistUpdateRequest;
-
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let request = CidrAllowlistUpdateRequest {
-                    subscription_id: None,
-                    cidr_ips: input.cidr_ips,
-                    security_group_ids: input.security_group_ids,
-                    command_type: None,
-                };
-
-                let handler = SubscriptionHandler::new(client);
-                let result = handler
-                    .update_subscription_cidr_allowlist(input.subscription_id, &request)
-                    .await
-                    .tool_context("Failed to update subscription CIDR allowlist")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// Input for getting subscription maintenance windows
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetSubscriptionMaintenanceWindowsInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the get_subscription_maintenance_windows tool
-pub fn get_subscription_maintenance_windows(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_subscription_maintenance_windows")
-        .description("Get maintenance windows for a subscription.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetSubscriptionMaintenanceWindowsInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = SubscriptionHandler::new(client);
-                let windows = handler
-                    .get_subscription_maintenance_windows(input.subscription_id)
-                    .await
-                    .tool_context("Failed to get subscription maintenance windows")?;
-
-                CallToolResult::from_serialize(&windows)
-            },
-        )
-        .build()
-}
+// ============================================================================
+// Helper structs used as field types in tool inputs
+// ============================================================================
 
 /// Input for a maintenance window specification
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct MaintenanceWindowInput {
     /// Start hour (0-23 UTC)
     pub start_hour: i32,
@@ -1285,614 +60,15 @@ pub struct MaintenanceWindowInput {
     pub days: Vec<String>,
 }
 
-/// Input for updating subscription maintenance windows
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct UpdateSubscriptionMaintenanceWindowsInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Maintenance mode: "manual" or "automatic"
-    pub mode: String,
-    /// Maintenance windows (required when mode is "manual")
-    #[serde(default)]
-    pub windows: Option<Vec<MaintenanceWindowInput>>,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the update_subscription_maintenance_windows tool
-pub fn update_subscription_maintenance_windows(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("update_subscription_maintenance_windows")
-        .description("Update maintenance windows for a subscription.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<UpdateSubscriptionMaintenanceWindowsInput>| async move {
-                use redis_cloud::flexible::subscriptions::{
-                    MaintenanceWindowSpec, SubscriptionMaintenanceWindowsSpec,
-                };
-
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let windows = input.windows.map(|ws| {
-                    ws.into_iter()
-                        .map(|w| MaintenanceWindowSpec {
-                            start_hour: w.start_hour,
-                            duration_in_hours: w.duration_in_hours,
-                            days: w.days,
-                        })
-                        .collect()
-                });
-
-                let request = SubscriptionMaintenanceWindowsSpec {
-                    mode: input.mode,
-                    windows,
-                };
-
-                let handler = SubscriptionHandler::new(client);
-                let result = handler
-                    .update_subscription_maintenance_windows(input.subscription_id, &request)
-                    .await
-                    .tool_context("Failed to update subscription maintenance windows")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// Input for getting Active-Active subscription regions
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetActiveActiveRegionsInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the get_active_active_regions tool
-pub fn get_active_active_regions(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_active_active_regions")
-        .description(
-            "Get regions from an Active-Active subscription.",
-        )
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetActiveActiveRegionsInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = SubscriptionHandler::new(client);
-                let regions = handler
-                    .get_regions_from_active_active_subscription(input.subscription_id)
-                    .await
-                    .tool_context("Failed to get Active-Active regions")?;
-
-                CallToolResult::from_serialize(&regions)
-            },
-        )
-        .build()
-}
-
-/// Input for adding a region to an Active-Active subscription
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct AddActiveActiveRegionInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Deployment CIDR for the new region (e.g., "10.0.0.0/24")
-    pub deployment_cidr: String,
-    /// Region name (e.g., "us-east-1")
-    #[serde(default)]
-    pub region: Option<String>,
-    /// VPC ID for the region
-    #[serde(default)]
-    pub vpc_id: Option<String>,
-    /// Whether to perform a dry run without making changes
-    #[serde(default)]
-    pub dry_run: Option<bool>,
-    /// RESP version for the region
-    #[serde(default)]
-    pub resp_version: Option<String>,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the add_active_active_region tool
-pub fn add_active_active_region(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("add_active_active_region")
-        .description(
-            "Add a new region to an Active-Active subscription.",
-        )
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<AddActiveActiveRegionInput>| async move {
-                use redis_cloud::flexible::subscriptions::ActiveActiveRegionCreateRequest;
-
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let request = ActiveActiveRegionCreateRequest {
-                    subscription_id: None,
-                    region: input.region,
-                    vpc_id: input.vpc_id,
-                    deployment_cidr: input.deployment_cidr,
-                    dry_run: input.dry_run,
-                    databases: None,
-                    resp_version: input.resp_version,
-                    customer_managed_key_resource_name: None,
-                    command_type: None,
-                };
-
-                let handler = SubscriptionHandler::new(client);
-                let result = handler
-                    .add_new_region_to_active_active_subscription(
-                        input.subscription_id,
-                        &request,
-                    )
-                    .await
-                    .tool_context("Failed to add Active-Active region")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
 /// Input for a region to delete from an Active-Active subscription
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct ActiveActiveRegionToDeleteInput {
     /// Region name to delete (e.g., "us-east-1")
     pub region: String,
 }
 
-/// Input for deleting regions from an Active-Active subscription
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct DeleteActiveActiveRegionsInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Regions to delete
-    pub regions: Vec<ActiveActiveRegionToDeleteInput>,
-    /// Whether to perform a dry run without making changes
-    #[serde(default)]
-    pub dry_run: Option<bool>,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the delete_active_active_regions tool
-pub fn delete_active_active_regions(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("delete_active_active_regions")
-        .description(
-            "DANGEROUS: Remove regions from an Active-Active subscription. May cause data loss in removed regions.",
-        )
-        .destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<DeleteActiveActiveRegionsInput>| async move {
-                use redis_cloud::flexible::subscriptions::{
-                    ActiveActiveRegionDeleteRequest, ActiveActiveRegionToDelete,
-                };
-
-                if !state.is_destructive_allowed() {
-                    return Err(McpError::tool(
-                        "Destructive operations require policy tier 'full'",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let regions = input
-                    .regions
-                    .into_iter()
-                    .map(|r| ActiveActiveRegionToDelete {
-                        region: Some(r.region),
-                    })
-                    .collect();
-
-                let request = ActiveActiveRegionDeleteRequest {
-                    subscription_id: None,
-                    regions: Some(regions),
-                    dry_run: input.dry_run,
-                    command_type: None,
-                };
-
-                let handler = SubscriptionHandler::new(client);
-                let result = handler
-                    .delete_regions_from_active_active_subscription(input.subscription_id, &request)
-                    .await
-                    .tool_context("Failed to delete Active-Active regions")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// Input for getting available database versions
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetAvailableDatabaseVersionsInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Database ID
-    pub database_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the get_available_database_versions tool
-pub fn get_available_database_versions(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_available_database_versions")
-        .description("Get available target Redis versions for upgrading a database.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetAvailableDatabaseVersionsInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = DatabaseHandler::new(client);
-                let versions = handler
-                    .get_available_target_versions(input.subscription_id, input.database_id)
-                    .await
-                    .tool_context("Failed to get available database versions")?;
-
-                CallToolResult::from_serialize(&versions)
-            },
-        )
-        .build()
-}
-
-/// Input for upgrading a database Redis version
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct UpgradeDatabaseRedisVersionInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Database ID
-    pub database_id: i32,
-    /// Target Redis version to upgrade to (e.g., "7.2")
-    pub target_redis_version: String,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the upgrade_database_redis_version tool
-pub fn upgrade_database_redis_version(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("upgrade_database_redis_version")
-        .description(
-            "Upgrade the Redis version of a database. \
-             Use get_available_database_versions to find valid target versions.",
-        )
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<UpgradeDatabaseRedisVersionInput>| async move {
-                use redis_cloud::databases::DatabaseUpgradeRedisVersionRequest;
-
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let request = DatabaseUpgradeRedisVersionRequest {
-                    database_id: None,
-                    subscription_id: None,
-                    target_redis_version: input.target_redis_version,
-                    command_type: None,
-                };
-
-                let handler = DatabaseHandler::new(client);
-                let result = handler
-                    .upgrade_database_redis_version(
-                        input.subscription_id,
-                        input.database_id,
-                        &request,
-                    )
-                    .await
-                    .tool_context("Failed to upgrade database Redis version")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// Input for getting database upgrade status
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetDatabaseUpgradeStatusInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Database ID
-    pub database_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the get_database_upgrade_status tool
-pub fn get_database_upgrade_status(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_database_upgrade_status")
-        .description("Get the Redis version upgrade status for a database.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetDatabaseUpgradeStatusInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = DatabaseHandler::new(client);
-                let status = handler
-                    .get_database_redis_version_upgrade_status(
-                        input.subscription_id,
-                        input.database_id,
-                    )
-                    .await
-                    .tool_context("Failed to get database upgrade status")?;
-
-                CallToolResult::from_serialize(&status)
-            },
-        )
-        .build()
-}
-
-/// Input for getting database import status
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetDatabaseImportStatusInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Database ID
-    pub database_id: i32,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the get_database_import_status tool
-pub fn get_database_import_status(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_database_import_status")
-        .description("Get the import status for a database.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetDatabaseImportStatusInput>| async move {
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = DatabaseHandler::new(client);
-                let status = handler
-                    .get_database_import_status(input.subscription_id, input.database_id)
-                    .await
-                    .tool_context("Failed to get database import status")?;
-
-                CallToolResult::from_serialize(&status)
-            },
-        )
-        .build()
-}
-
-/// Input for creating a database tag
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct CreateDatabaseTagInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Database ID
-    pub database_id: i32,
-    /// Tag key
-    pub key: String,
-    /// Tag value
-    pub value: String,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the create_database_tag tool
-pub fn create_database_tag(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("create_database_tag")
-        .description(
-            "Create a tag on a database.",
-        )
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<CreateDatabaseTagInput>| async move {
-                use redis_cloud::databases::DatabaseTagCreateRequest;
-
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let request = DatabaseTagCreateRequest {
-                    key: input.key,
-                    value: input.value,
-                    subscription_id: None,
-                    database_id: None,
-                    command_type: None,
-                };
-
-                let handler = DatabaseHandler::new(client);
-                let tag = handler
-                    .create_tag(input.subscription_id, input.database_id, &request)
-                    .await
-                    .tool_context("Failed to create database tag")?;
-
-                CallToolResult::from_serialize(&tag)
-            },
-        )
-        .build()
-}
-
-/// Input for updating a database tag
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct UpdateDatabaseTagInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Database ID
-    pub database_id: i32,
-    /// Tag key to update
-    pub tag_key: String,
-    /// New tag value
-    pub value: String,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the update_database_tag tool
-pub fn update_database_tag(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("update_database_tag")
-        .description(
-            "Update a tag on a database.",
-        )
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<UpdateDatabaseTagInput>| async move {
-                use redis_cloud::databases::DatabaseTagUpdateRequest;
-
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let request = DatabaseTagUpdateRequest {
-                    subscription_id: None,
-                    database_id: None,
-                    key: None,
-                    value: input.value,
-                    command_type: None,
-                };
-
-                let handler = DatabaseHandler::new(client);
-                let tag = handler
-                    .update_tag(
-                        input.subscription_id,
-                        input.database_id,
-                        input.tag_key,
-                        &request,
-                    )
-                    .await
-                    .tool_context("Failed to update database tag")?;
-
-                CallToolResult::from_serialize(&tag)
-            },
-        )
-        .build()
-}
-
-/// Input for deleting a database tag
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct DeleteDatabaseTagInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Database ID
-    pub database_id: i32,
-    /// Tag key to delete
-    pub tag_key: String,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the delete_database_tag tool
-pub fn delete_database_tag(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("delete_database_tag")
-        .description(
-            "DANGEROUS: Delete a tag from a database.",
-        )
-        .destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<DeleteDatabaseTagInput>| async move {
-                if !state.is_destructive_allowed() {
-                    return Err(McpError::tool(
-                        "Destructive operations require policy tier 'full'",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let handler = DatabaseHandler::new(client);
-                let result = handler
-                    .delete_tag(input.subscription_id, input.database_id, input.tag_key)
-                    .await
-                    .tool_context("Failed to delete database tag")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
 /// Input for a tag key-value pair
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct TagInput {
     /// Tag key
     pub key: String,
@@ -1900,257 +76,1167 @@ pub struct TagInput {
     pub value: String,
 }
 
-/// Input for updating all database tags
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct UpdateDatabaseTagsInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Database ID
-    pub database_id: i32,
-    /// Tags to set on the database (replaces all existing tags)
-    pub tags: Vec<TagInput>,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
+// ============================================================================
+// Module router
+// ============================================================================
+
+mcp_module! {
+    list_subscriptions => "list_subscriptions",
+    get_subscription => "get_subscription",
+    list_databases => "list_databases",
+    get_database => "get_database",
+    get_backup_status => "get_backup_status",
+    get_slow_log => "get_slow_log",
+    get_tags => "get_database_tags",
+    get_database_certificate => "get_database_certificate",
+    create_database => "create_database",
+    update_database => "update_database",
+    delete_database => "delete_database",
+    backup_database => "backup_database",
+    import_database => "import_database",
+    delete_subscription => "delete_subscription",
+    flush_database => "flush_database",
+    flush_crdb_database => "flush_crdb_database",
+    create_subscription => "create_subscription",
+    update_subscription => "update_subscription",
+    get_subscription_pricing => "get_subscription_pricing",
+    get_redis_versions => "get_redis_versions",
+    get_subscription_cidr_allowlist => "get_subscription_cidr_allowlist",
+    update_subscription_cidr_allowlist => "update_subscription_cidr_allowlist",
+    get_subscription_maintenance_windows => "get_subscription_maintenance_windows",
+    update_subscription_maintenance_windows => "update_subscription_maintenance_windows",
+    get_active_active_regions => "get_active_active_regions",
+    add_active_active_region => "add_active_active_region",
+    delete_active_active_regions => "delete_active_active_regions",
+    get_available_database_versions => "get_available_database_versions",
+    upgrade_database_redis_version => "upgrade_database_redis_version",
+    get_database_upgrade_status => "get_database_upgrade_status",
+    get_database_import_status => "get_database_import_status",
+    create_database_tag => "create_database_tag",
+    update_database_tag => "update_database_tag",
+    delete_database_tag => "delete_database_tag",
+    update_database_tags => "update_database_tags",
+    update_crdb_local_properties => "update_crdb_local_properties",
 }
 
-/// Build the update_database_tags tool
-pub fn update_database_tags(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("update_database_tags")
-        .description(
-            "Update all tags on a database (replaces existing tags).",
+// ============================================================================
+// Read-only tools
+// ============================================================================
+
+cloud_tool!(read_only, list_subscriptions, "list_subscriptions",
+    "List all subscriptions.",
+    {} => |client, _input| {
+        let handler = SubscriptionHandler::new(client);
+        let account_subs = handler
+            .get_all_subscriptions()
+            .await
+            .tool_context("Failed to list subscriptions")?;
+
+        CallToolResult::from_serialize(&account_subs)
+    }
+);
+
+cloud_tool!(read_only, get_subscription, "get_subscription",
+    "Get subscription details by ID.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+    } => |client, input| {
+        let handler = SubscriptionHandler::new(client);
+        let subscription = handler
+            .get_subscription_by_id(input.subscription_id)
+            .await
+            .tool_context("Failed to get subscription")?;
+
+        CallToolResult::from_serialize(&subscription)
+    }
+);
+
+cloud_tool!(read_only, list_databases, "list_databases",
+    "List all databases in a subscription.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+    } => |client, input| {
+        let handler = DatabaseHandler::new(client);
+        let databases = handler
+            .get_subscription_databases(input.subscription_id, None, None)
+            .await
+            .tool_context("Failed to list databases")?;
+
+        CallToolResult::from_serialize(&databases)
+    }
+);
+
+cloud_tool!(read_only, get_database, "get_database",
+    "Get database details by ID.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// Database ID
+        pub database_id: i32,
+    } => |client, input| {
+        let handler = DatabaseHandler::new(client);
+        let database = handler
+            .get_subscription_database_by_id(input.subscription_id, input.database_id)
+            .await
+            .tool_context("Failed to get database")?;
+
+        CallToolResult::from_serialize(&database)
+    }
+);
+
+cloud_tool!(read_only, get_backup_status, "get_backup_status",
+    "Get backup status and history for a database.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// Database ID
+        pub database_id: i32,
+        /// Optional region name for Active-Active databases
+        #[serde(default)]
+        pub region_name: Option<String>,
+    } => |client, input| {
+        let handler = DatabaseHandler::new(client);
+        let status = handler
+            .get_database_backup_status(
+                input.subscription_id,
+                input.database_id,
+                input.region_name,
+            )
+            .await
+            .tool_context("Failed to get backup status")?;
+
+        CallToolResult::from_serialize(&status)
+    }
+);
+
+cloud_tool!(read_only, get_slow_log, "get_slow_log",
+    "Get slow log entries for a database.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// Database ID
+        pub database_id: i32,
+        /// Optional region name for Active-Active databases
+        #[serde(default)]
+        pub region_name: Option<String>,
+    } => |client, input| {
+        let handler = DatabaseHandler::new(client);
+        let log = handler
+            .get_slow_log(input.subscription_id, input.database_id, input.region_name)
+            .await
+            .tool_context("Failed to get slow log")?;
+
+        CallToolResult::from_serialize(&log)
+    }
+);
+
+cloud_tool!(read_only, get_tags, "get_database_tags",
+    "Get tags for a database.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// Database ID
+        pub database_id: i32,
+    } => |client, input| {
+        let handler = DatabaseHandler::new(client);
+        let tags = handler
+            .get_tags(input.subscription_id, input.database_id)
+            .await
+            .tool_context("Failed to get tags")?;
+
+        CallToolResult::from_serialize(&tags)
+    }
+);
+
+cloud_tool!(read_only, get_database_certificate, "get_database_certificate",
+    "Get the TLS/SSL certificate for a database in PEM format.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// Database ID
+        pub database_id: i32,
+    } => |client, input| {
+        let handler = DatabaseHandler::new(client);
+        let cert = handler
+            .get_subscription_database_certificate(
+                input.subscription_id,
+                input.database_id,
+            )
+            .await
+            .tool_context("Failed to get certificate")?;
+
+        CallToolResult::from_serialize(&cert)
+    }
+);
+
+cloud_tool!(read_only, get_subscription_pricing, "get_subscription_pricing",
+    "Get pricing details for a subscription.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+    } => |client, input| {
+        let handler = SubscriptionHandler::new(client);
+        let pricing = handler
+            .get_subscription_pricing(input.subscription_id)
+            .await
+            .tool_context("Failed to get subscription pricing")?;
+
+        CallToolResult::from_serialize(&pricing)
+    }
+);
+
+cloud_tool!(read_only, get_redis_versions, "get_redis_versions",
+    "Get available Redis versions. Optionally filter by subscription ID.",
+    {
+        /// Optional subscription ID to filter versions
+        #[serde(default)]
+        pub subscription_id: Option<i32>,
+    } => |client, input| {
+        let handler = SubscriptionHandler::new(client);
+        let versions = handler
+            .get_redis_versions(input.subscription_id)
+            .await
+            .tool_context("Failed to get Redis versions")?;
+
+        CallToolResult::from_serialize(&versions)
+    }
+);
+
+cloud_tool!(read_only, get_subscription_cidr_allowlist, "get_subscription_cidr_allowlist",
+    "Get the CIDR allowlist for a subscription.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+    } => |client, input| {
+        let handler = SubscriptionHandler::new(client);
+        let allowlist = handler
+            .get_cidr_allowlist(input.subscription_id)
+            .await
+            .tool_context("Failed to get subscription CIDR allowlist")?;
+
+        CallToolResult::from_serialize(&allowlist)
+    }
+);
+
+cloud_tool!(read_only, get_subscription_maintenance_windows, "get_subscription_maintenance_windows",
+    "Get maintenance windows for a subscription.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+    } => |client, input| {
+        let handler = SubscriptionHandler::new(client);
+        let windows = handler
+            .get_subscription_maintenance_windows(input.subscription_id)
+            .await
+            .tool_context("Failed to get subscription maintenance windows")?;
+
+        CallToolResult::from_serialize(&windows)
+    }
+);
+
+cloud_tool!(read_only, get_active_active_regions, "get_active_active_regions",
+    "Get regions from an Active-Active subscription.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+    } => |client, input| {
+        let handler = SubscriptionHandler::new(client);
+        let regions = handler
+            .get_regions_from_active_active_subscription(input.subscription_id)
+            .await
+            .tool_context("Failed to get Active-Active regions")?;
+
+        CallToolResult::from_serialize(&regions)
+    }
+);
+
+cloud_tool!(read_only, get_available_database_versions, "get_available_database_versions",
+    "Get available target Redis versions for upgrading a database.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// Database ID
+        pub database_id: i32,
+    } => |client, input| {
+        let handler = DatabaseHandler::new(client);
+        let versions = handler
+            .get_available_target_versions(input.subscription_id, input.database_id)
+            .await
+            .tool_context("Failed to get available database versions")?;
+
+        CallToolResult::from_serialize(&versions)
+    }
+);
+
+cloud_tool!(read_only, get_database_upgrade_status, "get_database_upgrade_status",
+    "Get the Redis version upgrade status for a database.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// Database ID
+        pub database_id: i32,
+    } => |client, input| {
+        let handler = DatabaseHandler::new(client);
+        let status = handler
+            .get_database_redis_version_upgrade_status(
+                input.subscription_id,
+                input.database_id,
+            )
+            .await
+            .tool_context("Failed to get database upgrade status")?;
+
+        CallToolResult::from_serialize(&status)
+    }
+);
+
+cloud_tool!(read_only, get_database_import_status, "get_database_import_status",
+    "Get the import status for a database.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// Database ID
+        pub database_id: i32,
+    } => |client, input| {
+        let handler = DatabaseHandler::new(client);
+        let status = handler
+            .get_database_import_status(input.subscription_id, input.database_id)
+            .await
+            .tool_context("Failed to get database import status")?;
+
+        CallToolResult::from_serialize(&status)
+    }
+);
+
+// ============================================================================
+// Write tools (require write permission)
+// ============================================================================
+
+cloud_tool!(write, create_database, "create_database",
+    "Create a new database in a Pro subscription and wait for it to be ready. \
+     Prerequisites: 1) get_subscription -- verify the target subscription exists and is active. \
+     2) get_modules -- validate desired modules. \
+     3) get_redis_versions -- pick a supported Redis version.",
+    {
+        /// Subscription ID to create the database in
+        pub subscription_id: i32,
+        /// Database name
+        pub name: String,
+        /// Memory limit in GB (e.g., 1.0, 2.5, 10.0)
+        pub memory_limit_in_gb: f64,
+        /// Enable replication for high availability (default: true)
+        #[serde(default = "default_replication")]
+        pub replication: bool,
+        /// Protocol: "redis" (RESP2), "stack" (RESP2 with modules), or "memcached"
+        #[serde(default = "default_protocol")]
+        pub protocol: String,
+        /// Data persistence: "none", "aof-every-1-second", "aof-every-write", "snapshot-every-1-hour", etc.
+        #[serde(default)]
+        pub data_persistence: Option<String>,
+        /// Timeout in seconds to wait for database creation (default: 600)
+        #[serde(default = "default_timeout")]
+        pub timeout_seconds: u64,
+    } => |client, input| {
+        // Build the request using Layer 1's TypedBuilder
+        let request = match (input.protocol.as_str(), input.data_persistence.as_ref()) {
+            ("redis", None) => DatabaseCreateRequest::builder()
+                .name(&input.name)
+                .memory_limit_in_gb(input.memory_limit_in_gb)
+                .replication(input.replication)
+                .build(),
+            ("redis", Some(persistence)) => DatabaseCreateRequest::builder()
+                .name(&input.name)
+                .memory_limit_in_gb(input.memory_limit_in_gb)
+                .replication(input.replication)
+                .data_persistence(persistence)
+                .build(),
+            (protocol, None) => DatabaseCreateRequest::builder()
+                .name(&input.name)
+                .memory_limit_in_gb(input.memory_limit_in_gb)
+                .replication(input.replication)
+                .protocol(protocol)
+                .build(),
+            (protocol, Some(persistence)) => DatabaseCreateRequest::builder()
+                .name(&input.name)
+                .memory_limit_in_gb(input.memory_limit_in_gb)
+                .replication(input.replication)
+                .protocol(protocol)
+                .data_persistence(persistence)
+                .build(),
+        };
+
+        // Use Layer 2 workflow - no progress callback needed for MCP
+        let database = create_database_and_wait(
+            &client,
+            input.subscription_id,
+            &request,
+            Duration::from_secs(input.timeout_seconds),
+            None, // MCP doesn't need progress callbacks
         )
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<UpdateDatabaseTagsInput>| async move {
-                use redis_cloud::databases::{DatabaseTagsUpdateRequest, Tag};
+        .await
+        .tool_context("Failed to create database")?;
 
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
+        CallToolResult::from_serialize(&database)
+    }
+);
 
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
+cloud_tool!(write, update_database, "update_database",
+    "Update a database configuration.",
+    {
+        /// Subscription ID containing the database
+        pub subscription_id: i32,
+        /// Database ID to update
+        pub database_id: i32,
+        /// New database name (optional)
+        #[serde(default)]
+        pub name: Option<String>,
+        /// New memory limit in GB (optional)
+        #[serde(default)]
+        pub memory_limit_in_gb: Option<f64>,
+        /// Change replication setting (optional)
+        #[serde(default)]
+        pub replication: Option<bool>,
+        /// Change data persistence (optional)
+        #[serde(default)]
+        pub data_persistence: Option<String>,
+        /// Change eviction policy (optional)
+        #[serde(default)]
+        pub data_eviction_policy: Option<String>,
+        /// Timeout in seconds (default: 600)
+        #[serde(default = "default_timeout")]
+        pub timeout_seconds: u64,
+    } => |client, input| {
+        use redis_cloud::databases::DatabaseUpdateRequest;
 
-                let tags = input
-                    .tags
-                    .into_iter()
-                    .map(|t| Tag {
-                        key: t.key,
-                        value: t.value,
-                        command_type: None,
-                    })
-                    .collect();
+        // Build the update request
+        let mut request = DatabaseUpdateRequest::builder().build();
+        request.name = input.name.clone();
+        request.memory_limit_in_gb = input.memory_limit_in_gb;
+        request.replication = input.replication;
+        request.data_persistence = input.data_persistence.clone();
+        request.data_eviction_policy = input.data_eviction_policy.clone();
 
-                let request = DatabaseTagsUpdateRequest {
-                    subscription_id: None,
-                    database_id: None,
-                    tags,
-                    command_type: None,
-                };
+        // Validate at least one field is set
+        if request.name.is_none()
+            && request.memory_limit_in_gb.is_none()
+            && request.replication.is_none()
+            && request.data_persistence.is_none()
+            && request.data_eviction_policy.is_none()
+        {
+            return Err(tower_mcp::Error::tool(
+                "At least one update field is required",
+            ));
+        }
 
-                let handler = DatabaseHandler::new(client);
-                let result = handler
-                    .update_tags(input.subscription_id, input.database_id, &request)
-                    .await
-                    .tool_context("Failed to update database tags")?;
-
-                CallToolResult::from_serialize(&result)
-            },
+        // Use Layer 2 workflow
+        let database = update_database_and_wait(
+            &client,
+            input.subscription_id,
+            input.database_id,
+            &request,
+            Duration::from_secs(input.timeout_seconds),
+            None,
         )
-        .build()
-}
+        .await
+        .tool_context("Failed to update database")?;
 
-/// Input for updating CRDB local properties
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct UpdateCrdbLocalPropertiesInput {
-    /// Subscription ID
-    pub subscription_id: i32,
-    /// Database ID
-    pub database_id: i32,
-    /// Updated database name
-    #[serde(default)]
-    pub name: Option<String>,
-    /// Whether to perform a dry run without making changes
-    #[serde(default)]
-    pub dry_run: Option<bool>,
-    /// Total memory limit in GB including replication overhead
-    #[serde(default)]
-    pub memory_limit_in_gb: Option<f64>,
-    /// Maximum dataset size in GB
-    #[serde(default)]
-    pub dataset_size_in_gb: Option<f64>,
-    /// Enable OSS Cluster API support
-    #[serde(default)]
-    pub support_oss_cluster_api: Option<bool>,
-    /// Use external endpoint for OSS Cluster API
-    #[serde(default)]
-    pub use_external_endpoint_for_oss_cluster_api: Option<bool>,
-    /// Enable TLS for connections
-    #[serde(default)]
-    pub enable_tls: Option<bool>,
-    /// Global data persistence setting for all regions
-    #[serde(default)]
-    pub global_data_persistence: Option<String>,
-    /// Global password for all regions
-    #[serde(default)]
-    pub global_password: Option<String>,
-    /// Global source IP allowlist for all regions
-    #[serde(default)]
-    pub global_source_ip: Option<Vec<String>>,
-    /// Data eviction policy
-    #[serde(default)]
-    pub data_eviction_policy: Option<String>,
-    /// Profile name for multi-account support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+        CallToolResult::from_serialize(&database)
+    }
+);
 
-/// Build the update_crdb_local_properties tool
-pub fn update_crdb_local_properties(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("update_crdb_local_properties")
-        .description("Update local properties of an Active-Active (CRDB) database.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<UpdateCrdbLocalPropertiesInput>| async move {
-                use redis_cloud::databases::CrdbUpdatePropertiesRequest;
-
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .cloud_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("cloud", e))?;
-
-                let request = CrdbUpdatePropertiesRequest {
-                    subscription_id: None,
-                    database_id: None,
-                    name: input.name,
-                    dry_run: input.dry_run,
-                    memory_limit_in_gb: input.memory_limit_in_gb,
-                    dataset_size_in_gb: input.dataset_size_in_gb,
-                    support_oss_cluster_api: input.support_oss_cluster_api,
-                    use_external_endpoint_for_oss_cluster_api: input
-                        .use_external_endpoint_for_oss_cluster_api,
-                    client_ssl_certificate: None,
-                    client_tls_certificates: None,
-                    enable_tls: input.enable_tls,
-                    global_data_persistence: input.global_data_persistence,
-                    global_password: input.global_password,
-                    global_source_ip: input.global_source_ip,
-                    global_alerts: None,
-                    regions: None,
-                    data_eviction_policy: input.data_eviction_policy,
-                    command_type: None,
-                };
-
-                let handler = DatabaseHandler::new(client);
-                let result = handler
-                    .update_crdb_local_properties(
-                        input.subscription_id,
-                        input.database_id,
-                        &request,
-                    )
-                    .await
-                    .tool_context("Failed to update CRDB local properties")?;
-
-                CallToolResult::from_serialize(&result)
-            },
+cloud_tool!(write, backup_database, "backup_database",
+    "Trigger a manual backup of a database.",
+    {
+        /// Subscription ID containing the database
+        pub subscription_id: i32,
+        /// Database ID to backup
+        pub database_id: i32,
+        /// Region name (required for Active-Active databases)
+        #[serde(default)]
+        pub region_name: Option<String>,
+        /// Timeout in seconds (default: 600)
+        #[serde(default = "default_timeout")]
+        pub timeout_seconds: u64,
+    } => |client, input| {
+        // Use Layer 2 workflow
+        backup_database_and_wait(
+            &client,
+            input.subscription_id,
+            input.database_id,
+            input.region_name.as_deref(),
+            Duration::from_secs(input.timeout_seconds),
+            None,
         )
-        .build()
-}
+        .await
+        .tool_context("Failed to backup database")?;
 
-/// All tool names registered by this sub-module.
-pub(super) const TOOL_NAMES: &[&str] = &[
-    "list_subscriptions",
-    "get_subscription",
-    "list_databases",
-    "get_database",
-    "get_backup_status",
-    "get_slow_log",
-    "get_database_tags",
-    "get_database_certificate",
-    "create_database",
-    "update_database",
-    "delete_database",
-    "backup_database",
-    "import_database",
-    "delete_subscription",
-    "flush_database",
-    "flush_crdb_database",
-    "create_subscription",
-    "update_subscription",
-    "get_subscription_pricing",
-    "get_redis_versions",
-    "get_subscription_cidr_allowlist",
-    "update_subscription_cidr_allowlist",
-    "get_subscription_maintenance_windows",
-    "update_subscription_maintenance_windows",
-    "get_active_active_regions",
-    "add_active_active_region",
-    "delete_active_active_regions",
-    "get_available_database_versions",
-    "upgrade_database_redis_version",
-    "get_database_upgrade_status",
-    "get_database_import_status",
-    "create_database_tag",
-    "update_database_tag",
-    "delete_database_tag",
-    "update_database_tags",
-    "update_crdb_local_properties",
-];
+        CallToolResult::from_serialize(&serde_json::json!({
+            "message": "Backup completed successfully",
+            "subscription_id": input.subscription_id,
+            "database_id": input.database_id
+        }))
+    }
+);
 
-/// Build an MCP sub-router containing subscription and database tools
-pub fn router(state: Arc<AppState>) -> McpRouter {
-    McpRouter::new()
-        // Subscriptions & Databases
-        .tool(list_subscriptions(state.clone()))
-        .tool(get_subscription(state.clone()))
-        .tool(get_subscription_pricing(state.clone()))
-        .tool(get_redis_versions(state.clone()))
-        .tool(get_subscription_cidr_allowlist(state.clone()))
-        .tool(get_subscription_maintenance_windows(state.clone()))
-        .tool(get_active_active_regions(state.clone()))
-        .tool(list_databases(state.clone()))
-        .tool(get_database(state.clone()))
-        .tool(get_backup_status(state.clone()))
-        .tool(get_slow_log(state.clone()))
-        .tool(get_tags(state.clone()))
-        .tool(get_database_certificate(state.clone()))
-        .tool(get_available_database_versions(state.clone()))
-        .tool(get_database_upgrade_status(state.clone()))
-        .tool(get_database_import_status(state.clone()))
-        // Write Operations
-        .tool(create_database(state.clone()))
-        .tool(update_database(state.clone()))
-        .tool(delete_database(state.clone()))
-        .tool(backup_database(state.clone()))
-        .tool(import_database(state.clone()))
-        .tool(delete_subscription(state.clone()))
-        .tool(flush_database(state.clone()))
-        .tool(flush_crdb_database(state.clone()))
-        .tool(create_subscription(state.clone()))
-        .tool(update_subscription(state.clone()))
-        .tool(update_subscription_cidr_allowlist(state.clone()))
-        .tool(update_subscription_maintenance_windows(state.clone()))
-        .tool(add_active_active_region(state.clone()))
-        .tool(delete_active_active_regions(state.clone()))
-        .tool(upgrade_database_redis_version(state.clone()))
-        .tool(create_database_tag(state.clone()))
-        .tool(update_database_tag(state.clone()))
-        .tool(delete_database_tag(state.clone()))
-        .tool(update_database_tags(state.clone()))
-        .tool(update_crdb_local_properties(state.clone()))
-}
+cloud_tool!(write, import_database, "import_database",
+    "Import data into a database from an external source. WARNING: This will overwrite existing data.",
+    {
+        /// Subscription ID containing the database
+        pub subscription_id: i32,
+        /// Database ID to import into
+        pub database_id: i32,
+        /// Source type: "http", "redis", "ftp", "aws-s3", "azure-blob-storage", "google-blob-storage"
+        pub source_type: String,
+        /// URI to import from
+        pub import_from_uri: String,
+        /// Timeout in seconds (default: 1800 for imports)
+        #[serde(default = "default_import_timeout")]
+        pub timeout_seconds: u64,
+    } => |client, input| {
+        use redis_cloud::databases::DatabaseImportRequest;
+
+        // Build the import request
+        let request = DatabaseImportRequest::builder()
+            .source_type(&input.source_type)
+            .import_from_uri(vec![input.import_from_uri.clone()])
+            .build();
+
+        // Use Layer 2 workflow
+        import_database_and_wait(
+            &client,
+            input.subscription_id,
+            input.database_id,
+            &request,
+            Duration::from_secs(input.timeout_seconds),
+            None,
+        )
+        .await
+        .tool_context("Failed to import database")?;
+
+        CallToolResult::from_serialize(&serde_json::json!({
+            "message": "Import completed successfully",
+            "subscription_id": input.subscription_id,
+            "database_id": input.database_id
+        }))
+    }
+);
+
+cloud_tool!(write, create_subscription, "create_subscription",
+    "Create a new Pro subscription with an initial database. \
+     Prerequisites: 1) list_payment_methods -- verify a payment method exists. \
+     2) get_regions -- validate the target cloud provider and region. \
+     3) get_modules -- confirm desired database modules are available. \
+     4) get_redis_versions -- pick a supported Redis version.",
+    {
+        /// Subscription name
+        pub name: String,
+        /// Cloud provider: "AWS", "GCP", or "Azure"
+        pub cloud_provider: String,
+        /// Cloud region (e.g., "us-east-1" for AWS, "us-central1" for GCP)
+        pub region: String,
+        /// Cloud account ID (use list_cloud_accounts to find available accounts, or use 1 for internal account)
+        #[serde(default = "default_cloud_account_id")]
+        pub cloud_account_id: i32,
+        /// Database name for the initial database
+        pub database_name: String,
+        /// Memory limit in GB for the initial database
+        pub memory_limit_in_gb: f64,
+        /// Database protocol: "redis" (default), "stack", or "memcached"
+        #[serde(default = "default_protocol")]
+        pub protocol: String,
+        /// Enable replication for high availability (default: true)
+        #[serde(default = "default_replication")]
+        pub replication: bool,
+        /// Timeout in seconds (default: 1800 - subscriptions take longer)
+        #[serde(default = "default_subscription_timeout")]
+        pub timeout_seconds: u64,
+    } => |client, input| {
+        use redis_cloud::flexible::subscriptions::{
+            SubscriptionCreateRequest, SubscriptionDatabaseSpec, SubscriptionRegionSpec,
+            SubscriptionSpec,
+        };
+        use redisctl_core::cloud::create_subscription_and_wait;
+
+        // Build the subscription request
+        let request = SubscriptionCreateRequest::builder()
+            .name(&input.name)
+            .cloud_providers(vec![SubscriptionSpec {
+                provider: Some(input.cloud_provider.clone()),
+                cloud_account_id: Some(input.cloud_account_id),
+                regions: vec![SubscriptionRegionSpec {
+                    region: input.region.clone(),
+                    multiple_availability_zones: None,
+                    preferred_availability_zones: None,
+                    networking: None,
+                }],
+            }])
+            .databases(vec![SubscriptionDatabaseSpec {
+                name: input.database_name.clone(),
+                protocol: input.protocol.clone(),
+                memory_limit_in_gb: Some(input.memory_limit_in_gb),
+                dataset_size_in_gb: None,
+                support_oss_cluster_api: None,
+                data_persistence: None,
+                replication: Some(input.replication),
+                throughput_measurement: None,
+                local_throughput_measurement: None,
+                modules: None,
+                quantity: None,
+                average_item_size_in_bytes: None,
+                resp_version: None,
+                redis_version: None,
+                sharding_type: None,
+                query_performance_factor: None,
+            }])
+            .build();
+
+        // Use Layer 2 workflow
+        let subscription = create_subscription_and_wait(
+            &client,
+            &request,
+            Duration::from_secs(input.timeout_seconds),
+            None,
+        )
+        .await
+        .tool_context("Failed to create subscription")?;
+
+        CallToolResult::from_serialize(&subscription)
+    }
+);
+
+cloud_tool!(write, update_subscription, "update_subscription",
+    "Update a subscription.",
+    {
+        /// Subscription ID to update
+        pub subscription_id: i32,
+    } => |client, input| {
+        use redis_cloud::flexible::subscriptions::BaseSubscriptionUpdateRequest;
+
+        let request = BaseSubscriptionUpdateRequest {
+            subscription_id: None,
+            command_type: None,
+        };
+
+        let handler = SubscriptionHandler::new(client);
+        let result = handler
+            .update_subscription(input.subscription_id, &request)
+            .await
+            .tool_context("Failed to update subscription")?;
+
+        CallToolResult::from_serialize(&result)
+    }
+);
+
+cloud_tool!(write, update_subscription_cidr_allowlist, "update_subscription_cidr_allowlist",
+    "Update the CIDR allowlist for a subscription.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// List of CIDR IP ranges to allow (e.g., ["192.168.1.0/24", "10.0.0.0/8"])
+        #[serde(default)]
+        pub cidr_ips: Option<Vec<String>>,
+        /// List of security group IDs to allow (AWS only)
+        #[serde(default)]
+        pub security_group_ids: Option<Vec<String>>,
+    } => |client, input| {
+        use redis_cloud::flexible::subscriptions::CidrAllowlistUpdateRequest;
+
+        let request = CidrAllowlistUpdateRequest {
+            subscription_id: None,
+            cidr_ips: input.cidr_ips.clone(),
+            security_group_ids: input.security_group_ids.clone(),
+            command_type: None,
+        };
+
+        let handler = SubscriptionHandler::new(client);
+        let result = handler
+            .update_subscription_cidr_allowlist(input.subscription_id, &request)
+            .await
+            .tool_context("Failed to update subscription CIDR allowlist")?;
+
+        CallToolResult::from_serialize(&result)
+    }
+);
+
+cloud_tool!(write, update_subscription_maintenance_windows, "update_subscription_maintenance_windows",
+    "Update maintenance windows for a subscription.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// Maintenance mode: "manual" or "automatic"
+        pub mode: String,
+        /// Maintenance windows (required when mode is "manual")
+        #[serde(default)]
+        pub windows: Option<Vec<MaintenanceWindowInput>>,
+    } => |client, input| {
+        use redis_cloud::flexible::subscriptions::{
+            MaintenanceWindowSpec, SubscriptionMaintenanceWindowsSpec,
+        };
+
+        let windows = input.windows.map(|ws| {
+            ws.into_iter()
+                .map(|w| MaintenanceWindowSpec {
+                    start_hour: w.start_hour,
+                    duration_in_hours: w.duration_in_hours,
+                    days: w.days,
+                })
+                .collect()
+        });
+
+        let request = SubscriptionMaintenanceWindowsSpec {
+            mode: input.mode.clone(),
+            windows,
+        };
+
+        let handler = SubscriptionHandler::new(client);
+        let result = handler
+            .update_subscription_maintenance_windows(input.subscription_id, &request)
+            .await
+            .tool_context("Failed to update subscription maintenance windows")?;
+
+        CallToolResult::from_serialize(&result)
+    }
+);
+
+cloud_tool!(write, add_active_active_region, "add_active_active_region",
+    "Add a new region to an Active-Active subscription.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// Deployment CIDR for the new region (e.g., "10.0.0.0/24")
+        pub deployment_cidr: String,
+        /// Region name (e.g., "us-east-1")
+        #[serde(default)]
+        pub region: Option<String>,
+        /// VPC ID for the region
+        #[serde(default)]
+        pub vpc_id: Option<String>,
+        /// Whether to perform a dry run without making changes
+        #[serde(default)]
+        pub dry_run: Option<bool>,
+        /// RESP version for the region
+        #[serde(default)]
+        pub resp_version: Option<String>,
+    } => |client, input| {
+        use redis_cloud::flexible::subscriptions::ActiveActiveRegionCreateRequest;
+
+        let request = ActiveActiveRegionCreateRequest {
+            subscription_id: None,
+            region: input.region.clone(),
+            vpc_id: input.vpc_id.clone(),
+            deployment_cidr: input.deployment_cidr.clone(),
+            dry_run: input.dry_run,
+            databases: None,
+            resp_version: input.resp_version.clone(),
+            customer_managed_key_resource_name: None,
+            command_type: None,
+        };
+
+        let handler = SubscriptionHandler::new(client);
+        let result = handler
+            .add_new_region_to_active_active_subscription(
+                input.subscription_id,
+                &request,
+            )
+            .await
+            .tool_context("Failed to add Active-Active region")?;
+
+        CallToolResult::from_serialize(&result)
+    }
+);
+
+cloud_tool!(write, upgrade_database_redis_version, "upgrade_database_redis_version",
+    "Upgrade the Redis version of a database. \
+     Use get_available_database_versions to find valid target versions.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// Database ID
+        pub database_id: i32,
+        /// Target Redis version to upgrade to (e.g., "7.2")
+        pub target_redis_version: String,
+    } => |client, input| {
+        use redis_cloud::databases::DatabaseUpgradeRedisVersionRequest;
+
+        let request = DatabaseUpgradeRedisVersionRequest {
+            database_id: None,
+            subscription_id: None,
+            target_redis_version: input.target_redis_version.clone(),
+            command_type: None,
+        };
+
+        let handler = DatabaseHandler::new(client);
+        let result = handler
+            .upgrade_database_redis_version(
+                input.subscription_id,
+                input.database_id,
+                &request,
+            )
+            .await
+            .tool_context("Failed to upgrade database Redis version")?;
+
+        CallToolResult::from_serialize(&result)
+    }
+);
+
+cloud_tool!(write, create_database_tag, "create_database_tag",
+    "Create a tag on a database.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// Database ID
+        pub database_id: i32,
+        /// Tag key
+        pub key: String,
+        /// Tag value
+        pub value: String,
+    } => |client, input| {
+        use redis_cloud::databases::DatabaseTagCreateRequest;
+
+        let request = DatabaseTagCreateRequest {
+            key: input.key.clone(),
+            value: input.value.clone(),
+            subscription_id: None,
+            database_id: None,
+            command_type: None,
+        };
+
+        let handler = DatabaseHandler::new(client);
+        let tag = handler
+            .create_tag(input.subscription_id, input.database_id, &request)
+            .await
+            .tool_context("Failed to create database tag")?;
+
+        CallToolResult::from_serialize(&tag)
+    }
+);
+
+cloud_tool!(write, update_database_tag, "update_database_tag",
+    "Update a tag on a database.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// Database ID
+        pub database_id: i32,
+        /// Tag key to update
+        pub tag_key: String,
+        /// New tag value
+        pub value: String,
+    } => |client, input| {
+        use redis_cloud::databases::DatabaseTagUpdateRequest;
+
+        let request = DatabaseTagUpdateRequest {
+            subscription_id: None,
+            database_id: None,
+            key: None,
+            value: input.value.clone(),
+            command_type: None,
+        };
+
+        let handler = DatabaseHandler::new(client);
+        let tag = handler
+            .update_tag(
+                input.subscription_id,
+                input.database_id,
+                input.tag_key.clone(),
+                &request,
+            )
+            .await
+            .tool_context("Failed to update database tag")?;
+
+        CallToolResult::from_serialize(&tag)
+    }
+);
+
+cloud_tool!(write, update_database_tags, "update_database_tags",
+    "Update all tags on a database (replaces existing tags).",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// Database ID
+        pub database_id: i32,
+        /// Tags to set on the database (replaces all existing tags)
+        pub tags: Vec<TagInput>,
+    } => |client, input| {
+        use redis_cloud::databases::{DatabaseTagsUpdateRequest, Tag};
+
+        let tags = input
+            .tags
+            .into_iter()
+            .map(|t| Tag {
+                key: t.key,
+                value: t.value,
+                command_type: None,
+            })
+            .collect();
+
+        let request = DatabaseTagsUpdateRequest {
+            subscription_id: None,
+            database_id: None,
+            tags,
+            command_type: None,
+        };
+
+        let handler = DatabaseHandler::new(client);
+        let result = handler
+            .update_tags(input.subscription_id, input.database_id, &request)
+            .await
+            .tool_context("Failed to update database tags")?;
+
+        CallToolResult::from_serialize(&result)
+    }
+);
+
+cloud_tool!(write, update_crdb_local_properties, "update_crdb_local_properties",
+    "Update local properties of an Active-Active (CRDB) database.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// Database ID
+        pub database_id: i32,
+        /// Updated database name
+        #[serde(default)]
+        pub name: Option<String>,
+        /// Whether to perform a dry run without making changes
+        #[serde(default)]
+        pub dry_run: Option<bool>,
+        /// Total memory limit in GB including replication overhead
+        #[serde(default)]
+        pub memory_limit_in_gb: Option<f64>,
+        /// Maximum dataset size in GB
+        #[serde(default)]
+        pub dataset_size_in_gb: Option<f64>,
+        /// Enable OSS Cluster API support
+        #[serde(default)]
+        pub support_oss_cluster_api: Option<bool>,
+        /// Use external endpoint for OSS Cluster API
+        #[serde(default)]
+        pub use_external_endpoint_for_oss_cluster_api: Option<bool>,
+        /// Enable TLS for connections
+        #[serde(default)]
+        pub enable_tls: Option<bool>,
+        /// Global data persistence setting for all regions
+        #[serde(default)]
+        pub global_data_persistence: Option<String>,
+        /// Global password for all regions
+        #[serde(default)]
+        pub global_password: Option<String>,
+        /// Global source IP allowlist for all regions
+        #[serde(default)]
+        pub global_source_ip: Option<Vec<String>>,
+        /// Data eviction policy
+        #[serde(default)]
+        pub data_eviction_policy: Option<String>,
+    } => |client, input| {
+        use redis_cloud::databases::CrdbUpdatePropertiesRequest;
+
+        let request = CrdbUpdatePropertiesRequest {
+            subscription_id: None,
+            database_id: None,
+            name: input.name.clone(),
+            dry_run: input.dry_run,
+            memory_limit_in_gb: input.memory_limit_in_gb,
+            dataset_size_in_gb: input.dataset_size_in_gb,
+            support_oss_cluster_api: input.support_oss_cluster_api,
+            use_external_endpoint_for_oss_cluster_api: input
+                .use_external_endpoint_for_oss_cluster_api,
+            client_ssl_certificate: None,
+            client_tls_certificates: None,
+            enable_tls: input.enable_tls,
+            global_data_persistence: input.global_data_persistence.clone(),
+            global_password: input.global_password.clone(),
+            global_source_ip: input.global_source_ip.clone(),
+            global_alerts: None,
+            regions: None,
+            data_eviction_policy: input.data_eviction_policy.clone(),
+            command_type: None,
+        };
+
+        let handler = DatabaseHandler::new(client);
+        let result = handler
+            .update_crdb_local_properties(
+                input.subscription_id,
+                input.database_id,
+                &request,
+            )
+            .await
+            .tool_context("Failed to update CRDB local properties")?;
+
+        CallToolResult::from_serialize(&result)
+    }
+);
+
+// ============================================================================
+// Destructive tools (require destructive permission)
+// ============================================================================
+
+cloud_tool!(destructive, delete_database, "delete_database",
+    "DANGEROUS: Delete a database and all its data.",
+    {
+        /// Subscription ID containing the database
+        pub subscription_id: i32,
+        /// Database ID to delete
+        pub database_id: i32,
+        /// Timeout in seconds (default: 600)
+        #[serde(default = "default_timeout")]
+        pub timeout_seconds: u64,
+    } => |client, input| {
+        // Use Layer 2 workflow
+        delete_database_and_wait(
+            &client,
+            input.subscription_id,
+            input.database_id,
+            Duration::from_secs(input.timeout_seconds),
+            None,
+        )
+        .await
+        .tool_context("Failed to delete database")?;
+
+        CallToolResult::from_serialize(&serde_json::json!({
+            "message": "Database deleted successfully",
+            "subscription_id": input.subscription_id,
+            "database_id": input.database_id
+        }))
+    }
+);
+
+cloud_tool!(destructive, delete_subscription, "delete_subscription",
+    "DANGEROUS: Delete a subscription. All databases must be deleted first.",
+    {
+        /// Subscription ID to delete
+        pub subscription_id: i32,
+        /// Timeout in seconds (default: 600)
+        #[serde(default = "default_timeout")]
+        pub timeout_seconds: u64,
+    } => |client, input| {
+        // Use Layer 2 workflow
+        delete_subscription_and_wait(
+            &client,
+            input.subscription_id,
+            Duration::from_secs(input.timeout_seconds),
+            None,
+        )
+        .await
+        .tool_context("Failed to delete subscription")?;
+
+        CallToolResult::from_serialize(&serde_json::json!({
+            "message": "Subscription deleted successfully",
+            "subscription_id": input.subscription_id
+        }))
+    }
+);
+
+cloud_tool!(destructive, flush_database, "flush_database",
+    "DANGEROUS: Removes all data from a database.",
+    {
+        /// Subscription ID containing the database
+        pub subscription_id: i32,
+        /// Database ID to flush
+        pub database_id: i32,
+        /// Timeout in seconds (default: 300)
+        #[serde(default = "default_flush_timeout")]
+        pub timeout_seconds: u64,
+    } => |client, input| {
+        // Use Layer 2 workflow
+        flush_database_and_wait(
+            &client,
+            input.subscription_id,
+            input.database_id,
+            Duration::from_secs(input.timeout_seconds),
+            None,
+        )
+        .await
+        .tool_context("Failed to flush database")?;
+
+        CallToolResult::from_serialize(&serde_json::json!({
+            "message": "Database flushed successfully",
+            "subscription_id": input.subscription_id,
+            "database_id": input.database_id
+        }))
+    }
+);
+
+cloud_tool!(destructive, flush_crdb_database, "flush_crdb_database",
+    "DANGEROUS: Removes all data from an Active-Active (CRDB) database. \
+     Use this instead of regular flush for Active-Active databases.",
+    {
+        /// Subscription ID containing the database
+        pub subscription_id: i32,
+        /// Database ID to flush
+        pub database_id: i32,
+    } => |client, input| {
+        let handler = DatabaseHandler::new(client);
+        let request = redis_cloud::databases::CrdbFlushRequest {
+            subscription_id: None,
+            database_id: None,
+            command_type: None,
+        };
+        let result = handler
+            .flush_crdb(input.subscription_id, input.database_id, &request)
+            .await
+            .tool_context("Failed to flush CRDB database")?;
+
+        CallToolResult::from_serialize(&result)
+    }
+);
+
+cloud_tool!(destructive, delete_active_active_regions, "delete_active_active_regions",
+    "DANGEROUS: Remove regions from an Active-Active subscription. May cause data loss in removed regions.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// Regions to delete
+        pub regions: Vec<ActiveActiveRegionToDeleteInput>,
+        /// Whether to perform a dry run without making changes
+        #[serde(default)]
+        pub dry_run: Option<bool>,
+    } => |client, input| {
+        use redis_cloud::flexible::subscriptions::{
+            ActiveActiveRegionDeleteRequest, ActiveActiveRegionToDelete,
+        };
+
+        let regions = input
+            .regions
+            .into_iter()
+            .map(|r| ActiveActiveRegionToDelete {
+                region: Some(r.region),
+            })
+            .collect();
+
+        let request = ActiveActiveRegionDeleteRequest {
+            subscription_id: None,
+            regions: Some(regions),
+            dry_run: input.dry_run,
+            command_type: None,
+        };
+
+        let handler = SubscriptionHandler::new(client);
+        let result = handler
+            .delete_regions_from_active_active_subscription(input.subscription_id, &request)
+            .await
+            .tool_context("Failed to delete Active-Active regions")?;
+
+        CallToolResult::from_serialize(&result)
+    }
+);
+
+cloud_tool!(destructive, delete_database_tag, "delete_database_tag",
+    "DANGEROUS: Delete a tag from a database.",
+    {
+        /// Subscription ID
+        pub subscription_id: i32,
+        /// Database ID
+        pub database_id: i32,
+        /// Tag key to delete
+        pub tag_key: String,
+    } => |client, input| {
+        let handler = DatabaseHandler::new(client);
+        let result = handler
+            .delete_tag(input.subscription_id, input.database_id, input.tag_key.clone())
+            .await
+            .tool_context("Failed to delete database tag")?;
+
+        CallToolResult::from_serialize(&result)
+    }
+);


### PR DESCRIPTION
## Summary

- Convert 147 cloud tools across 4 files to `cloud_tool!` and `mcp_module!` macros
- First real use of the `cloud_tool!` macro (validates the cloud platform pattern)
- Raw tool (`cloud_raw_api`) stays manual due to custom method-dependent permission logic
- Net reduction: -3668 lines (7754 removed, 4086 added)

| File | Before | After | Reduction |
|---|---|---|---|
| subscriptions.rs (36 tools) | 2156 | 1242 | 42% |
| account.rs (33 tools) | 1646 | 852 | 48% |
| networking.rs (51 tools) | 2753 | 1465 | 47% |
| fixed.rs (27 tools) | 1455 | 783 | 46% |

Continues #791

## Test plan

- [x] `cargo clippy -p redisctl-mcp --all-features -- -D warnings` clean
- [x] `cargo check -p redisctl-mcp --no-default-features` compiles
- [x] All 95 lib tests pass
- [x] `cargo fmt --all -- --check` clean