### PR TITLE
docs: clarify Docker env var forwarding in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ tier = "standard"  # read-only (default) | standard (read-write) | full (destruc
 
 ### Zero-Install with Docker
 
+`REDIS_ENTERPRISE_PASSWORD` is passed without a value so Docker forwards it from your host environment (keeps the secret out of the config file):
+
 ```json
 {
   "mcpServers": {


### PR DESCRIPTION
## Summary

- Adds a note above the Docker MCP config example explaining that `REDIS_ENTERPRISE_PASSWORD` without a value forwards from the host environment (keeps the secret out of the config file)

## Test plan

- [ ] README renders correctly on GitHub