### PR TITLE
docs(mcp): architecture overview and audit logging guide

### DIFF
--- a/docs/docs/mcp/architecture.md
+++ b/docs/docs/mcp/architecture.md
@@ -1,0 +1,166 @@
+# Architecture
+
+How the redisctl MCP server is structured internally.
+
+## Overview
+
+`redisctl-mcp` is a standalone binary built on [tower-mcp](https://crates.io/crates/tower-mcp), a Rust MCP framework. It exposes Redis management operations as MCP tools that AI assistants can discover and invoke.
+
+```
+AI Assistant (Claude, Cursor, etc.)
+    |
+    | MCP protocol (stdio or HTTP/SSE)
+    v
+redisctl-mcp
+    |
+    +-- Policy engine (tier checks, allow/deny lists)
+    +-- Audit layer (structured logging of tool calls)
+    +-- Tool router (340 tools across 4 toolsets)
+    |       |
+    |       +-- Cloud tools -> redis-cloud client -> Cloud REST API
+    |       +-- Enterprise tools -> redis-enterprise client -> Enterprise REST API
+    |       +-- Database tools -> redis crate -> Redis protocol
+    |       +-- App tools -> redisctl-core -> local config
+    |
+    +-- Credential resolution (profiles or OAuth)
+```
+
+## Feature Flags
+
+The binary is compiled with feature flags that gate platform-specific dependencies:
+
+| Feature | Default | Gates |
+|---------|---------|-------|
+| `cloud` | yes | `redis-cloud` crate + cloud toolset |
+| `enterprise` | yes | `redis-enterprise` crate + enterprise toolset |
+| `database` | yes | `redis` crate + database toolset |
+| `http` | yes | HTTP/SSE transport with optional OAuth |
+
+Profile/app tools and the two system tools are always compiled in (they only depend on `redisctl-core`).
+
+Compile with `--no-default-features` and selectively enable what you need:
+
+```bash
+# Cloud-only binary
+cargo install redisctl-mcp --no-default-features --features cloud
+
+# Database-only binary
+cargo install redisctl-mcp --no-default-features --features database
+```
+
+## Toolset and Sub-Module System
+
+Tools are organized into **toolsets** (cloud, enterprise, database, app) and **sub-modules** within each toolset. Each sub-module is a Rust module that declares:
+
+- A `TOOL_NAMES` constant listing all tool names in the module
+- A `router()` function that registers tools with the MCP router
+
+The `mcp_module!` macro generates both from a single declaration:
+
+```rust
+mcp_module! {
+    ping => "redis_ping",
+    info => "redis_info",
+    dbsize => "redis_dbsize",
+}
+```
+
+This produces a `TOOL_NAMES` array and a `router()` function that builds tools and merges them into the MCP router.
+
+### Tool Macros
+
+Three platform-specific macros eliminate per-tool boilerplate:
+
+- `database_tool!` -- resolves a Redis connection from URL or profile, then runs the handler
+- `cloud_tool!` -- resolves a Cloud API client from profile, then runs the handler
+- `enterprise_tool!` -- resolves an Enterprise API client from profile, then runs the handler
+
+Each macro accepts a safety tier (`read_only`, `write`, or `destructive`) that sets the tool's MCP annotations and generates runtime permission guards:
+
+```rust
+database_tool!(read_only, ping, "redis_ping",
+    "Test connectivity by sending a PING command",
+    {} => |conn, _input| {
+        let response: String = redis::cmd("PING")
+            .query_async(&mut conn).await.tool_context("PING failed")?;
+        Ok(CallToolResult::text(format!("Response: {}", response)))
+    }
+);
+```
+
+## Transport Modes
+
+### stdio (default)
+
+Standard input/output. The AI assistant spawns the `redisctl-mcp` process and communicates over stdin/stdout. This is the standard MCP transport used by Claude Desktop, Cursor, Claude Code, and others.
+
+### HTTP/SSE
+
+HTTP transport with Server-Sent Events for streaming. Useful for shared deployments where multiple clients connect to a single MCP server instance.
+
+```bash
+redisctl-mcp --transport http --host 0.0.0.0 --port 8080
+```
+
+Optional OAuth authentication protects the HTTP endpoint:
+
+```bash
+redisctl-mcp --transport http --oauth \
+  --oauth-issuer https://auth.example.com \
+  --oauth-audience my-audience \
+  --jwks-uri https://auth.example.com/.well-known/jwks.json
+```
+
+## Credential Resolution
+
+Credentials are resolved at tool invocation time, not at server startup. This allows multi-profile configurations where different tools target different clusters.
+
+### Profile-based (stdio mode)
+
+1. Tool call includes optional `profile` parameter
+2. If no profile specified, use the first `--profile` from CLI args
+3. If no CLI profile, fall back to the default profile from `~/.config/redisctl/config.toml`
+4. Resolve credentials from the profile (including keyring lookups)
+5. Build or reuse a cached API client for that profile
+
+### OAuth-based (HTTP mode)
+
+In HTTP mode with OAuth enabled, credentials come from environment variables (`REDIS_CLOUD_API_KEY`, `REDIS_ENTERPRISE_URL`, etc.) rather than profiles.
+
+## Policy Engine
+
+The policy engine evaluates every tool call against the active policy before execution. See [Configuration](configuration.md) for the full policy reference.
+
+The evaluation flow:
+
+1. **Registration-time filtering** -- tools outside the active tier are hidden from the AI (not registered with the router)
+2. **Runtime guards** -- write and destructive tools check the policy tier again inside the handler as defense-in-depth
+3. **Allow/deny lists** -- evaluated per the [policy evaluation order](configuration.md#evaluation-order)
+
+## Audit Layer
+
+A tower middleware (`AuditLayer`) sits between the transport and the tool router. It intercepts every tool call and emits structured events via the `tracing` crate with `target: "audit"`. See [Audit Logging](audit-logging.md) for configuration details.
+
+## Concurrency and Rate Limiting
+
+The server enforces concurrency and rate limits via CLI flags:
+
+- `--max-concurrent 10` -- maximum parallel tool calls (default: 10)
+- `--rate-limit-ms 100` -- minimum interval between calls in milliseconds (default: 100)
+- `--request-timeout-secs 30` -- per-request timeout for HTTP transport (default: 30)
+
+## Request Flow
+
+A typical tool call flows through these layers:
+
+1. **Transport** -- receives MCP JSON-RPC message (stdio or HTTP)
+2. **Audit layer** -- records the call, starts timer
+3. **Capability filter** -- checks if the tool is visible under the current preset
+4. **Router** -- dispatches to the tool handler
+5. **Tool handler** -- runs the platform macro which:
+    - Checks safety tier (write/destructive guard)
+    - Resolves credentials and builds/reuses API client
+    - Executes the operation
+    - Returns `CallToolResult`
+6. **Audit layer** -- records result status and duration
+7. **Transport** -- sends MCP JSON-RPC response

--- a/docs/docs/mcp/audit-logging.md
+++ b/docs/docs/mcp/audit-logging.md
@@ -1,0 +1,162 @@
+# Audit Logging
+
+Track every tool invocation for compliance, debugging, and operational visibility.
+
+## Enabling Audit Logging
+
+Audit logging is disabled by default. Enable it in your policy file:
+
+```toml
+[audit]
+enabled = true
+```
+
+Or for a more complete configuration:
+
+```toml
+[audit]
+enabled = true
+level = "all"
+include_args = true
+redact_fields = ["password", "api_key", "api_secret", "secret"]
+```
+
+## Configuration Reference
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `false` | Master switch for audit logging |
+| `level` | string | `"all"` | Which events to log (see levels below) |
+| `include_args` | bool | `false` | Include tool arguments in log entries |
+| `redact_fields` | list | `["password", "api_key", "api_secret", "secret"]` | Field names to redact when `include_args` is true |
+
+## Audit Levels
+
+| Level | Logs |
+|-------|------|
+| `all` | Every tool call (success, error, and denied) |
+| `writes` | Non-read-only calls + errors + denied |
+| `destructive` | Destructive calls + errors + denied |
+| `denied` | Only policy-denied calls and errors |
+
+Choose based on your needs:
+
+- **Production monitoring**: `"denied"` -- catch policy violations without log noise
+- **Development/debugging**: `"all"` -- see everything
+- **Compliance**: `"writes"` or `"all"` with `include_args = true` -- full mutation audit trail
+
+## Log Format
+
+Audit events are emitted as structured JSON via the `tracing` crate with `target: "audit"`. When using JSON log output (`--log-level` with `RUST_LOG` filtering), each event includes:
+
+```json
+{
+  "timestamp": "2026-03-05T10:30:00.123Z",
+  "level": "INFO",
+  "target": "audit",
+  "fields": {
+    "event": "tool_invocation",
+    "tool": "list_enterprise_databases",
+    "toolset": "enterprise",
+    "result": "success",
+    "duration_ms": 45
+  }
+}
+```
+
+### Event Types
+
+| Event | Description |
+|-------|-------------|
+| `tool_invocation` | Tool was called and completed successfully |
+| `tool_denied` | Tool call was blocked by policy (error code -32007) |
+| `tool_error` | Tool call failed with an error |
+
+### With Arguments
+
+When `include_args = true`, an `arguments` field is added containing the tool's input parameters. Sensitive fields listed in `redact_fields` are replaced with `[REDACTED]`:
+
+```json
+{
+  "fields": {
+    "event": "tool_invocation",
+    "tool": "create_enterprise_database",
+    "toolset": "enterprise",
+    "result": "success",
+    "duration_ms": 1200,
+    "arguments": "{\"name\":\"cache-db\",\"memory_size\":104857600,\"password\":\"[REDACTED]\"}"
+  }
+}
+```
+
+Redaction is recursive -- fields are redacted at any depth in the JSON structure.
+
+## Routing Audit Logs
+
+Audit events use `target: "audit"` so you can route them separately from application logs using `RUST_LOG` filtering:
+
+```bash
+# All logs at info, audit at debug
+RUST_LOG=info,audit=debug redisctl-mcp --profile my-profile
+
+# Only audit logs
+RUST_LOG=warn,audit=info redisctl-mcp --profile my-profile
+```
+
+### Log Aggregation
+
+To send audit logs to an external system, pipe JSON output to your collector:
+
+```bash
+# Datadog
+redisctl-mcp --profile my-profile 2>&1 | datadog-agent pipe
+
+# Fluentd
+redisctl-mcp --profile my-profile 2>&1 | fluent-cat audit.mcp
+
+# File-based (rotate with logrotate)
+redisctl-mcp --profile my-profile 2>> /var/log/redisctl-mcp-audit.jsonl
+```
+
+Since the MCP server uses stderr for logs and stdout for MCP protocol messages, redirect stderr (`2>`) to capture audit output without interfering with the MCP transport.
+
+## Practical Examples
+
+### Compliance: Full Mutation Audit
+
+Track all state-changing operations with arguments:
+
+```toml
+tier = "read-write"
+
+[audit]
+enabled = true
+level = "writes"
+include_args = true
+redact_fields = ["password", "api_key", "api_secret", "secret", "token"]
+```
+
+### Security: Denied Operations Only
+
+Alert on policy violations:
+
+```toml
+tier = "read-only"
+
+[audit]
+enabled = true
+level = "denied"
+```
+
+### Debugging: Everything
+
+Full visibility during development:
+
+```toml
+tier = "full"
+
+[audit]
+enabled = true
+level = "all"
+include_args = true
+```

--- a/docs/docs/mcp/getting-started.md
+++ b/docs/docs/mcp/getting-started.md
@@ -403,5 +403,7 @@ Want a faster path to try things out? Check out our quickstart guides:
 
 - [Configuration](configuration.md) - Tool selection, safety tiers, and presets
 - [Tools Reference](tools-reference.md) - Complete list of available tools
+- [Architecture](architecture.md) - How the server works internally
+- [Audit Logging](audit-logging.md) - Compliance and operational visibility
 - [Advanced Usage](advanced-usage.md) - JMESPath integration and analytics
 - [Workflows](workflows.md) - Real-world use cases and examples

--- a/docs/docs/mcp/index.md
+++ b/docs/docs/mcp/index.md
@@ -77,3 +77,5 @@ Ready to set up MCP? Choose your path:
 - **[Enterprise Quickstart](enterprise-quickstart.md)** - Redis Enterprise users: includes multi-cluster setup
 
 Want to see what's possible? Check out [Advanced Usage](advanced-usage.md) for JMESPath integration and complex analytics pipelines.
+
+For operators, see [Architecture](architecture.md) for how the server works internally, and [Audit Logging](audit-logging.md) for compliance and operational visibility.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -171,6 +171,8 @@ nav:
       - Cloud Quickstart: mcp/cloud-quickstart.md
       - Enterprise Quickstart: mcp/enterprise-quickstart.md
       - Tools Reference: mcp/tools-reference.md
+      - Architecture: mcp/architecture.md
+      - Audit Logging: mcp/audit-logging.md
       - Advanced Usage: mcp/advanced-usage.md
       - Workflows: mcp/workflows.md
   - Developer:


### PR DESCRIPTION
## Summary

- Add **Architecture** page covering server structure, feature flags, toolset/sub-module system, tool macros, transport modes, credential resolution, policy engine, audit layer, and request flow
- Add **Audit Logging** page covering configuration, audit levels, log format with JSON examples, argument redaction, RUST_LOG routing, log aggregation, and practical examples
- Update mkdocs nav, MCP index, and getting-started Next Steps with links to new pages

Closes #775 (remaining deliverables)

## Test plan

- [ ] `mkdocs serve` renders both new pages correctly
- [ ] All internal links resolve (architecture.md, audit-logging.md cross-references)
- [ ] Nav entries appear in correct position under MCP section