### PR TITLE
docs: fix stale command syntax and tool counts

### DIFF
--- a/docs/docs/developer/contributing.md
+++ b/docs/docs/developer/contributing.md
@@ -92,7 +92,7 @@ Then create a PR on GitHub.
 
 ```
 crates/
-├── redisctl-config/    # Profile and credential management
+├── redisctl-core/      # Core library - config, workflows, and shared logic
 ├── redisctl/           # CLI
 │   ├── src/commands/   # Command implementations
 │   ├── src/workflows/  # Multi-step workflows

--- a/docs/docs/developer/index.md
+++ b/docs/docs/developer/index.md
@@ -12,7 +12,7 @@ The Redis API client libraries are available for both Rust and Python:
 |-------|-------------|---------|
 | `redis-cloud` | Redis Cloud API client | [docs](https://docs.rs/redis-cloud) |
 | `redis-enterprise` | Redis Enterprise API client | [docs](https://docs.rs/redis-enterprise) |
-| `redisctl-config` | Profile and credential management | [docs](https://docs.rs/redisctl-config) |
+| `redisctl-core` | Profile and credential management | [docs](https://docs.rs/redisctl-core) |
 
 ### Python Packages
 

--- a/docs/docs/developer/libraries.md
+++ b/docs/docs/developer/libraries.md
@@ -8,7 +8,7 @@ Use the Redis API client libraries in your own Rust or Python projects.
 |-------|-------------|---------|------------|
 | `redis-cloud` | Redis Cloud API client | [docs](https://docs.rs/redis-cloud) | [redis-cloud-rs](https://github.com/redis-developer/redis-cloud-rs) |
 | `redis-enterprise` | Redis Enterprise API client | [docs](https://docs.rs/redis-enterprise) | [redis-enterprise-rs](https://github.com/redis-developer/redis-enterprise-rs) |
-| `redisctl-config` | Profile and credential management | [docs](https://docs.rs/redisctl-config) | [redisctl](https://github.com/redis-developer/redisctl) |
+| `redisctl-core` | Profile and credential management | [docs](https://docs.rs/redisctl-core) | [redisctl](https://github.com/redis-developer/redisctl) |
 
 **Note:** `redis-cloud` and `redis-enterprise` are maintained in separate repositories and also provide Python bindings via PyPI.
 
@@ -101,21 +101,21 @@ async fn main() -> anyhow::Result<()> {
 }
 ```
 
-## redisctl-config
+## redisctl-core
 
-Profile and credential management.
+Core library for config, workflows, and shared logic.
 
 ### Installation
 
 ```toml
 [dependencies]
-redisctl-config = "0.1"
+redisctl-core = "0.8"
 ```
 
 ### Example
 
 ```rust
-use redisctl_config::{Config, Profile};
+use redisctl_core::{Config, Profile};
 
 fn main() -> anyhow::Result<()> {
     // Load config

--- a/docs/docs/integrations/mcp.md
+++ b/docs/docs/integrations/mcp.md
@@ -56,12 +56,12 @@ Before using the MCP server, configure a profile with your Redis credentials:
 
 ```bash
 # Interactive setup (prompts for API keys)
-redisctl profile add my-cloud-profile --cloud
+redisctl profile set my-cloud-profile --type cloud
 
 # Or provide keys directly
-redisctl profile add my-cloud-profile --cloud \
+redisctl profile set my-cloud-profile --type cloud \
   --api-key YOUR_API_KEY \
-  --secret-key YOUR_SECRET_KEY
+  --api-secret YOUR_SECRET_KEY
 ```
 
 Get your API keys from the [Redis Cloud Console](https://app.redislabs.com/) under Account > API Keys.
@@ -70,10 +70,10 @@ Get your API keys from the [Redis Cloud Console](https://app.redislabs.com/) und
 
 ```bash
 # Interactive setup
-redisctl profile add my-enterprise-profile --enterprise
+redisctl profile set my-enterprise-profile --type enterprise
 
 # Or provide credentials directly
-redisctl profile add my-enterprise-profile --enterprise \
+redisctl profile set my-enterprise-profile --type enterprise \
   --url https://your-cluster:9443 \
   --username admin@redis.com \
   --password YOUR_PASSWORD \

--- a/docs/docs/mcp/advanced-usage.md
+++ b/docs/docs/mcp/advanced-usage.md
@@ -21,8 +21,8 @@ Configure both MCP servers in your AI assistant:
     {
       "mcpServers": {
         "redisctl": {
-          "command": "redisctl",
-          "args": ["-p", "my-profile", "mcp", "serve", "--allow-writes"]
+          "command": "redisctl-mcp",
+          "args": ["--profile", "my-profile", "--read-only=false"]
         },
         "jpx": {
           "command": "jpx",
@@ -38,11 +38,11 @@ Configure both MCP servers in your AI assistant:
     {
       "mcpServers": {
         "redisctl": {
-          "command": "/path/to/redisctl",
-          "args": ["-p", "my-profile", "mcp", "serve"]
+          "command": "redisctl-mcp",
+          "args": ["--profile", "my-profile"]
         },
         "jpx": {
-          "command": "/path/to/jpx",
+          "command": "jpx",
           "args": ["mcp"]
         }
       }

--- a/docs/docs/mcp/configuration.md
+++ b/docs/docs/mcp/configuration.md
@@ -67,7 +67,7 @@ The server resolves which toolsets to load in this order:
 |---------|-------------|-------------|
 | `cloud` | `subscriptions`, `account`, `networking`, `fixed`, `raw` | 148 |
 | `enterprise` | `cluster`, `databases`, `rbac`, `observability`, `proxy`, `services`, `raw` | 92 |
-| `database` | `server`, `keys`, `structures`, `diagnostics`, `raw` | 55 |
+| `database` | `server`, `keys`, `structures`, `diagnostics`, `raw` | 90 |
 | `app` | *(none -- flat toolset)* | 8 |
 | *(system)* | *(always loaded)* | 2 |
 
@@ -93,7 +93,7 @@ redisctl-mcp --profile my-cloud --tools cloud:subscriptions,cloud:networking
 redisctl-mcp --profile my-re --tools enterprise:cluster,enterprise:observability
 ```
 
-**Database only** -- direct Redis operations (55 tools + system):
+**Database only** -- direct Redis operations (90 tools + system):
 
 ```bash
 redisctl-mcp --database-url redis://localhost:6379 --tools database

--- a/docs/docs/mcp/getting-started.md
+++ b/docs/docs/mcp/getting-started.md
@@ -60,12 +60,12 @@ Before using the MCP server, configure a profile with your Redis credentials.
 
 ```bash
 # Interactive setup (prompts for API keys)
-redisctl profile add my-cloud-profile --cloud
+redisctl profile set my-cloud-profile --type cloud
 
 # Or provide keys directly
-redisctl profile add my-cloud-profile --cloud \
+redisctl profile set my-cloud-profile --type cloud \
   --api-key YOUR_API_KEY \
-  --secret-key YOUR_SECRET_KEY
+  --api-secret YOUR_SECRET_KEY
 ```
 
 Get your API keys from the [Redis Cloud Console](https://app.redislabs.com/) under Account > API Keys.
@@ -74,10 +74,10 @@ Get your API keys from the [Redis Cloud Console](https://app.redislabs.com/) und
 
 ```bash
 # Interactive setup
-redisctl profile add my-enterprise-profile --enterprise
+redisctl profile set my-enterprise-profile --type enterprise
 
 # Or provide credentials directly
-redisctl profile add my-enterprise-profile --enterprise \
+redisctl profile set my-enterprise-profile --type enterprise \
   --url https://your-cluster:9443 \
   --username admin@redis.com \
   --password YOUR_PASSWORD \


### PR DESCRIPTION
## Summary

Quality pass across MCP and developer docs fixing stale references:

- `profile add` -> `profile set` (3 files)
- `--cloud`/`--enterprise` shorthand -> `--type cloud`/`--type enterprise`
- `--secret-key` -> `--api-secret`
- `redisctl mcp serve --allow-writes` -> `redisctl-mcp --read-only=false` (advanced-usage.md)
- `redisctl-config` -> `redisctl-core` (crate was renamed; developer docs, libraries, contributing)
- Database tool count 55 -> 90 in configuration.md (was stale after structures expansion)

Presentation slides (`docs/presentation/`) have the same issues but are tracked separately by #706.

Part of #682

## Test plan

- [ ] Verify all command examples match `redisctl profile set --help` output
- [ ] Tool counts match source: cloud 148, enterprise 92, database 90, app 8, system 2 = 340