### PR TITLE
feat: add AGENTS.md and CLI agent skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,144 @@
+# AGENTS.md
+
+Context and instructions for AI coding agents working on the redisctl project.
+
+## Project Overview
+
+redisctl is a Rust workspace with three crates that share a lockstep version (currently 0.9.1):
+
+| Crate | Path | Purpose |
+|-------|------|---------|
+| **redisctl-core** | `crates/redisctl-core/` | Shared library: config/profile management, Cloud and Enterprise API clients, error handling |
+| **redisctl** | `crates/redisctl/` | CLI binary: commands, workflows, connection management |
+| **redisctl-mcp** | `crates/redisctl-mcp/` | MCP server for AI agents: ~371 tools, policy engine, skills system |
+
+## Build and Test
+
+```bash
+# Format (required before push)
+cargo fmt --all
+
+# Lint (all warnings are errors in CI)
+cargo clippy --all-targets --all-features -- -D warnings
+
+# Unit tests
+cargo test --workspace
+
+# Integration tests (requires Docker for Redis)
+cargo test --workspace --test '*' --all-features
+
+# Reuse Docker containers across test runs
+REUSE_CONTAINERS=1 cargo test --workspace --test '*' --all-features
+```
+
+**Always run fmt + clippy before pushing.** CI will reject unformatted code or clippy warnings.
+
+## CI Checks
+
+PRs must pass:
+1. `cargo fmt --all -- --check`
+2. `cargo clippy --all-targets --all-features -- -D warnings`
+3. Unit tests per crate (parallel)
+4. Integration tests
+5. Platform builds (Linux required; macOS and Windows are optional)
+
+## Crate Architecture
+
+### Feature Flags
+
+**redisctl** (CLI):
+- `default = ["full", "secure-storage"]`
+- `full = ["cloud", "enterprise", "upload"]`
+- `secure-storage` enables keyring-based credential storage
+
+**redisctl-mcp** (MCP server):
+- `default = ["http", "cloud", "enterprise", "database"]`
+- Each toolset (`cloud`, `enterprise`, `database`) can be compiled independently
+
+### Key Patterns
+
+**database_tool! macro** (`crates/redisctl-mcp/src/tools/macros.rs`):
+Generates MCP tool structs with safety annotations. Three safety tiers:
+- `database_tool!(read_only, ...)` -- no side effects
+- `database_tool!(write, ...)` -- creates or modifies data
+- `database_tool!(destructive, ...)` -- irreversible operations
+
+Field attributes like `#[serde(...)]` pass through the macro. Numeric parameters that might arrive as strings from MCP clients use custom deserializers from `serde_helpers.rs`.
+
+**mcp_module! macro**: Generates `TOOL_NAMES` constant and `router()` function for each tool sub-module.
+
+**Policy system** (`crates/redisctl-mcp/src/policy.rs`): TOML-based policy engine with three safety tiers (ReadOnly, ReadWrite, Full), per-toolset overrides, and allow/deny lists.
+
+**Profile system** (`crates/redisctl-core/`): TOML config at `~/.config/redisctl/config.toml` with profiles for Cloud, Enterprise, and direct Redis connections. Supports env var substitution.
+
+### Module Organization
+
+MCP tools are organized into toolsets with sub-modules:
+```
+tools/
+  redis/          # ~125 tools: server, keys, structures, json, search, diagnostics, bulk
+  cloud/          # ~147 tools: subscriptions, account, networking, fixed
+  enterprise/     # ~91 tools: cluster, databases, rbac, observability, proxy, services
+  profile.rs      # 8 tools: profile management
+```
+
+CLI commands mirror this structure:
+```
+cli/
+  cloud.rs        # Cloud subcommands
+  enterprise.rs   # Enterprise subcommands
+  mod.rs          # Top-level command tree
+```
+
+## Conventions
+
+### Commits
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
+- `feat:` new feature (minor version bump)
+- `fix:` bug fix (patch bump)
+- `docs:` documentation only
+- `refactor:` no behavior change
+- `test:` test additions or fixes
+- `chore:` maintenance
+
+Scope by crate when relevant: `feat(mcp):`, `fix(core):`, `docs(cli):`.
+
+### Code Style
+
+- Rust edition 2024, MSRV 1.90+
+- No `unwrap()` in production code -- use proper error handling
+- Prefer `anyhow` for CLI errors, `tower_mcp::Error` for MCP tool errors
+- Tool descriptions are the primary documentation for MCP tools -- keep them accurate and concise
+
+### PRs
+
+- Use feature branches (`feat/`, `fix/`, `docs/`)
+- Open Draft PRs early
+- Squash and merge to main
+- Versions are bumped automatically by release-plz based on commit types
+
+## Dependencies
+
+API client crates are external git dependencies on the `main` branch:
+- `redis-cloud` from `github.com/redis-developer/redis-cloud-rs`
+- `redis-enterprise` from `github.com/redis-developer/redis-enterprise-rs`
+
+These are published separately and versioned independently.
+
+## MCP Skills
+
+Skills are workflow templates in `crates/redisctl-mcp/skills/` following the [agentskills.io spec](https://agentskills.io/specification):
+
+```
+skills/
+  index-advisor/SKILL.md      # Recommend search index schemas
+  query-tuning/SKILL.md       # Optimize queries with FT.EXPLAIN/FT.PROFILE
+  index-ab-test/SKILL.md      # Compare multiple index configurations
+```
+
+Each SKILL.md has YAML frontmatter (`name`, `description`) and a markdown body with step-by-step instructions that reference MCP tools.
+
+## License
+
+MIT OR Apache-2.0

--- a/skills/redisctl-cloud-management/SKILL.md
+++ b/skills/redisctl-cloud-management/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: redisctl-cloud-management
+description: Manage Redis Cloud subscriptions, databases, and resources via the redisctl CLI. Use when provisioning, updating, or monitoring Redis Cloud infrastructure.
+---
+
+## Overview
+
+Manage the full lifecycle of Redis Cloud resources: subscriptions, databases, users, ACLs, and tasks.
+
+## Subscriptions
+
+```bash
+# List all subscriptions
+redisctl cloud subscription list
+
+# Get subscription details
+redisctl cloud subscription get --id 12345
+
+# Create a subscription (JSON input)
+redisctl cloud subscription create --data '{...}'
+
+# Update a subscription
+redisctl cloud subscription update --id 12345 --data '{...}'
+
+# Delete a subscription
+redisctl cloud subscription delete --id 12345
+```
+
+## Databases
+
+```bash
+# List databases in a subscription
+redisctl cloud database list --subscription-id 12345
+
+# Get database details
+redisctl cloud database get --subscription-id 12345 --id 67890
+
+# Create a database
+redisctl cloud database create --subscription-id 12345 --data '{...}'
+
+# Update a database
+redisctl cloud database update --subscription-id 12345 --id 67890 --data '{...}'
+
+# Delete a database
+redisctl cloud database delete --subscription-id 12345 --id 67890
+
+# Pause/recover a database
+redisctl cloud database pause --subscription-id 12345 --id 67890
+redisctl cloud database recover --subscription-id 12345 --id 67890
+
+# Backup a database
+redisctl cloud database backup --subscription-id 12345 --id 67890
+```
+
+## Essentials / Fixed Tier
+
+For smaller, fixed-price databases:
+
+```bash
+redisctl cloud fixed-subscription list
+redisctl cloud fixed-database list --subscription-id 12345
+redisctl cloud fixed-database create --subscription-id 12345 --data '{...}'
+```
+
+## Task Tracking
+
+Cloud operations are async. Track tasks:
+
+```bash
+# List recent tasks
+redisctl cloud task list
+
+# Get task status
+redisctl cloud task get --id <task-id>
+
+# Wait for a task to complete
+redisctl cloud task wait --id <task-id>
+```
+
+## Workflows
+
+Multi-step operations:
+
+```bash
+# Complete subscription setup with optional database
+redisctl cloud workflow subscription-setup
+```
+
+## Cost Reports
+
+```bash
+# Generate a cost report (FOCUS format)
+redisctl cloud cost-report generate --start 2026-01-01 --end 2026-01-31
+
+# Download a generated report
+redisctl cloud cost-report download --id <report-id>
+
+# Generate and download in one step
+redisctl cloud cost-report export --start 2026-01-01 --end 2026-01-31
+```
+
+## Account Management
+
+```bash
+# Get account details
+redisctl cloud account get
+
+# List/manage users
+redisctl cloud user list
+redisctl cloud user create --data '{...}'
+
+# ACL management
+redisctl cloud acl list
+redisctl cloud acl create --data '{...}'
+```
+
+## Tips
+
+- Use `--profile <name>` to target a specific Cloud profile
+- Use `--output json` for machine-readable output
+- Most create/update commands accept `--data` with a JSON payload or `--file` for a JSON file
+- Task IDs are returned from async operations -- use `cloud task wait` to block until completion

--- a/skills/redisctl-database-connect/SKILL.md
+++ b/skills/redisctl-database-connect/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: redisctl-database-connect
+description: Connect to Redis databases using the redisctl CLI. Use when opening redis-cli sessions, managing connection profiles, or working with multiple Redis clusters.
+---
+
+## Overview
+
+Connect to Redis databases using profile-based credential management. Supports direct Redis connections, Cloud databases, and Enterprise databases.
+
+## Quick Connect
+
+```bash
+# Open redis-cli using the default database profile
+redisctl db open
+
+# Open redis-cli with a specific profile
+redisctl db open --profile my-redis
+```
+
+## Profile-Based Connection Management
+
+### Create Database Profiles
+
+```bash
+# Local Redis
+redisctl profile set local --type database --url "redis://localhost:6379"
+
+# Redis with password
+redisctl profile set staging --type database --url "redis://:password@host:6379"
+
+# Redis with TLS
+redisctl profile set prod --type database --url "rediss://host:6380"
+
+# Set as default
+redisctl profile default-database local
+```
+
+### Multi-Cluster Workflows
+
+Create profiles for each environment:
+
+```bash
+redisctl profile set dev-redis --type database --url "redis://dev:6379"
+redisctl profile set staging-redis --type database --url "rediss://staging:6380"
+redisctl profile set prod-redis --type database --url "rediss://prod:6380"
+```
+
+Switch between them:
+
+```bash
+# Connect to dev
+redisctl db open --profile dev-redis
+
+# Connect to staging
+redisctl db open --profile staging-redis
+```
+
+## Raw API Access
+
+For operations not covered by specific commands:
+
+```bash
+# Cloud API
+redisctl api cloud GET /subscriptions
+redisctl api cloud POST /subscriptions/12345/databases --data '{...}'
+
+# Enterprise API
+redisctl api enterprise GET /v1/bdbs
+redisctl api enterprise PUT /v1/bdbs/1 --data '{...}'
+```
+
+## Tips
+
+- Database profile URLs follow the standard Redis URI scheme: `redis://[user:password@]host[:port][/db]`
+- Use `rediss://` (double s) for TLS connections
+- Profile credentials support environment variable substitution: `--url "redis://:${REDIS_PASSWORD}@host:6379"`
+- Run `redisctl profile validate` to test all profile connections

--- a/skills/redisctl-enterprise-admin/SKILL.md
+++ b/skills/redisctl-enterprise-admin/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: redisctl-enterprise-admin
+description: Advanced Redis Enterprise administration via the redisctl CLI. Use for RBAC, LDAP, cluster policy, licensing, certificates, proxy management, and diagnostics.
+---
+
+## Overview
+
+Advanced cluster administration tasks: access control, security, licensing, maintenance, and troubleshooting.
+
+## RBAC (Role-Based Access Control)
+
+### Users
+
+```bash
+redisctl enterprise user list
+redisctl enterprise user get --id 1
+redisctl enterprise user create --data '{...}'
+redisctl enterprise user update --id 1 --data '{...}'
+redisctl enterprise user delete --id 1
+```
+
+### Roles
+
+```bash
+redisctl enterprise role list
+redisctl enterprise role get --id 1
+redisctl enterprise role create --data '{...}'
+redisctl enterprise role update --id 1 --data '{...}'
+redisctl enterprise role delete --id 1
+```
+
+### ACLs
+
+```bash
+redisctl enterprise acl list
+redisctl enterprise acl get --id 1
+redisctl enterprise acl create --data '{...}'
+redisctl enterprise acl update --id 1 --data '{...}'
+redisctl enterprise acl delete --id 1
+```
+
+## LDAP Integration
+
+```bash
+# Get LDAP configuration
+redisctl enterprise ldap get
+
+# Update LDAP configuration
+redisctl enterprise ldap update --data '{...}'
+
+# Test LDAP connectivity
+redisctl enterprise ldap test
+
+# Manage LDAP role mappings
+redisctl enterprise ldap-mappings list
+redisctl enterprise ldap-mappings create --data '{...}'
+redisctl enterprise ldap-mappings update --id 1 --data '{...}'
+redisctl enterprise ldap-mappings delete --id 1
+```
+
+## Cluster Configuration
+
+```bash
+# Get cluster config
+redisctl enterprise cluster get
+
+# Update cluster config
+redisctl enterprise cluster update --data '{...}'
+
+# Get/update cluster policies
+redisctl enterprise cluster get-policy
+redisctl enterprise cluster update-policy --data '{...}'
+```
+
+## Maintenance Mode
+
+```bash
+# Enable maintenance mode (prevents automatic failover)
+redisctl enterprise cluster enable-maintenance-mode
+
+# Disable maintenance mode
+redisctl enterprise cluster disable-maintenance-mode
+```
+
+## Licensing
+
+```bash
+# Get current license info
+redisctl enterprise license get
+
+# Update license
+redisctl enterprise license update --file license.key
+```
+
+## Proxy Management
+
+```bash
+redisctl enterprise proxy list
+redisctl enterprise proxy get --id 1
+redisctl enterprise proxy update --id 1 --data '{...}'
+```
+
+## Service Management
+
+```bash
+redisctl enterprise services list
+redisctl enterprise services get --name <service>
+redisctl enterprise services update --name <service> --data '{...}'
+```
+
+## Diagnostics
+
+```bash
+# Cluster diagnostics
+redisctl enterprise diagnostics cluster
+
+# Node diagnostics
+redisctl enterprise diagnostics node
+
+# Debug info collection
+redisctl enterprise debug-info
+
+# Support package for Redis support
+redisctl enterprise support-package create
+redisctl enterprise support-package status --id <pkg-id>
+redisctl enterprise support-package download --id <pkg-id>
+```
+
+## Tips
+
+- Maintenance mode should be enabled before planned node maintenance to prevent automatic failover
+- Always test LDAP configuration with `ldap test` before applying to production
+- Support packages contain sensitive data -- handle with care
+- License operations may require cluster restart for some changes

--- a/skills/redisctl-enterprise-ops/SKILL.md
+++ b/skills/redisctl-enterprise-ops/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: redisctl-enterprise-ops
+description: Day-to-day Redis Enterprise cluster operations via the redisctl CLI. Use when checking cluster status, managing databases, viewing stats and logs, or monitoring Active-Active deployments.
+---
+
+## Overview
+
+Manage Redis Enterprise clusters, databases, and operational monitoring through the CLI.
+
+## Cluster Status
+
+```bash
+# Comprehensive status overview
+redisctl enterprise status
+
+# With specific sections
+redisctl enterprise status --cluster --nodes --databases --shards
+
+# Brief summary
+redisctl enterprise status --brief
+```
+
+## Database Management
+
+```bash
+# List all databases
+redisctl enterprise database list
+
+# Get database details
+redisctl enterprise database get --id 1
+
+# Create a database
+redisctl enterprise database create --data '{...}'
+
+# Update a database
+redisctl enterprise database update --id 1 --data '{...}'
+
+# Delete a database
+redisctl enterprise database delete --id 1
+```
+
+## Active-Active (CRDB)
+
+```bash
+# List CRDBs
+redisctl enterprise crdb list
+
+# Get CRDB details
+redisctl enterprise crdb get --id <guid>
+
+# Create a CRDB
+redisctl enterprise crdb create --data '{...}'
+
+# Update a CRDB
+redisctl enterprise crdb update --id <guid> --data '{...}'
+
+# Check CRDB task status
+redisctl enterprise crdb-task list
+redisctl enterprise crdb-task get --id <task-id>
+```
+
+## Stats and Metrics
+
+```bash
+# Cluster-level stats
+redisctl enterprise stats cluster
+
+# Per-node stats
+redisctl enterprise stats node
+
+# Per-database stats
+redisctl enterprise stats database
+
+# Per-shard stats
+redisctl enterprise stats shard
+```
+
+## Logs and Alerts
+
+```bash
+# View cluster logs
+redisctl enterprise logs cluster
+
+# View node-specific logs
+redisctl enterprise logs node
+
+# List alerts
+redisctl enterprise alerts list
+
+# Get alert details
+redisctl enterprise alerts get --id <alert-id>
+```
+
+## Module Management
+
+```bash
+# List installed modules
+redisctl enterprise module list
+
+# Get module details
+redisctl enterprise module get --id <module-id>
+```
+
+## Nodes and Shards
+
+```bash
+# List nodes
+redisctl enterprise node list
+
+# Get node details
+redisctl enterprise node get --id 1
+
+# List shards
+redisctl enterprise shard list
+
+# Get shard details
+redisctl enterprise shard get --id 1
+```
+
+## Tips
+
+- Use `--profile <name>` to target a specific Enterprise cluster
+- Manage multiple clusters by creating separate profiles and switching with `--profile`
+- Use `redisctl enterprise status --brief` for a quick health check
+- Database IDs are numeric (BDB IDs), CRDB IDs are GUIDs

--- a/skills/redisctl-networking/SKILL.md
+++ b/skills/redisctl-networking/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: redisctl-networking
+description: Configure network connectivity for Redis Cloud deployments via the redisctl CLI. Use when setting up VPC peering, Transit Gateway, Private Service Connect, or PrivateLink.
+---
+
+## Overview
+
+Set up private network connectivity between your infrastructure and Redis Cloud deployments. Supports VPC Peering, Transit Gateway, Private Service Connect (GCP), and AWS PrivateLink.
+
+## VPC Peering
+
+```bash
+# List VPC peering connections
+redisctl cloud connectivity vpc-peering list --subscription-id 12345
+
+# Get peering details
+redisctl cloud connectivity vpc-peering get --subscription-id 12345 --id 1
+
+# Create a peering connection
+redisctl cloud connectivity vpc-peering create \
+  --subscription-id 12345 \
+  --data '{
+    "region": "us-east-1",
+    "aws_account_id": "123456789012",
+    "vpc_id": "vpc-abc123",
+    "vpc_cidr": "10.0.0.0/16"
+  }'
+
+# Delete a peering connection
+redisctl cloud connectivity vpc-peering delete --subscription-id 12345 --id 1
+```
+
+## Transit Gateway (AWS)
+
+```bash
+# List TGW attachments
+redisctl cloud connectivity tgw list --subscription-id 12345
+
+# Create a TGW attachment
+redisctl cloud connectivity tgw create \
+  --subscription-id 12345 \
+  --data '{...}'
+
+# Accept a TGW invitation
+redisctl cloud connectivity tgw accept --subscription-id 12345 --id 1
+```
+
+## Private Service Connect (GCP)
+
+```bash
+# List PSC endpoints
+redisctl cloud connectivity psc list --subscription-id 12345
+
+# Create a PSC endpoint
+redisctl cloud connectivity psc create \
+  --subscription-id 12345 \
+  --data '{...}'
+
+# Get connection scripts
+redisctl cloud connectivity psc scripts --subscription-id 12345 --id 1
+```
+
+## AWS PrivateLink
+
+```bash
+# List PrivateLink endpoints
+redisctl cloud connectivity privatelink list --subscription-id 12345
+
+# Create a PrivateLink endpoint
+redisctl cloud connectivity privatelink create \
+  --subscription-id 12345 \
+  --data '{...}'
+```
+
+## Cloud Provider Accounts
+
+Required for some networking operations:
+
+```bash
+# List provider accounts
+redisctl cloud provider-account list
+
+# Create a provider account
+redisctl cloud provider-account create --data '{...}'
+```
+
+## Tips
+
+- VPC peering requires matching CIDR ranges -- ensure no overlap with Redis Cloud VPC
+- Transit Gateway and PrivateLink are AWS-only features
+- Private Service Connect is GCP-only
+- Most connectivity operations are async -- use `redisctl cloud task wait` after creation
+- Active-Active subscriptions have separate connectivity endpoints per region

--- a/skills/redisctl-setup/SKILL.md
+++ b/skills/redisctl-setup/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: redisctl-setup
+description: Install and configure redisctl CLI for Redis Cloud, Enterprise, and direct database access. Use when setting up redisctl for the first time, creating profiles, or configuring shell completions.
+---
+
+## Overview
+
+redisctl is a unified CLI for managing Redis Cloud, Redis Enterprise, and direct Redis database connections. This skill covers installation, profile setup, and validation.
+
+## Installation
+
+Choose one method:
+
+```bash
+# Homebrew (macOS/Linux)
+brew install redis-developer/tap/redisctl
+
+# Cargo (from source)
+cargo install redisctl
+
+# Docker
+docker run --rm -it ghcr.io/redis-developer/redisctl --help
+```
+
+## Profile Setup
+
+Profiles store connection credentials. Use the interactive wizard for guided setup:
+
+```bash
+redisctl profile init
+```
+
+Or create profiles directly:
+
+### Redis Cloud Profile
+
+```bash
+redisctl profile set cloud-prod \
+  --type cloud \
+  --api-key "$REDIS_CLOUD_API_KEY" \
+  --api-secret "$REDIS_CLOUD_API_SECRET"
+
+redisctl profile default-cloud cloud-prod
+```
+
+### Redis Enterprise Profile
+
+```bash
+redisctl profile set ent-staging \
+  --type enterprise \
+  --url "https://cluster.internal:9443" \
+  --username admin \
+  --password "$RE_PASSWORD"
+
+redisctl profile default-enterprise ent-staging
+```
+
+### Direct Database Profile
+
+```bash
+redisctl profile set local-redis \
+  --type database \
+  --url "redis://localhost:6379"
+
+redisctl profile default-database local-redis
+```
+
+## Validation
+
+After creating profiles, verify connectivity:
+
+```bash
+# List all profiles
+redisctl profile list
+
+# Show a specific profile
+redisctl profile show cloud-prod
+
+# Validate connectivity for all profiles
+redisctl profile validate
+```
+
+## Shell Completions
+
+Generate completions for your shell:
+
+```bash
+# Bash
+redisctl completions bash > ~/.bash_completion.d/redisctl
+
+# Zsh
+redisctl completions zsh > ~/.zfunc/_redisctl
+
+# Fish
+redisctl completions fish > ~/.config/fish/completions/redisctl.fish
+```
+
+## Common Issues
+
+- **Credential errors**: Check that environment variables are set and profile type matches the command namespace (cloud profile for cloud commands, etc.)
+- **Enterprise TLS errors**: Use `--insecure` flag for self-signed certificates during setup
+- **Config file location**: Run `redisctl profile path` to find the config file

--- a/skills/redisctl-workflows/SKILL.md
+++ b/skills/redisctl-workflows/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: redisctl-workflows
+description: Multi-step operational workflows combining redisctl commands. Use for end-to-end provisioning, cluster initialization, migrations, and backup and recovery procedures.
+---
+
+## Overview
+
+Workflows combine multiple redisctl commands into common operational patterns. Use these as templates for provisioning, maintenance, and recovery tasks.
+
+## Cloud: Provision a Subscription and Database
+
+```bash
+# 1. Create a subscription
+redisctl cloud subscription create --data '{
+  "name": "my-app-prod",
+  "cloudProviders": [{
+    "provider": "AWS",
+    "regions": [{"region": "us-east-1"}]
+  }]
+}'
+
+# 2. Wait for provisioning
+redisctl cloud task wait --id <task-id>
+
+# 3. Create a database
+redisctl cloud database create \
+  --subscription-id <sub-id> \
+  --data '{
+    "name": "cache",
+    "memoryLimitInGb": 1,
+    "modules": [{"name": "RedisJSON"}]
+  }'
+
+# 4. Wait for database creation
+redisctl cloud task wait --id <task-id>
+
+# 5. Get connection details
+redisctl cloud database get --subscription-id <sub-id> --id <db-id>
+```
+
+Or use the built-in workflow:
+
+```bash
+redisctl cloud workflow subscription-setup
+```
+
+## Enterprise: Initialize a Cluster
+
+```bash
+# Built-in workflow for cluster initialization
+redisctl enterprise workflow init-cluster
+```
+
+Or step by step:
+
+```bash
+# 1. Check cluster status
+redisctl enterprise status --brief
+
+# 2. Upload license
+redisctl enterprise license update --file license.key
+
+# 3. Configure cluster policy
+redisctl enterprise cluster update-policy --data '{...}'
+
+# 4. Create a database
+redisctl enterprise database create --data '{
+  "name": "my-app",
+  "memory_size": 1073741824,
+  "type": "redis",
+  "replication": true
+}'
+
+# 5. Verify
+redisctl enterprise status --databases
+```
+
+## Enterprise: License Management
+
+```bash
+redisctl enterprise workflow license
+```
+
+## Backup and Recovery
+
+### Cloud
+
+```bash
+# Trigger a backup
+redisctl cloud database backup \
+  --subscription-id <sub-id> \
+  --id <db-id>
+
+# Check backup status
+redisctl cloud task wait --id <task-id>
+
+# Import from backup
+redisctl cloud database import \
+  --subscription-id <sub-id> \
+  --id <db-id> \
+  --data '{"sourceType": "aws-s3", "importFromUri": "s3://..."}'
+```
+
+### Enterprise
+
+```bash
+# Export a database
+redisctl enterprise database export --id 1
+
+# Restore from backup
+redisctl enterprise database restore --id 1 --data '{...}'
+```
+
+## Health Check Pattern
+
+Quick health check across environments:
+
+```bash
+# Cloud
+redisctl cloud subscription list
+redisctl cloud database list --subscription-id <sub-id>
+
+# Enterprise
+redisctl enterprise status --brief
+
+# Direct Redis
+redisctl db open --profile prod-redis
+# then: INFO, DBSIZE, SLOWLOG GET 10
+```
+
+## Migration Pattern
+
+Move data between Redis instances:
+
+```bash
+# 1. Get source database info
+redisctl enterprise database get --id 1
+
+# 2. Create target database with matching config
+redisctl cloud database create --subscription-id <sub-id> --data '{...}'
+
+# 3. Wait for target to be ready
+redisctl cloud task wait --id <task-id>
+
+# 4. Get target connection details
+redisctl cloud database get --subscription-id <sub-id> --id <db-id>
+
+# 5. Use redis-cli or migration tool to replicate data
+```
+
+## Tips
+
+- Always check task status after async operations with `cloud task wait`
+- Use `--profile` to target specific environments in each step
+- Enterprise workflows may require maintenance mode for some operations
+- Back up before any destructive operation
+- For complex multi-step operations, consider scripting with the raw API: `redisctl api`


### PR DESCRIPTION
## Summary

- **AGENTS.md** in repo root: gives coding agents context for working on the redisctl codebase (build/test commands, crate architecture, conventions, macro patterns, CI requirements)
- **7 CLI agent skills** in `skills/` following the [agentskills.io spec](https://agentskills.io/specification): teach agents how to use the redisctl CLI for Redis management tasks

## Skills

| Skill | Description |
|-------|-------------|
| `redisctl-setup` | Installation, profile creation, shell completions |
| `redisctl-cloud-management` | Cloud subscription/database lifecycle, tasks, cost reports |
| `redisctl-enterprise-ops` | Cluster status, database management, stats, logs, CRDBs |
| `redisctl-enterprise-admin` | RBAC, LDAP, licensing, certs, proxy, diagnostics |
| `redisctl-networking` | VPC peering, Transit Gateway, PSC, PrivateLink |
| `redisctl-database-connect` | redis-cli sessions, multi-cluster profiles, raw API |
| `redisctl-workflows` | End-to-end provisioning, backup/recovery, migration patterns |

## Context

- Complements existing MCP skills in `crates/redisctl-mcp/skills/` (index-advisor, query-tuning, index-ab-test)
- AGENTS.md helps agents *work on* redisctl; skills help agents *use* redisctl
- Skills are designed for eventual inclusion in [redis/agent-skills](https://github.com/redis/agent-skills)
- See also: [agents.md](https://agents.md/) standard for project-level agent context

Ref #883

## Test plan
- [ ] Verify AGENTS.md renders correctly on GitHub
- [ ] Verify all SKILL.md files have valid frontmatter (name + description)
- [ ] Skill directory names match frontmatter `name` field