### PR TITLE
chore: pin Redis Enterprise Docker image to 8.0.10-81

### DIFF
--- a/docker/docker-compose.enterprise-demo.yml
+++ b/docker/docker-compose.enterprise-demo.yml
@@ -43,8 +43,7 @@ services:
   # allowing dependent services to start.
   # ==============================================================================
   redis-enterprise:
-    image: ${REDIS_ENTERPRISE_IMAGE:-redislabs/redis:latest}
-    platform: ${REDIS_ENTERPRISE_PLATFORM:-linux/amd64}
+    image: redislabs/redis:8.0.10-81
     container_name: redis-enterprise
     tty: true
     cap_add:

--- a/docker/docker-compose.multi-cluster.yml
+++ b/docker/docker-compose.multi-cluster.yml
@@ -11,31 +11,27 @@
 #   docker compose -f docker/docker-compose.multi-cluster.yml down -v
 #
 # After startup, configure profiles:
-#   redisctl profile create cluster-west \
-#     --type enterprise \
-#     --enterprise-url https://localhost:9443 \
-#     --enterprise-user admin@redis.local \
-#     --enterprise-password Redis123! \
-#     --enterprise-insecure
+#   redisctl profile set cluster-west --type enterprise \
+#     --url https://localhost:9443 \
+#     --username admin@redis.local \
+#     --password Redis123! \
+#     --insecure
 #
-#   redisctl profile create cluster-east \
-#     --type enterprise \
-#     --enterprise-url https://localhost:9543 \
-#     --enterprise-user admin@redis.local \
-#     --enterprise-password Redis123! \
-#     --enterprise-insecure
+#   redisctl profile set cluster-east --type enterprise \
+#     --url https://localhost:9543 \
+#     --username admin@redis.local \
+#     --password Redis123! \
+#     --insecure
 #
-#   redisctl profile create cluster-central \
-#     --type enterprise \
-#     --enterprise-url https://localhost:9643 \
-#     --enterprise-user admin@redis.local \
-#     --enterprise-password Redis123! \
-#     --enterprise-insecure
+#   redisctl profile set cluster-central --type enterprise \
+#     --url https://localhost:9643 \
+#     --username admin@redis.local \
+#     --password Redis123! \
+#     --insecure
 # ==============================================================================
 
 x-redis-enterprise-base: &redis-enterprise-base
-  image: ${REDIS_ENTERPRISE_IMAGE:-redislabs/redis:latest}
-  platform: ${REDIS_ENTERPRISE_PLATFORM:-linux/amd64}
+  image: redislabs/redis:8.0.10-81
   tty: true
   cap_add:
     - ALL


### PR DESCRIPTION
## Summary

- Pin both compose files to `redislabs/redis:8.0.10-81` (multi-arch: amd64 + arm64)
- Remove `platform` directive and `REDIS_ENTERPRISE_IMAGE`/`REDIS_ENTERPRISE_PLATFORM` env var overrides (the arm64 workaround via `kurtfm/rs-arm:latest` is no longer needed)
- Fix stale CLI syntax in multi-cluster compose header comments (`profile create` -> `profile set`, old flags -> current flags)

Closes #822

## Test plan

- [ ] `docker compose -f docker/docker-compose.enterprise-demo.yml up -d` works on Apple Silicon
- [ ] `docker compose -f docker/docker-compose.multi-cluster.yml up -d` works on Apple Silicon