### PR TITLE
fix(mcp): bail when --oauth is used (not yet implemented)

### DIFF
--- a/crates/redisctl-mcp/src/main.rs
+++ b/crates/redisctl-mcp/src/main.rs
@@ -907,7 +907,9 @@ async fn run_http_server(
 
     if args.oauth {
         // OAuth-enabled HTTP transport
-        bail!("OAuth support is not yet implemented. Remove --oauth to start the server without authentication.");
+        bail!(
+            "OAuth support is not yet implemented. Remove --oauth to start the server without authentication."
+        );
     }
 
     transport.serve(&addr).await?;


### PR DESCRIPTION
## Summary
- Replace silent pass-through in `--oauth` code path with `bail!()` 
- Prevents server from starting unauthenticated when user expects OAuth enforcement

Closes #847