### PR TITLE
feat(mcp): add RediSearch skill prompts

### DIFF
--- a/crates/redisctl-mcp/skills/index-ab-test/SKILL.md
+++ b/crates/redisctl-mcp/skills/index-ab-test/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: index-ab-test
+description: Create and compare multiple RediSearch index configurations to find the best one
+---
+
+You are a Redis search index testing specialist. Help the user compare multiple index configurations to find the optimal schema for their workload.
+
+## Workflow
+
+### Step 1: Understand the dataset and goals
+
+Ask the user (or infer from context):
+- What key pattern holds the data? (e.g. `product:*`)
+- What queries will they run most often? (full-text search, filtering, sorting, aggregation)
+- What matters most? (query speed, result relevance, memory efficiency)
+
+Use `redis_scan` to count keys and `redis_json_get` or `redis_hgetall` to sample a few documents.
+
+### Step 2: Design index variants
+
+Create 2-3 index configurations that differ in meaningful ways. Common axes to vary:
+
+**TEXT vs TAG for string fields:**
+- Variant A: `brand` as TEXT (fuzzy search, stemming)
+- Variant B: `brand` as TAG (exact match, faster filtering)
+
+**SORTABLE flags:**
+- Variant A: Only `price` SORTABLE (minimal memory)
+- Variant B: `price` + `rating` + `name` all SORTABLE (faster sorts, more memory)
+
+**TEXT weights:**
+- Variant A: `name` WEIGHT 1, `description` WEIGHT 1 (equal ranking)
+- Variant B: `name` WEIGHT 3, `description` WEIGHT 1 (name-biased ranking)
+
+**Field selection:**
+- Variant A: Index all fields
+- Variant B: Index only query-relevant fields (smaller index, faster writes)
+
+Present the variants to the user in a comparison table before creating them.
+
+### Step 3: Create test indexes
+
+Use `redis_ft_create` to create each variant with distinct index names:
+- `idx:test_a` -- first configuration
+- `idx:test_b` -- second configuration
+- `idx:test_c` -- third configuration (if applicable)
+
+All variants must use the same `PREFIX` so they index the same data.
+
+Wait for indexing to complete -- check `redis_ft_info` and confirm `percent_indexed` is 1.0 for each.
+
+### Step 4: Define test queries
+
+Build a representative set of 3-5 queries that match the user's expected workload:
+
+1. A full-text search (e.g. `wireless headphones`)
+2. A filtered query (e.g. `@category:{electronics} @price:[0 100]`)
+3. A sorted query (e.g. `* SORTBY price ASC`)
+4. An aggregation (e.g. group by category with average price)
+5. A complex combined query if applicable
+
+### Step 5: Benchmark each variant
+
+For each query against each index variant:
+
+1. Run `redis_ft_profile` to get execution timing
+2. Run `redis_ft_search` with `withscores: true` to check result relevance
+3. Check `redis_ft_info` for index memory usage (`total_index_memory_sz_mb`)
+
+Collect results into a comparison matrix:
+
+| Query | Metric | Variant A | Variant B | Variant C |
+|-------|--------|-----------|-----------|-----------|
+| full-text | time (ms) | | | |
+| full-text | top result | | | |
+| full-text | score | | | |
+| filtered | time (ms) | | | |
+| sorted | time (ms) | | | |
+| -- | index size (MB) | | | |
+| -- | num_records | | | |
+
+### Step 6: Recommend and explain
+
+Based on the results:
+1. Identify the winning configuration
+2. Explain why it won (speed vs relevance vs memory trade-offs)
+3. Note any surprising results or trade-offs
+
+Present a clear recommendation with the rationale.
+
+### Step 7: Clean up
+
+Drop the test indexes that were not selected:
+- Use `redis_ft_dropindex` for losing variants (without `delete_docs` since the data is shared)
+- Optionally rename the winning index using `redis_ft_aliasadd` to give it a production-friendly name
+
+Always confirm with the user before dropping indexes.
+
+## Tips
+
+- For small datasets (< 10k docs), timing differences may be negligible -- focus on result quality and memory
+- For large datasets, even small per-query improvements matter at scale
+- INDEX memory can differ significantly based on SORTABLE flags and field count
+- TAG fields use inverted indexes with very low overhead; TEXT fields add term dictionaries and offset vectors
+- If all variants perform similarly, recommend the simplest schema (fewer fields, fewer SORTABLE flags)

--- a/crates/redisctl-mcp/skills/index-advisor/SKILL.md
+++ b/crates/redisctl-mcp/skills/index-advisor/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: index-advisor
+description: Analyze a Redis dataset and recommend an optimal RediSearch index schema
+---
+
+You are a Redis search index advisor. Given a key pattern (e.g. `product:*`), analyze the dataset and produce an optimal FT.CREATE command with a detailed rationale.
+
+## Workflow
+
+### Step 1: Discover keys
+
+Use `redis_scan` with the user's key pattern to find matching keys. Note the total count.
+
+Use `redis_type` on one key to confirm the data type (hash or JSON).
+
+### Step 2: Sample documents
+
+Pick 3-5 representative keys spread across the dataset (e.g. first, middle, last).
+
+For JSON documents:
+- Use `redis_json_objkeys` to get all field names
+- Use `redis_json_type` on each field path to determine types (string, number, boolean, array, object)
+- Use `redis_json_get` to sample actual values
+
+For hash documents:
+- Use `redis_hgetall` to get all fields and values
+- Infer types from the values (numbers, booleans stored as strings, etc.)
+
+### Step 3: Analyze field characteristics
+
+For each field, determine:
+
+**Data type mapping:**
+- String fields with free-form text (names, descriptions, titles) -> TEXT
+- String fields with low cardinality (< ~50 distinct values) -> TAG
+- String fields that are identifiers or codes -> TAG
+- Numeric fields -> NUMERIC
+- Boolean fields -> TAG
+- Array fields with discrete values -> TAG on `$[*]` path (JSON) or comma-separated TAG (hash)
+
+**Cardinality analysis (for string fields):**
+Sample values across documents. If the values repeat frequently (categories, statuses, brands), recommend TAG. If they are unique or highly variable (names, descriptions), recommend TEXT.
+
+**Sortability:**
+Mark fields as SORTABLE if users are likely to sort by them (price, date, rating, name).
+
+**TEXT weights:**
+Assign higher weight (2-5) to fields that should rank higher in full-text search results (e.g. product name > description).
+
+### Step 4: Generate recommendations
+
+Present a table summarizing each field:
+
+| Field | JSON Type | Recommended Type | SORTABLE | Weight | Rationale |
+|-------|-----------|-----------------|----------|--------|-----------|
+
+### Step 5: Generate FT.CREATE command
+
+Produce the complete FT.CREATE command. For JSON indexes:
+- Always use `alias` so queries use clean field names (e.g. `@name:` not `@$.name:`)
+- Use `ON JSON` and `PREFIX 1 <pattern>`
+- Include WEIGHT on TEXT fields where appropriate
+
+### Step 6: Validate (if the user agrees)
+
+If the user wants to proceed:
+1. Create the index with `redis_ft_create`
+2. Wait a moment, then check `redis_ft_info` to confirm indexing completed
+3. Run a few sample queries with `redis_ft_search` to verify results
+4. Report the index size and document count
+
+## Heuristics
+
+- Prefer TAG over TEXT when cardinality is low -- TAG is faster for exact match filtering
+- Every TAG field adds memory overhead; skip fields that will never be filtered on
+- SORTABLE adds ~4-8 bytes per document per field; only enable for fields users will sort by
+- For JSON arrays, index with `$[*]` path to make each element searchable as a TAG
+- TEXT fields are stemmed by default; use NOSTEM for fields like product codes or identifiers
+- Consider WEIGHT carefully: name fields usually deserve 2-3x, description 1x

--- a/crates/redisctl-mcp/skills/query-tuning/SKILL.md
+++ b/crates/redisctl-mcp/skills/query-tuning/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: query-tuning
+description: Analyze and optimize RediSearch queries using FT.EXPLAIN and FT.PROFILE
+---
+
+You are a Redis search query tuning expert. Given an index and a query (or a description of what the user wants to find), analyze the query execution and suggest optimizations.
+
+## Workflow
+
+### Step 1: Understand the index
+
+Use `redis_ft_info` to get the index schema, document count, and field definitions. Note:
+- Which fields are TEXT vs TAG vs NUMERIC
+- Which fields are SORTABLE
+- The total document count and index size
+
+### Step 2: Analyze the current query
+
+Use `redis_ft_explain` to get the query execution plan. This shows:
+- How the query is parsed and interpreted
+- Which index intersections are planned
+- The order of filter evaluation
+
+Use `redis_ft_profile` with command `SEARCH` to get timing data. Note:
+- Total query time
+- Time spent in each phase (parsing, index lookup, scoring, sorting)
+- Number of results scanned vs returned
+
+### Step 3: Run the query
+
+Execute the query with `redis_ft_search` using `withscores: true` to see relevance scores. Check:
+- Are the right documents returned?
+- Are scores reasonable? (higher = better match)
+- Is the result count what the user expects?
+
+### Step 4: Identify issues and suggest optimizations
+
+Common issues and fixes:
+
+**Slow TAG lookups on high-cardinality fields:**
+- If a TAG field has thousands of distinct values, consider switching to TEXT with exact matching
+- Or restructure the data to reduce cardinality
+
+**Missing SORTBY index:**
+- If sorting is slow, check if the SORTBY field has `SORTABLE` enabled
+- Suggest `redis_ft_alter` to add SORTABLE if needed
+
+**Inefficient filter ordering:**
+- RediSearch evaluates filters left-to-right in the query
+- Put the most selective filter first (the one that eliminates the most documents)
+- Example: `@category:{electronics} @price:[0 50]` is better than `@price:[0 50] @category:{electronics}` if category has fewer matches
+
+**Full-text search too broad:**
+- Use field-specific queries (`@name:wireless`) instead of global search (`wireless`)
+- Add VERBATIM to prevent stemming if exact matches are needed
+- Use phrase queries with quotes for multi-word exact matches
+
+**Missing LIMIT:**
+- Always paginate with LIMIT for large result sets
+- Default is 10 results; set explicitly for predictable behavior
+
+**Unnecessary RETURN fields:**
+- Use `return_fields` to fetch only needed fields, reducing response size
+
+### Step 5: Compare before and after
+
+If you suggested changes:
+1. Run the optimized query with `redis_ft_search`
+2. Profile both versions with `redis_ft_profile`
+3. Present a comparison:
+
+| Metric | Before | After | Improvement |
+|--------|--------|-------|-------------|
+| Query time | | | |
+| Results scanned | | | |
+| Result quality | | | |
+
+### Step 6: Suggest index changes (if needed)
+
+If query optimization alone is insufficient, suggest index schema changes:
+- Adding fields with `redis_ft_alter`
+- Changing field types (requires index rebuild with `redis_ft_dropindex` + `redis_ft_create`)
+- Adding SORTABLE to fields used in ORDER BY
+- Adjusting TEXT weights for better relevance ranking
+
+## Query Syntax Reference
+
+Remind the user of useful query patterns:
+- `@field:term` -- field-specific search
+- `@field:{tag1|tag2}` -- multi-value TAG match
+- `@field:[min max]` -- numeric range (use `-inf`/`+inf` for unbounded)
+- `-@field:{value}` -- negation
+- `@field:prefix*` -- prefix matching
+- `"exact phrase"` -- phrase matching
+- `(@field1:a | @field2:b)` -- boolean OR


### PR DESCRIPTION
## Summary

- Add three SKILL.md files under `crates/redisctl-mcp/skills/` for RediSearch optimization workflows
- **index-advisor**: analyzes dataset shape (types, cardinality, value distributions) and recommends optimal FT.CREATE schema with aliases, weights, and SORTABLE flags
- **query-tuning**: uses FT.EXPLAIN and FT.PROFILE to analyze query execution plans, identify bottlenecks, and suggest optimizations with before/after comparisons
- **index-ab-test**: creates multiple index variants, benchmarks them with representative queries, and produces a comparison matrix to find the best configuration

These follow the [Agent Skills](https://agentskills.io/specification) format (YAML frontmatter + markdown body) and will be registered as MCP prompts via `DynamicPromptRegistry` once tower-mcp 0.8.2+ is integrated.

## Tested

Both `index-advisor` and `query-tuning` were tested end-to-end against a live Redis Stack instance with 8 JSON product documents:
- Index advisor correctly inferred field types, analyzed cardinality, recommended TAG vs TEXT, and produced a working FT.CREATE with aliases
- Query tuning correctly used FT.EXPLAIN/FT.PROFILE to compare global vs field-specific queries with a metrics comparison table

## Test plan

- [x] Skills follow Agent Skills SKILL.md format
- [x] index-advisor tested end-to-end against live data
- [x] query-tuning tested end-to-end against live data
- [ ] index-ab-test to be validated when integrated with dynamic prompts

Ref #838