### PR TITLE
fix(mcp): harden YAML frontmatter parser and add tests

### DIFF
--- a/crates/redisctl-mcp/src/main.rs
+++ b/crates/redisctl-mcp/src/main.rs
@@ -1695,8 +1695,7 @@ mod tests {
 
     #[test]
     fn parse_skill_quoted_yaml_values() {
-        let content =
-            "---\nname: \"quoted-name\"\ndescription: 'quoted desc'\n---\nBody";
+        let content = "---\nname: \"quoted-name\"\ndescription: 'quoted desc'\n---\nBody";
         let skill = parse_skill(content).unwrap();
         assert_eq!(skill.name, "quoted-name");
         assert_eq!(skill.description, "quoted desc");


### PR DESCRIPTION
## Summary
- Fix `---` delimiter matching to use `\n---` so dashes inside YAML values don't break parsing
- Strip surrounding quotes from parsed YAML values
- Add `tracing::debug!` for parse failures
- Add 7 unit tests covering valid skill, missing frontmatter, missing fields, extra dashes in body, quoted values, trailing whitespace

Closes #853