### PR TITLE
fix(mcp): place NOSTEM before WEIGHT in FT.CREATE field args

### DIFF
--- a/crates/redisctl-mcp/src/tools/redis/search.rs
+++ b/crates/redisctl-mcp/src/tools/redis/search.rs
@@ -82,6 +82,9 @@ impl FieldDefinition {
             args.push(alias.clone());
         }
         args.push(self.field_type.to_uppercase());
+        if self.nostem {
+            args.push("NOSTEM".to_string());
+        }
         if let Some(weight) = self.weight {
             args.push("WEIGHT".to_string());
             args.push(weight.to_string());
@@ -95,9 +98,6 @@ impl FieldDefinition {
         }
         if self.noindex {
             args.push("NOINDEX".to_string());
-        }
-        if self.nostem {
-            args.push("NOSTEM".to_string());
         }
         args
     }


### PR DESCRIPTION
## Summary
- Fix NOSTEM field attribute ordering in `FieldDefinition::to_args()` — must appear immediately after the field type, before WEIGHT, per [FT.CREATE syntax](https://redis.io/docs/latest/commands/ft.create/)
- Previously appended after SORTABLE/NOINDEX, causing Redis to reject with "Invalid: field type for field NOSTEM"

## Test plan
- [ ] Verify `FT.CREATE` with `nostem: true` on a TEXT field succeeds
- [ ] Verify existing indexes without NOSTEM are unaffected

Fixes #876