### PR TITLE
fix(mcp): reclassify ft_aliasdel and ft_dictdel as write tier

### DIFF
--- a/crates/redisctl-mcp/src/tools/redis/search.rs
+++ b/crates/redisctl-mcp/src/tools/redis/search.rs
@@ -662,8 +662,8 @@ database_tool!(destructive, ft_dropindex, "redis_ft_dropindex",
     }
 );
 
-database_tool!(destructive, ft_aliasdel, "redis_ft_aliasdel",
-    "DANGEROUS: Delete a search index alias.",
+database_tool!(write, ft_aliasdel, "redis_ft_aliasdel",
+    "Delete a search index alias.",
     {
         /// Alias name to delete
         pub alias: String,
@@ -680,8 +680,8 @@ database_tool!(destructive, ft_aliasdel, "redis_ft_aliasdel",
     }
 );
 
-database_tool!(destructive, ft_dictdel, "redis_ft_dictdel",
-    "DANGEROUS: Remove terms from a dictionary.",
+database_tool!(write, ft_dictdel, "redis_ft_dictdel",
+    "Remove terms from a dictionary.",
     {
         /// Dictionary name
         pub dict: String,


### PR DESCRIPTION
## Summary
- Downgrade `ft_aliasdel` and `ft_dictdel` from `destructive` to `write` tier
- Remove misleading "DANGEROUS" prefix from descriptions
- Alias deletion doesn't destroy data; dictionary term deletion is trivially reversible

Closes #855