### PR TITLE
chore: release v0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2896,7 +2896,7 @@ dependencies = [
 
 [[package]]
 name = "redisctl"
-version = "0.8.3"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2946,7 +2946,7 @@ dependencies = [
 
 [[package]]
 name = "redisctl-core"
-version = "0.8.3"
+version = "0.9.0"
 dependencies = [
  "clap",
  "directories",
@@ -2967,7 +2967,7 @@ dependencies = [
 
 [[package]]
 name = "redisctl-mcp"
-version = "0.8.3"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4186,9 +4186,9 @@ checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-mcp"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e2b98008d0a81257c60db5b861fafc3baed09d11f4a87fe988f4fccf1451997"
+checksum = "2d88b4123c665f11cbf44f70a33470e40dfdd48edce3d2f713fa422cb9af555e"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ default-members = [
 version = "0.3.1"
 
 [workspace.package]
-version = "0.8.3"
+version = "0.9.0"
 edition = "2024"
 rust-version = "1.90"
 authors = ["Josh Rotenberg <josh.rotenberg@redis.com>"]

--- a/crates/redisctl-mcp/CHANGELOG.md
+++ b/crates/redisctl-mcp/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/redis-developer/redisctl/compare/redisctl-mcp-v0.8.3...redisctl-mcp-v0.9.0) - 2026-03-06
+
+### Added
+
+- *(mcp)* add Docker Compose demo and upgrade tower-mcp to 0.8.1 ([#831](https://github.com/redis-developer/redisctl/pull/831))
+
+### Fixed
+
+- *(mcp)* accept --read-only=false and add REV to redis_zrange ([#827](https://github.com/redis-developer/redisctl/pull/827))
+
+### Other
+
+- *(mcp)* upgrade tower-mcp to 0.8.0 ([#830](https://github.com/redis-developer/redisctl/pull/830))
+
 ## [0.8.3](https://github.com/redis-developer/redisctl/compare/redisctl-mcp-v0.8.2...redisctl-mcp-v0.8.3) - 2026-03-06
 
 ### Other

--- a/crates/redisctl-mcp/Cargo.toml
+++ b/crates/redisctl-mcp/Cargo.toml
@@ -21,7 +21,7 @@ tower-mcp = { version = "0.8.1", features = ["http", "oauth"] }
 schemars = "1.2"
 
 # Internal crates
-redisctl-core = { version = "0.8.3", path = "../redisctl-core" }
+redisctl-core = { version = "0.9.0", path = "../redisctl-core" }
 
 # External API clients (optional, gated by features)
 redis-cloud = { workspace = true, optional = true }

--- a/crates/redisctl/CHANGELOG.md
+++ b/crates/redisctl/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/redis-developer/redisctl/compare/redisctl-v0.8.3...redisctl-v0.9.0) - 2026-03-06
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.8.3](https://github.com/redis-developer/redisctl/compare/redisctl-v0.8.2...redisctl-v0.8.3) - 2026-03-06
 
 ### Other

--- a/crates/redisctl/Cargo.toml
+++ b/crates/redisctl/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 
 
 [dependencies]
-redisctl-core = { version = "0.8.3", path = "../redisctl-core" }
+redisctl-core = { version = "0.9.0", path = "../redisctl-core" }
 redis-cloud = { workspace = true, features = ["tower-integration"] }
 redis-enterprise = { workspace = true, features = ["tower-integration"] }
 files-sdk = { workspace = true, optional = true }


### PR DESCRIPTION



## 🤖 New release

* `redisctl-core`: 0.8.3 -> 0.9.0
* `redisctl`: 0.8.3 -> 0.9.0 (✓ API compatible changes)
* `redisctl-mcp`: 0.8.3 -> 0.9.0 (⚠ API breaking changes)

### ⚠ `redisctl-mcp` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ZrangeInput.rev in /tmp/.tmpFCnx1K/redisctl/crates/redisctl-mcp/src/tools/redis/structures.rs:183

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_missing.ron

Failed in:
  function redisctl_mcp::tools::wrap_list, previously in file /tmp/.tmpoWalL3/redisctl-mcp/src/tools/mod.rs:36
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `redisctl-core`

<blockquote>

## [0.2.0](https://github.com/redis-developer/redisctl/compare/redisctl-core-v0.1.0...redisctl-core-v0.2.0) - 2026-02-28

### Added

- *(cli)* add profile tags for organizing many profiles ([#692](https://github.com/redis-developer/redisctl/pull/692)) ([#705](https://github.com/redis-developer/redisctl/pull/705))

### Other

- add edge case tests for profile config loading ([#696](https://github.com/redis-developer/redisctl/pull/696)) ([#699](https://github.com/redis-developer/redisctl/pull/699))
- add repository and homepage metadata to redisctl-core ([#685](https://github.com/redis-developer/redisctl/pull/685))
</blockquote>

## `redisctl`

<blockquote>

## [0.9.0](https://github.com/redis-developer/redisctl/compare/redisctl-v0.8.3...redisctl-v0.9.0) - 2026-03-06

### Other

- update Cargo.toml dependencies
</blockquote>

## `redisctl-mcp`

<blockquote>

## [0.9.0](https://github.com/redis-developer/redisctl/compare/redisctl-mcp-v0.8.3...redisctl-mcp-v0.9.0) - 2026-03-06

### Added

- *(mcp)* add Docker Compose demo and upgrade tower-mcp to 0.8.1 ([#831](https://github.com/redis-developer/redisctl/pull/831))

### Fixed

- *(mcp)* accept --read-only=false and add REV to redis_zrange ([#827](https://github.com/redis-developer/redisctl/pull/827))

### Other

- *(mcp)* upgrade tower-mcp to 0.8.0 ([#830](https://github.com/redis-developer/redisctl/pull/830))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).