### PR TITLE
fix(mcp): validate nx/xx mutual exclusivity in json_set

### DIFF
--- a/crates/redisctl-mcp/src/tools/redis/json.rs
+++ b/crates/redisctl-mcp/src/tools/redis/json.rs
@@ -210,6 +210,12 @@ database_tool!(write, json_set, "redis_json_set",
         #[serde(default)]
         pub xx: bool,
     } => |conn, input| {
+        if input.nx && input.xx {
+            return Err(tower_mcp::Error::tool(
+                "Cannot set both nx and xx: NX (only set if not exists) and XX (only set if exists) are mutually exclusive",
+            ));
+        }
+
         let mut cmd = redis::cmd("JSON.SET");
         cmd.arg(&input.key).arg(&input.path).arg(&input.value);
         if input.nx {


### PR DESCRIPTION
## Summary
- Add validation that rejects `nx: true` + `xx: true` (always a no-op)
- Returns clear tool error explaining the conflict

Closes #850