### PR TITLE
chore: release v0.8.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2896,7 +2896,7 @@ dependencies = [
 
 [[package]]
 name = "redisctl"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2946,7 +2946,7 @@ dependencies = [
 
 [[package]]
 name = "redisctl-core"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "clap",
  "directories",
@@ -2967,7 +2967,7 @@ dependencies = [
 
 [[package]]
 name = "redisctl-mcp"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ default-members = [
 version = "0.3.1"
 
 [workspace.package]
-version = "0.8.2"
+version = "0.8.3"
 edition = "2024"
 rust-version = "1.90"
 authors = ["Josh Rotenberg <josh.rotenberg@redis.com>"]

--- a/crates/redisctl-mcp/CHANGELOG.md
+++ b/crates/redisctl-mcp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.3](https://github.com/redis-developer/redisctl/compare/redisctl-mcp-v0.8.2...redisctl-mcp-v0.8.3) - 2026-03-06
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.5.0](https://github.com/redis-developer/redisctl/compare/redisctl-mcp-v0.4.0...redisctl-mcp-v0.5.0) - 2026-03-04
 
 ### Added

--- a/crates/redisctl-mcp/Cargo.toml
+++ b/crates/redisctl-mcp/Cargo.toml
@@ -21,7 +21,7 @@ tower-mcp = { version = "0.7.0", features = ["http", "oauth"] }
 schemars = "1.2"
 
 # Internal crates
-redisctl-core = { version = "0.8.2", path = "../redisctl-core" }
+redisctl-core = { version = "0.8.3", path = "../redisctl-core" }
 
 # External API clients (optional, gated by features)
 redis-cloud = { workspace = true, optional = true }

--- a/crates/redisctl/CHANGELOG.md
+++ b/crates/redisctl/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.3](https://github.com/redis-developer/redisctl/compare/redisctl-v0.8.2...redisctl-v0.8.3) - 2026-03-06
+
+### Other
+
+- clarify Docker env var forwarding for password in README ([#819](https://github.com/redis-developer/redisctl/pull/819))
+- rewrite README with elevator pitch and streamlined structure ([#817](https://github.com/redis-developer/redisctl/pull/817)) ([#818](https://github.com/redis-developer/redisctl/pull/818))
+- sync all workspace crate versions to 0.8.2 ([#816](https://github.com/redis-developer/redisctl/pull/816))
+
 ## [0.8.2](https://github.com/redis-developer/redisctl/compare/redisctl-v0.8.1...redisctl-v0.8.2) - 2026-03-04
 
 ### Added

--- a/crates/redisctl/Cargo.toml
+++ b/crates/redisctl/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 
 
 [dependencies]
-redisctl-core = { version = "0.8.2", path = "../redisctl-core" }
+redisctl-core = { version = "0.8.3", path = "../redisctl-core" }
 redis-cloud = { workspace = true, features = ["tower-integration"] }
 redis-enterprise = { workspace = true, features = ["tower-integration"] }
 files-sdk = { workspace = true, optional = true }


### PR DESCRIPTION



## 🤖 New release

* `redisctl-core`: 0.8.2 -> 0.8.3
* `redisctl`: 0.8.2 -> 0.8.3 (✓ API compatible changes)
* `redisctl-mcp`: 0.8.2 -> 0.8.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `redisctl-core`

<blockquote>

## [0.2.0](https://github.com/redis-developer/redisctl/compare/redisctl-core-v0.1.0...redisctl-core-v0.2.0) - 2026-02-28

### Added

- *(cli)* add profile tags for organizing many profiles ([#692](https://github.com/redis-developer/redisctl/pull/692)) ([#705](https://github.com/redis-developer/redisctl/pull/705))

### Other

- add edge case tests for profile config loading ([#696](https://github.com/redis-developer/redisctl/pull/696)) ([#699](https://github.com/redis-developer/redisctl/pull/699))
- add repository and homepage metadata to redisctl-core ([#685](https://github.com/redis-developer/redisctl/pull/685))
</blockquote>

## `redisctl`

<blockquote>

## [0.8.3](https://github.com/redis-developer/redisctl/compare/redisctl-v0.8.2...redisctl-v0.8.3) - 2026-03-06

### Other

- clarify Docker env var forwarding for password in README ([#819](https://github.com/redis-developer/redisctl/pull/819))
- rewrite README with elevator pitch and streamlined structure ([#817](https://github.com/redis-developer/redisctl/pull/817)) ([#818](https://github.com/redis-developer/redisctl/pull/818))
- sync all workspace crate versions to 0.8.2 ([#816](https://github.com/redis-developer/redisctl/pull/816))
</blockquote>

## `redisctl-mcp`

<blockquote>

## [0.8.3](https://github.com/redis-developer/redisctl/compare/redisctl-mcp-v0.8.2...redisctl-mcp-v0.8.3) - 2026-03-06

### Other

- update Cargo.toml dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).