### PR TITLE
docs(mcp): clarify FT.ALTER limitations in query-tuning skill

### DIFF
--- a/crates/redisctl-mcp/skills/query-tuning/SKILL.md
+++ b/crates/redisctl-mcp/skills/query-tuning/SKILL.md
@@ -43,7 +43,8 @@ Common issues and fixes:
 
 **Missing SORTBY index:**
 - If sorting is slow, check if the SORTBY field has `SORTABLE` enabled
-- Suggest `redis_ft_alter` to add SORTABLE if needed
+- `redis_ft_alter` can only add NEW fields with SORTABLE — it cannot modify existing fields
+- To make an existing field SORTABLE, the index must be dropped (`redis_ft_dropindex`) and recreated (`redis_ft_create`) with the field marked SORTABLE
 
 **Inefficient filter ordering:**
 - RediSearch evaluates filters left-to-right in the query


### PR DESCRIPTION
## Summary
- Clarify that `FT.ALTER` can only add new fields, not modify existing ones
- Note that making an existing field SORTABLE requires drop + recreate

Closes #848