### PR TITLE
refactor(mcp): unify static and dynamic prompt registration

### DIFF
--- a/crates/redisctl-mcp/src/main.rs
+++ b/crates/redisctl-mcp/src/main.rs
@@ -800,6 +800,12 @@ fn build_router(
         router = merge_toolset_router(router, toolset, selection, state.clone());
     }
 
+    // Register built-in prompts
+    prompt_registry.register(crate::prompts::troubleshoot_database_prompt());
+    prompt_registry.register(crate::prompts::analyze_performance_prompt());
+    prompt_registry.register(crate::prompts::capacity_planning_prompt());
+    prompt_registry.register(crate::prompts::migration_planning_prompt());
+
     // Load skills as dynamic prompts
     if let Some(dir) = skills_dir {
         let count = load_skills(dir, &prompt_registry);

--- a/crates/redisctl-mcp/src/tools/profile.rs
+++ b/crates/redisctl-mcp/src/tools/profile.rs
@@ -953,9 +953,4 @@ pub fn router(state: Arc<AppState>) -> McpRouter {
         .resource(crate::resources::config_path_resource())
         .resource(crate::resources::profiles_resource())
         .resource(crate::resources::help_resource())
-        // Prompts
-        .prompt(crate::prompts::troubleshoot_database_prompt())
-        .prompt(crate::prompts::analyze_performance_prompt())
-        .prompt(crate::prompts::capacity_planning_prompt())
-        .prompt(crate::prompts::migration_planning_prompt())
 }


### PR DESCRIPTION
## Summary
- Migrate four static prompts from `McpRouter::prompt()` to `DynamicPromptRegistry::register()`
- All prompts now go through a single registration path
- Removes split between static and dynamic prompt registration

Closes #854