### PR TITLE
feat(mcp): add Docker Compose demo and upgrade tower-mcp to 0.8.1

### DIFF
--- a/crates/redisctl-mcp/Cargo.toml
+++ b/crates/redisctl-mcp/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 # MCP framework
-tower-mcp = { version = "0.8.0", features = ["http", "oauth"] }
+tower-mcp = { version = "0.8.1", features = ["http", "oauth"] }
 schemars = "1.2"
 
 # Internal crates

--- a/crates/redisctl-mcp/src/main.rs
+++ b/crates/redisctl-mcp/src/main.rs
@@ -212,10 +212,6 @@ struct Args {
     #[arg(long, default_value = "10")]
     max_concurrent: usize,
 
-    /// Rate limit interval in milliseconds
-    #[arg(long, default_value = "100")]
-    rate_limit_ms: u64,
-
     /// Request timeout in seconds (HTTP mode)
     #[arg(long, default_value = "30")]
     request_timeout_secs: u64,

--- a/docker/docker-compose.mcp-demo.yml
+++ b/docker/docker-compose.mcp-demo.yml
@@ -1,0 +1,142 @@
+# ==============================================================================
+# MCP Server Demo with Redis Enterprise
+# ==============================================================================
+# Spins up a Redis Enterprise cluster and an MCP server in HTTP mode,
+# ready for any MCP client to connect.
+#
+# Usage:
+#   docker compose -f docker/docker-compose.mcp-demo.yml up -d
+#   docker compose -f docker/docker-compose.mcp-demo.yml logs -f
+#   docker compose -f docker/docker-compose.mcp-demo.yml down -v
+#
+# Once running, configure your MCP client to connect:
+#
+#   Claude Desktop / Claude Code / Cursor (streamable HTTP):
+#     {
+#       "mcpServers": {
+#         "redisctl": {
+#           "type": "streamable-http",
+#           "url": "http://localhost:3001/"
+#         }
+#       }
+#     }
+#
+#   The MCP server exposes 92 Enterprise tools and 90 database tools
+#   in read-only mode by default. The database tools connect directly
+#   to the default database on the Enterprise cluster (port 12000).
+#
+# To enable write operations:
+#   Change --read-only to --read-only=false in the mcp-server command.
+# ==============================================================================
+
+x-redis-enterprise-env: &redis-enterprise-env
+  REDIS_ENTERPRISE_URL: "https://redis-enterprise:9443"
+  REDIS_ENTERPRISE_USER: "admin@redis.local"
+  REDIS_ENTERPRISE_PASSWORD: "Redis123!"
+  REDIS_ENTERPRISE_INSECURE: "true"
+
+services:
+  # ==============================================================================
+  # Redis Enterprise Cluster
+  # ==============================================================================
+  redis-enterprise:
+    image: redislabs/redis:8.0.10-81
+    container_name: mcp-demo-enterprise
+    tty: true
+    cap_add:
+      - ALL
+    ports:
+      - "9443:9443"   # REST API
+      - "8443:8443"   # Admin UI
+      - "12000:12000" # Default database port
+    networks:
+      - mcp-demo-network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "-k", "https://localhost:9443/v1/bootstrap"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+      start_period: 10s
+
+  # ==============================================================================
+  # Cluster Initialization
+  # ==============================================================================
+  # Creates the cluster, admin user, and default database.
+  redis-enterprise-init:
+    image: ghcr.io/redis-developer/redisctl:latest
+    container_name: mcp-demo-init
+    depends_on:
+      redis-enterprise:
+        condition: service_healthy
+    networks:
+      - mcp-demo-network
+    environment:
+      REDIS_ENTERPRISE_URL: "https://redis-enterprise:9443"
+      REDIS_ENTERPRISE_INSECURE: "true"
+    command:
+      [
+        "enterprise", "workflow", "init-cluster",
+        "--name", "mcp-demo-cluster",
+        "--username", "admin@redis.local",
+        "--password", "Redis123!",
+      ]
+
+  # ==============================================================================
+  # Seed Data
+  # ==============================================================================
+  # Adds sample data to the default database so the MCP tools have
+  # something to query out of the box.
+  seed-data:
+    image: redis:7-alpine
+    container_name: mcp-demo-seed
+    depends_on:
+      redis-enterprise-init:
+        condition: service_completed_successfully
+    networks:
+      - mcp-demo-network
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        echo "Waiting for database to be ready..."
+        sleep 5
+        echo "Seeding sample data..."
+        redis-cli -h redis-enterprise -p 12000 SET greeting "Hello from the MCP demo"
+        redis-cli -h redis-enterprise -p 12000 HSET user:1 name Alice email alice@example.com role admin
+        redis-cli -h redis-enterprise -p 12000 HSET user:2 name Bob email bob@example.com role developer
+        redis-cli -h redis-enterprise -p 12000 HSET user:3 name Charlie email charlie@example.com role viewer
+        redis-cli -h redis-enterprise -p 12000 ZADD leaderboard 100 alice 85 bob 92 charlie 78 dave 95 eve
+        redis-cli -h redis-enterprise -p 12000 LPUSH recent:events "user:1 logged in" "user:2 deployed v2.1" "user:3 viewed dashboard"
+        redis-cli -h redis-enterprise -p 12000 SADD tags:project:alpha redis enterprise mcp demo
+        echo "Sample data seeded"
+
+  # ==============================================================================
+  # MCP Server (HTTP mode)
+  # ==============================================================================
+  # Runs redisctl-mcp in HTTP mode with Enterprise and database tools.
+  # Connects to the Enterprise cluster API and directly to the default
+  # database for Redis data operations.
+  mcp-server:
+    image: ghcr.io/redis-developer/redisctl:latest
+    container_name: mcp-demo-server
+    depends_on:
+      seed-data:
+        condition: service_completed_successfully
+    networks:
+      - mcp-demo-network
+    ports:
+      - "3001:3001"
+    environment:
+      <<: *redis-enterprise-env
+      REDIS_URL: "redis://redis-enterprise:12000"
+    entrypoint: ["redisctl-mcp"]
+    command:
+      [
+        "--transport", "http",
+        "--host", "0.0.0.0",
+        "--port", "3001",
+        "--tools", "enterprise,database",
+      ]
+
+networks:
+  mcp-demo-network:
+    driver: bridge


### PR DESCRIPTION
## Summary

- Add Docker Compose demo (`docker/docker-compose.mcp-demo.yml`) for running the MCP server in HTTP mode with Redis Enterprise
- Upgrade tower-mcp from 0.8.0 to 0.8.1, which fixes `poll_ready()` not being called before `call()` in the HTTP transport (joshrotenberg/tower-mcp#598)

## Docker Compose Demo

Spins up:
- Redis Enterprise cluster with auto-init and seed data (strings, hashes, sorted set, list, set)
- MCP server in HTTP mode on port 3001 with enterprise + database tools

```bash
docker compose -f docker/docker-compose.mcp-demo.yml up -d
```

## Test plan

- [x] `cargo clippy -p redisctl-mcp --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] HTTP transport tested locally with `ConcurrencyLimitLayer` -- no panics
- [x] `redis_ping`, `redis_health_check`, `redis_dbsize` all respond correctly over HTTP
- [ ] CI passes