### PR TITLE
chore: sync workspace crate versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2946,7 +2946,7 @@ dependencies = [
 
 [[package]]
 name = "redisctl-core"
-version = "0.2.0"
+version = "0.8.2"
 dependencies = [
  "clap",
  "directories",
@@ -2967,7 +2967,7 @@ dependencies = [
 
 [[package]]
 name = "redisctl-mcp"
-version = "0.5.0"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ default-members = [
 version = "0.3.1"
 
 [workspace.package]
-version = "0.6.2"
+version = "0.8.2"
 edition = "2024"
 rust-version = "1.90"
 authors = ["Josh Rotenberg <josh.rotenberg@redis.com>"]

--- a/crates/redisctl-core/Cargo.toml
+++ b/crates/redisctl-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redisctl-core"
-version = "0.2.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/redisctl-mcp/Cargo.toml
+++ b/crates/redisctl-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redisctl-mcp"
-version = "0.5.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
@@ -21,7 +21,7 @@ tower-mcp = { version = "0.7.0", features = ["http", "oauth"] }
 schemars = "1.2"
 
 # Internal crates
-redisctl-core = { version = "0.2.0", path = "../redisctl-core" }
+redisctl-core = { version = "0.8.2", path = "../redisctl-core" }
 
 # External API clients (optional, gated by features)
 redis-cloud = { workspace = true, optional = true }

--- a/crates/redisctl/Cargo.toml
+++ b/crates/redisctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redisctl"
-version = "0.8.2"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
@@ -18,7 +18,7 @@ path = "src/main.rs"
 
 
 [dependencies]
-redisctl-core = { version = "0.2.0", path = "../redisctl-core" }
+redisctl-core = { version = "0.8.2", path = "../redisctl-core" }
 redis-cloud = { workspace = true, features = ["tower-integration"] }
 redis-enterprise = { workspace = true, features = ["tower-integration"] }
 files-sdk = { workspace = true, optional = true }


### PR DESCRIPTION
## Summary

- Unify all three workspace crates to a single version using `version.workspace = true`
- Set workspace version to 0.8.2 (current highest) so release-plz bumps naturally from here
- Update internal `redisctl-core` dependency references to match

| Crate | Before | After |
|---|---|---|
| redisctl | 0.8.2 | 0.8.2 (workspace) |
| redisctl-mcp | 0.5.0 | 0.8.2 (workspace) |
| redisctl-core | 0.2.0 | 0.8.2 (workspace) |

Closes #812

## Test plan

- [x] `cargo check --workspace` builds all three crates at v0.8.2