### PR TITLE
docs: update presentation slides with current CLI syntax and MCP coverage

### DIFF
--- a/docs/docs/presentation/index.md
+++ b/docs/docs/presentation/index.md
@@ -47,7 +47,7 @@ The slides use [reveal.js](https://revealjs.com/). To customize:
 
 Need a one-liner?
 
-> **redisctl** is the first CLI for Redis Cloud and Enterprise. Type-safe API clients, async operation handling, support package automation, and structured output for scripting.
+> **redisctl** manages Redis Cloud, Redis Enterprise, and Redis databases from one tool -- as a CLI for humans or an MCP server for AI agents.
 
 ## Demo Script
 
@@ -59,9 +59,10 @@ brew install redis-developer/homebrew-tap/redisctl
 
 # Configure profile
 redisctl profile set demo \
-  --enterprise-url "https://cluster:9443" \
-  --enterprise-user "admin@cluster.local" \
-  --enterprise-password "$PASSWORD"
+  --type enterprise \
+  --url "https://cluster:9443" \
+  --username "admin@cluster.local" \
+  --password "$PASSWORD"
 ```
 
 ### 2. Basic Commands (1 minute)
@@ -175,20 +176,20 @@ redisctl provides unified multi-cluster management through profiles:
 
 ```bash
 # Add each cluster as a profile
-redisctl profile create cluster-west --type enterprise \
-  --enterprise-url https://west.example.com:9443 \
-  --enterprise-user admin@redis.local \
-  --enterprise-password "$PASSWORD"
+redisctl profile set cluster-west --type enterprise \
+  --url https://west.example.com:9443 \
+  --username admin@redis.local \
+  --password "$PASSWORD"
 
-redisctl profile create cluster-east --type enterprise \
-  --enterprise-url https://east.example.com:9443 \
-  --enterprise-user admin@redis.local \
-  --enterprise-password "$PASSWORD"
+redisctl profile set cluster-east --type enterprise \
+  --url https://east.example.com:9443 \
+  --username admin@redis.local \
+  --password "$PASSWORD"
 
-redisctl profile create cluster-central --type enterprise \
-  --enterprise-url https://central.example.com:9443 \
-  --enterprise-user admin@redis.local \
-  --enterprise-password "$PASSWORD"
+redisctl profile set cluster-central --type enterprise \
+  --url https://central.example.com:9443 \
+  --username admin@redis.local \
+  --password "$PASSWORD"
 ```
 
 ### 2. Cross-Cluster CLI Queries
@@ -227,7 +228,7 @@ With MCP, the AI can query across clusters conversationally:
 - "Which databases across all clusters don't have persistence enabled?"
 - "Total up all the databases across my fleet"
 
-The AI uses `profile_list` to discover clusters and `profile_set_default_enterprise` to switch between them, then aggregates the results.
+The AI uses `profile_list` to discover clusters and targets each one via the `profile` parameter on tool calls, then aggregates the results.
 
 ### Key Differentiators
 

--- a/docs/docs/presentation/slides.html
+++ b/docs/docs/presentation/slides.html
@@ -226,12 +226,12 @@ ENDPOINT=$(curl -s ... | jq -r '.publicEndpoint')
                     <h2><span class="redis-red">Layer 1:</span> Profiles</h2>
                     <p>Manage credentials across environments</p>
                     <pre><code class="language-bash"># Set up profiles for each environment
-redisctl profile set dev --cloud-api-key $DEV_KEY --cloud-secret-key $DEV_SECRET
-redisctl profile set staging --cloud-api-key $STG_KEY --cloud-secret-key $STG_SECRET
-redisctl profile set prod --cloud-api-key $PROD_KEY --cloud-secret-key $PROD_SECRET
+redisctl profile set dev --type cloud --api-key $DEV_KEY --api-secret $DEV_SECRET
+redisctl profile set staging --type cloud --api-key $STG_KEY --api-secret $STG_SECRET
+redisctl profile set prod --type cloud --api-key $PROD_KEY --api-secret $PROD_SECRET
 
 # Set a default
-redisctl profile set-default prod
+redisctl profile default-cloud prod
 
 # Switch easily
 redisctl --profile dev cloud database list
@@ -245,19 +245,19 @@ redisctl --profile prod cloud database list</code></pre>
                     </h2>
                     <p>Keep credentials out of scripts and env vars</p>
                     <pre><code class="language-bash"># Store credentials in OS keychain (macOS Keychain, Windows Credential Manager)
-redisctl profile set prod \
-  --cloud-api-key $KEY \
-  --cloud-secret-key $SECRET \
+redisctl profile set prod --type cloud \
+  --api-key $KEY \
+  --api-secret $SECRET \
   --use-keyring
 
 # Or reference environment variables
-redisctl profile set prod \
-  --cloud-api-key '${REDIS_CLOUD_API_KEY}' \
-  --cloud-secret-key '${REDIS_CLOUD_SECRET_KEY}'
+redisctl profile set prod --type cloud \
+  --api-key '${REDIS_CLOUD_API_KEY}' \
+  --api-secret '${REDIS_CLOUD_SECRET_KEY}'
 
 # Credentials never appear in config file
 cat ~/.config/redisctl/config.toml
-# cloud_api_key = "keyring:prod-api-key"</code></pre>
+# api_key = "keyring:prod-api-key"</code></pre>
                 </section>
 
                 <!-- Layer 2: Raw API -->
@@ -441,25 +441,33 @@ Case: https://files.redis.com/f/abc123</code></pre>
                     <h2>MCP: AI-Powered Redis Management</h2>
                     <p>
                         redisctl includes an MCP server with
-                        <strong>~100 tools</strong> for AI assistants
+                        <strong>340 tools</strong> for AI assistants
                     </p>
                     <div class="columns">
                         <div class="column">
-                            <h3 class="cloud-blue small">Cloud Operations</h3>
+                            <h3 class="cloud-blue small">Cloud (148 tools)</h3>
                             <ul class="small">
                                 <li>Subscriptions & databases</li>
-                                <li>Create, update, delete databases</li>
-                                <li>Backup & import operations</li>
-                                <li>ACL & user management</li>
+                                <li>VPC peering, PrivateLink, PSC</li>
+                                <li>ACLs, users, cloud accounts</li>
+                            </ul>
+                            <h3 class="green small">Database (90 tools)</h3>
+                            <ul class="small">
+                                <li>Keys, data structures, diagnostics</li>
+                                <li>Server info, health checks</li>
                             </ul>
                         </div>
                         <div class="column">
-                            <h3 class="orange small">Enterprise Operations</h3>
+                            <h3 class="orange small">Enterprise (92 tools)</h3>
                             <ul class="small">
-                                <li>License management & validation</li>
-                                <li>Cluster & policy configuration</li>
-                                <li>Maintenance mode control</li>
-                                <li>Certificate management</li>
+                                <li>License, cluster, maintenance</li>
+                                <li>Databases, RBAC, certificates</li>
+                                <li>Observability, proxy, services</li>
+                            </ul>
+                            <h3 class="redis-red small">Safety</h3>
+                            <ul class="small">
+                                <li>Read-only by default</li>
+                                <li>Policy tiers: read-only / standard / full</li>
                             </ul>
                         </div>
                     </div>
@@ -731,7 +739,7 @@ curl -L https://github.com/redis-developer/redisctl/releases/latest/download/red
 brew install redis-developer/homebrew-tap/redisctl
 
 # Setup profile
-redisctl profile set mycloud --cloud-api-key $KEY --cloud-secret-key $SECRET
+redisctl profile set mycloud --type cloud --api-key $KEY --api-secret $SECRET
 
 # Start using
 redisctl cloud subscription list


### PR DESCRIPTION
## Summary

Full revision of presentation slides and demo scripts to reflect the current state of the CLI:

**Stale flag fixes:**
- `--cloud-api-key` -> `--api-key`, `--cloud-secret-key` -> `--api-secret`
- `--enterprise-url` -> `--url`, `--enterprise-user` -> `--username`, `--enterprise-password` -> `--password`
- `profile create` -> `profile set`, `profile set-default` -> `profile default-cloud`
- Added `--type cloud`/`--type enterprise` to all profile set examples

**MCP updates:**
- Tool count from ~100 to 340
- Expanded MCP slide to show all three toolsets (Cloud 148, Enterprise 92, Database 90) with safety model
- Updated multi-cluster demo to use direct profile targeting

**Other:**
- Updated quick pitch to match new README
- Fixed keyring config example

Closes #706

## Test plan

- [ ] Slides render correctly in reveal.js (open slides.html in browser)
- [ ] Demo script commands match `redisctl profile set --help` output
- [ ] All old flags eliminated (`grep` for `--cloud-api-key` etc.)