### PR TITLE
refactor(mcp): convert enterprise tools to declarative macros

### DIFF
--- a/crates/redisctl-mcp/src/tools/enterprise/cluster.rs
+++ b/crates/redisctl-mcp/src/tools/enterprise/cluster.rs
@@ -1,1125 +1,523 @@
 //! Cluster, license, node, maintenance, and certificate tools
 
-use std::sync::Arc;
-
 use redis_enterprise::cluster::ClusterHandler;
 use redis_enterprise::license::{LicenseHandler, LicenseUpdateRequest};
 use redis_enterprise::nodes::NodeHandler;
 use redis_enterprise::stats::{StatsHandler, StatsQuery};
-use schemars::JsonSchema;
-use serde::Deserialize;
 use serde_json::Value;
-use tower_mcp::extract::{Json, State};
-use tower_mcp::{CallToolResult, Error as McpError, McpRouter, ResultExt, Tool, ToolBuilder};
+use tower_mcp::{CallToolResult, ResultExt};
 
-use crate::state::AppState;
+use crate::tools::macros::{enterprise_tool, mcp_module};
 
-/// Input for getting cluster info (no required parameters)
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetClusterInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the get_cluster tool
-pub fn get_cluster(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_cluster")
-        .description("Get cluster information including name, version, and configuration")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<GetClusterInput>| async move {
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let handler = ClusterHandler::new(client);
-                let cluster = handler
-                    .info()
-                    .await
-                    .tool_context("Failed to get cluster info")?;
-
-                CallToolResult::from_serialize(&cluster)
-            },
-        )
-        .build()
+mcp_module! {
+    get_cluster => "get_cluster",
+    get_cluster_stats => "get_cluster_stats",
+    update_cluster => "update_enterprise_cluster",
+    get_cluster_policy => "get_enterprise_cluster_policy",
+    update_cluster_policy => "update_enterprise_cluster_policy",
+    enable_maintenance_mode => "enable_enterprise_maintenance_mode",
+    disable_maintenance_mode => "disable_enterprise_maintenance_mode",
+    get_cluster_certificates => "get_enterprise_cluster_certificates",
+    rotate_cluster_certificates => "rotate_enterprise_cluster_certificates",
+    update_cluster_certificates => "update_enterprise_cluster_certificates",
+    get_license => "get_license",
+    get_license_usage => "get_license_usage",
+    update_license => "update_enterprise_license",
+    validate_license => "validate_enterprise_license",
+    list_nodes => "list_nodes",
+    get_node => "get_node",
+    get_node_stats => "get_node_stats",
+    enable_node_maintenance => "enable_enterprise_node_maintenance",
+    disable_node_maintenance => "disable_enterprise_node_maintenance",
+    rebalance_node => "rebalance_enterprise_node",
+    drain_node => "drain_enterprise_node",
+    update_enterprise_node => "update_enterprise_node",
+    remove_enterprise_node => "remove_enterprise_node",
+    get_enterprise_cluster_services => "get_enterprise_cluster_services",
 }
 
 // ============================================================================
-// License tools
+// Cluster tools
 // ============================================================================
 
-/// Input for getting license info
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetLicenseInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+enterprise_tool!(read_only, get_cluster, "get_cluster",
+    "Get cluster information including name, version, and configuration",
+    {} => |client, _input| {
+        let handler = ClusterHandler::new(client);
+        let cluster = handler
+            .info()
+            .await
+            .tool_context("Failed to get cluster info")?;
 
-/// Build the get_license tool
-pub fn get_license(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_license")
-        .description("Get license information including type, expiration, and enabled features")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<GetLicenseInput>| async move {
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+        CallToolResult::from_serialize(&cluster)
+    }
+);
 
-                let handler = LicenseHandler::new(client);
-                let license = handler.get().await.tool_context("Failed to get license")?;
+enterprise_tool!(read_only, get_cluster_stats, "get_cluster_stats",
+    "Get cluster-level statistics. Optionally specify interval and time range \
+     for historical data.",
+    {
+        /// Time interval for aggregation: "1sec", "10sec", "5min", "15min", "1hour", "12hour", "1week"
+        #[serde(default)]
+        pub interval: Option<String>,
+        /// Start time for historical query (ISO 8601 format, e.g., "2024-01-15T10:00:00Z")
+        #[serde(default)]
+        pub start_time: Option<String>,
+        /// End time for historical query (ISO 8601 format)
+        #[serde(default)]
+        pub end_time: Option<String>,
+    } => |client, input| {
+        let handler = StatsHandler::new(client);
 
-                CallToolResult::from_serialize(&license)
-            },
-        )
-        .build()
-}
+        if input.interval.is_some()
+            || input.start_time.is_some()
+            || input.end_time.is_some()
+        {
+            let query = StatsQuery {
+                interval: input.interval,
+                stime: input.start_time,
+                etime: input.end_time,
+                metrics: None,
+            };
+            let stats = handler
+                .cluster(Some(query))
+                .await
+                .tool_context("Failed to get cluster stats")?;
+            CallToolResult::from_serialize(&stats)
+        } else {
+            let stats = handler
+                .cluster_last()
+                .await
+                .tool_context("Failed to get cluster stats")?;
+            CallToolResult::from_serialize(&stats)
+        }
+    }
+);
 
-/// Input for getting license usage
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetLicenseUsageInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+enterprise_tool!(write, update_cluster, "update_enterprise_cluster",
+    "Update cluster configuration settings. Pass fields to update as JSON.",
+    {
+        /// JSON object with cluster settings to update (e.g., {"name": "my-cluster", "email_alerts": true})
+        pub updates: Value,
+    } => |client, input| {
+        let handler = ClusterHandler::new(client);
+        let result = handler
+            .update(input.updates)
+            .await
+            .tool_context("Failed to update cluster")?;
 
-/// Build the get_license_usage tool
-pub fn get_license_usage(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_license_usage")
-        .description(
-            "Get license utilization statistics including shards, nodes, and RAM usage against limits",
-        )
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetLicenseUsageInput>| async move {
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+        CallToolResult::from_serialize(&result)
+    }
+);
 
-                let handler = LicenseHandler::new(client);
-                let usage = handler
-                    .usage()
-                    .await
-                    .tool_context("Failed to get license usage")?;
+enterprise_tool!(read_only, get_cluster_policy, "get_enterprise_cluster_policy",
+    "Get cluster policy settings including default shards placement, \
+     rack awareness, and default Redis version.",
+    {} => |client, _input| {
+        let handler = ClusterHandler::new(client);
+        let policy = handler
+            .policy()
+            .await
+            .tool_context("Failed to get cluster policy")?;
 
-                CallToolResult::from_serialize(&usage)
-            },
-        )
-        .build()
-}
+        CallToolResult::from_serialize(&policy)
+    }
+);
 
-// ============================================================================
-// License Write Operations
-// ============================================================================
+enterprise_tool!(write, update_cluster_policy, "update_enterprise_cluster_policy",
+    "Update cluster policy settings. Pass fields to update as JSON.",
+    {
+        /// JSON object with policy settings to update
+        /// (e.g., {"default_shards_placement": "sparse", "rack_aware": true, "default_provisioned_redis_version": "7.2"})
+        pub policy: Value,
+    } => |client, input| {
+        let handler = ClusterHandler::new(client);
+        let result = handler
+            .policy_update(input.policy)
+            .await
+            .tool_context("Failed to update cluster policy")?;
 
-/// Input for updating license
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct UpdateLicenseInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// The license key string to install
-    pub license_key: String,
-}
-
-/// Build the update_license tool
-pub fn update_license(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("update_enterprise_license")
-        .description("Apply a new license key to the cluster.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<UpdateLicenseInput>| async move {
-                // Check write permission
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let handler = LicenseHandler::new(client);
-                let request = LicenseUpdateRequest {
-                    license: input.license_key,
-                };
-                let license = handler
-                    .update(request)
-                    .await
-                    .tool_context("Failed to update license")?;
-
-                CallToolResult::from_serialize(&license)
-            },
-        )
-        .build()
-}
-
-/// Input for validating license
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ValidateLicenseInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// The license key string to validate
-    pub license_key: String,
-}
-
-/// Build the validate_license tool
-pub fn validate_license(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("validate_enterprise_license")
-        .description("Validate a license key without applying it (dry-run).")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<ValidateLicenseInput>| async move {
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let handler = LicenseHandler::new(client);
-                let license = handler
-                    .validate(&input.license_key)
-                    .await
-                    .tool_context("License validation failed")?;
-
-                CallToolResult::from_serialize(&license)
-            },
-        )
-        .build()
-}
-
-// ============================================================================
-// Cluster Configuration Operations
-// ============================================================================
-
-/// Input for updating cluster configuration
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct UpdateClusterInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// JSON object with cluster settings to update (e.g., {"name": "my-cluster", "email_alerts": true})
-    pub updates: Value,
-}
-
-/// Build the update_cluster tool
-pub fn update_cluster(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("update_enterprise_cluster")
-        .description("Update cluster configuration settings. Pass fields to update as JSON.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<UpdateClusterInput>| async move {
-                // Check write permission
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let handler = ClusterHandler::new(client);
-                let result = handler
-                    .update(input.updates)
-                    .await
-                    .tool_context("Failed to update cluster")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// Input for getting cluster policy (no required parameters)
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetClusterPolicyInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the get_cluster_policy tool
-pub fn get_cluster_policy(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_enterprise_cluster_policy")
-        .description(
-            "Get cluster policy settings including default shards placement, \
-             rack awareness, and default Redis version.",
-        )
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetClusterPolicyInput>| async move {
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let handler = ClusterHandler::new(client);
-                let policy = handler
-                    .policy()
-                    .await
-                    .tool_context("Failed to get cluster policy")?;
-
-                CallToolResult::from_serialize(&policy)
-            },
-        )
-        .build()
-}
-
-/// Input for updating cluster policy
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct UpdateClusterPolicyInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// JSON object with policy settings to update
-    /// (e.g., {"default_shards_placement": "sparse", "rack_aware": true, "default_provisioned_redis_version": "7.2"})
-    pub policy: Value,
-}
-
-/// Build the update_cluster_policy tool
-pub fn update_cluster_policy(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("update_enterprise_cluster_policy")
-        .description(
-            "Update cluster policy settings. Pass fields to update as JSON.",
-        )
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<UpdateClusterPolicyInput>| async move {
-                // Check write permission
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let handler = ClusterHandler::new(client);
-                let result = handler
-                    .policy_update(input.policy)
-                    .await
-                    .tool_context("Failed to update cluster policy")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
+        CallToolResult::from_serialize(&result)
+    }
+);
 
 // ============================================================================
 // Maintenance Mode Operations
 // ============================================================================
 
-/// Input for enabling maintenance mode (no required parameters)
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct EnableMaintenanceModeInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+enterprise_tool!(write, enable_maintenance_mode, "enable_enterprise_maintenance_mode",
+    "Enable maintenance mode. Configuration changes will be blocked \
+     until maintenance mode is disabled.",
+    {} => |client, _input| {
+        let handler = ClusterHandler::new(client);
+        let result = handler
+            .update(serde_json::json!({"block_cluster_changes": true}))
+            .await
+            .tool_context("Failed to enable maintenance mode")?;
 
-/// Build the enable_maintenance_mode tool
-pub fn enable_maintenance_mode(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("enable_enterprise_maintenance_mode")
-        .description(
-            "Enable maintenance mode. Configuration changes will be blocked \
-             until maintenance mode is disabled.",
-        )
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<EnableMaintenanceModeInput>| async move {
-                // Check write permission
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
+        CallToolResult::from_serialize(&serde_json::json!({
+            "message": "Maintenance mode enabled",
+            "result": result
+        }))
+    }
+);
 
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+enterprise_tool!(write, disable_maintenance_mode, "disable_enterprise_maintenance_mode",
+    "Disable maintenance mode and re-enable configuration changes.",
+    {} => |client, _input| {
+        let handler = ClusterHandler::new(client);
+        let result = handler
+            .update(serde_json::json!({"block_cluster_changes": false}))
+            .await
+            .tool_context("Failed to disable maintenance mode")?;
 
-                let handler = ClusterHandler::new(client);
-                // Enable maintenance mode by setting block_cluster_changes to true
-                let result = handler
-                    .update(serde_json::json!({"block_cluster_changes": true}))
-                    .await
-                    .tool_context("Failed to enable maintenance mode")?;
-
-                CallToolResult::from_serialize(&serde_json::json!({
-                    "message": "Maintenance mode enabled",
-                    "result": result
-                }))
-            },
-        )
-        .build()
-}
-
-/// Input for disabling maintenance mode (no required parameters)
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct DisableMaintenanceModeInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the disable_maintenance_mode tool
-pub fn disable_maintenance_mode(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("disable_enterprise_maintenance_mode")
-        .description("Disable maintenance mode and re-enable configuration changes.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<DisableMaintenanceModeInput>| async move {
-                // Check write permission
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let handler = ClusterHandler::new(client);
-                // Disable maintenance mode by setting block_cluster_changes to false
-                let result = handler
-                    .update(serde_json::json!({"block_cluster_changes": false}))
-                    .await
-                    .tool_context("Failed to disable maintenance mode")?;
-
-                CallToolResult::from_serialize(&serde_json::json!({
-                    "message": "Maintenance mode disabled",
-                    "result": result
-                }))
-            },
-        )
-        .build()
-}
+        CallToolResult::from_serialize(&serde_json::json!({
+            "message": "Maintenance mode disabled",
+            "result": result
+        }))
+    }
+);
 
 // ============================================================================
 // Certificate Operations
 // ============================================================================
 
-/// Input for getting cluster certificates (no required parameters)
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetClusterCertificatesInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+enterprise_tool!(read_only, get_cluster_certificates, "get_enterprise_cluster_certificates",
+    "Get all configured certificates (proxy, syncer, API).",
+    {} => |client, _input| {
+        let handler = ClusterHandler::new(client);
+        let certificates = handler
+            .certificates()
+            .await
+            .tool_context("Failed to get certificates")?;
 
-/// Build the get_cluster_certificates tool
-pub fn get_cluster_certificates(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_enterprise_cluster_certificates")
-        .description("Get all configured certificates (proxy, syncer, API).")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetClusterCertificatesInput>| async move {
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+        CallToolResult::from_serialize(&certificates)
+    }
+);
 
-                let handler = ClusterHandler::new(client);
-                let certificates = handler
-                    .certificates()
-                    .await
-                    .tool_context("Failed to get certificates")?;
+enterprise_tool!(write, rotate_cluster_certificates, "rotate_enterprise_cluster_certificates",
+    "Rotate all certificates, generating new ones to replace existing.",
+    {} => |client, _input| {
+        let handler = ClusterHandler::new(client);
+        let result = handler
+            .certificates_rotate()
+            .await
+            .tool_context("Failed to rotate certificates")?;
 
-                CallToolResult::from_serialize(&certificates)
-            },
-        )
-        .build()
-}
+        CallToolResult::from_serialize(&serde_json::json!({
+            "message": "Certificate rotation initiated",
+            "result": result
+        }))
+    }
+);
 
-/// Input for rotating cluster certificates (no required parameters)
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct RotateClusterCertificatesInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+enterprise_tool!(write, update_cluster_certificates, "update_enterprise_cluster_certificates",
+    "Update a specific certificate. Provide the certificate name (proxy, syncer, api), \
+     PEM-encoded certificate, and PEM-encoded private key.",
+    {
+        /// Certificate name (e.g., "proxy", "syncer", "api")
+        pub name: String,
+        /// PEM-encoded certificate content
+        pub certificate: String,
+        /// PEM-encoded private key content
+        pub key: String,
+    } => |client, input| {
+        let handler = ClusterHandler::new(client);
+        let body = serde_json::json!({
+            "name": &input.name,
+            "certificate": input.certificate,
+            "key": input.key
+        });
+        let result = handler
+            .update_cert(body)
+            .await
+            .tool_context("Failed to update certificate")?;
 
-/// Build the rotate_cluster_certificates tool
-pub fn rotate_cluster_certificates(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("rotate_enterprise_cluster_certificates")
-        .description("Rotate all certificates, generating new ones to replace existing.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<RotateClusterCertificatesInput>| async move {
-                // Check write permission
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
+        CallToolResult::from_serialize(&serde_json::json!({
+            "message": "Certificate updated successfully",
+            "name": input.name,
+            "result": result
+        }))
+    }
+);
 
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+// ============================================================================
+// License tools
+// ============================================================================
 
-                let handler = ClusterHandler::new(client);
-                let result = handler
-                    .certificates_rotate()
-                    .await
-                    .tool_context("Failed to rotate certificates")?;
+enterprise_tool!(read_only, get_license, "get_license",
+    "Get license information including type, expiration, and enabled features",
+    {} => |client, _input| {
+        let handler = LicenseHandler::new(client);
+        let license = handler.get().await.tool_context("Failed to get license")?;
 
-                CallToolResult::from_serialize(&serde_json::json!({
-                    "message": "Certificate rotation initiated",
-                    "result": result
-                }))
-            },
-        )
-        .build()
-}
+        CallToolResult::from_serialize(&license)
+    }
+);
 
-/// Input for updating cluster certificates
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct UpdateClusterCertificatesInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Certificate name (e.g., "proxy", "syncer", "api")
-    pub name: String,
-    /// PEM-encoded certificate content
-    pub certificate: String,
-    /// PEM-encoded private key content
-    pub key: String,
-}
+enterprise_tool!(read_only, get_license_usage, "get_license_usage",
+    "Get license utilization statistics including shards, nodes, and RAM usage against limits",
+    {} => |client, _input| {
+        let handler = LicenseHandler::new(client);
+        let usage = handler
+            .usage()
+            .await
+            .tool_context("Failed to get license usage")?;
 
-/// Build the update_cluster_certificates tool
-pub fn update_cluster_certificates(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("update_enterprise_cluster_certificates")
-        .description(
-            "Update a specific certificate. Provide the certificate name (proxy, syncer, api), \
-             PEM-encoded certificate, and PEM-encoded private key.",
-        )
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<UpdateClusterCertificatesInput>| async move {
-                // Check write permission
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
+        CallToolResult::from_serialize(&usage)
+    }
+);
 
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+enterprise_tool!(write, update_license, "update_enterprise_license",
+    "Apply a new license key to the cluster.",
+    {
+        /// The license key string to install
+        pub license_key: String,
+    } => |client, input| {
+        let handler = LicenseHandler::new(client);
+        let request = LicenseUpdateRequest {
+            license: input.license_key,
+        };
+        let license = handler
+            .update(request)
+            .await
+            .tool_context("Failed to update license")?;
 
-                let handler = ClusterHandler::new(client);
-                let body = serde_json::json!({
-                    "name": input.name,
-                    "certificate": input.certificate,
-                    "key": input.key
-                });
-                let result = handler
-                    .update_cert(body)
-                    .await
-                    .tool_context("Failed to update certificate")?;
+        CallToolResult::from_serialize(&license)
+    }
+);
 
-                CallToolResult::from_serialize(&serde_json::json!({
-                    "message": "Certificate updated successfully",
-                    "name": input.name,
-                    "result": result
-                }))
-            },
-        )
-        .build()
-}
+enterprise_tool!(read_only, validate_license, "validate_enterprise_license",
+    "Validate a license key without applying it (dry-run).",
+    {
+        /// The license key string to validate
+        pub license_key: String,
+    } => |client, input| {
+        let handler = LicenseHandler::new(client);
+        let license = handler
+            .validate(&input.license_key)
+            .await
+            .tool_context("License validation failed")?;
+
+        CallToolResult::from_serialize(&license)
+    }
+);
 
 // ============================================================================
 // Node tools
 // ============================================================================
 
-/// Input for listing nodes
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ListNodesInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+enterprise_tool!(read_only, list_nodes, "list_nodes",
+    "List all nodes.",
+    {} => |client, _input| {
+        let handler = NodeHandler::new(client);
+        let nodes = handler.list().await.tool_context("Failed to list nodes")?;
 
-/// Build the list_nodes tool
-pub fn list_nodes(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("list_nodes")
-        .description("List all nodes.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<ListNodesInput>| async move {
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+        crate::tools::wrap_list("nodes", &nodes)
+    }
+);
 
-                let handler = NodeHandler::new(client);
-                let nodes = handler.list().await.tool_context("Failed to list nodes")?;
+enterprise_tool!(read_only, get_node, "get_node",
+    "Get detailed information about a specific node by UID.",
+    {
+        /// Node UID
+        pub uid: u32,
+    } => |client, input| {
+        let handler = NodeHandler::new(client);
+        let node = handler
+            .get(input.uid)
+            .await
+            .tool_context("Failed to get node")?;
 
-                crate::tools::wrap_list("nodes", &nodes)
-            },
-        )
-        .build()
-}
+        CallToolResult::from_serialize(&node)
+    }
+);
 
-/// Input for getting a specific node
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetNodeInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Node UID
-    pub uid: u32,
-}
+enterprise_tool!(read_only, get_node_stats, "get_node_stats",
+    "Get statistics for a specific node. Optionally specify interval and time range \
+     for historical data.",
+    {
+        /// Node UID
+        pub uid: u32,
+        /// Time interval for aggregation: "1sec", "10sec", "5min", "15min", "1hour", "12hour", "1week"
+        #[serde(default)]
+        pub interval: Option<String>,
+        /// Start time for historical query (ISO 8601 format, e.g., "2024-01-15T10:00:00Z")
+        #[serde(default)]
+        pub start_time: Option<String>,
+        /// End time for historical query (ISO 8601 format)
+        #[serde(default)]
+        pub end_time: Option<String>,
+    } => |client, input| {
+        let handler = StatsHandler::new(client);
 
-/// Build the get_node tool
-pub fn get_node(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_node")
-        .description("Get detailed information about a specific node by UID.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<GetNodeInput>| async move {
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let handler = NodeHandler::new(client);
-                let node = handler
-                    .get(input.uid)
-                    .await
-                    .tool_context("Failed to get node")?;
-
-                CallToolResult::from_serialize(&node)
-            },
-        )
-        .build()
-}
-
-/// Input for getting node stats
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetNodeStatsInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Node UID
-    pub uid: u32,
-    /// Time interval for aggregation: "1sec", "10sec", "5min", "15min", "1hour", "12hour", "1week"
-    #[serde(default)]
-    pub interval: Option<String>,
-    /// Start time for historical query (ISO 8601 format, e.g., "2024-01-15T10:00:00Z")
-    #[serde(default)]
-    pub start_time: Option<String>,
-    /// End time for historical query (ISO 8601 format)
-    #[serde(default)]
-    pub end_time: Option<String>,
-}
-
-/// Build the get_node_stats tool
-pub fn get_node_stats(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_node_stats")
-        .description(
-            "Get statistics for a specific node. Optionally specify interval and time range \
-             for historical data.",
-        )
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<GetNodeStatsInput>| async move {
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let handler = StatsHandler::new(client);
-
-                if input.interval.is_some()
-                    || input.start_time.is_some()
-                    || input.end_time.is_some()
-                {
-                    let query = StatsQuery {
-                        interval: input.interval,
-                        stime: input.start_time,
-                        etime: input.end_time,
-                        metrics: None,
-                    };
-                    let stats = handler
-                        .node(input.uid, Some(query))
-                        .await
-                        .tool_context("Failed to get node stats")?;
-                    CallToolResult::from_serialize(&stats)
-                } else {
-                    let stats = handler
-                        .node_last(input.uid)
-                        .await
-                        .tool_context("Failed to get node stats")?;
-                    CallToolResult::from_serialize(&stats)
-                }
-            },
-        )
-        .build()
-}
+        if input.interval.is_some()
+            || input.start_time.is_some()
+            || input.end_time.is_some()
+        {
+            let query = StatsQuery {
+                interval: input.interval,
+                stime: input.start_time,
+                etime: input.end_time,
+                metrics: None,
+            };
+            let stats = handler
+                .node(input.uid, Some(query))
+                .await
+                .tool_context("Failed to get node stats")?;
+            CallToolResult::from_serialize(&stats)
+        } else {
+            let stats = handler
+                .node_last(input.uid)
+                .await
+                .tool_context("Failed to get node stats")?;
+            CallToolResult::from_serialize(&stats)
+        }
+    }
+);
 
 // ============================================================================
 // Node Action Operations
 // ============================================================================
 
-/// Input for a node action (maintenance, rebalance, drain)
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct NodeActionInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Node UID
-    pub uid: u32,
-}
+enterprise_tool!(write, enable_node_maintenance, "enable_enterprise_node_maintenance",
+    "Enable maintenance mode on a specific node. Shards will be migrated off first.",
+    {
+        /// Node UID
+        pub uid: u32,
+    } => |client, input| {
+        let handler = NodeHandler::new(client);
+        let result = handler
+            .execute_action(input.uid, "maintenance_on")
+            .await
+            .tool_context("Failed to enable node maintenance")?;
 
-/// Build the enable_node_maintenance tool
-pub fn enable_node_maintenance(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("enable_enterprise_node_maintenance")
-        .description(
-            "Enable maintenance mode on a specific node. Shards will be migrated off first.",
-        )
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<NodeActionInput>| async move {
-                // Check write permission
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
+        CallToolResult::from_serialize(&serde_json::json!({
+            "message": "Node maintenance mode enabled",
+            "node_uid": input.uid,
+            "action_uid": result.action_uid,
+            "description": result.description
+        }))
+    }
+);
 
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+enterprise_tool!(write, disable_node_maintenance, "disable_enterprise_node_maintenance",
+    "Disable maintenance mode on a specific node. The node will accept shards again.",
+    {
+        /// Node UID
+        pub uid: u32,
+    } => |client, input| {
+        let handler = NodeHandler::new(client);
+        let result = handler
+            .execute_action(input.uid, "maintenance_off")
+            .await
+            .tool_context("Failed to disable node maintenance")?;
 
-                let handler = NodeHandler::new(client);
-                let result = handler
-                    .execute_action(input.uid, "maintenance_on")
-                    .await
-                    .tool_context("Failed to enable node maintenance")?;
+        CallToolResult::from_serialize(&serde_json::json!({
+            "message": "Node maintenance mode disabled",
+            "node_uid": input.uid,
+            "action_uid": result.action_uid,
+            "description": result.description
+        }))
+    }
+);
 
-                CallToolResult::from_serialize(&serde_json::json!({
-                    "message": "Node maintenance mode enabled",
-                    "node_uid": input.uid,
-                    "action_uid": result.action_uid,
-                    "description": result.description
-                }))
-            },
-        )
-        .build()
-}
+enterprise_tool!(write, rebalance_node, "rebalance_enterprise_node",
+    "Rebalance shards on a specific node for optimal distribution.",
+    {
+        /// Node UID
+        pub uid: u32,
+    } => |client, input| {
+        let handler = NodeHandler::new(client);
+        let result = handler
+            .execute_action(input.uid, "rebalance")
+            .await
+            .tool_context("Failed to rebalance node")?;
 
-/// Build the disable_node_maintenance tool
-pub fn disable_node_maintenance(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("disable_enterprise_node_maintenance")
-        .description(
-            "Disable maintenance mode on a specific node. The node will accept shards again.",
-        )
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<NodeActionInput>| async move {
-                // Check write permission
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
+        CallToolResult::from_serialize(&serde_json::json!({
+            "message": "Node rebalance initiated",
+            "node_uid": input.uid,
+            "action_uid": result.action_uid,
+            "description": result.description
+        }))
+    }
+);
 
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+enterprise_tool!(write, drain_node, "drain_enterprise_node",
+    "Drain all shards from a specific node, migrating them to other nodes.",
+    {
+        /// Node UID
+        pub uid: u32,
+    } => |client, input| {
+        let handler = NodeHandler::new(client);
+        let result = handler
+            .execute_action(input.uid, "drain")
+            .await
+            .tool_context("Failed to drain node")?;
 
-                let handler = NodeHandler::new(client);
-                let result = handler
-                    .execute_action(input.uid, "maintenance_off")
-                    .await
-                    .tool_context("Failed to disable node maintenance")?;
-
-                CallToolResult::from_serialize(&serde_json::json!({
-                    "message": "Node maintenance mode disabled",
-                    "node_uid": input.uid,
-                    "action_uid": result.action_uid,
-                    "description": result.description
-                }))
-            },
-        )
-        .build()
-}
-
-/// Build the rebalance_node tool
-pub fn rebalance_node(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("rebalance_enterprise_node")
-        .description("Rebalance shards on a specific node for optimal distribution.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<NodeActionInput>| async move {
-                // Check write permission
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let handler = NodeHandler::new(client);
-                let result = handler
-                    .execute_action(input.uid, "rebalance")
-                    .await
-                    .tool_context("Failed to rebalance node")?;
-
-                CallToolResult::from_serialize(&serde_json::json!({
-                    "message": "Node rebalance initiated",
-                    "node_uid": input.uid,
-                    "action_uid": result.action_uid,
-                    "description": result.description
-                }))
-            },
-        )
-        .build()
-}
-
-/// Build the drain_node tool
-pub fn drain_node(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("drain_enterprise_node")
-        .description("Drain all shards from a specific node, migrating them to other nodes.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<NodeActionInput>| async move {
-                // Check write permission
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let handler = NodeHandler::new(client);
-                let result = handler
-                    .execute_action(input.uid, "drain")
-                    .await
-                    .tool_context("Failed to drain node")?;
-
-                CallToolResult::from_serialize(&serde_json::json!({
-                    "message": "Node drain initiated",
-                    "node_uid": input.uid,
-                    "action_uid": result.action_uid,
-                    "description": result.description
-                }))
-            },
-        )
-        .build()
-}
+        CallToolResult::from_serialize(&serde_json::json!({
+            "message": "Node drain initiated",
+            "node_uid": input.uid,
+            "action_uid": result.action_uid,
+            "description": result.description
+        }))
+    }
+);
 
 // ============================================================================
 // Node Update/Remove Operations
 // ============================================================================
 
-/// Input for updating a node
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct UpdateNodeInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Node UID
-    pub uid: u32,
-    /// JSON object with node settings to update
-    pub updates: Value,
-}
+enterprise_tool!(write, update_enterprise_node, "update_enterprise_node",
+    "Update a node's configuration. Pass fields to update as JSON.",
+    {
+        /// Node UID
+        pub uid: u32,
+        /// JSON object with node settings to update
+        pub updates: Value,
+    } => |client, input| {
+        let handler = NodeHandler::new(client);
+        let node = handler
+            .update(input.uid, input.updates)
+            .await
+            .tool_context("Failed to update node")?;
 
-/// Build the update_enterprise_node tool
-pub fn update_enterprise_node(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("update_enterprise_node")
-        .description("Update a node's configuration. Pass fields to update as JSON.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<UpdateNodeInput>| async move {
-                // Check write permission
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
+        CallToolResult::from_serialize(&node)
+    }
+);
 
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+enterprise_tool!(destructive, remove_enterprise_node, "remove_enterprise_node",
+    "DANGEROUS: Remove a node. All shards must be drained first.",
+    {
+        /// Node UID
+        pub uid: u32,
+    } => |client, input| {
+        let handler = NodeHandler::new(client);
+        handler
+            .remove(input.uid)
+            .await
+            .tool_context("Failed to remove node")?;
 
-                let handler = NodeHandler::new(client);
-                let node = handler
-                    .update(input.uid, input.updates)
-                    .await
-                    .tool_context("Failed to update node")?;
-
-                CallToolResult::from_serialize(&node)
-            },
-        )
-        .build()
-}
-
-/// Input for removing a node
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct RemoveNodeInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Node UID
-    pub uid: u32,
-}
-
-/// Build the remove_enterprise_node tool
-pub fn remove_enterprise_node(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("remove_enterprise_node")
-        .description("DANGEROUS: Remove a node. All shards must be drained first.")
-        .destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<RemoveNodeInput>| async move {
-                // Check destructive permission
-                if !state.is_destructive_allowed() {
-                    return Err(McpError::tool(
-                        "Destructive operations require policy tier 'full'",
-                    ));
-                }
-
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let handler = NodeHandler::new(client);
-                handler
-                    .remove(input.uid)
-                    .await
-                    .tool_context("Failed to remove node")?;
-
-                CallToolResult::from_serialize(&serde_json::json!({
-                    "message": "Node removed successfully",
-                    "uid": input.uid
-                }))
-            },
-        )
-        .build()
-}
+        CallToolResult::from_serialize(&serde_json::json!({
+            "message": "Node removed successfully",
+            "uid": input.uid
+        }))
+    }
+);
 
 // ============================================================================
 // Cluster Services
 // ============================================================================
 
-/// Input for getting cluster services (no required parameters)
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetClusterServicesInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+enterprise_tool!(read_only, get_enterprise_cluster_services, "get_enterprise_cluster_services",
+    "Get the list of cluster services.",
+    {} => |client, _input| {
+        let handler = ClusterHandler::new(client);
+        let services = handler
+            .services_configuration()
+            .await
+            .tool_context("Failed to get cluster services")?;
 
-/// Build the get_enterprise_cluster_services tool
-pub fn get_enterprise_cluster_services(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_enterprise_cluster_services")
-        .description("Get the list of cluster services.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetClusterServicesInput>| async move {
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let handler = ClusterHandler::new(client);
-                let services = handler
-                    .services_configuration()
-                    .await
-                    .tool_context("Failed to get cluster services")?;
-
-                CallToolResult::from_serialize(&services)
-            },
-        )
-        .build()
-}
-
-/// Input for getting cluster stats
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetClusterStatsInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Time interval for aggregation: "1sec", "10sec", "5min", "15min", "1hour", "12hour", "1week"
-    #[serde(default)]
-    pub interval: Option<String>,
-    /// Start time for historical query (ISO 8601 format, e.g., "2024-01-15T10:00:00Z")
-    #[serde(default)]
-    pub start_time: Option<String>,
-    /// End time for historical query (ISO 8601 format)
-    #[serde(default)]
-    pub end_time: Option<String>,
-}
-
-/// Build the get_cluster_stats tool
-pub fn get_cluster_stats(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_cluster_stats")
-        .description(
-            "Get cluster-level statistics. Optionally specify interval and time range \
-             for historical data.",
-        )
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetClusterStatsInput>| async move {
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let handler = StatsHandler::new(client);
-
-                // If any query params provided, get historical stats
-                if input.interval.is_some()
-                    || input.start_time.is_some()
-                    || input.end_time.is_some()
-                {
-                    let query = StatsQuery {
-                        interval: input.interval,
-                        stime: input.start_time,
-                        etime: input.end_time,
-                        metrics: None,
-                    };
-                    let stats = handler
-                        .cluster(Some(query))
-                        .await
-                        .tool_context("Failed to get cluster stats")?;
-                    CallToolResult::from_serialize(&stats)
-                } else {
-                    let stats = handler
-                        .cluster_last()
-                        .await
-                        .tool_context("Failed to get cluster stats")?;
-                    CallToolResult::from_serialize(&stats)
-                }
-            },
-        )
-        .build()
-}
-
-/// All tool names registered by this sub-module.
-pub(super) const TOOL_NAMES: &[&str] = &[
-    "get_cluster",
-    "get_license",
-    "get_license_usage",
-    "update_enterprise_license",
-    "validate_enterprise_license",
-    "update_enterprise_cluster",
-    "get_enterprise_cluster_policy",
-    "update_enterprise_cluster_policy",
-    "enable_enterprise_maintenance_mode",
-    "disable_enterprise_maintenance_mode",
-    "get_enterprise_cluster_certificates",
-    "rotate_enterprise_cluster_certificates",
-    "update_enterprise_cluster_certificates",
-    "get_enterprise_cluster_services",
-    "list_nodes",
-    "get_node",
-    "get_node_stats",
-    "enable_enterprise_node_maintenance",
-    "disable_enterprise_node_maintenance",
-    "rebalance_enterprise_node",
-    "drain_enterprise_node",
-    "update_enterprise_node",
-    "remove_enterprise_node",
-    "get_cluster_stats",
-];
-
-/// Build an MCP sub-router containing cluster, license, and node tools
-pub fn router(state: Arc<AppState>) -> McpRouter {
-    McpRouter::new()
-        // Cluster
-        .tool(get_cluster(state.clone()))
-        .tool(get_cluster_stats(state.clone()))
-        .tool(update_cluster(state.clone()))
-        .tool(get_cluster_policy(state.clone()))
-        .tool(update_cluster_policy(state.clone()))
-        .tool(enable_maintenance_mode(state.clone()))
-        .tool(disable_maintenance_mode(state.clone()))
-        .tool(get_cluster_certificates(state.clone()))
-        .tool(rotate_cluster_certificates(state.clone()))
-        .tool(update_cluster_certificates(state.clone()))
-        // License
-        .tool(get_license(state.clone()))
-        .tool(get_license_usage(state.clone()))
-        .tool(update_license(state.clone()))
-        .tool(validate_license(state.clone()))
-        // Nodes
-        .tool(list_nodes(state.clone()))
-        .tool(get_node(state.clone()))
-        .tool(get_node_stats(state.clone()))
-        .tool(enable_node_maintenance(state.clone()))
-        .tool(disable_node_maintenance(state.clone()))
-        .tool(rebalance_node(state.clone()))
-        .tool(drain_node(state.clone()))
-        .tool(update_enterprise_node(state.clone()))
-        .tool(remove_enterprise_node(state.clone()))
-        // Cluster Services
-        .tool(get_enterprise_cluster_services(state.clone()))
-}
+        CallToolResult::from_serialize(&services)
+    }
+);

--- a/crates/redisctl-mcp/src/tools/enterprise/databases.rs
+++ b/crates/redisctl-mcp/src/tools/enterprise/databases.rs
@@ -1,6 +1,5 @@
 //! Database, CRDB, and database alert tools
 
-use std::sync::Arc;
 use std::time::Duration;
 
 use redis_enterprise::alerts::AlertHandler;
@@ -10,247 +9,171 @@ use redis_enterprise::stats::{StatsHandler, StatsQuery};
 use redisctl_core::enterprise::{
     backup_database_and_wait, flush_database_and_wait, import_database_and_wait,
 };
-use schemars::JsonSchema;
-use serde::Deserialize;
 use serde_json::Value;
-use tower_mcp::extract::{Json, State};
-use tower_mcp::{CallToolResult, Error as McpError, McpRouter, ResultExt, Tool, ToolBuilder};
+use tower_mcp::{CallToolResult, ResultExt};
 
-use crate::state::AppState;
+use crate::tools::macros::{enterprise_tool, mcp_module};
 use crate::tools::wrap_list;
 
-/// Input for listing databases
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ListDatabasesInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Optional filter by database name (case-insensitive substring match)
-    #[serde(default)]
-    pub name_filter: Option<String>,
-    /// Optional filter by database status (e.g., "active", "pending", "creation-failed")
-    #[serde(default)]
-    pub status_filter: Option<String>,
+mcp_module! {
+    list_databases => "list_enterprise_databases",
+    get_database => "get_enterprise_database",
+    get_database_stats => "get_database_stats",
+    get_database_endpoints => "get_database_endpoints",
+    list_database_alerts => "list_database_alerts",
+    backup_enterprise_database => "backup_enterprise_database",
+    import_enterprise_database => "import_enterprise_database",
+    create_enterprise_database => "create_enterprise_database",
+    update_enterprise_database => "update_enterprise_database",
+    delete_enterprise_database => "delete_enterprise_database",
+    flush_enterprise_database => "flush_enterprise_database",
+    export_enterprise_database => "export_enterprise_database",
+    restore_enterprise_database => "restore_enterprise_database",
+    upgrade_enterprise_database_redis => "upgrade_enterprise_database_redis",
+    list_enterprise_crdbs => "list_enterprise_crdbs",
+    get_enterprise_crdb => "get_enterprise_crdb",
+    get_enterprise_crdb_tasks => "get_enterprise_crdb_tasks",
+    create_enterprise_crdb => "create_enterprise_crdb",
+    update_enterprise_crdb => "update_enterprise_crdb",
+    delete_enterprise_crdb => "delete_enterprise_crdb",
 }
 
-/// Build the list_databases tool
-pub fn list_databases(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("list_enterprise_databases")
-        .description("List all databases. Supports filtering by name and status.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<ListDatabasesInput>| async move {
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+// ============================================================================
+// Database Read Operations
+// ============================================================================
 
-                let handler = DatabaseHandler::new(client);
-                let databases = handler
-                    .list()
-                    .await
-                    .tool_context("Failed to list databases")?;
+enterprise_tool!(read_only, list_databases, "list_enterprise_databases",
+    "List all databases. Supports filtering by name and status.",
+    {
+        /// Optional filter by database name (case-insensitive substring match)
+        #[serde(default)]
+        pub name_filter: Option<String>,
+        /// Optional filter by database status (e.g., "active", "pending", "creation-failed")
+        #[serde(default)]
+        pub status_filter: Option<String>,
+    } => |client, input| {
+        let handler = DatabaseHandler::new(client);
+        let databases = handler
+            .list()
+            .await
+            .tool_context("Failed to list databases")?;
 
-                // Apply name filter
-                let filtered: Vec<_> = databases
-                    .into_iter()
-                    .filter(|db| {
-                        if let Some(filter) = &input.name_filter {
-                            db.name.to_lowercase().contains(&filter.to_lowercase())
-                        } else {
-                            true
-                        }
-                    })
-                    .filter(|db| {
-                        if let Some(filter) = &input.status_filter {
-                            db.status
-                                .as_ref()
-                                .map(|s| s.to_lowercase() == filter.to_lowercase())
-                                .unwrap_or(false)
-                        } else {
-                            true
-                        }
-                    })
-                    .collect();
-
-                wrap_list("databases", &filtered)
-            },
-        )
-        .build()
-}
-
-/// Input for getting a specific database
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetDatabaseInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Database UID
-    pub uid: u32,
-}
-
-/// Build the get_database tool
-pub fn get_database(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_enterprise_database")
-        .description("Get database details by UID.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<GetDatabaseInput>| async move {
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let handler = DatabaseHandler::new(client);
-                let database = handler
-                    .get(input.uid)
-                    .await
-                    .tool_context("Failed to get database")?;
-
-                CallToolResult::from_serialize(&database)
-            },
-        )
-        .build()
-}
-
-/// Input for getting database stats
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetDatabaseStatsInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Database UID
-    pub uid: u32,
-    /// Time interval for aggregation: "1sec", "10sec", "5min", "15min", "1hour", "12hour", "1week"
-    #[serde(default)]
-    pub interval: Option<String>,
-    /// Start time for historical query (ISO 8601 format, e.g., "2024-01-15T10:00:00Z")
-    #[serde(default)]
-    pub start_time: Option<String>,
-    /// End time for historical query (ISO 8601 format)
-    #[serde(default)]
-    pub end_time: Option<String>,
-}
-
-/// Build the get_database_stats tool
-pub fn get_database_stats(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_database_stats")
-        .description(
-            "Get statistics for a specific database. Optionally specify interval and time range \
-             for historical data.",
-        )
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetDatabaseStatsInput>| async move {
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let handler = StatsHandler::new(client);
-
-                if input.interval.is_some()
-                    || input.start_time.is_some()
-                    || input.end_time.is_some()
-                {
-                    let query = StatsQuery {
-                        interval: input.interval,
-                        stime: input.start_time,
-                        etime: input.end_time,
-                        metrics: None,
-                    };
-                    let stats = handler
-                        .database(input.uid, Some(query))
-                        .await
-                        .tool_context("Failed to get database stats")?;
-                    CallToolResult::from_serialize(&stats)
+        // Apply name filter
+        let filtered: Vec<_> = databases
+            .into_iter()
+            .filter(|db| {
+                if let Some(filter) = &input.name_filter {
+                    db.name.to_lowercase().contains(&filter.to_lowercase())
                 } else {
-                    let stats = handler
-                        .database_last(input.uid)
-                        .await
-                        .tool_context("Failed to get database stats")?;
-                    CallToolResult::from_serialize(&stats)
+                    true
                 }
-            },
-        )
-        .build()
-}
+            })
+            .filter(|db| {
+                if let Some(filter) = &input.status_filter {
+                    db.status
+                        .as_ref()
+                        .map(|s| s.to_lowercase() == filter.to_lowercase())
+                        .unwrap_or(false)
+                } else {
+                    true
+                }
+            })
+            .collect();
 
-/// Input for getting database endpoints
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetDatabaseEndpointsInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Database UID
-    pub uid: u32,
-}
+        wrap_list("databases", &filtered)
+    }
+);
 
-/// Build the get_database_endpoints tool
-pub fn get_database_endpoints(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_database_endpoints")
-        .description("Get connection endpoints for a specific database.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetDatabaseEndpointsInput>| async move {
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+enterprise_tool!(read_only, get_database, "get_enterprise_database",
+    "Get database details by UID.",
+    {
+        /// Database UID
+        pub uid: u32,
+    } => |client, input| {
+        let handler = DatabaseHandler::new(client);
+        let database = handler
+            .get(input.uid)
+            .await
+            .tool_context("Failed to get database")?;
 
-                let handler = DatabaseHandler::new(client);
-                let endpoints = handler
-                    .endpoints(input.uid)
-                    .await
-                    .tool_context("Failed to get endpoints")?;
+        CallToolResult::from_serialize(&database)
+    }
+);
 
-                wrap_list("endpoints", &endpoints)
-            },
-        )
-        .build()
-}
+enterprise_tool!(read_only, get_database_stats, "get_database_stats",
+    "Get statistics for a specific database. Optionally specify interval and time range \
+     for historical data.",
+    {
+        /// Database UID
+        pub uid: u32,
+        /// Time interval for aggregation: "1sec", "10sec", "5min", "15min", "1hour", "12hour", "1week"
+        #[serde(default)]
+        pub interval: Option<String>,
+        /// Start time for historical query (ISO 8601 format, e.g., "2024-01-15T10:00:00Z")
+        #[serde(default)]
+        pub start_time: Option<String>,
+        /// End time for historical query (ISO 8601 format)
+        #[serde(default)]
+        pub end_time: Option<String>,
+    } => |client, input| {
+        let handler = StatsHandler::new(client);
 
-/// Input for listing database alerts
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ListDatabaseAlertsInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Database UID
-    pub uid: u32,
-}
+        if input.interval.is_some()
+            || input.start_time.is_some()
+            || input.end_time.is_some()
+        {
+            let query = StatsQuery {
+                interval: input.interval,
+                stime: input.start_time,
+                etime: input.end_time,
+                metrics: None,
+            };
+            let stats = handler
+                .database(input.uid, Some(query))
+                .await
+                .tool_context("Failed to get database stats")?;
+            CallToolResult::from_serialize(&stats)
+        } else {
+            let stats = handler
+                .database_last(input.uid)
+                .await
+                .tool_context("Failed to get database stats")?;
+            CallToolResult::from_serialize(&stats)
+        }
+    }
+);
 
-/// Build the list_database_alerts tool
-pub fn list_database_alerts(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("list_database_alerts")
-        .description("List all alerts for a specific database.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<ListDatabaseAlertsInput>| async move {
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+enterprise_tool!(read_only, get_database_endpoints, "get_database_endpoints",
+    "Get connection endpoints for a specific database.",
+    {
+        /// Database UID
+        pub uid: u32,
+    } => |client, input| {
+        let handler = DatabaseHandler::new(client);
+        let endpoints = handler
+            .endpoints(input.uid)
+            .await
+            .tool_context("Failed to get endpoints")?;
 
-                let handler = AlertHandler::new(client);
-                let alerts = handler
-                    .list_by_database(input.uid)
-                    .await
-                    .tool_context("Failed to list database alerts")?;
+        wrap_list("endpoints", &endpoints)
+    }
+);
 
-                wrap_list("alerts", &alerts)
-            },
-        )
-        .build()
-}
+enterprise_tool!(read_only, list_database_alerts, "list_database_alerts",
+    "List all alerts for a specific database.",
+    {
+        /// Database UID
+        pub uid: u32,
+    } => |client, input| {
+        let handler = AlertHandler::new(client);
+        let alerts = handler
+            .list_by_database(input.uid)
+            .await
+            .tool_context("Failed to list database alerts")?;
+
+        wrap_list("alerts", &alerts)
+    }
+);
 
 // ============================================================================
 // Database Write Operations
@@ -260,784 +183,345 @@ fn default_enterprise_timeout() -> u64 {
     600
 }
 
-/// Input for backing up an Enterprise database
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct BackupDatabaseInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Database UID to backup
-    pub bdb_uid: u32,
-    /// Timeout in seconds (default: 600)
-    #[serde(default = "default_enterprise_timeout")]
-    pub timeout_seconds: u64,
-}
-
-/// Build the backup_enterprise_database tool
-pub fn backup_enterprise_database(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("backup_enterprise_database")
-        .description("Trigger a database backup and wait for completion.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<BackupDatabaseInput>| async move {
-                // Check write permission
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                // Use Layer 2 workflow
-                backup_database_and_wait(
-                    &client,
-                    input.bdb_uid,
-                    Duration::from_secs(input.timeout_seconds),
-                    None,
-                )
-                .await
-                .tool_context("Failed to backup database")?;
-
-                CallToolResult::from_serialize(&serde_json::json!({
-                    "message": "Backup completed successfully",
-                    "bdb_uid": input.bdb_uid
-                }))
-            },
+enterprise_tool!(write, backup_enterprise_database, "backup_enterprise_database",
+    "Trigger a database backup and wait for completion.",
+    {
+        /// Database UID to backup
+        pub bdb_uid: u32,
+        /// Timeout in seconds (default: 600)
+        #[serde(default = "default_enterprise_timeout")]
+        pub timeout_seconds: u64,
+    } => |client, input| {
+        // Use Layer 2 workflow
+        backup_database_and_wait(
+            &client,
+            input.bdb_uid,
+            Duration::from_secs(input.timeout_seconds),
+            None,
         )
-        .build()
-}
+        .await
+        .tool_context("Failed to backup database")?;
 
-/// Input for importing data into an Enterprise database
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ImportDatabaseInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Database UID to import into
-    pub bdb_uid: u32,
-    /// Import location (file path or URL)
-    pub import_location: String,
-    /// Whether to flush the database before import (default: false)
-    #[serde(default)]
-    pub flush: bool,
-    /// Timeout in seconds (default: 600)
-    #[serde(default = "default_enterprise_timeout")]
-    pub timeout_seconds: u64,
-}
+        CallToolResult::from_serialize(&serde_json::json!({
+            "message": "Backup completed successfully",
+            "bdb_uid": input.bdb_uid
+        }))
+    }
+);
 
-/// Build the import_enterprise_database tool
-pub fn import_enterprise_database(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("import_enterprise_database")
-        .description(
-            "Import data into a database from an external source and wait for completion. \
-             WARNING: If flush is true, existing data will be deleted before import.",
+enterprise_tool!(write, import_enterprise_database, "import_enterprise_database",
+    "Import data into a database from an external source and wait for completion. \
+     WARNING: If flush is true, existing data will be deleted before import.",
+    {
+        /// Database UID to import into
+        pub bdb_uid: u32,
+        /// Import location (file path or URL)
+        pub import_location: String,
+        /// Whether to flush the database before import (default: false)
+        #[serde(default)]
+        pub flush: bool,
+        /// Timeout in seconds (default: 600)
+        #[serde(default = "default_enterprise_timeout")]
+        pub timeout_seconds: u64,
+    } => |client, input| {
+        // Use Layer 2 workflow
+        import_database_and_wait(
+            &client,
+            input.bdb_uid,
+            &input.import_location,
+            input.flush,
+            Duration::from_secs(input.timeout_seconds),
+            None,
         )
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<ImportDatabaseInput>| async move {
-                // Check write permission
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
+        .await
+        .tool_context("Failed to import database")?;
 
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+        CallToolResult::from_serialize(&serde_json::json!({
+            "message": "Import completed successfully",
+            "bdb_uid": input.bdb_uid,
+            "import_location": input.import_location
+        }))
+    }
+);
 
-                // Use Layer 2 workflow
-                import_database_and_wait(
-                    &client,
-                    input.bdb_uid,
-                    &input.import_location,
-                    input.flush,
-                    Duration::from_secs(input.timeout_seconds),
-                    None,
-                )
-                .await
-                .tool_context("Failed to import database")?;
+enterprise_tool!(write, create_enterprise_database, "create_enterprise_database",
+    "Create a new database on the Enterprise cluster. \
+     Prerequisites: 1) get_cluster -- verify the cluster is healthy and has capacity. \
+     2) list_enterprise_databases -- review existing databases.",
+    {
+        /// Database name
+        pub name: String,
+        /// Memory size in bytes (e.g., 1073741824 for 1GB)
+        pub memory_size: Option<u64>,
+        /// Port number (optional, cluster will assign if not specified)
+        pub port: Option<u16>,
+        /// Enable replication for high availability
+        #[serde(default)]
+        pub replication: Option<bool>,
+        /// Persistence mode: "disabled", "aof", "snapshot", "aof_and_snapshot"
+        pub persistence: Option<String>,
+        /// Eviction policy: "noeviction", "allkeys-lru", "volatile-lru", etc.
+        pub eviction_policy: Option<String>,
+        /// Enable sharding (clustering)
+        #[serde(default)]
+        pub sharding: Option<bool>,
+        /// Number of shards (if sharding is enabled)
+        pub shards_count: Option<u32>,
+    } => |client, input| {
+        // Build the request using struct construction (all Option fields have defaults)
+        let request = CreateDatabaseRequest {
+            name: input.name.clone(),
+            memory_size: input.memory_size,
+            port: input.port,
+            replication: input.replication,
+            persistence: input.persistence.clone(),
+            eviction_policy: input.eviction_policy.clone(),
+            sharding: input.sharding,
+            shards_count: input.shards_count,
+            shard_count: None,
+            proxy_policy: None,
+            rack_aware: None,
+            module_list: None,
+            crdt: None,
+            authentication_redis_pass: None,
+        };
 
-                CallToolResult::from_serialize(&serde_json::json!({
-                    "message": "Import completed successfully",
-                    "bdb_uid": input.bdb_uid,
-                    "import_location": input.import_location
-                }))
-            },
+        let handler = DatabaseHandler::new(client);
+        let database = handler
+            .create(request)
+            .await
+            .tool_context("Failed to create database")?;
+
+        CallToolResult::from_serialize(&database)
+    }
+);
+
+enterprise_tool!(write, update_enterprise_database, "update_enterprise_database",
+    "Update database configuration. Pass fields to update as JSON.",
+    {
+        /// Database UID to update
+        pub uid: u32,
+        /// JSON object with fields to update (e.g., {"memory_size": 2147483648, "replication": true})
+        pub updates: Value,
+    } => |client, input| {
+        let handler = DatabaseHandler::new(client);
+        let database = handler
+            .update(input.uid, input.updates)
+            .await
+            .tool_context("Failed to update database")?;
+
+        CallToolResult::from_serialize(&database)
+    }
+);
+
+enterprise_tool!(destructive, delete_enterprise_database, "delete_enterprise_database",
+    "DANGEROUS: Delete a database and all its data.",
+    {
+        /// Database UID to delete
+        pub uid: u32,
+    } => |client, input| {
+        let handler = DatabaseHandler::new(client);
+        handler
+            .delete(input.uid)
+            .await
+            .tool_context("Failed to delete database")?;
+
+        CallToolResult::from_serialize(&serde_json::json!({
+            "message": "Database deleted successfully",
+            "uid": input.uid
+        }))
+    }
+);
+
+enterprise_tool!(destructive, flush_enterprise_database, "flush_enterprise_database",
+    "DANGEROUS: Flush all data from a database.",
+    {
+        /// Database UID to flush
+        pub bdb_uid: u32,
+        /// Timeout in seconds (default: 600)
+        #[serde(default = "default_enterprise_timeout")]
+        pub timeout_seconds: u64,
+    } => |client, input| {
+        // Use Layer 2 workflow
+        flush_database_and_wait(
+            &client,
+            input.bdb_uid,
+            Duration::from_secs(input.timeout_seconds),
+            None,
         )
-        .build()
-}
+        .await
+        .tool_context("Failed to flush database")?;
 
-/// Input for creating an Enterprise database
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct CreateEnterpriseDatabaseInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Database name
-    pub name: String,
-    /// Memory size in bytes (e.g., 1073741824 for 1GB)
-    pub memory_size: Option<u64>,
-    /// Port number (optional, cluster will assign if not specified)
-    pub port: Option<u16>,
-    /// Enable replication for high availability
-    #[serde(default)]
-    pub replication: Option<bool>,
-    /// Persistence mode: "disabled", "aof", "snapshot", "aof_and_snapshot"
-    pub persistence: Option<String>,
-    /// Eviction policy: "noeviction", "allkeys-lru", "volatile-lru", etc.
-    pub eviction_policy: Option<String>,
-    /// Enable sharding (clustering)
-    #[serde(default)]
-    pub sharding: Option<bool>,
-    /// Number of shards (if sharding is enabled)
-    pub shards_count: Option<u32>,
-}
+        CallToolResult::from_serialize(&serde_json::json!({
+            "message": "Database flushed successfully",
+            "bdb_uid": input.bdb_uid
+        }))
+    }
+);
 
-/// Build the create_enterprise_database tool
-pub fn create_enterprise_database(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("create_enterprise_database")
-        .description(
-            "Create a new database on the Enterprise cluster. \
-             Prerequisites: 1) get_cluster -- verify the cluster is healthy and has capacity. \
-             2) list_enterprise_databases -- review existing databases.",
-        )
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<CreateEnterpriseDatabaseInput>| async move {
-                // Check write permission
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
+enterprise_tool!(write, export_enterprise_database, "export_enterprise_database",
+    "Export a database to a specified location (e.g., S3, FTP).",
+    {
+        /// Database UID to export
+        pub uid: u32,
+        /// Export location (e.g., S3 URL or FTP path)
+        pub export_location: String,
+    } => |client, input| {
+        let handler = DatabaseHandler::new(client);
+        let response = handler
+            .export(input.uid, &input.export_location)
+            .await
+            .tool_context("Failed to export database")?;
 
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+        CallToolResult::from_serialize(&response)
+    }
+);
 
-                // Build the request using struct construction (all Option fields have defaults)
-                let request = CreateDatabaseRequest {
-                    name: input.name.clone(),
-                    memory_size: input.memory_size,
-                    port: input.port,
-                    replication: input.replication,
-                    persistence: input.persistence.clone(),
-                    eviction_policy: input.eviction_policy.clone(),
-                    sharding: input.sharding,
-                    shards_count: input.shards_count,
-                    shard_count: None,
-                    proxy_policy: None,
-                    rack_aware: None,
-                    module_list: None,
-                    crdt: None,
-                    authentication_redis_pass: None,
-                };
+enterprise_tool!(write, restore_enterprise_database, "restore_enterprise_database",
+    "Restore a database from a backup.",
+    {
+        /// Database UID to restore
+        pub uid: u32,
+        /// Optional backup UID to restore from (uses latest if not specified)
+        #[serde(default)]
+        pub backup_uid: Option<String>,
+    } => |client, input| {
+        let handler = DatabaseHandler::new(client);
+        let response = handler
+            .restore(input.uid, input.backup_uid.as_deref())
+            .await
+            .tool_context("Failed to restore database")?;
 
-                let handler = DatabaseHandler::new(client);
-                let database = handler
-                    .create(request)
-                    .await
-                    .tool_context("Failed to create database")?;
+        CallToolResult::from_serialize(&response)
+    }
+);
 
-                CallToolResult::from_serialize(&database)
-            },
-        )
-        .build()
-}
+enterprise_tool!(write, upgrade_enterprise_database_redis, "upgrade_enterprise_database_redis",
+    "Upgrade the Redis version of a database.",
+    {
+        /// Database UID to upgrade
+        pub uid: u32,
+        /// Target Redis version (defaults to latest if not specified)
+        #[serde(default)]
+        pub redis_version: Option<String>,
+        /// Restart shards even if no version change
+        #[serde(default)]
+        pub force_restart: Option<bool>,
+        /// Allow data loss in non-replicated, non-persistent databases
+        #[serde(default)]
+        pub may_discard_data: Option<bool>,
+    } => |client, input| {
+        let request = DatabaseUpgradeRequest {
+            redis_version: input.redis_version,
+            force_restart: input.force_restart,
+            may_discard_data: input.may_discard_data,
+            ..Default::default()
+        };
 
-/// Input for updating an Enterprise database
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct UpdateEnterpriseDatabaseInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Database UID to update
-    pub uid: u32,
-    /// JSON object with fields to update (e.g., {"memory_size": 2147483648, "replication": true})
-    pub updates: Value,
-}
+        let handler = DatabaseHandler::new(client);
+        let response = handler
+            .upgrade_redis_version(input.uid, request)
+            .await
+            .tool_context("Failed to upgrade database Redis version")?;
 
-/// Build the update_enterprise_database tool
-pub fn update_enterprise_database(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("update_enterprise_database")
-        .description("Update database configuration. Pass fields to update as JSON.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<UpdateEnterpriseDatabaseInput>| async move {
-                // Check write permission
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let handler = DatabaseHandler::new(client);
-                let database = handler
-                    .update(input.uid, input.updates)
-                    .await
-                    .tool_context("Failed to update database")?;
-
-                CallToolResult::from_serialize(&database)
-            },
-        )
-        .build()
-}
-
-/// Input for deleting an Enterprise database
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct DeleteEnterpriseDatabaseInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Database UID to delete
-    pub uid: u32,
-}
-
-/// Build the delete_enterprise_database tool
-pub fn delete_enterprise_database(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("delete_enterprise_database")
-        .description("DANGEROUS: Delete a database and all its data.")
-        .destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<DeleteEnterpriseDatabaseInput>| async move {
-                // Check destructive permission
-                if !state.is_destructive_allowed() {
-                    return Err(McpError::tool(
-                        "Destructive operations require policy tier 'full'",
-                    ));
-                }
-
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let handler = DatabaseHandler::new(client);
-                handler
-                    .delete(input.uid)
-                    .await
-                    .tool_context("Failed to delete database")?;
-
-                CallToolResult::from_serialize(&serde_json::json!({
-                    "message": "Database deleted successfully",
-                    "uid": input.uid
-                }))
-            },
-        )
-        .build()
-}
-
-/// Input for flushing an Enterprise database
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct FlushEnterpriseDatabaseInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Database UID to flush
-    pub bdb_uid: u32,
-    /// Timeout in seconds (default: 600)
-    #[serde(default = "default_enterprise_timeout")]
-    pub timeout_seconds: u64,
-}
-
-/// Build the flush_enterprise_database tool
-pub fn flush_enterprise_database(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("flush_enterprise_database")
-        .description("DANGEROUS: Flush all data from a database.")
-        .destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<FlushEnterpriseDatabaseInput>| async move {
-                // Check destructive permission
-                if !state.is_destructive_allowed() {
-                    return Err(McpError::tool(
-                        "Destructive operations require policy tier 'full'",
-                    ));
-                }
-
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                // Use Layer 2 workflow
-                flush_database_and_wait(
-                    &client,
-                    input.bdb_uid,
-                    Duration::from_secs(input.timeout_seconds),
-                    None,
-                )
-                .await
-                .tool_context("Failed to flush database")?;
-
-                CallToolResult::from_serialize(&serde_json::json!({
-                    "message": "Database flushed successfully",
-                    "bdb_uid": input.bdb_uid
-                }))
-            },
-        )
-        .build()
-}
-
-/// Input for exporting an Enterprise database
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ExportEnterpriseDatabaseInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Database UID to export
-    pub uid: u32,
-    /// Export location (e.g., S3 URL or FTP path)
-    pub export_location: String,
-}
-
-/// Build the export_enterprise_database tool
-pub fn export_enterprise_database(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("export_enterprise_database")
-        .description("Export a database to a specified location (e.g., S3, FTP).")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<ExportEnterpriseDatabaseInput>| async move {
-                // Check write permission
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations require policy tier 'read-write' or 'full'",
-                    ));
-                }
-
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let handler = DatabaseHandler::new(client);
-                let response = handler
-                    .export(input.uid, &input.export_location)
-                    .await
-                    .tool_context("Failed to export database")?;
-
-                CallToolResult::from_serialize(&response)
-            },
-        )
-        .build()
-}
-
-/// Input for restoring an Enterprise database
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct RestoreEnterpriseDatabaseInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Database UID to restore
-    pub uid: u32,
-    /// Optional backup UID to restore from (uses latest if not specified)
-    #[serde(default)]
-    pub backup_uid: Option<String>,
-}
-
-/// Build the restore_enterprise_database tool
-pub fn restore_enterprise_database(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("restore_enterprise_database")
-        .description("Restore a database from a backup.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<RestoreEnterpriseDatabaseInput>| async move {
-                // Check write permission
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations require policy tier 'read-write' or 'full'",
-                    ));
-                }
-
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let handler = DatabaseHandler::new(client);
-                let response = handler
-                    .restore(input.uid, input.backup_uid.as_deref())
-                    .await
-                    .tool_context("Failed to restore database")?;
-
-                CallToolResult::from_serialize(&response)
-            },
-        )
-        .build()
-}
-
-/// Input for upgrading Redis version of an Enterprise database
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct UpgradeEnterpriseDatabaseRedisInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Database UID to upgrade
-    pub uid: u32,
-    /// Target Redis version (defaults to latest if not specified)
-    #[serde(default)]
-    pub redis_version: Option<String>,
-    /// Restart shards even if no version change
-    #[serde(default)]
-    pub force_restart: Option<bool>,
-    /// Allow data loss in non-replicated, non-persistent databases
-    #[serde(default)]
-    pub may_discard_data: Option<bool>,
-}
-
-/// Build the upgrade_enterprise_database_redis tool
-pub fn upgrade_enterprise_database_redis(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("upgrade_enterprise_database_redis")
-        .description("Upgrade the Redis version of a database.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<UpgradeEnterpriseDatabaseRedisInput>| async move {
-                // Check write permission
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations require policy tier 'read-write' or 'full'",
-                    ));
-                }
-
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let request = DatabaseUpgradeRequest {
-                    redis_version: input.redis_version,
-                    force_restart: input.force_restart,
-                    may_discard_data: input.may_discard_data,
-                    ..Default::default()
-                };
-
-                let handler = DatabaseHandler::new(client);
-                let response = handler
-                    .upgrade_redis_version(input.uid, request)
-                    .await
-                    .tool_context("Failed to upgrade database Redis version")?;
-
-                CallToolResult::from_serialize(&response)
-            },
-        )
-        .build()
-}
+        CallToolResult::from_serialize(&response)
+    }
+);
 
 // ============================================================================
 // CRDB (Active-Active) tools
 // ============================================================================
 
-/// Input for listing CRDBs (no required parameters)
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ListCrdbsInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+enterprise_tool!(read_only, list_enterprise_crdbs, "list_enterprise_crdbs",
+    "List all Active-Active (CRDB) databases.",
+    {} => |client, _input| {
+        let handler = CrdbHandler::new(client);
+        let crdbs = handler.list().await.tool_context("Failed to list CRDBs")?;
 
-/// Build the list_enterprise_crdbs tool
-pub fn list_enterprise_crdbs(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("list_enterprise_crdbs")
-        .description("List all Active-Active (CRDB) databases.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<ListCrdbsInput>| async move {
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+        wrap_list("crdbs", &crdbs)
+    }
+);
 
-                let handler = CrdbHandler::new(client);
-                let crdbs = handler.list().await.tool_context("Failed to list CRDBs")?;
+enterprise_tool!(read_only, get_enterprise_crdb, "get_enterprise_crdb",
+    "Get details of a specific Active-Active (CRDB) database by GUID.",
+    {
+        /// CRDB GUID (globally unique identifier)
+        pub guid: String,
+    } => |client, input| {
+        let handler = CrdbHandler::new(client);
+        let crdb = handler
+            .get(&input.guid)
+            .await
+            .tool_context("Failed to get CRDB")?;
 
-                wrap_list("crdbs", &crdbs)
-            },
-        )
-        .build()
-}
+        CallToolResult::from_serialize(&crdb)
+    }
+);
 
-/// Input for getting a specific CRDB
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetCrdbInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// CRDB GUID (globally unique identifier)
-    pub guid: String,
-}
+enterprise_tool!(read_only, get_enterprise_crdb_tasks, "get_enterprise_crdb_tasks",
+    "Get tasks for a specific Active-Active (CRDB) database.",
+    {
+        /// CRDB GUID (globally unique identifier)
+        pub guid: String,
+    } => |client, input| {
+        let handler = CrdbHandler::new(client);
+        let tasks = handler
+            .tasks(&input.guid)
+            .await
+            .tool_context("Failed to get CRDB tasks")?;
 
-/// Build the get_enterprise_crdb tool
-pub fn get_enterprise_crdb(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_enterprise_crdb")
-        .description("Get details of a specific Active-Active (CRDB) database by GUID.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<GetCrdbInput>| async move {
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+        CallToolResult::from_serialize(&tasks)
+    }
+);
 
-                let handler = CrdbHandler::new(client);
-                let crdb = handler
-                    .get(&input.guid)
-                    .await
-                    .tool_context("Failed to get CRDB")?;
+enterprise_tool!(write, create_enterprise_crdb, "create_enterprise_crdb",
+    "Create a new Active-Active (CRDB) database. Pass full configuration as JSON.",
+    {
+        /// Full CRDB configuration as JSON (name, memory_size, instances, etc.)
+        pub request: Value,
+    } => |client, input| {
+        let crdb: Value = client
+            .post("/v1/crdbs", &input.request)
+            .await
+            .tool_context("Failed to create CRDB")?;
 
-                CallToolResult::from_serialize(&crdb)
-            },
-        )
-        .build()
-}
+        CallToolResult::from_serialize(&crdb)
+    }
+);
 
-/// Input for getting CRDB tasks
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetCrdbTasksInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// CRDB GUID (globally unique identifier)
-    pub guid: String,
-}
+enterprise_tool!(write, update_enterprise_crdb, "update_enterprise_crdb",
+    "Update an Active-Active (CRDB) database. Pass fields to update as JSON.",
+    {
+        /// CRDB GUID (globally unique identifier)
+        pub guid: String,
+        /// JSON object with fields to update
+        pub updates: Value,
+    } => |client, input| {
+        let handler = CrdbHandler::new(client);
+        let crdb = handler
+            .update(&input.guid, input.updates)
+            .await
+            .tool_context("Failed to update CRDB")?;
 
-/// Build the get_enterprise_crdb_tasks tool
-pub fn get_enterprise_crdb_tasks(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_enterprise_crdb_tasks")
-        .description("Get tasks for a specific Active-Active (CRDB) database.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<GetCrdbTasksInput>| async move {
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+        CallToolResult::from_serialize(&crdb)
+    }
+);
 
-                let handler = CrdbHandler::new(client);
-                let tasks = handler
-                    .tasks(&input.guid)
-                    .await
-                    .tool_context("Failed to get CRDB tasks")?;
+enterprise_tool!(destructive, delete_enterprise_crdb, "delete_enterprise_crdb",
+    "DANGEROUS: Delete an Active-Active (CRDB) database across all participating clusters.",
+    {
+        /// CRDB GUID (globally unique identifier) to delete
+        pub guid: String,
+    } => |client, input| {
+        let handler = CrdbHandler::new(client);
+        handler
+            .delete(&input.guid)
+            .await
+            .tool_context("Failed to delete CRDB")?;
 
-                CallToolResult::from_serialize(&tasks)
-            },
-        )
-        .build()
-}
-
-/// Input for creating an Active-Active (CRDB) database
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct CreateEnterpriseCrdbInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Full CRDB configuration as JSON (name, memory_size, instances, etc.)
-    pub request: Value,
-}
-
-/// Build the create_enterprise_crdb tool
-pub fn create_enterprise_crdb(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("create_enterprise_crdb")
-        .description("Create a new Active-Active (CRDB) database. Pass full configuration as JSON.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<CreateEnterpriseCrdbInput>| async move {
-                // Check write permission
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations require policy tier 'read-write' or 'full'",
-                    ));
-                }
-
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let crdb: Value = client
-                    .post("/v1/crdbs", &input.request)
-                    .await
-                    .tool_context("Failed to create CRDB")?;
-
-                CallToolResult::from_serialize(&crdb)
-            },
-        )
-        .build()
-}
-
-/// Input for updating an Active-Active (CRDB) database
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct UpdateEnterpriseCrdbInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// CRDB GUID (globally unique identifier)
-    pub guid: String,
-    /// JSON object with fields to update
-    pub updates: Value,
-}
-
-/// Build the update_enterprise_crdb tool
-pub fn update_enterprise_crdb(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("update_enterprise_crdb")
-        .description("Update an Active-Active (CRDB) database. Pass fields to update as JSON.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<UpdateEnterpriseCrdbInput>| async move {
-                // Check write permission
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations require policy tier 'read-write' or 'full'",
-                    ));
-                }
-
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let handler = CrdbHandler::new(client);
-                let crdb = handler
-                    .update(&input.guid, input.updates)
-                    .await
-                    .tool_context("Failed to update CRDB")?;
-
-                CallToolResult::from_serialize(&crdb)
-            },
-        )
-        .build()
-}
-
-/// Input for deleting an Active-Active (CRDB) database
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct DeleteEnterpriseCrdbInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// CRDB GUID (globally unique identifier) to delete
-    pub guid: String,
-}
-
-/// Build the delete_enterprise_crdb tool
-pub fn delete_enterprise_crdb(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("delete_enterprise_crdb")
-        .description("DANGEROUS: Delete an Active-Active (CRDB) database across all participating clusters.")
-        .destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<DeleteEnterpriseCrdbInput>| async move {
-                // Check destructive permission
-                if !state.is_destructive_allowed() {
-                    return Err(McpError::tool(
-                        "Destructive operations require policy tier 'full'",
-                    ));
-                }
-
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let handler = CrdbHandler::new(client);
-                handler
-                    .delete(&input.guid)
-                    .await
-                    .tool_context("Failed to delete CRDB")?;
-
-                CallToolResult::from_serialize(&serde_json::json!({
-                    "message": "CRDB deleted successfully",
-                    "guid": input.guid
-                }))
-            },
-        )
-        .build()
-}
-
-/// All tool names registered by this sub-module.
-pub(super) const TOOL_NAMES: &[&str] = &[
-    "list_enterprise_databases",
-    "get_enterprise_database",
-    "get_database_stats",
-    "get_database_endpoints",
-    "list_database_alerts",
-    "backup_enterprise_database",
-    "import_enterprise_database",
-    "create_enterprise_database",
-    "update_enterprise_database",
-    "delete_enterprise_database",
-    "flush_enterprise_database",
-    "export_enterprise_database",
-    "restore_enterprise_database",
-    "upgrade_enterprise_database_redis",
-    "list_enterprise_crdbs",
-    "get_enterprise_crdb",
-    "get_enterprise_crdb_tasks",
-    "create_enterprise_crdb",
-    "update_enterprise_crdb",
-    "delete_enterprise_crdb",
-];
-
-/// Build an MCP sub-router containing database tools
-pub fn router(state: Arc<AppState>) -> McpRouter {
-    McpRouter::new()
-        // Databases
-        .tool(list_databases(state.clone()))
-        .tool(get_database(state.clone()))
-        .tool(get_database_stats(state.clone()))
-        .tool(get_database_endpoints(state.clone()))
-        .tool(list_database_alerts(state.clone()))
-        // CRDBs (Active-Active)
-        .tool(list_enterprise_crdbs(state.clone()))
-        .tool(get_enterprise_crdb(state.clone()))
-        .tool(get_enterprise_crdb_tasks(state.clone()))
-        // CRDB Write Operations
-        .tool(create_enterprise_crdb(state.clone()))
-        .tool(update_enterprise_crdb(state.clone()))
-        .tool(delete_enterprise_crdb(state.clone()))
-        // Database Write Operations
-        .tool(backup_enterprise_database(state.clone()))
-        .tool(import_enterprise_database(state.clone()))
-        .tool(create_enterprise_database(state.clone()))
-        .tool(update_enterprise_database(state.clone()))
-        .tool(delete_enterprise_database(state.clone()))
-        .tool(flush_enterprise_database(state.clone()))
-        .tool(export_enterprise_database(state.clone()))
-        .tool(restore_enterprise_database(state.clone()))
-        .tool(upgrade_enterprise_database_redis(state.clone()))
-}
+        CallToolResult::from_serialize(&serde_json::json!({
+            "message": "CRDB deleted successfully",
+            "guid": input.guid
+        }))
+    }
+);

--- a/crates/redisctl-mcp/src/tools/enterprise/observability.rs
+++ b/crates/redisctl-mcp/src/tools/enterprise/observability.rs
@@ -1,720 +1,336 @@
 //! Alerts, logs, aggregate stats, shards, debug info, and module tools
 
-use std::sync::Arc;
-
-use redis_enterprise::alerts::AlertHandler;
 use redis_enterprise::debuginfo::{DebugInfoHandler, DebugInfoRequest};
 use redis_enterprise::logs::{LogsHandler, LogsQuery};
-use redis_enterprise::modules::ModuleHandler;
-use redis_enterprise::shards::ShardHandler;
-use redis_enterprise::stats::StatsHandler;
-use schemars::JsonSchema;
-use serde::Deserialize;
-use tower_mcp::extract::{Json, State};
-use tower_mcp::{CallToolResult, Error as McpError, McpRouter, ResultExt, Tool, ToolBuilder};
+use tower_mcp::{CallToolResult, ResultExt};
 
-use crate::state::AppState;
+use crate::tools::macros::{enterprise_tool, mcp_module};
 use crate::tools::wrap_list;
+
+mcp_module! {
+    list_alerts => "list_alerts",
+    acknowledge_enterprise_alert => "acknowledge_enterprise_alert",
+    list_logs => "list_logs",
+    get_all_nodes_stats => "get_all_nodes_stats",
+    get_all_databases_stats => "get_all_databases_stats",
+    get_shard_stats => "get_shard_stats",
+    get_all_shards_stats => "get_all_shards_stats",
+    list_shards => "list_shards",
+    get_shard => "get_shard",
+    list_shards_by_database => "list_shards_by_database",
+    list_shards_by_node => "list_shards_by_node",
+    list_debug_info_tasks => "list_debug_info_tasks",
+    get_debug_info_status => "get_debug_info_status",
+    create_debug_info => "create_debug_info",
+    list_modules => "list_modules",
+    get_module => "get_module",
+}
 
 // ============================================================================
 // Alert tools
 // ============================================================================
 
-/// Input for listing alerts
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ListAlertsInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+enterprise_tool!(read_only, list_alerts, "list_alerts",
+    "List all active alerts.",
+    {} => |client, _input| {
+        let handler = redis_enterprise::alerts::AlertHandler::new(client);
+        let alerts = handler.list().await.tool_context("Failed to list alerts")?;
+        wrap_list("alerts", &alerts)
+    }
+);
 
-/// Build the list_alerts tool
-pub fn list_alerts(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("list_alerts")
-        .description("List all active alerts.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<ListAlertsInput>| async move {
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+enterprise_tool!(write, acknowledge_enterprise_alert, "acknowledge_enterprise_alert",
+    "Acknowledge (clear) a specific alert by ID.",
+    {
+        /// Alert UID to acknowledge
+        pub alert_uid: String,
+    } => |client, input| {
+        let handler = redis_enterprise::alerts::AlertHandler::new(client);
+        handler
+            .clear(&input.alert_uid)
+            .await
+            .tool_context("Failed to acknowledge alert")?;
 
-                let handler = AlertHandler::new(client);
-                let alerts = handler.list().await.tool_context("Failed to list alerts")?;
-
-                wrap_list("alerts", &alerts)
-            },
-        )
-        .build()
-}
+        CallToolResult::from_serialize(&serde_json::json!({
+            "message": "Alert acknowledged successfully",
+            "alert_uid": input.alert_uid
+        }))
+    }
+);
 
 // ============================================================================
 // Logs tools
 // ============================================================================
 
-/// Input for listing cluster logs
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ListLogsInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Start time - only return events after this time (ISO 8601 format, e.g., "2024-01-15T10:00:00Z")
-    #[serde(default)]
-    pub start_time: Option<String>,
-    /// End time - only return events before this time (ISO 8601 format)
-    #[serde(default)]
-    pub end_time: Option<String>,
-    /// Sort order: "asc" (oldest first) or "desc" (newest first, default)
-    #[serde(default)]
-    pub order: Option<String>,
-    /// Maximum number of log entries to return
-    #[serde(default)]
-    pub limit: Option<u32>,
-    /// Number of entries to skip (for pagination)
-    #[serde(default)]
-    pub offset: Option<u32>,
-}
+enterprise_tool!(read_only, list_logs, "list_logs",
+    "List cluster event logs. Supports filtering by time range and pagination.",
+    {
+        /// Start time - only return events after this time (ISO 8601 format, e.g., "2024-01-15T10:00:00Z")
+        #[serde(default)]
+        pub start_time: Option<String>,
+        /// End time - only return events before this time (ISO 8601 format)
+        #[serde(default)]
+        pub end_time: Option<String>,
+        /// Sort order: "asc" (oldest first) or "desc" (newest first, default)
+        #[serde(default)]
+        pub order: Option<String>,
+        /// Maximum number of log entries to return
+        #[serde(default)]
+        pub limit: Option<u32>,
+        /// Number of entries to skip (for pagination)
+        #[serde(default)]
+        pub offset: Option<u32>,
+    } => |client, input| {
+        let query = if input.start_time.is_some()
+            || input.end_time.is_some()
+            || input.order.is_some()
+            || input.limit.is_some()
+            || input.offset.is_some()
+        {
+            Some(LogsQuery {
+                stime: input.start_time,
+                etime: input.end_time,
+                order: input.order,
+                limit: input.limit,
+                offset: input.offset,
+            })
+        } else {
+            None
+        };
 
-/// Build the list_logs tool
-pub fn list_logs(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("list_logs")
-        .description("List cluster event logs. Supports filtering by time range and pagination.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<ListLogsInput>| async move {
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+        let handler = LogsHandler::new(client);
+        let logs = handler
+            .list(query)
+            .await
+            .tool_context("Failed to list logs")?;
 
-                let query = if input.start_time.is_some()
-                    || input.end_time.is_some()
-                    || input.order.is_some()
-                    || input.limit.is_some()
-                    || input.offset.is_some()
-                {
-                    Some(LogsQuery {
-                        stime: input.start_time,
-                        etime: input.end_time,
-                        order: input.order,
-                        limit: input.limit,
-                        offset: input.offset,
-                    })
-                } else {
-                    None
-                };
-
-                let handler = LogsHandler::new(client);
-                let logs = handler
-                    .list(query)
-                    .await
-                    .tool_context("Failed to list logs")?;
-
-                wrap_list("logs", &logs)
-            },
-        )
-        .build()
-}
+        wrap_list("logs", &logs)
+    }
+);
 
 // ============================================================================
 // Aggregate Stats tools
 // ============================================================================
 
-/// Input for getting all nodes stats
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetAllNodesStatsInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+enterprise_tool!(read_only, get_all_nodes_stats, "get_all_nodes_stats",
+    "Get current statistics for all nodes including CPU, memory, and network metrics.",
+    {} => |client, _input| {
+        let handler = redis_enterprise::stats::StatsHandler::new(client);
+        let stats = handler
+            .nodes_last()
+            .await
+            .tool_context("Failed to get all nodes stats")?;
 
-/// Build the get_all_nodes_stats tool
-pub fn get_all_nodes_stats(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_all_nodes_stats")
-        .description("Get current statistics for all nodes including CPU, memory, and network metrics.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetAllNodesStatsInput>| async move {
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+        CallToolResult::from_serialize(&stats)
+    }
+);
 
-                let handler = StatsHandler::new(client);
-                let stats = handler
-                    .nodes_last()
-                    .await
-                    .tool_context("Failed to get all nodes stats")?;
+enterprise_tool!(read_only, get_all_databases_stats, "get_all_databases_stats",
+    "Get current statistics for all databases including latency, throughput, and memory usage.",
+    {} => |client, _input| {
+        let handler = redis_enterprise::stats::StatsHandler::new(client);
+        let stats = handler
+            .databases_last()
+            .await
+            .tool_context("Failed to get all databases stats")?;
 
-                CallToolResult::from_serialize(&stats)
-            },
-        )
-        .build()
-}
+        CallToolResult::from_serialize(&stats)
+    }
+);
 
-/// Input for getting all databases stats
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetAllDatabasesStatsInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+enterprise_tool!(read_only, get_shard_stats, "get_shard_stats",
+    "Get current statistics for a specific shard.",
+    {
+        /// Shard UID
+        pub uid: u32,
+    } => |client, input| {
+        let handler = redis_enterprise::stats::StatsHandler::new(client);
+        let stats = handler
+            .shard(input.uid, None)
+            .await
+            .tool_context("Failed to get shard stats")?;
 
-/// Build the get_all_databases_stats tool
-pub fn get_all_databases_stats(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_all_databases_stats")
-        .description(
-            "Get current statistics for all databases including latency, throughput, and memory usage.",
-        )
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetAllDatabasesStatsInput>| async move {
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+        CallToolResult::from_serialize(&stats)
+    }
+);
 
-                let handler = StatsHandler::new(client);
-                let stats = handler.databases_last().await.tool_context("Failed to get all databases stats")?;
+enterprise_tool!(read_only, get_all_shards_stats, "get_all_shards_stats",
+    "Get current statistics for all shards.",
+    {} => |client, _input| {
+        let handler = redis_enterprise::stats::StatsHandler::new(client);
+        let stats = handler
+            .shards(None)
+            .await
+            .tool_context("Failed to get all shards stats")?;
 
-                CallToolResult::from_serialize(&stats)
-            },
-        )
-        .build()
-}
-
-/// Input for getting shard stats
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetShardStatsInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Shard UID
-    pub uid: u32,
-}
-
-/// Build the get_shard_stats tool
-pub fn get_shard_stats(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_shard_stats")
-        .description("Get current statistics for a specific shard.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<GetShardStatsInput>| async move {
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let handler = StatsHandler::new(client);
-                let stats = handler
-                    .shard(input.uid, None)
-                    .await
-                    .tool_context("Failed to get shard stats")?;
-
-                CallToolResult::from_serialize(&stats)
-            },
-        )
-        .build()
-}
-
-/// Input for getting all shards stats
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetAllShardsStatsInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the get_all_shards_stats tool
-pub fn get_all_shards_stats(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_all_shards_stats")
-        .description("Get current statistics for all shards.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetAllShardsStatsInput>| async move {
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let handler = StatsHandler::new(client);
-                let stats = handler
-                    .shards(None)
-                    .await
-                    .tool_context("Failed to get all shards stats")?;
-
-                CallToolResult::from_serialize(&stats)
-            },
-        )
-        .build()
-}
+        CallToolResult::from_serialize(&stats)
+    }
+);
 
 // ============================================================================
 // Shard tools
 // ============================================================================
 
-/// Input for listing shards
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ListShardsInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Optional database UID to filter by
-    #[serde(default)]
-    pub database_uid: Option<u32>,
-}
+enterprise_tool!(read_only, list_shards, "list_shards",
+    "List all shards. Optionally filter by database UID.",
+    {
+        /// Optional database UID to filter by
+        #[serde(default)]
+        pub database_uid: Option<u32>,
+    } => |client, input| {
+        let handler = redis_enterprise::shards::ShardHandler::new(client);
+        let shards = if let Some(db_uid) = input.database_uid {
+            handler
+                .list_by_database(db_uid)
+                .await
+                .tool_context("Failed to list shards")?
+        } else {
+            handler.list().await.tool_context("Failed to list shards")?
+        };
 
-/// Build the list_shards tool
-pub fn list_shards(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("list_shards")
-        .description("List all shards. Optionally filter by database UID.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<ListShardsInput>| async move {
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+        wrap_list("shards", &shards)
+    }
+);
 
-                let handler = ShardHandler::new(client);
-                let shards = if let Some(db_uid) = input.database_uid {
-                    handler
-                        .list_by_database(db_uid)
-                        .await
-                        .tool_context("Failed to list shards")?
-                } else {
-                    handler.list().await.tool_context("Failed to list shards")?
-                };
+enterprise_tool!(read_only, get_shard, "get_shard",
+    "Get shard details including role (master/replica), status, and assigned node.",
+    {
+        /// Shard UID (e.g., "1" or "2")
+        pub uid: String,
+    } => |client, input| {
+        let handler = redis_enterprise::shards::ShardHandler::new(client);
+        let shard = handler
+            .get(&input.uid)
+            .await
+            .tool_context("Failed to get shard")?;
 
-                wrap_list("shards", &shards)
-            },
-        )
-        .build()
-}
+        CallToolResult::from_serialize(&shard)
+    }
+);
 
-/// Input for getting a specific shard
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetShardInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Shard UID (e.g., "1" or "2")
-    pub uid: String,
-}
+enterprise_tool!(read_only, list_shards_by_database, "list_shards_by_database",
+    "List all shards for a specific database.",
+    {
+        /// Database UID to list shards for
+        pub bdb_uid: u32,
+    } => |client, input| {
+        let handler = redis_enterprise::shards::ShardHandler::new(client);
+        let shards = handler
+            .list_by_database(input.bdb_uid)
+            .await
+            .tool_context("Failed to list shards by database")?;
 
-/// Build the get_shard tool
-pub fn get_shard(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_shard")
-        .description(
-            "Get shard details including role (master/replica), status, and assigned node.",
-        )
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<GetShardInput>| async move {
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+        wrap_list("shards", &shards)
+    }
+);
 
-                let handler = ShardHandler::new(client);
-                let shard = handler
-                    .get(&input.uid)
-                    .await
-                    .tool_context("Failed to get shard")?;
+enterprise_tool!(read_only, list_shards_by_node, "list_shards_by_node",
+    "List all shards on a specific node.",
+    {
+        /// Node UID to list shards for
+        pub node_uid: u32,
+    } => |client, input| {
+        let handler = redis_enterprise::shards::ShardHandler::new(client);
+        let shards = handler
+            .list_by_node(input.node_uid)
+            .await
+            .tool_context("Failed to list shards by node")?;
 
-                CallToolResult::from_serialize(&shard)
-            },
-        )
-        .build()
-}
+        wrap_list("shards", &shards)
+    }
+);
 
 // ============================================================================
 // Debug Info tools
 // ============================================================================
 
-/// Input for listing debug info tasks
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ListDebugInfoTasksInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+enterprise_tool!(read_only, list_debug_info_tasks, "list_debug_info_tasks",
+    "List all debug info collection tasks and their statuses.",
+    {} => |client, _input| {
+        let handler = DebugInfoHandler::new(client);
+        let tasks = handler
+            .list()
+            .await
+            .tool_context("Failed to list debug info tasks")?;
 
-/// Build the list_debug_info_tasks tool
-pub fn list_debug_info_tasks(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("list_debug_info_tasks")
-        .description("List all debug info collection tasks and their statuses.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<ListDebugInfoTasksInput>| async move {
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+        wrap_list("tasks", &tasks)
+    }
+);
 
-                let handler = DebugInfoHandler::new(client);
-                let tasks = handler
-                    .list()
-                    .await
-                    .tool_context("Failed to list debug info tasks")?;
+enterprise_tool!(read_only, get_debug_info_status, "get_debug_info_status",
+    "Get the status of a debug info collection task by ID.",
+    {
+        /// The task ID returned when debug info collection was started
+        pub task_id: String,
+    } => |client, input| {
+        let handler = DebugInfoHandler::new(client);
+        let status = handler
+            .status(&input.task_id)
+            .await
+            .tool_context("Failed to get debug info status")?;
 
-                wrap_list("tasks", &tasks)
-            },
-        )
-        .build()
-}
+        CallToolResult::from_serialize(&status)
+    }
+);
 
-/// Input for getting debug info task status
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetDebugInfoStatusInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// The task ID returned when debug info collection was started
-    pub task_id: String,
-}
+enterprise_tool!(write, create_debug_info, "create_debug_info",
+    "Start a debug info collection task. Optionally scope to specific nodes or databases.",
+    {
+        /// List of node UIDs to collect debug info from (if not specified, collects from all nodes)
+        #[serde(default)]
+        pub node_uids: Option<Vec<u32>>,
+        /// List of database UIDs to collect debug info for (if not specified, collects for all databases)
+        #[serde(default)]
+        pub bdb_uids: Option<Vec<u32>>,
+    } => |client, input| {
+        let request = DebugInfoRequest {
+            node_uids: input.node_uids,
+            bdb_uids: input.bdb_uids,
+            include_logs: None,
+            include_metrics: None,
+            include_configs: None,
+            time_range: None,
+        };
 
-/// Build the get_debug_info_status tool
-pub fn get_debug_info_status(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_debug_info_status")
-        .description("Get the status of a debug info collection task by ID.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetDebugInfoStatusInput>| async move {
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+        let handler = DebugInfoHandler::new(client);
+        let status = handler
+            .create(request)
+            .await
+            .tool_context("Failed to create debug info collection")?;
 
-                let handler = DebugInfoHandler::new(client);
-                let status = handler
-                    .status(&input.task_id)
-                    .await
-                    .tool_context("Failed to get debug info status")?;
-
-                CallToolResult::from_serialize(&status)
-            },
-        )
-        .build()
-}
+        CallToolResult::from_serialize(&status)
+    }
+);
 
 // ============================================================================
 // Module tools
 // ============================================================================
 
-/// Input for listing modules
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ListModulesInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+enterprise_tool!(read_only, list_modules, "list_modules",
+    "List all installed Redis modules.",
+    {} => |client, _input| {
+        let handler = redis_enterprise::modules::ModuleHandler::new(client);
+        let modules = handler
+            .list()
+            .await
+            .tool_context("Failed to list modules")?;
 
-/// Build the list_modules tool
-pub fn list_modules(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("list_modules")
-        .description("List all installed Redis modules.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<ListModulesInput>| async move {
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+        wrap_list("modules", &modules)
+    }
+);
 
-                let handler = ModuleHandler::new(client);
-                let modules = handler
-                    .list()
-                    .await
-                    .tool_context("Failed to list modules")?;
+enterprise_tool!(read_only, get_module, "get_module",
+    "Get details of a specific Redis module by UID.",
+    {
+        /// Module UID
+        pub uid: String,
+    } => |client, input| {
+        let handler = redis_enterprise::modules::ModuleHandler::new(client);
+        let module = handler
+            .get(&input.uid)
+            .await
+            .tool_context("Failed to get module")?;
 
-                wrap_list("modules", &modules)
-            },
-        )
-        .build()
-}
-
-/// Input for getting a specific module
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetModuleInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Module UID
-    pub uid: String,
-}
-
-/// Build the get_module tool
-pub fn get_module(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_module")
-        .description("Get details of a specific Redis module by UID.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<GetModuleInput>| async move {
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let handler = ModuleHandler::new(client);
-                let module = handler
-                    .get(&input.uid)
-                    .await
-                    .tool_context("Failed to get module")?;
-
-                CallToolResult::from_serialize(&module)
-            },
-        )
-        .build()
-}
-
-// ============================================================================
-// Filtered Shard tools
-// ============================================================================
-
-/// Input for listing shards by database
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ListShardsByDatabaseInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Database UID to list shards for
-    pub bdb_uid: u32,
-}
-
-/// Build the list_shards_by_database tool
-pub fn list_shards_by_database(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("list_shards_by_database")
-        .description("List all shards for a specific database.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<ListShardsByDatabaseInput>| async move {
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let handler = ShardHandler::new(client);
-                let shards = handler
-                    .list_by_database(input.bdb_uid)
-                    .await
-                    .tool_context("Failed to list shards by database")?;
-
-                wrap_list("shards", &shards)
-            },
-        )
-        .build()
-}
-
-/// Input for listing shards by node
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ListShardsByNodeInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Node UID to list shards for
-    pub node_uid: u32,
-}
-
-/// Build the list_shards_by_node tool
-pub fn list_shards_by_node(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("list_shards_by_node")
-        .description("List all shards on a specific node.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<ListShardsByNodeInput>| async move {
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let handler = ShardHandler::new(client);
-                let shards = handler
-                    .list_by_node(input.node_uid)
-                    .await
-                    .tool_context("Failed to list shards by node")?;
-
-                wrap_list("shards", &shards)
-            },
-        )
-        .build()
-}
-
-// ============================================================================
-// Alert Acknowledge
-// ============================================================================
-
-/// Input for acknowledging an alert
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct AcknowledgeAlertInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Alert UID to acknowledge
-    pub alert_uid: String,
-}
-
-/// Build the acknowledge_enterprise_alert tool
-pub fn acknowledge_enterprise_alert(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("acknowledge_enterprise_alert")
-        .description("Acknowledge (clear) a specific alert by ID.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<AcknowledgeAlertInput>| async move {
-                // Check write permission
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let handler = AlertHandler::new(client);
-                handler
-                    .clear(&input.alert_uid)
-                    .await
-                    .tool_context("Failed to acknowledge alert")?;
-
-                CallToolResult::from_serialize(&serde_json::json!({
-                    "message": "Alert acknowledged successfully",
-                    "alert_uid": input.alert_uid
-                }))
-            },
-        )
-        .build()
-}
-
-// ============================================================================
-// Debug Info Create
-// ============================================================================
-
-/// Input for creating a debug info collection task
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct CreateDebugInfoInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// List of node UIDs to collect debug info from (if not specified, collects from all nodes)
-    #[serde(default)]
-    pub node_uids: Option<Vec<u32>>,
-    /// List of database UIDs to collect debug info for (if not specified, collects for all databases)
-    #[serde(default)]
-    pub bdb_uids: Option<Vec<u32>>,
-}
-
-/// Build the create_debug_info tool
-pub fn create_debug_info(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("create_debug_info")
-        .description("Start a debug info collection task. Optionally scope to specific nodes or databases.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<CreateDebugInfoInput>| async move {
-                // Check write permission
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let request = DebugInfoRequest {
-                    node_uids: input.node_uids,
-                    bdb_uids: input.bdb_uids,
-                    include_logs: None,
-                    include_metrics: None,
-                    include_configs: None,
-                    time_range: None,
-                };
-
-                let handler = DebugInfoHandler::new(client);
-                let status = handler
-                    .create(request)
-                    .await
-                    .tool_context("Failed to create debug info collection")?;
-
-                CallToolResult::from_serialize(&status)
-            },
-        )
-        .build()
-}
-
-/// All tool names registered by this sub-module.
-pub(super) const TOOL_NAMES: &[&str] = &[
-    "list_alerts",
-    "acknowledge_enterprise_alert",
-    "list_logs",
-    "get_all_nodes_stats",
-    "get_all_databases_stats",
-    "get_shard_stats",
-    "get_all_shards_stats",
-    "list_shards",
-    "get_shard",
-    "list_shards_by_database",
-    "list_shards_by_node",
-    "list_debug_info_tasks",
-    "get_debug_info_status",
-    "create_debug_info",
-    "list_modules",
-    "get_module",
-];
-
-/// Build an MCP sub-router containing observability tools
-pub fn router(state: Arc<AppState>) -> McpRouter {
-    McpRouter::new()
-        // Alerts
-        .tool(list_alerts(state.clone()))
-        .tool(acknowledge_enterprise_alert(state.clone()))
-        // Logs
-        .tool(list_logs(state.clone()))
-        // Aggregate Stats
-        .tool(get_all_nodes_stats(state.clone()))
-        .tool(get_all_databases_stats(state.clone()))
-        .tool(get_shard_stats(state.clone()))
-        .tool(get_all_shards_stats(state.clone()))
-        // Shards
-        .tool(list_shards(state.clone()))
-        .tool(get_shard(state.clone()))
-        .tool(list_shards_by_database(state.clone()))
-        .tool(list_shards_by_node(state.clone()))
-        // Debug Info
-        .tool(list_debug_info_tasks(state.clone()))
-        .tool(get_debug_info_status(state.clone()))
-        .tool(create_debug_info(state.clone()))
-        // Modules
-        .tool(list_modules(state.clone()))
-        .tool(get_module(state.clone()))
-}
+        CallToolResult::from_serialize(&module)
+    }
+);

--- a/crates/redisctl-mcp/src/tools/enterprise/proxy.rs
+++ b/crates/redisctl-mcp/src/tools/enterprise/proxy.rs
@@ -1,180 +1,79 @@
 //! Proxy management tools for Redis Enterprise
 
-use std::sync::Arc;
-
-use redis_enterprise::proxies::ProxyHandler;
-use schemars::JsonSchema;
-use serde::Deserialize;
 use serde_json::Value;
-use tower_mcp::extract::{Json, State};
-use tower_mcp::{CallToolResult, Error as McpError, McpRouter, ResultExt, Tool, ToolBuilder};
+use tower_mcp::{CallToolResult, ResultExt};
 
-use crate::state::AppState;
+use crate::tools::macros::{enterprise_tool, mcp_module};
 use crate::tools::wrap_list;
 
-/// Input for listing proxies
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ListProxiesInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
+mcp_module! {
+    list_proxies => "list_enterprise_proxies",
+    get_proxy => "get_enterprise_proxy",
+    get_proxy_stats => "get_enterprise_proxy_stats",
+    update_proxy => "update_enterprise_proxy",
 }
 
-/// Build the list_enterprise_proxies tool
-pub fn list_proxies(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("list_enterprise_proxies")
-        .description("List all proxy instances.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<ListProxiesInput>| async move {
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+enterprise_tool!(read_only, list_proxies, "list_enterprise_proxies",
+    "List all proxy instances.",
+    {} => |client, _input| {
+        let handler = redis_enterprise::proxies::ProxyHandler::new(client);
+        let proxies = handler
+            .list()
+            .await
+            .tool_context("Failed to list proxies")?;
 
-                let handler = ProxyHandler::new(client);
-                let proxies = handler
-                    .list()
-                    .await
-                    .tool_context("Failed to list proxies")?;
+        wrap_list("proxies", &proxies)
+    }
+);
 
-                wrap_list("proxies", &proxies)
-            },
-        )
-        .build()
-}
+enterprise_tool!(read_only, get_proxy, "get_enterprise_proxy",
+    "Get proxy details by UID.",
+    {
+        /// Proxy UID
+        pub uid: u32,
+    } => |client, input| {
+        let handler = redis_enterprise::proxies::ProxyHandler::new(client);
+        let proxy = handler
+            .get(input.uid)
+            .await
+            .tool_context("Failed to get proxy")?;
 
-/// Input for getting a specific proxy
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetProxyInput {
-    /// Proxy UID
-    pub uid: u32,
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+        CallToolResult::from_serialize(&proxy)
+    }
+);
 
-/// Build the get_enterprise_proxy tool
-pub fn get_proxy(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_enterprise_proxy")
-        .description("Get proxy details by UID.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<GetProxyInput>| async move {
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+enterprise_tool!(read_only, get_proxy_stats, "get_enterprise_proxy_stats",
+    "Get statistics for a specific proxy including connection counts and throughput.",
+    {
+        /// Proxy UID
+        pub uid: u32,
+    } => |client, input| {
+        let handler = redis_enterprise::proxies::ProxyHandler::new(client);
+        let stats = handler
+            .stats(input.uid)
+            .await
+            .tool_context("Failed to get proxy stats")?;
 
-                let handler = ProxyHandler::new(client);
-                let proxy = handler
-                    .get(input.uid)
-                    .await
-                    .tool_context("Failed to get proxy")?;
+        CallToolResult::from_serialize(&stats)
+    }
+);
 
-                CallToolResult::from_serialize(&proxy)
-            },
-        )
-        .build()
-}
+enterprise_tool!(write, update_proxy, "update_enterprise_proxy",
+    "Update a proxy's configuration. Pass fields to update as JSON.",
+    {
+        /// Proxy UID to update
+        pub uid: u32,
+        /// Updated proxy configuration as JSON (e.g., max_connections, threads)
+        pub updates: Value,
+    } => |client, input| {
+        let handler = redis_enterprise::proxies::ProxyHandler::new(client);
+        let update = serde_json::from_value(input.updates)
+            .map_err(|e| tower_mcp::Error::tool(format!("Invalid proxy update: {}", e)))?;
+        let result = handler
+            .update(input.uid, update)
+            .await
+            .tool_context("Failed to update proxy")?;
 
-/// Input for getting proxy stats
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetProxyStatsInput {
-    /// Proxy UID
-    pub uid: u32,
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the get_enterprise_proxy_stats tool
-pub fn get_proxy_stats(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_enterprise_proxy_stats")
-        .description(
-            "Get statistics for a specific proxy including connection counts and throughput.",
-        )
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<GetProxyStatsInput>| async move {
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let handler = ProxyHandler::new(client);
-                let stats = handler
-                    .stats(input.uid)
-                    .await
-                    .tool_context("Failed to get proxy stats")?;
-
-                CallToolResult::from_serialize(&stats)
-            },
-        )
-        .build()
-}
-
-/// Input for updating a proxy
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct UpdateProxyInput {
-    /// Proxy UID to update
-    pub uid: u32,
-    /// Updated proxy configuration as JSON (e.g., max_connections, threads)
-    pub updates: Value,
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the update_enterprise_proxy tool
-pub fn update_proxy(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("update_enterprise_proxy")
-        .description("Update a proxy's configuration. Pass fields to update as JSON.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<UpdateProxyInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations require policy tier 'read-write' or 'full'",
-                    ));
-                }
-
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let handler = ProxyHandler::new(client);
-                let update = serde_json::from_value(input.updates)
-                    .map_err(|e| McpError::tool(format!("Invalid proxy update: {}", e)))?;
-                let result = handler
-                    .update(input.uid, update)
-                    .await
-                    .tool_context("Failed to update proxy")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// All tool names registered by this sub-module.
-pub(super) const TOOL_NAMES: &[&str] = &[
-    "list_enterprise_proxies",
-    "get_enterprise_proxy",
-    "get_enterprise_proxy_stats",
-    "update_enterprise_proxy",
-];
-
-/// Build the proxy sub-router
-pub fn router(state: Arc<AppState>) -> McpRouter {
-    McpRouter::new()
-        .tool(list_proxies(state.clone()))
-        .tool(get_proxy(state.clone()))
-        .tool(get_proxy_stats(state.clone()))
-        .tool(update_proxy(state.clone()))
-}
+        CallToolResult::from_serialize(&result)
+    }
+);

--- a/crates/redisctl-mcp/src/tools/enterprise/rbac.rs
+++ b/crates/redisctl-mcp/src/tools/enterprise/rbac.rs
@@ -1,1009 +1,492 @@
 //! User, role, ACL, and LDAP tools
 
-use std::sync::Arc;
-
 use redis_enterprise::ldap_mappings::LdapMappingHandler;
 use redis_enterprise::redis_acls::{CreateRedisAclRequest, RedisAclHandler};
 use redis_enterprise::roles::{CreateRoleRequest, RolesHandler};
 use redis_enterprise::users::{CreateUserRequest, UpdateUserRequest, UserHandler};
-use schemars::JsonSchema;
-use serde::Deserialize;
 use serde_json::Value;
-use tower_mcp::extract::{Json, State};
-use tower_mcp::{CallToolResult, Error as McpError, McpRouter, ResultExt, Tool, ToolBuilder};
+use tower_mcp::{CallToolResult, ResultExt};
 
-use crate::state::AppState;
+use crate::tools::macros::{enterprise_tool, mcp_module};
 use crate::tools::wrap_list;
+
+mcp_module! {
+    list_users => "list_enterprise_users",
+    get_user => "get_enterprise_user",
+    create_enterprise_user => "create_enterprise_user",
+    update_enterprise_user => "update_enterprise_user",
+    delete_enterprise_user => "delete_enterprise_user",
+    get_enterprise_user_permissions => "get_enterprise_user_permissions",
+    list_roles => "list_enterprise_roles",
+    get_role => "get_enterprise_role",
+    create_enterprise_role => "create_enterprise_role",
+    update_enterprise_role => "update_enterprise_role",
+    delete_enterprise_role => "delete_enterprise_role",
+    get_enterprise_builtin_roles => "get_enterprise_builtin_roles",
+    list_redis_acls => "list_enterprise_acls",
+    get_redis_acl => "get_enterprise_acl",
+    create_enterprise_acl => "create_enterprise_acl",
+    update_enterprise_acl => "update_enterprise_acl",
+    delete_enterprise_acl => "delete_enterprise_acl",
+    validate_enterprise_acl => "validate_enterprise_acl",
+    get_enterprise_ldap_config => "get_enterprise_ldap_config",
+    update_enterprise_ldap_config => "update_enterprise_ldap_config",
+}
 
 // ============================================================================
 // User tools
 // ============================================================================
 
-/// Input for listing users
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ListUsersInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the list_users tool
-pub fn list_users(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("list_enterprise_users")
-        .description("List all users.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<ListUsersInput>| async move {
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let handler = UserHandler::new(client);
-                let users = handler.list().await.tool_context("Failed to list users")?;
-
-                wrap_list("users", &users)
-            },
-        )
-        .build()
-}
-
-/// Input for getting a specific user
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetUserInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// User UID
-    pub uid: u32,
-}
-
-/// Build the get_user tool
-pub fn get_user(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_enterprise_user")
-        .description("Get user details by UID.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<GetUserInput>| async move {
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let handler = UserHandler::new(client);
-                let user = handler
-                    .get(input.uid)
-                    .await
-                    .tool_context("Failed to get user")?;
-
-                CallToolResult::from_serialize(&user)
-            },
-        )
-        .build()
-}
-
-/// Input for creating a user
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct CreateEnterpriseUserInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// User email address (used as login)
-    pub email: String,
-    /// User password
-    pub password: String,
-    /// Role name: "admin", "cluster_member", "cluster_viewer", "db_member", "db_viewer", or "none"
-    pub role: String,
-    /// Display name
-    #[serde(default)]
-    pub name: Option<String>,
-    /// Whether the user receives email alerts
-    #[serde(default)]
-    pub email_alerts: Option<bool>,
-    /// Role UIDs to assign (for custom role-based access)
-    #[serde(default)]
-    pub role_uids: Option<Vec<u32>>,
-}
-
-/// Build the create_enterprise_user tool
-pub fn create_enterprise_user(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("create_enterprise_user")
-        .description(
-            "Create a new user. \
-             Prerequisites: 1) list_enterprise_roles -- identify roles to assign. \
-             2) list_enterprise_users -- check for existing users to avoid duplicates.",
-        )
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<CreateEnterpriseUserInput>| async move {
-                // Check write permission
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let request = CreateUserRequest {
-                    email: input.email,
-                    password: input.password,
-                    role: input.role,
-                    name: input.name,
-                    email_alerts: input.email_alerts,
-                    bdbs_email_alerts: None,
-                    role_uids: input.role_uids,
-                    auth_method: None,
-                };
-
-                let handler = UserHandler::new(client);
-                let user = handler
-                    .create(request)
-                    .await
-                    .tool_context("Failed to create user")?;
-
-                CallToolResult::from_serialize(&user)
-            },
-        )
-        .build()
-}
-
-/// Input for updating a user
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct UpdateEnterpriseUserInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// User UID to update
-    pub uid: u32,
-    /// New password
-    #[serde(default)]
-    pub password: Option<String>,
-    /// New role: "admin", "cluster_member", "cluster_viewer", "db_member", "db_viewer", or "none"
-    #[serde(default)]
-    pub role: Option<String>,
-    /// New email address
-    #[serde(default)]
-    pub email: Option<String>,
-    /// New display name
-    #[serde(default)]
-    pub name: Option<String>,
-    /// Whether the user receives email alerts
-    #[serde(default)]
-    pub email_alerts: Option<bool>,
-    /// Role UIDs to assign (for custom role-based access)
-    #[serde(default)]
-    pub role_uids: Option<Vec<u32>>,
-}
-
-/// Build the update_enterprise_user tool
-pub fn update_enterprise_user(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("update_enterprise_user")
-        .description("Update an existing user. Only specified fields will be modified.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<UpdateEnterpriseUserInput>| async move {
-                // Check write permission
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let request = UpdateUserRequest {
-                    password: input.password,
-                    role: input.role,
-                    email: input.email,
-                    name: input.name,
-                    email_alerts: input.email_alerts,
-                    bdbs_email_alerts: None,
-                    role_uids: input.role_uids,
-                    auth_method: None,
-                };
-
-                let handler = UserHandler::new(client);
-                let user = handler
-                    .update(input.uid, request)
-                    .await
-                    .tool_context("Failed to update user")?;
-
-                CallToolResult::from_serialize(&user)
-            },
-        )
-        .build()
-}
-
-/// Input for deleting a user
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct DeleteEnterpriseUserInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// User UID to delete
-    pub uid: u32,
-}
-
-/// Build the delete_enterprise_user tool
-pub fn delete_enterprise_user(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("delete_enterprise_user")
-        .description("DANGEROUS: Delete a user. Active sessions will be terminated.")
-        .destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<DeleteEnterpriseUserInput>| async move {
-                // Check destructive permission
-                if !state.is_destructive_allowed() {
-                    return Err(McpError::tool(
-                        "Destructive operations require policy tier 'full'",
-                    ));
-                }
-
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let handler = UserHandler::new(client);
-                handler
-                    .delete(input.uid)
-                    .await
-                    .tool_context("Failed to delete user")?;
-
-                CallToolResult::from_serialize(&serde_json::json!({
-                    "message": "User deleted successfully",
-                    "uid": input.uid
-                }))
-            },
-        )
-        .build()
-}
-
-// ============================================================================
-// Role tools
-// ============================================================================
-
-/// Input for listing roles (no required parameters)
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ListRolesInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the list_roles tool
-pub fn list_roles(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("list_enterprise_roles")
-        .description("List all roles.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<ListRolesInput>| async move {
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let handler = RolesHandler::new(client);
-                let roles = handler.list().await.tool_context("Failed to list roles")?;
-
-                wrap_list("roles", &roles)
-            },
-        )
-        .build()
-}
-
-/// Input for getting a specific role
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetRoleInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Role UID
-    pub uid: u32,
-}
-
-/// Build the get_role tool
-pub fn get_role(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_enterprise_role")
-        .description("Get role details by UID, including permissions and assignments.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<GetRoleInput>| async move {
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let handler = RolesHandler::new(client);
-                let role = handler
-                    .get(input.uid)
-                    .await
-                    .tool_context("Failed to get role")?;
-
-                CallToolResult::from_serialize(&role)
-            },
-        )
-        .build()
-}
-
-/// Input for creating a role
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct CreateEnterpriseRoleInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Role name
-    pub name: String,
-    /// Management permission level: "admin", "db_member", "db_viewer", "cluster_member", "cluster_viewer", or "none"
-    #[serde(default)]
-    pub management: Option<String>,
-    /// Data access permission level: "redis_acl" or "none"
-    #[serde(default)]
-    pub data_access: Option<String>,
-}
-
-/// Build the create_enterprise_role tool
-pub fn create_enterprise_role(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("create_enterprise_role")
-        .description(
-            "Create a new role. \
-             Prerequisites: 1) get_enterprise_builtin_roles -- review built-in roles before creating custom ones. \
-             2) list_enterprise_acls -- identify Redis ACLs to attach to the role.",
-        )
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<CreateEnterpriseRoleInput>| async move {
-                // Check write permission
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let request = CreateRoleRequest {
-                    name: input.name,
-                    management: input.management,
-                    data_access: input.data_access,
-                    bdb_roles: None,
-                    cluster_roles: None,
-                };
-
-                let handler = RolesHandler::new(client);
-                let role = handler
-                    .create(request)
-                    .await
-                    .tool_context("Failed to create role")?;
-
-                CallToolResult::from_serialize(&role)
-            },
-        )
-        .build()
-}
-
-/// Input for updating a role
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct UpdateEnterpriseRoleInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Role UID to update
-    pub uid: u32,
-    /// Role name
-    pub name: String,
-    /// Management permission level: "admin", "db_member", "db_viewer", "cluster_member", "cluster_viewer", or "none"
-    #[serde(default)]
-    pub management: Option<String>,
-    /// Data access permission level: "redis_acl" or "none"
-    #[serde(default)]
-    pub data_access: Option<String>,
-}
-
-/// Build the update_enterprise_role tool
-pub fn update_enterprise_role(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("update_enterprise_role")
-        .description("Update an existing role.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<UpdateEnterpriseRoleInput>| async move {
-                // Check write permission
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let request = CreateRoleRequest {
-                    name: input.name,
-                    management: input.management,
-                    data_access: input.data_access,
-                    bdb_roles: None,
-                    cluster_roles: None,
-                };
-
-                let handler = RolesHandler::new(client);
-                let role = handler
-                    .update(input.uid, request)
-                    .await
-                    .tool_context("Failed to update role")?;
-
-                CallToolResult::from_serialize(&role)
-            },
-        )
-        .build()
-}
-
-/// Input for deleting a role
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct DeleteEnterpriseRoleInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// Role UID to delete
-    pub uid: u32,
-}
-
-/// Build the delete_enterprise_role tool
-pub fn delete_enterprise_role(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("delete_enterprise_role")
-        .description("DANGEROUS: Delete a role. Users assigned to it will lose their permissions.")
-        .destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<DeleteEnterpriseRoleInput>| async move {
-                // Check destructive permission
-                if !state.is_destructive_allowed() {
-                    return Err(McpError::tool(
-                        "Destructive operations require policy tier 'full'",
-                    ));
-                }
-
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let handler = RolesHandler::new(client);
-                handler
-                    .delete(input.uid)
-                    .await
-                    .tool_context("Failed to delete role")?;
-
-                CallToolResult::from_serialize(&serde_json::json!({
-                    "message": "Role deleted successfully",
-                    "uid": input.uid
-                }))
-            },
-        )
-        .build()
-}
-
-// ============================================================================
-// Redis ACL tools
-// ============================================================================
-
-/// Input for listing Redis ACLs (no required parameters)
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ListRedisAclsInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the list_redis_acls tool
-pub fn list_redis_acls(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("list_enterprise_acls")
-        .description("List all Redis ACLs.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<ListRedisAclsInput>| async move {
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let handler = RedisAclHandler::new(client);
-                let acls = handler.list().await.tool_context("Failed to list ACLs")?;
-
-                wrap_list("acls", &acls)
-            },
-        )
-        .build()
-}
-
-/// Input for getting a specific Redis ACL
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetRedisAclInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// ACL UID
-    pub uid: u32,
-}
-
-/// Build the get_redis_acl tool
-pub fn get_redis_acl(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_enterprise_acl")
-        .description(
-            "Get Redis ACL details by UID, including rule string and associated databases.",
-        )
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<GetRedisAclInput>| async move {
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let handler = RedisAclHandler::new(client);
-                let acl = handler
-                    .get(input.uid)
-                    .await
-                    .tool_context("Failed to get ACL")?;
-
-                CallToolResult::from_serialize(&acl)
-            },
-        )
-        .build()
-}
-
-/// Input for creating a Redis ACL
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct CreateEnterpriseAclInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// ACL name
-    pub name: String,
-    /// ACL rule string (e.g., "+@all ~*" or "+get +set ~cache:*")
-    pub acl: String,
-    /// Description of the ACL
-    #[serde(default)]
-    pub description: Option<String>,
-}
-
-/// Build the create_enterprise_acl tool
-pub fn create_enterprise_acl(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("create_enterprise_acl")
-        .description(
-            "Create a new Redis ACL using Redis ACL syntax (e.g., \"+@all ~*\"). \
-             Prerequisites: 1) list_enterprise_acls -- review existing ACLs to avoid duplicates. \
-             2) validate_enterprise_acl -- validate ACL syntax before creation.",
-        )
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<CreateEnterpriseAclInput>| async move {
-                // Check write permission
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let request = CreateRedisAclRequest {
-                    name: input.name,
-                    acl: input.acl,
-                    description: input.description,
-                };
-
-                let handler = RedisAclHandler::new(client);
-                let acl = handler
-                    .create(request)
-                    .await
-                    .tool_context("Failed to create ACL")?;
-
-                CallToolResult::from_serialize(&acl)
-            },
-        )
-        .build()
-}
-
-/// Input for updating a Redis ACL
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct UpdateEnterpriseAclInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// ACL UID to update
-    pub uid: u32,
-    /// ACL name
-    pub name: String,
-    /// ACL rule string (e.g., "+@all ~*" or "+get +set ~cache:*")
-    pub acl: String,
-    /// Description of the ACL
-    #[serde(default)]
-    pub description: Option<String>,
-}
-
-/// Build the update_enterprise_acl tool
-pub fn update_enterprise_acl(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("update_enterprise_acl")
-        .description("Update an existing Redis ACL.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<UpdateEnterpriseAclInput>| async move {
-                // Check write permission
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let request = CreateRedisAclRequest {
-                    name: input.name,
-                    acl: input.acl,
-                    description: input.description,
-                };
-
-                let handler = RedisAclHandler::new(client);
-                let acl = handler
-                    .update(input.uid, request)
-                    .await
-                    .tool_context("Failed to update ACL")?;
-
-                CallToolResult::from_serialize(&acl)
-            },
-        )
-        .build()
-}
-
-/// Input for deleting a Redis ACL
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct DeleteEnterpriseAclInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// ACL UID to delete
-    pub uid: u32,
-}
-
-/// Build the delete_enterprise_acl tool
-pub fn delete_enterprise_acl(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("delete_enterprise_acl")
-        .description("DANGEROUS: Delete a Redis ACL. Databases using it will lose those access controls.")
-        .destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<DeleteEnterpriseAclInput>| async move {
-                // Check destructive permission
-                if !state.is_destructive_allowed() {
-                    return Err(McpError::tool(
-                        "Destructive operations require policy tier 'full'",
-                    ));
-                }
-
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let handler = RedisAclHandler::new(client);
-                handler
-                    .delete(input.uid)
-                    .await
-                    .tool_context("Failed to delete ACL")?;
-
-                CallToolResult::from_serialize(&serde_json::json!({
-                    "message": "ACL deleted successfully",
-                    "uid": input.uid
-                }))
-            },
-        )
-        .build()
-}
-
-// ============================================================================
-// LDAP tools
-// ============================================================================
-
-/// Input for getting LDAP config (no required parameters)
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetLdapConfigInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the get_enterprise_ldap_config tool
-pub fn get_enterprise_ldap_config(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_enterprise_ldap_config")
-        .description(
-            "Get the LDAP configuration including server settings, bind DN, and query suffixes.",
-        )
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<GetLdapConfigInput>| async move {
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let handler = LdapMappingHandler::new(client);
-                let config = handler
-                    .get_config()
-                    .await
-                    .tool_context("Failed to get LDAP config")?;
-
-                CallToolResult::from_serialize(&config)
-            },
-        )
-        .build()
-}
-
-/// Input for updating LDAP config
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct UpdateLdapConfigInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// LDAP configuration as a JSON object. Fields: enabled (bool), servers (array of {host, port, use_tls, starttls}),
-    /// cache_refresh_interval, authentication_query_suffix, authorization_query_suffix, bind_dn, bind_pass
-    pub config: Value,
-}
-
-/// Build the update_enterprise_ldap_config tool
-pub fn update_enterprise_ldap_config(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("update_enterprise_ldap_config")
-        .description("Update the LDAP configuration. Pass LDAP settings as JSON.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<UpdateLdapConfigInput>| async move {
-                // Check write permission
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations not allowed in read-only mode",
-                    ));
-                }
-
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let config = serde_json::from_value(input.config)
-                    .tool_context("Invalid LDAP config")?;
-
-                let handler = LdapMappingHandler::new(client);
-                let result = handler
-                    .update_config(config)
-                    .await
-                    .tool_context("Failed to update LDAP config")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
+enterprise_tool!(read_only, list_users, "list_enterprise_users",
+    "List all users.",
+    {} => |client, _input| {
+        let handler = UserHandler::new(client);
+        let users = handler.list().await.tool_context("Failed to list users")?;
+
+        wrap_list("users", &users)
+    }
+);
+
+enterprise_tool!(read_only, get_user, "get_enterprise_user",
+    "Get user details by UID.",
+    {
+        /// User UID
+        pub uid: u32,
+    } => |client, input| {
+        let handler = UserHandler::new(client);
+        let user = handler
+            .get(input.uid)
+            .await
+            .tool_context("Failed to get user")?;
+
+        CallToolResult::from_serialize(&user)
+    }
+);
+
+enterprise_tool!(write, create_enterprise_user, "create_enterprise_user",
+    "Create a new user. \
+     Prerequisites: 1) list_enterprise_roles -- identify roles to assign. \
+     2) list_enterprise_users -- check for existing users to avoid duplicates.",
+    {
+        /// User email address (used as login)
+        pub email: String,
+        /// User password
+        pub password: String,
+        /// Role name: "admin", "cluster_member", "cluster_viewer", "db_member", "db_viewer", or "none"
+        pub role: String,
+        /// Display name
+        #[serde(default)]
+        pub name: Option<String>,
+        /// Whether the user receives email alerts
+        #[serde(default)]
+        pub email_alerts: Option<bool>,
+        /// Role UIDs to assign (for custom role-based access)
+        #[serde(default)]
+        pub role_uids: Option<Vec<u32>>,
+    } => |client, input| {
+        let request = CreateUserRequest {
+            email: input.email,
+            password: input.password,
+            role: input.role,
+            name: input.name,
+            email_alerts: input.email_alerts,
+            bdbs_email_alerts: None,
+            role_uids: input.role_uids,
+            auth_method: None,
+        };
+
+        let handler = UserHandler::new(client);
+        let user = handler
+            .create(request)
+            .await
+            .tool_context("Failed to create user")?;
+
+        CallToolResult::from_serialize(&user)
+    }
+);
+
+enterprise_tool!(write, update_enterprise_user, "update_enterprise_user",
+    "Update an existing user. Only specified fields will be modified.",
+    {
+        /// User UID to update
+        pub uid: u32,
+        /// New password
+        #[serde(default)]
+        pub password: Option<String>,
+        /// New role: "admin", "cluster_member", "cluster_viewer", "db_member", "db_viewer", or "none"
+        #[serde(default)]
+        pub role: Option<String>,
+        /// New email address
+        #[serde(default)]
+        pub email: Option<String>,
+        /// New display name
+        #[serde(default)]
+        pub name: Option<String>,
+        /// Whether the user receives email alerts
+        #[serde(default)]
+        pub email_alerts: Option<bool>,
+        /// Role UIDs to assign (for custom role-based access)
+        #[serde(default)]
+        pub role_uids: Option<Vec<u32>>,
+    } => |client, input| {
+        let request = UpdateUserRequest {
+            password: input.password,
+            role: input.role,
+            email: input.email,
+            name: input.name,
+            email_alerts: input.email_alerts,
+            bdbs_email_alerts: None,
+            role_uids: input.role_uids,
+            auth_method: None,
+        };
+
+        let handler = UserHandler::new(client);
+        let user = handler
+            .update(input.uid, request)
+            .await
+            .tool_context("Failed to update user")?;
+
+        CallToolResult::from_serialize(&user)
+    }
+);
+
+enterprise_tool!(destructive, delete_enterprise_user, "delete_enterprise_user",
+    "DANGEROUS: Delete a user. Active sessions will be terminated.",
+    {
+        /// User UID to delete
+        pub uid: u32,
+    } => |client, input| {
+        let handler = UserHandler::new(client);
+        handler
+            .delete(input.uid)
+            .await
+            .tool_context("Failed to delete user")?;
+
+        CallToolResult::from_serialize(&serde_json::json!({
+            "message": "User deleted successfully",
+            "uid": input.uid
+        }))
+    }
+);
 
 // ============================================================================
 // User Permissions
 // ============================================================================
 
-/// Input for getting user permissions (no required parameters)
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetUserPermissionsInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+enterprise_tool!(read_only, get_enterprise_user_permissions, "get_enterprise_user_permissions",
+    "Get all available permission types for user management.",
+    {} => |client, _input| {
+        let handler = UserHandler::new(client);
+        let permissions = handler
+            .permissions()
+            .await
+            .tool_context("Failed to get user permissions")?;
 
-/// Build the get_enterprise_user_permissions tool
-pub fn get_enterprise_user_permissions(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_enterprise_user_permissions")
-        .description("Get all available permission types for user management.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetUserPermissionsInput>| async move {
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+        CallToolResult::from_serialize(&permissions)
+    }
+);
 
-                let handler = UserHandler::new(client);
-                let permissions = handler
-                    .permissions()
-                    .await
-                    .tool_context("Failed to get user permissions")?;
+// ============================================================================
+// Role tools
+// ============================================================================
 
-                CallToolResult::from_serialize(&permissions)
-            },
-        )
-        .build()
-}
+enterprise_tool!(read_only, list_roles, "list_enterprise_roles",
+    "List all roles.",
+    {} => |client, _input| {
+        let handler = RolesHandler::new(client);
+        let roles = handler.list().await.tool_context("Failed to list roles")?;
+
+        wrap_list("roles", &roles)
+    }
+);
+
+enterprise_tool!(read_only, get_role, "get_enterprise_role",
+    "Get role details by UID, including permissions and assignments.",
+    {
+        /// Role UID
+        pub uid: u32,
+    } => |client, input| {
+        let handler = RolesHandler::new(client);
+        let role = handler
+            .get(input.uid)
+            .await
+            .tool_context("Failed to get role")?;
+
+        CallToolResult::from_serialize(&role)
+    }
+);
+
+enterprise_tool!(write, create_enterprise_role, "create_enterprise_role",
+    "Create a new role. \
+     Prerequisites: 1) get_enterprise_builtin_roles -- review built-in roles before creating custom ones. \
+     2) list_enterprise_acls -- identify Redis ACLs to attach to the role.",
+    {
+        /// Role name
+        pub name: String,
+        /// Management permission level: "admin", "db_member", "db_viewer", "cluster_member", "cluster_viewer", or "none"
+        #[serde(default)]
+        pub management: Option<String>,
+        /// Data access permission level: "redis_acl" or "none"
+        #[serde(default)]
+        pub data_access: Option<String>,
+    } => |client, input| {
+        let request = CreateRoleRequest {
+            name: input.name,
+            management: input.management,
+            data_access: input.data_access,
+            bdb_roles: None,
+            cluster_roles: None,
+        };
+
+        let handler = RolesHandler::new(client);
+        let role = handler
+            .create(request)
+            .await
+            .tool_context("Failed to create role")?;
+
+        CallToolResult::from_serialize(&role)
+    }
+);
+
+enterprise_tool!(write, update_enterprise_role, "update_enterprise_role",
+    "Update an existing role.",
+    {
+        /// Role UID to update
+        pub uid: u32,
+        /// Role name
+        pub name: String,
+        /// Management permission level: "admin", "db_member", "db_viewer", "cluster_member", "cluster_viewer", or "none"
+        #[serde(default)]
+        pub management: Option<String>,
+        /// Data access permission level: "redis_acl" or "none"
+        #[serde(default)]
+        pub data_access: Option<String>,
+    } => |client, input| {
+        let request = CreateRoleRequest {
+            name: input.name,
+            management: input.management,
+            data_access: input.data_access,
+            bdb_roles: None,
+            cluster_roles: None,
+        };
+
+        let handler = RolesHandler::new(client);
+        let role = handler
+            .update(input.uid, request)
+            .await
+            .tool_context("Failed to update role")?;
+
+        CallToolResult::from_serialize(&role)
+    }
+);
+
+enterprise_tool!(destructive, delete_enterprise_role, "delete_enterprise_role",
+    "DANGEROUS: Delete a role. Users assigned to it will lose their permissions.",
+    {
+        /// Role UID to delete
+        pub uid: u32,
+    } => |client, input| {
+        let handler = RolesHandler::new(client);
+        handler
+            .delete(input.uid)
+            .await
+            .tool_context("Failed to delete role")?;
+
+        CallToolResult::from_serialize(&serde_json::json!({
+            "message": "Role deleted successfully",
+            "uid": input.uid
+        }))
+    }
+);
 
 // ============================================================================
 // Built-in Roles
 // ============================================================================
 
-/// Input for getting built-in roles (no required parameters)
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetBuiltinRolesInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+enterprise_tool!(read_only, get_enterprise_builtin_roles, "get_enterprise_builtin_roles",
+    "Get the list of built-in roles.",
+    {} => |client, _input| {
+        let handler = RolesHandler::new(client);
+        let roles = handler
+            .built_in()
+            .await
+            .tool_context("Failed to get built-in roles")?;
 
-/// Build the get_enterprise_builtin_roles tool
-pub fn get_enterprise_builtin_roles(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_enterprise_builtin_roles")
-        .description("Get the list of built-in roles.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetBuiltinRolesInput>| async move {
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+        wrap_list("roles", &roles)
+    }
+);
 
-                let handler = RolesHandler::new(client);
-                let roles = handler
-                    .built_in()
-                    .await
-                    .tool_context("Failed to get built-in roles")?;
+// ============================================================================
+// Redis ACL tools
+// ============================================================================
 
-                wrap_list("roles", &roles)
-            },
-        )
-        .build()
-}
+enterprise_tool!(read_only, list_redis_acls, "list_enterprise_acls",
+    "List all Redis ACLs.",
+    {} => |client, _input| {
+        let handler = RedisAclHandler::new(client);
+        let acls = handler.list().await.tool_context("Failed to list ACLs")?;
+
+        wrap_list("acls", &acls)
+    }
+);
+
+enterprise_tool!(read_only, get_redis_acl, "get_enterprise_acl",
+    "Get Redis ACL details by UID, including rule string and associated databases.",
+    {
+        /// ACL UID
+        pub uid: u32,
+    } => |client, input| {
+        let handler = RedisAclHandler::new(client);
+        let acl = handler
+            .get(input.uid)
+            .await
+            .tool_context("Failed to get ACL")?;
+
+        CallToolResult::from_serialize(&acl)
+    }
+);
+
+enterprise_tool!(write, create_enterprise_acl, "create_enterprise_acl",
+    "Create a new Redis ACL using Redis ACL syntax (e.g., \"+@all ~*\"). \
+     Prerequisites: 1) list_enterprise_acls -- review existing ACLs to avoid duplicates. \
+     2) validate_enterprise_acl -- validate ACL syntax before creation.",
+    {
+        /// ACL name
+        pub name: String,
+        /// ACL rule string (e.g., "+@all ~*" or "+get +set ~cache:*")
+        pub acl: String,
+        /// Description of the ACL
+        #[serde(default)]
+        pub description: Option<String>,
+    } => |client, input| {
+        let request = CreateRedisAclRequest {
+            name: input.name,
+            acl: input.acl,
+            description: input.description,
+        };
+
+        let handler = RedisAclHandler::new(client);
+        let acl = handler
+            .create(request)
+            .await
+            .tool_context("Failed to create ACL")?;
+
+        CallToolResult::from_serialize(&acl)
+    }
+);
+
+enterprise_tool!(write, update_enterprise_acl, "update_enterprise_acl",
+    "Update an existing Redis ACL.",
+    {
+        /// ACL UID to update
+        pub uid: u32,
+        /// ACL name
+        pub name: String,
+        /// ACL rule string (e.g., "+@all ~*" or "+get +set ~cache:*")
+        pub acl: String,
+        /// Description of the ACL
+        #[serde(default)]
+        pub description: Option<String>,
+    } => |client, input| {
+        let request = CreateRedisAclRequest {
+            name: input.name,
+            acl: input.acl,
+            description: input.description,
+        };
+
+        let handler = RedisAclHandler::new(client);
+        let acl = handler
+            .update(input.uid, request)
+            .await
+            .tool_context("Failed to update ACL")?;
+
+        CallToolResult::from_serialize(&acl)
+    }
+);
+
+enterprise_tool!(destructive, delete_enterprise_acl, "delete_enterprise_acl",
+    "DANGEROUS: Delete a Redis ACL. Databases using it will lose those access controls.",
+    {
+        /// ACL UID to delete
+        pub uid: u32,
+    } => |client, input| {
+        let handler = RedisAclHandler::new(client);
+        handler
+            .delete(input.uid)
+            .await
+            .tool_context("Failed to delete ACL")?;
+
+        CallToolResult::from_serialize(&serde_json::json!({
+            "message": "ACL deleted successfully",
+            "uid": input.uid
+        }))
+    }
+);
 
 // ============================================================================
 // ACL Validation
 // ============================================================================
 
-/// Input for validating a Redis ACL
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ValidateEnterpriseAclInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-    /// ACL name
-    pub name: String,
-    /// ACL rule string (e.g., "+@all ~*" or "+get +set ~cache:*")
-    pub acl: String,
-    /// Description of the ACL
-    #[serde(default)]
-    pub description: Option<String>,
-}
+enterprise_tool!(read_only, validate_enterprise_acl, "validate_enterprise_acl",
+    "Validate a Redis ACL rule before creating it.",
+    {
+        /// ACL name
+        pub name: String,
+        /// ACL rule string (e.g., "+@all ~*" or "+get +set ~cache:*")
+        pub acl: String,
+        /// Description of the ACL
+        #[serde(default)]
+        pub description: Option<String>,
+    } => |client, input| {
+        let request = CreateRedisAclRequest {
+            name: input.name,
+            acl: input.acl,
+            description: input.description,
+        };
 
-/// Build the validate_enterprise_acl tool
-pub fn validate_enterprise_acl(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("validate_enterprise_acl")
-        .description("Validate a Redis ACL rule before creating it.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<ValidateEnterpriseAclInput>| async move {
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+        let handler = RedisAclHandler::new(client);
+        let result = handler
+            .validate(request)
+            .await
+            .tool_context("Failed to validate ACL")?;
 
-                let request = CreateRedisAclRequest {
-                    name: input.name,
-                    acl: input.acl,
-                    description: input.description,
-                };
+        CallToolResult::from_serialize(&result)
+    }
+);
 
-                let handler = RedisAclHandler::new(client);
-                let result = handler
-                    .validate(request)
-                    .await
-                    .tool_context("Failed to validate ACL")?;
+// ============================================================================
+// LDAP tools
+// ============================================================================
 
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
+enterprise_tool!(read_only, get_enterprise_ldap_config, "get_enterprise_ldap_config",
+    "Get the LDAP configuration including server settings, bind DN, and query suffixes.",
+    {} => |client, _input| {
+        let handler = LdapMappingHandler::new(client);
+        let config = handler
+            .get_config()
+            .await
+            .tool_context("Failed to get LDAP config")?;
 
-/// All tool names registered by this sub-module.
-pub(super) const TOOL_NAMES: &[&str] = &[
-    "list_enterprise_users",
-    "get_enterprise_user",
-    "create_enterprise_user",
-    "update_enterprise_user",
-    "delete_enterprise_user",
-    "get_enterprise_user_permissions",
-    "list_enterprise_roles",
-    "get_enterprise_role",
-    "create_enterprise_role",
-    "update_enterprise_role",
-    "delete_enterprise_role",
-    "get_enterprise_builtin_roles",
-    "list_enterprise_acls",
-    "get_enterprise_acl",
-    "create_enterprise_acl",
-    "update_enterprise_acl",
-    "delete_enterprise_acl",
-    "validate_enterprise_acl",
-    "get_enterprise_ldap_config",
-    "update_enterprise_ldap_config",
-];
+        CallToolResult::from_serialize(&config)
+    }
+);
 
-/// Build an MCP sub-router containing RBAC and LDAP tools
-pub fn router(state: Arc<AppState>) -> McpRouter {
-    McpRouter::new()
-        // Users
-        .tool(list_users(state.clone()))
-        .tool(get_user(state.clone()))
-        .tool(create_enterprise_user(state.clone()))
-        .tool(update_enterprise_user(state.clone()))
-        .tool(delete_enterprise_user(state.clone()))
-        // Roles
-        .tool(list_roles(state.clone()))
-        .tool(get_role(state.clone()))
-        .tool(create_enterprise_role(state.clone()))
-        .tool(update_enterprise_role(state.clone()))
-        .tool(delete_enterprise_role(state.clone()))
-        // ACLs
-        .tool(list_redis_acls(state.clone()))
-        .tool(get_redis_acl(state.clone()))
-        .tool(create_enterprise_acl(state.clone()))
-        .tool(update_enterprise_acl(state.clone()))
-        .tool(delete_enterprise_acl(state.clone()))
-        // User Permissions
-        .tool(get_enterprise_user_permissions(state.clone()))
-        // Built-in Roles
-        .tool(get_enterprise_builtin_roles(state.clone()))
-        // ACL Validation
-        .tool(validate_enterprise_acl(state.clone()))
-        // LDAP
-        .tool(get_enterprise_ldap_config(state.clone()))
-        .tool(update_enterprise_ldap_config(state.clone()))
-}
+enterprise_tool!(write, update_enterprise_ldap_config, "update_enterprise_ldap_config",
+    "Update the LDAP configuration. Pass LDAP settings as JSON.",
+    {
+        /// LDAP configuration as a JSON object. Fields: enabled (bool), servers (array of {host, port, use_tls, starttls}),
+        /// cache_refresh_interval, authentication_query_suffix, authorization_query_suffix, bind_dn, bind_pass
+        pub config: Value,
+    } => |client, input| {
+        let config = serde_json::from_value(input.config)
+            .tool_context("Invalid LDAP config")?;
+
+        let handler = LdapMappingHandler::new(client);
+        let result = handler
+            .update_config(config)
+            .await
+            .tool_context("Failed to update LDAP config")?;
+
+        CallToolResult::from_serialize(&result)
+    }
+);

--- a/crates/redisctl-mcp/src/tools/enterprise/services.rs
+++ b/crates/redisctl-mcp/src/tools/enterprise/services.rs
@@ -1,288 +1,130 @@
 //! Cluster service management tools for Redis Enterprise
 
-use std::sync::Arc;
-
-use redis_enterprise::services::ServicesHandler;
-use schemars::JsonSchema;
-use serde::Deserialize;
 use serde_json::Value;
-use tower_mcp::extract::{Json, State};
-use tower_mcp::{CallToolResult, Error as McpError, McpRouter, ResultExt, Tool, ToolBuilder};
+use tower_mcp::{CallToolResult, ResultExt};
 
-use crate::state::AppState;
+use crate::tools::macros::{enterprise_tool, mcp_module};
 use crate::tools::wrap_list;
 
-/// Input for listing services
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ListServicesInput {
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
+mcp_module! {
+    list_services => "list_enterprise_services",
+    get_service => "get_enterprise_service",
+    get_service_status => "get_enterprise_service_status",
+    update_service => "update_enterprise_service",
+    start_service => "start_enterprise_service",
+    stop_service => "stop_enterprise_service",
+    restart_service => "restart_enterprise_service",
 }
 
-/// Build the list_enterprise_services tool
-pub fn list_services(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("list_enterprise_services")
-        .description("List all cluster services.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<ListServicesInput>| async move {
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+enterprise_tool!(read_only, list_services, "list_enterprise_services",
+    "List all cluster services.",
+    {} => |client, _input| {
+        let handler = redis_enterprise::services::ServicesHandler::new(client);
+        let services = handler
+            .list()
+            .await
+            .tool_context("Failed to list services")?;
 
-                let handler = ServicesHandler::new(client);
-                let services = handler
-                    .list()
-                    .await
-                    .tool_context("Failed to list services")?;
+        wrap_list("services", &services)
+    }
+);
 
-                wrap_list("services", &services)
-            },
-        )
-        .build()
-}
+enterprise_tool!(read_only, get_service, "get_enterprise_service",
+    "Get service details by ID.",
+    {
+        /// Service ID (e.g., "cm_server", "mdns_server", "stats_archiver")
+        pub service_id: String,
+    } => |client, input| {
+        let handler = redis_enterprise::services::ServicesHandler::new(client);
+        let service = handler
+            .get(&input.service_id)
+            .await
+            .tool_context("Failed to get service")?;
 
-/// Input for getting a specific service
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetServiceInput {
-    /// Service ID (e.g., "cm_server", "mdns_server", "stats_archiver")
-    pub service_id: String,
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+        CallToolResult::from_serialize(&service)
+    }
+);
 
-/// Build the get_enterprise_service tool
-pub fn get_service(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_enterprise_service")
-        .description("Get service details by ID.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<GetServiceInput>| async move {
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+enterprise_tool!(read_only, get_service_status, "get_enterprise_service_status",
+    "Get service status including per-node status.",
+    {
+        /// Service ID
+        pub service_id: String,
+    } => |client, input| {
+        let handler = redis_enterprise::services::ServicesHandler::new(client);
+        let status = handler
+            .status(&input.service_id)
+            .await
+            .tool_context("Failed to get service status")?;
 
-                let handler = ServicesHandler::new(client);
-                let service = handler
-                    .get(&input.service_id)
-                    .await
-                    .tool_context("Failed to get service")?;
+        CallToolResult::from_serialize(&status)
+    }
+);
 
-                CallToolResult::from_serialize(&service)
-            },
-        )
-        .build()
-}
+enterprise_tool!(write, update_service, "update_enterprise_service",
+    "Update a service's configuration. Pass fields as JSON.",
+    {
+        /// Service ID to update
+        pub service_id: String,
+        /// Updated service configuration as JSON (e.g., enabled, config, node_uids)
+        pub config: Value,
+    } => |client, input| {
+        let handler = redis_enterprise::services::ServicesHandler::new(client);
+        let request = serde_json::from_value(input.config)
+            .map_err(|e| tower_mcp::Error::tool(format!("Invalid service config: {}", e)))?;
+        let result = handler
+            .update(&input.service_id, request)
+            .await
+            .tool_context("Failed to update service")?;
 
-/// Input for getting service status
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetServiceStatusInput {
-    /// Service ID
-    pub service_id: String,
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+        CallToolResult::from_serialize(&result)
+    }
+);
 
-/// Build the get_enterprise_service_status tool
-pub fn get_service_status(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("get_enterprise_service_status")
-        .description("Get service status including per-node status.")
-        .read_only_safe()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>,
-             Json(input): Json<GetServiceStatusInput>| async move {
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
+enterprise_tool!(write, start_service, "start_enterprise_service",
+    "Start a stopped service.",
+    {
+        /// Service ID
+        pub service_id: String,
+    } => |client, input| {
+        let handler = redis_enterprise::services::ServicesHandler::new(client);
+        let result = handler
+            .start(&input.service_id)
+            .await
+            .tool_context("Failed to start service")?;
 
-                let handler = ServicesHandler::new(client);
-                let status = handler
-                    .status(&input.service_id)
-                    .await
-                    .tool_context("Failed to get service status")?;
+        CallToolResult::from_serialize(&result)
+    }
+);
 
-                CallToolResult::from_serialize(&status)
-            },
-        )
-        .build()
-}
+enterprise_tool!(write, stop_service, "stop_enterprise_service",
+    "Stop a running service.",
+    {
+        /// Service ID
+        pub service_id: String,
+    } => |client, input| {
+        let handler = redis_enterprise::services::ServicesHandler::new(client);
+        let result = handler
+            .stop(&input.service_id)
+            .await
+            .tool_context("Failed to stop service")?;
 
-/// Input for updating a service
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct UpdateServiceInput {
-    /// Service ID to update
-    pub service_id: String,
-    /// Updated service configuration as JSON (e.g., enabled, config, node_uids)
-    pub config: Value,
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
+        CallToolResult::from_serialize(&result)
+    }
+);
 
-/// Build the update_enterprise_service tool
-pub fn update_service(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("update_enterprise_service")
-        .description("Update a service's configuration. Pass fields as JSON.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<UpdateServiceInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations require policy tier 'read-write' or 'full'",
-                    ));
-                }
+enterprise_tool!(write, restart_service, "restart_enterprise_service",
+    "Restart a service (stop then start).",
+    {
+        /// Service ID
+        pub service_id: String,
+    } => |client, input| {
+        let handler = redis_enterprise::services::ServicesHandler::new(client);
+        let result = handler
+            .restart(&input.service_id)
+            .await
+            .tool_context("Failed to restart service")?;
 
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let handler = ServicesHandler::new(client);
-                let request = serde_json::from_value(input.config)
-                    .map_err(|e| McpError::tool(format!("Invalid service config: {}", e)))?;
-                let result = handler
-                    .update(&input.service_id, request)
-                    .await
-                    .tool_context("Failed to update service")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// Input for service action (start/stop/restart)
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ServiceActionInput {
-    /// Service ID
-    pub service_id: String,
-    /// Profile name for multi-cluster support. If not specified, uses the first configured profile or default.
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-/// Build the start_enterprise_service tool
-pub fn start_service(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("start_enterprise_service")
-        .description("Start a stopped service.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<ServiceActionInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations require policy tier 'read-write' or 'full'",
-                    ));
-                }
-
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let handler = ServicesHandler::new(client);
-                let result = handler
-                    .start(&input.service_id)
-                    .await
-                    .tool_context("Failed to start service")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// Build the stop_enterprise_service tool
-pub fn stop_service(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("stop_enterprise_service")
-        .description("Stop a running service.")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<ServiceActionInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations require policy tier 'read-write' or 'full'",
-                    ));
-                }
-
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let handler = ServicesHandler::new(client);
-                let result = handler
-                    .stop(&input.service_id)
-                    .await
-                    .tool_context("Failed to stop service")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// Build the restart_enterprise_service tool
-pub fn restart_service(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("restart_enterprise_service")
-        .description("Restart a service (stop then start).")
-        .non_destructive()
-        .extractor_handler(
-            state,
-            |State(state): State<Arc<AppState>>, Json(input): Json<ServiceActionInput>| async move {
-                if !state.is_write_allowed() {
-                    return Err(McpError::tool(
-                        "Write operations require policy tier 'read-write' or 'full'",
-                    ));
-                }
-
-                let client = state
-                    .enterprise_client_for_profile(input.profile.as_deref())
-                    .await
-                    .map_err(|e| crate::tools::credential_error("enterprise", e))?;
-
-                let handler = ServicesHandler::new(client);
-                let result = handler
-                    .restart(&input.service_id)
-                    .await
-                    .tool_context("Failed to restart service")?;
-
-                CallToolResult::from_serialize(&result)
-            },
-        )
-        .build()
-}
-
-/// All tool names registered by this sub-module.
-pub(super) const TOOL_NAMES: &[&str] = &[
-    "list_enterprise_services",
-    "get_enterprise_service",
-    "get_enterprise_service_status",
-    "update_enterprise_service",
-    "start_enterprise_service",
-    "stop_enterprise_service",
-    "restart_enterprise_service",
-];
-
-/// Build the services sub-router
-pub fn router(state: Arc<AppState>) -> McpRouter {
-    McpRouter::new()
-        .tool(list_services(state.clone()))
-        .tool(get_service(state.clone()))
-        .tool(get_service_status(state.clone()))
-        .tool(update_service(state.clone()))
-        .tool(start_service(state.clone()))
-        .tool(stop_service(state.clone()))
-        .tool(restart_service(state.clone()))
-}
+        CallToolResult::from_serialize(&result)
+    }
+);


### PR DESCRIPTION
## Summary

- Convert 91 enterprise tools across 6 files to `enterprise_tool!` and `mcp_module!` macros
- First real use of the `enterprise_tool!` macro (validates the enterprise platform pattern)
- Raw tool (`enterprise_raw_api`) stays manual due to custom method-dependent permission logic
- Net reduction: -2278 lines (4193 removed, 1915 added)

| File | Before | After | Reduction |
|---|---|---|---|
| cluster.rs (24 tools) | 1125 | 523 | 54% |
| databases.rs (20 tools) | 1043 | 527 | 49% |
| rbac.rs (20 tools) | 1009 | 492 | 51% |
| observability.rs (16 tools) | 720 | 336 | 53% |
| proxy.rs (4 tools) | 180 | 79 | 56% |
| services.rs (7 tools) | 288 | 130 | 55% |

Completes #791 Phase 1 (all three platform macros validated)

## Test plan

- [x] `cargo clippy -p redisctl-mcp --all-features -- -D warnings` clean
- [x] `cargo check -p redisctl-mcp --no-default-features` compiles
- [x] All 95 lib tests pass
- [x] `cargo fmt --all -- --check` clean