### PR TITLE
chore: release v0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2896,7 +2896,7 @@ dependencies = [
 
 [[package]]
 name = "redisctl"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2946,7 +2946,7 @@ dependencies = [
 
 [[package]]
 name = "redisctl-core"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "clap",
  "directories",
@@ -2967,7 +2967,7 @@ dependencies = [
 
 [[package]]
 name = "redisctl-mcp"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ default-members = [
 version = "0.3.1"
 
 [workspace.package]
-version = "0.9.1"
+version = "0.10.0"
 edition = "2024"
 rust-version = "1.90"
 authors = ["Josh Rotenberg <josh.rotenberg@redis.com>"]

--- a/crates/redisctl-mcp/CHANGELOG.md
+++ b/crates/redisctl-mcp/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/redis-developer/redisctl/compare/redisctl-mcp-v0.9.1...redisctl-mcp-v0.10.0) - 2026-03-17
+
+### Added
+
+- *(mcp)* add session-scoped command aliases ([#891](https://github.com/redis-developer/redisctl/pull/891))
+- *(mcp)* add if_exists option to redis_ft_create ([#889](https://github.com/redis-developer/redisctl/pull/889))
+- *(mcp)* improve bulk_load for JSON seeding + collect_results flag ([#888](https://github.com/redis-developer/redisctl/pull/888))
+- *(mcp)* upgrade tower-mcp to 0.8.2 with dynamic prompt skills ([#845](https://github.com/redis-developer/redisctl/pull/845))
+- *(mcp)* add RediSearch skill prompts for index optimization workflows ([#843](https://github.com/redis-developer/redisctl/pull/843))
+
+### Fixed
+
+- *(mcp)* place NOSTEM before WEIGHT in FT.CREATE field args ([#879](https://github.com/redis-developer/redisctl/pull/879))
+- *(mcp)* serde coercion for numeric params + bulk load/seed tools ([#875](https://github.com/redis-developer/redisctl/pull/875))
+- *(mcp)* bail when --oauth is used (not yet implemented) ([#860](https://github.com/redis-developer/redisctl/pull/860))
+- *(mcp)* validate enum-like string params in RediSearch tools ([#864](https://github.com/redis-developer/redisctl/pull/864))
+- *(mcp)* harden YAML frontmatter parser and add tests ([#868](https://github.com/redis-developer/redisctl/pull/868))
+- *(mcp)* validate nx/xx mutual exclusivity in json_set ([#863](https://github.com/redis-developer/redisctl/pull/863))
+- *(mcp)* validate non-empty collections in RediSearch tools ([#865](https://github.com/redis-developer/redisctl/pull/865))
+- *(mcp)* validate non-empty collections in RedisJSON tools ([#862](https://github.com/redis-developer/redisctl/pull/862))
+- *(mcp)* reclassify ft_aliasdel and ft_dictdel as write tier ([#870](https://github.com/redis-developer/redisctl/pull/870))
+- *(mcp)* set permissive default on app tracing filter when audit enabled ([#859](https://github.com/redis-developer/redisctl/pull/859))
+
+### Other
+
+- *(mcp)* improve tool descriptions for search and bulk/seed tools ([#880](https://github.com/redis-developer/redisctl/pull/880))
+- *(mcp)* extract K/V pair formatting helper in search tools ([#871](https://github.com/redis-developer/redisctl/pull/871))
+- *(mcp)* clarify FT.ALTER limitations in query-tuning skill ([#861](https://github.com/redis-developer/redisctl/pull/861))
+- *(mcp)* remove unnecessary HashMap clones in main ([#866](https://github.com/redis-developer/redisctl/pull/866))
+- *(mcp)* clean up misleading _name param and blanket allow(dead_code) ([#867](https://github.com/redis-developer/redisctl/pull/867))
+- *(mcp)* unify static and dynamic prompt registration ([#869](https://github.com/redis-developer/redisctl/pull/869))
+
 ## [0.9.1](https://github.com/redis-developer/redisctl/compare/redisctl-mcp-v0.9.0...redisctl-mcp-v0.9.1) - 2026-03-07
 
 ### Added

--- a/crates/redisctl-mcp/Cargo.toml
+++ b/crates/redisctl-mcp/Cargo.toml
@@ -21,7 +21,7 @@ tower-mcp = { version = "0.8.2", features = ["http", "oauth", "dynamic-tools"] }
 schemars = "1.2"
 
 # Internal crates
-redisctl-core = { version = "0.9.1", path = "../redisctl-core" }
+redisctl-core = { version = "0.10.0", path = "../redisctl-core" }
 
 # External API clients (optional, gated by features)
 redis-cloud = { workspace = true, optional = true }

--- a/crates/redisctl/CHANGELOG.md
+++ b/crates/redisctl/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/redis-developer/redisctl/compare/redisctl-v0.9.1...redisctl-v0.10.0) - 2026-03-17
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.9.1](https://github.com/redis-developer/redisctl/compare/redisctl-v0.9.0...redisctl-v0.9.1) - 2026-03-07
 
 ### Other

--- a/crates/redisctl/Cargo.toml
+++ b/crates/redisctl/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 
 
 [dependencies]
-redisctl-core = { version = "0.9.1", path = "../redisctl-core" }
+redisctl-core = { version = "0.10.0", path = "../redisctl-core" }
 redis-cloud = { workspace = true, features = ["tower-integration"] }
 redis-enterprise = { workspace = true, features = ["tower-integration"] }
 files-sdk = { workspace = true, optional = true }


### PR DESCRIPTION



## 🤖 New release

* `redisctl-core`: 0.9.1 -> 0.10.0
* `redisctl`: 0.9.1 -> 0.10.0 (✓ API compatible changes)
* `redisctl-mcp`: 0.9.1 -> 0.10.0 (⚠ API breaking changes)

### ⚠ `redisctl-mcp` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field FtCreateInput.if_exists in /tmp/.tmpeHNO7k/redisctl/crates/redisctl-mcp/src/tools/redis/search.rs:524
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `redisctl-core`

<blockquote>

## [0.2.0](https://github.com/redis-developer/redisctl/compare/redisctl-core-v0.1.0...redisctl-core-v0.2.0) - 2026-02-28

### Added

- *(cli)* add profile tags for organizing many profiles ([#692](https://github.com/redis-developer/redisctl/pull/692)) ([#705](https://github.com/redis-developer/redisctl/pull/705))

### Other

- add edge case tests for profile config loading ([#696](https://github.com/redis-developer/redisctl/pull/696)) ([#699](https://github.com/redis-developer/redisctl/pull/699))
- add repository and homepage metadata to redisctl-core ([#685](https://github.com/redis-developer/redisctl/pull/685))
</blockquote>

## `redisctl`

<blockquote>

## [0.10.0](https://github.com/redis-developer/redisctl/compare/redisctl-v0.9.1...redisctl-v0.10.0) - 2026-03-17

### Other

- update Cargo.toml dependencies
</blockquote>

## `redisctl-mcp`

<blockquote>

## [0.10.0](https://github.com/redis-developer/redisctl/compare/redisctl-mcp-v0.9.1...redisctl-mcp-v0.10.0) - 2026-03-17

### Added

- *(mcp)* add session-scoped command aliases ([#891](https://github.com/redis-developer/redisctl/pull/891))
- *(mcp)* add if_exists option to redis_ft_create ([#889](https://github.com/redis-developer/redisctl/pull/889))
- *(mcp)* improve bulk_load for JSON seeding + collect_results flag ([#888](https://github.com/redis-developer/redisctl/pull/888))
- *(mcp)* upgrade tower-mcp to 0.8.2 with dynamic prompt skills ([#845](https://github.com/redis-developer/redisctl/pull/845))
- *(mcp)* add RediSearch skill prompts for index optimization workflows ([#843](https://github.com/redis-developer/redisctl/pull/843))

### Fixed

- *(mcp)* place NOSTEM before WEIGHT in FT.CREATE field args ([#879](https://github.com/redis-developer/redisctl/pull/879))
- *(mcp)* serde coercion for numeric params + bulk load/seed tools ([#875](https://github.com/redis-developer/redisctl/pull/875))
- *(mcp)* bail when --oauth is used (not yet implemented) ([#860](https://github.com/redis-developer/redisctl/pull/860))
- *(mcp)* validate enum-like string params in RediSearch tools ([#864](https://github.com/redis-developer/redisctl/pull/864))
- *(mcp)* harden YAML frontmatter parser and add tests ([#868](https://github.com/redis-developer/redisctl/pull/868))
- *(mcp)* validate nx/xx mutual exclusivity in json_set ([#863](https://github.com/redis-developer/redisctl/pull/863))
- *(mcp)* validate non-empty collections in RediSearch tools ([#865](https://github.com/redis-developer/redisctl/pull/865))
- *(mcp)* validate non-empty collections in RedisJSON tools ([#862](https://github.com/redis-developer/redisctl/pull/862))
- *(mcp)* reclassify ft_aliasdel and ft_dictdel as write tier ([#870](https://github.com/redis-developer/redisctl/pull/870))
- *(mcp)* set permissive default on app tracing filter when audit enabled ([#859](https://github.com/redis-developer/redisctl/pull/859))

### Other

- *(mcp)* improve tool descriptions for search and bulk/seed tools ([#880](https://github.com/redis-developer/redisctl/pull/880))
- *(mcp)* extract K/V pair formatting helper in search tools ([#871](https://github.com/redis-developer/redisctl/pull/871))
- *(mcp)* clarify FT.ALTER limitations in query-tuning skill ([#861](https://github.com/redis-developer/redisctl/pull/861))
- *(mcp)* remove unnecessary HashMap clones in main ([#866](https://github.com/redis-developer/redisctl/pull/866))
- *(mcp)* clean up misleading _name param and blanket allow(dead_code) ([#867](https://github.com/redis-developer/redisctl/pull/867))
- *(mcp)* unify static and dynamic prompt registration ([#869](https://github.com/redis-developer/redisctl/pull/869))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).