### PR TITLE
docs(mcp): improve tool descriptions for search and bulk/seed tools

### DIFF
--- a/crates/redisctl-mcp/src/tools/redis/bulk.rs
+++ b/crates/redisctl-mcp/src/tools/redis/bulk.rs
@@ -58,7 +58,13 @@ mcp_module! {
 database_tool!(write, bulk_load, "redis_bulk_load",
     "Pipelined command execution. Accept a batch of Redis commands and execute them \
      using Redis pipelining for high throughput. Returns count of commands executed, \
-     elapsed time, and throughput.",
+     elapsed time, and throughput.\n\n\
+     Important notes:\n\
+     - Commands are fire-and-forget: individual command errors are not reported. \
+     The batch succeeds if the pipeline as a whole completes.\n\
+     - Pipelines are NOT atomic — other clients may interleave commands between batches.\n\
+     - Tune batch_size for your use case: smaller batches (100-500) reduce memory per round-trip, \
+     larger batches (1000-5000) maximize throughput.",
     {
         /// List of commands to execute. Each command is an args array (e.g. [\"SET\", \"k\", \"v\"]).
         pub commands: Vec<Command>,
@@ -112,12 +118,18 @@ database_tool!(write, seed, "redis_seed",
     "Declarative data generation for test/prototype data. Generates keys matching a pattern \
      using Redis pipelining for high throughput.\n\n\
      Supported data_type values: \"string\", \"hash\", \"sorted_set\", \"set\", \"list\", \"json\".\n\n\
-     Pattern substitution: use {i} for the index, {i:0N} for zero-padded (e.g. {i:06} for 6 digits).\n\n\
+     Pattern substitution: use {i} for the index (0-based), {i:0N} for zero-padded where N is \
+     the total width (e.g. {i:06} produces 000000, 000001, ...).\n\n\
      Examples:\n\
      - String: key_pattern=\"user:{i}\", value_pattern=\"value-{i}\", count=1000\n\
      - Hash: key_pattern=\"user:{i}\", field_values=[{name:\"name\",value:\"user-{i}\"},{name:\"score\",value:\"{i}\"}], count=1000\n\
      - Sorted set: key_pattern=\"leaderboard\", member_pattern=\"player-{i:06}\", count=10000, score_min=0, score_max=10000\n\
-     - JSON: key_pattern=\"doc:{i}\", value_pattern='{\"id\":{i},\"name\":\"item-{i}\"}', count=1000",
+     - JSON: key_pattern=\"doc:{i}\", value_pattern='{\"id\":{i},\"name\":\"item-{i}\"}', count=1000\n\n\
+     Notes:\n\
+     - For JSON type, value_pattern must be a valid JSON string with {i} placeholders.\n\
+     - For sorted_set, scores are linearly interpolated between score_min and score_max.\n\
+     - TTL is supported for string, hash, and json types only (ignored for set, list, sorted_set).\n\
+     - For sorted_set with a single key, each {i} produces a new member; duplicate member patterns overwrite.",
     {
         /// Data type to generate: "string", "hash", "sorted_set", "set", "list", "json"
         pub data_type: String,

--- a/crates/redisctl-mcp/src/tools/redis/search.rs
+++ b/crates/redisctl-mcp/src/tools/redis/search.rs
@@ -172,7 +172,21 @@ database_tool!(read_only, ft_info, "redis_ft_info",
 );
 
 database_tool!(read_only, ft_search, "redis_ft_search",
-    "Execute a full-text search query against an index. Requires the RediSearch module.\n\nQuery syntax examples:\n- Full-text: `wireless headphones`\n- Field-specific text: `@name:wireless`\n- TAG exact match: `@category:{electronics}`\n- Multiple tags: `@category:{electronics|sports}`\n- Numeric range: `@price:[50 200]`\n- Numeric comparison: `@rating:[(4 +inf]` (greater than 4)\n- Negation: `-@category:{kitchen}`\n- Wildcard: `wire*`\n- All documents: `*`\n- Combined: `@category:{electronics} @price:[0 100]`\n\nFor JSON indexes, use field aliases (set via AS in FT.CREATE) in queries, not the raw JSONPath.",
+    "Execute a full-text search query against an index. Requires the RediSearch module.\n\n\
+     Query syntax examples:\n\
+     - Full-text: `wireless headphones`\n\
+     - Field-specific text: `@name:wireless`\n\
+     - TAG exact match: `@category:{electronics}`\n\
+     - Multiple tags: `@category:{electronics|sports}`\n\
+     - Numeric range: `@price:[50 200]`\n\
+     - Numeric comparison: `@rating:[(4 +inf]` (greater than 4)\n\
+     - Negation: `-@category:{kitchen}`\n\
+     - Wildcard: `wire*`\n\
+     - All documents: `*`\n\
+     - Combined: `@category:{electronics} @price:[0 100]`\n\n\
+     For JSON indexes, use field aliases (set via AS in FT.CREATE) in queries, not the raw JSONPath.\n\n\
+     Field-specific queries (e.g. `@name:value`) only work on fields that are included in the index schema. \
+     Querying a field that is not indexed returns zero results without an error.",
     {
         /// Index name
         pub index: String,
@@ -377,7 +391,14 @@ database_tool!(read_only, ft_explain, "redis_ft_explain",
 );
 
 database_tool!(read_only, ft_profile, "redis_ft_profile",
-    "Profile a search or aggregate query to analyze performance. Shows timing and index intersection details. Requires the RediSearch module.",
+    "Profile a search or aggregate query to analyze performance. Shows timing and index intersection details. Requires the RediSearch module.\n\n\
+     The output includes:\n\
+     - **Iterators profile**: Shows which index iterators were used (TEXT, TAG, NUMERIC, INTERSECT, UNION), \
+     how many documents each scanned (Counter), and the index size (Size). \
+     Intersect iterators combine multiple conditions; the smallest child drives performance.\n\
+     - **Result processors**: Shows time spent in scoring, sorting, and loading document content.\n\
+     - **Total profile time**: Wall-clock microseconds for the entire query.\n\n\
+     Use this to identify which query clause is the bottleneck and whether adding/removing index fields would help.",
     {
         /// Index name
         pub index: String,
@@ -501,7 +522,21 @@ database_tool!(read_only, ft_dictdump, "redis_ft_dictdump",
 // ---------------------------------------------------------------------------
 
 database_tool!(write, ft_create, "redis_ft_create",
-    "Create a search index with the specified schema. Requires the RediSearch module.\n\nFor JSON indexes, set `on` to `JSON` and use JSONPath expressions as field names (e.g. `$.name`). Always set `alias` on JSON fields to provide clean query names (e.g. alias `name` for `$.name`), since raw JSONPath cannot be used in search queries.\n\nField types: TEXT (full-text searchable), NUMERIC (range queries), TAG (exact match/filtering), GEO (geo queries), VECTOR (similarity search).\n\nExample schema for JSON:\n```\n{\"name\": \"$.name\", \"alias\": \"name\", \"field_type\": \"TEXT\", \"sortable\": true}\n{\"name\": \"$.price\", \"alias\": \"price\", \"field_type\": \"NUMERIC\", \"sortable\": true}\n{\"name\": \"$.category\", \"alias\": \"category\", \"field_type\": \"TAG\"}\n```",
+    "Create a search index with the specified schema. Requires the RediSearch module.\n\n\
+     For JSON indexes, set `on` to `JSON` and use JSONPath expressions as field names (e.g. `$.name`). \
+     Always set `alias` on JSON fields to provide clean query names (e.g. alias `name` for `$.name`), \
+     since raw JSONPath cannot be used in search queries.\n\n\
+     For HASH indexes (default), use plain field names (e.g. `name`, `price`) — no JSONPath or alias needed.\n\n\
+     Field types: TEXT (full-text searchable, stemmed by default), NUMERIC (range queries), \
+     TAG (exact match/filtering, case-insensitive), GEO (geo queries), VECTOR (similarity search).\n\n\
+     Example schema for JSON:\n\
+     ```\n\
+     {\"name\": \"$.name\", \"alias\": \"name\", \"field_type\": \"TEXT\", \"sortable\": true}\n\
+     {\"name\": \"$.price\", \"alias\": \"price\", \"field_type\": \"NUMERIC\", \"sortable\": true}\n\
+     {\"name\": \"$.category\", \"alias\": \"category\", \"field_type\": \"TAG\"}\n\
+     ```\n\n\
+     Note: Changing a schema requires dropping and recreating the index — indexes do not auto-update. \
+     Use FT.ALIASUPDATE for zero-downtime index swaps.",
     {
         /// Index name
         pub index: String,


### PR DESCRIPTION
## Summary
- **FT.CREATE**: Add HASH vs JSON field name guidance, note that schema changes require drop+recreate, mention FT.ALIASUPDATE for zero-downtime swaps
- **FT.SEARCH**: Note that field-specific queries only work on indexed fields
- **FT.PROFILE**: Add output interpretation guide (iterator types, counters, result processors)
- **bulk_load**: Document fire-and-forget behavior, non-atomicity, batch_size tuning guidance
- **seed**: Document JSON value format requirement, sorted_set score interpolation, TTL support matrix, member collision behavior

## Test plan
- [ ] Verify tool descriptions render correctly in MCP clients
- [ ] No code logic changes — description strings only

Fixes #877