### PR TITLE
feat(mcp): improve bulk_load for JSON seeding + collect_results flag

### DIFF
--- a/crates/redisctl-mcp/src/tools/redis/bulk.rs
+++ b/crates/redisctl-mcp/src/tools/redis/bulk.rs
@@ -59,18 +59,32 @@ database_tool!(write, bulk_load, "redis_bulk_load",
     "Pipelined command execution. Accept a batch of Redis commands and execute them \
      using Redis pipelining for high throughput. Returns count of commands executed, \
      elapsed time, and throughput.\n\n\
+     Each command is a raw args array — the first element is the Redis command name, \
+     the rest are its arguments. This works for any Redis command including module commands.\n\n\
+     JSON document seeding example (use this instead of calling redis_json_set N times):\n\
+     commands: [\n\
+       [\"JSON.SET\", \"user:1\", \"$\", \"{\\\"name\\\":\\\"Alice\\\",\\\"age\\\":30}\"],\n\
+       [\"JSON.SET\", \"user:2\", \"$\", \"{\\\"name\\\":\\\"Bob\\\",\\\"age\\\":25}\"]\n\
+     ]\n\
+     Append \"NX\" or \"XX\" to a JSON.SET args array to set only-if-absent or only-if-present.\n\n\
      Important notes:\n\
-     - Commands are fire-and-forget: individual command errors are not reported. \
-     The batch succeeds if the pipeline as a whole completes.\n\
+     - Default mode is fire-and-forget: per-command results are not returned. \
+     Set collect_results=true to get per-command output (useful for small batches \
+     where you need to verify NX/XX conditions were met).\n\
      - Pipelines are NOT atomic — other clients may interleave commands between batches.\n\
      - Tune batch_size for your use case: smaller batches (100-500) reduce memory per round-trip, \
      larger batches (1000-5000) maximize throughput.",
     {
-        /// List of commands to execute. Each command is an args array (e.g. [\"SET\", \"k\", \"v\"]).
+        /// List of commands to execute. Each command is an args array
+        /// (e.g. [\"SET\", \"k\", \"v\"] or [\"JSON.SET\", \"doc:1\", \"$\", \"{}\", \"NX\"]).
         pub commands: Vec<Command>,
         /// Pipeline batch size (default: 1000). Commands are sent in batches of this size.
         #[serde(default = "default_batch_size", deserialize_with = "serde_helpers::string_or_usize::deserialize")]
         pub batch_size: usize,
+        /// Collect and return per-command results instead of fire-and-forget (default: false).
+        /// Useful for small batches where you need to inspect individual results (e.g. NX/XX outcomes).
+        #[serde(default)]
+        pub collect_results: bool,
     } => |conn, input| {
         if input.commands.is_empty() {
             return Ok(CallToolResult::text("No commands to execute"));
@@ -78,39 +92,85 @@ database_tool!(write, bulk_load, "redis_bulk_load",
 
         let batch_size = input.batch_size.max(1);
         let start = Instant::now();
-        let mut total_ok = 0usize;
+        let total = input.commands.len();
 
-        for (batch_idx, chunk) in input.commands.chunks(batch_size).enumerate() {
-            let mut pipe = redis::pipe();
-            for cmd_input in chunk {
-                if cmd_input.args.is_empty() {
-                    continue;
+        if input.collect_results {
+            let mut all_results: Vec<redis::Value> = Vec::with_capacity(total);
+
+            for (batch_idx, chunk) in input.commands.chunks(batch_size).enumerate() {
+                let mut pipe = redis::pipe();
+                for cmd_input in chunk {
+                    if cmd_input.args.is_empty() {
+                        continue;
+                    }
+                    let mut cmd = redis::cmd(&cmd_input.args[0]);
+                    for arg in &cmd_input.args[1..] {
+                        cmd.arg(arg);
+                    }
+                    pipe.add_command(cmd);
                 }
-                let mut cmd = redis::cmd(&cmd_input.args[0]);
-                for arg in &cmd_input.args[1..] {
-                    cmd.arg(arg);
-                }
-                pipe.add_command(cmd).ignore();
+                let batch_results: Vec<redis::Value> = pipe
+                    .query_async(&mut conn)
+                    .await
+                    .tool_context(format!("Pipeline batch {} failed", batch_idx))?;
+                all_results.extend(batch_results);
             }
-            pipe.query_async::<()>(&mut conn)
-                .await
-                .tool_context(format!("Pipeline batch {} failed", batch_idx))?;
-            total_ok += chunk.len();
-        }
 
-        let elapsed = start.elapsed();
-        let rate = if elapsed.as_secs_f64() > 0.0 {
-            total_ok as f64 / elapsed.as_secs_f64()
+            let elapsed = start.elapsed();
+            let mut lines = Vec::with_capacity(all_results.len() + 2);
+            for (i, (cmd_input, result)) in input.commands.iter().zip(all_results.iter()).enumerate() {
+                let label = cmd_input.args.first().map(|s| s.as_str()).unwrap_or("?");
+                let key = cmd_input.args.get(1).map(|s| s.as_str()).unwrap_or("");
+                let result_str = match result {
+                    redis::Value::Nil => "nil".to_string(),
+                    redis::Value::SimpleString(s) => s.clone(),
+                    redis::Value::Int(n) => n.to_string(),
+                    other => format!("{:?}", other),
+                };
+                lines.push(format!("[{:>4}] {:<12} {}  →  {}", i, label, key, result_str));
+            }
+            lines.push(String::new());
+            lines.push(format!(
+                "Summary: {} commands in {:.2}s ({:.0} cmd/s)",
+                all_results.len(),
+                elapsed.as_secs_f64(),
+                all_results.len() as f64 / elapsed.as_secs_f64().max(f64::EPSILON),
+            ));
+            Ok(CallToolResult::text(lines.join("\n")))
         } else {
-            total_ok as f64
-        };
+            let mut total_ok = 0usize;
+            for (batch_idx, chunk) in input.commands.chunks(batch_size).enumerate() {
+                let mut pipe = redis::pipe();
+                for cmd_input in chunk {
+                    if cmd_input.args.is_empty() {
+                        continue;
+                    }
+                    let mut cmd = redis::cmd(&cmd_input.args[0]);
+                    for arg in &cmd_input.args[1..] {
+                        cmd.arg(arg);
+                    }
+                    pipe.add_command(cmd).ignore();
+                }
+                pipe.query_async::<()>(&mut conn)
+                    .await
+                    .tool_context(format!("Pipeline batch {} failed", batch_idx))?;
+                total_ok += chunk.len();
+            }
 
-        Ok(CallToolResult::text(format!(
-            "Bulk load complete: {} commands executed in {:.2}s ({:.0} cmd/s)",
-            total_ok,
-            elapsed.as_secs_f64(),
-            rate
-        )))
+            let elapsed = start.elapsed();
+            let rate = if elapsed.as_secs_f64() > 0.0 {
+                total_ok as f64 / elapsed.as_secs_f64()
+            } else {
+                total_ok as f64
+            };
+
+            Ok(CallToolResult::text(format!(
+                "Bulk load complete: {} commands executed in {:.2}s ({:.0} cmd/s)",
+                total_ok,
+                elapsed.as_secs_f64(),
+                rate
+            )))
+        }
     }
 );
 

--- a/crates/redisctl-mcp/src/tools/redis/json.rs
+++ b/crates/redisctl-mcp/src/tools/redis/json.rs
@@ -15,7 +15,6 @@ mcp_module! {
     json_objlen => "redis_json_objlen",
     json_strlen => "redis_json_strlen",
     json_set => "redis_json_set",
-    json_mset => "redis_json_mset",
     json_numincrby => "redis_json_numincrby",
     json_arrappend => "redis_json_arrappend",
     json_arrinsert => "redis_json_arrinsert",
@@ -243,94 +242,6 @@ database_tool!(write, json_set, "redis_json_set",
                 "Not set (NX/XX condition not met)".to_string()
             )),
         }
-    }
-);
-
-/// A single document entry for json_mset.
-#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
-pub struct JsonDocument {
-    /// Key to set
-    pub key: String,
-    /// JSONPath expression (default: "$")
-    #[serde(default = "default_root_path")]
-    pub path: String,
-    /// JSON value to set (as a JSON string, e.g. "{\"name\":\"Alice\",\"age\":30}")
-    pub value: String,
-}
-
-database_tool!(write, json_mset, "redis_json_mset",
-    "Set multiple JSON documents in a single pipelined call. Each entry specifies a key, \
-     optional path (default \"$\"), and a JSON value string. Requires the RedisJSON module.\n\n\
-     Use this instead of calling redis_json_set repeatedly — a 100-document seed that would \
-     require 100 tool calls becomes one.\n\n\
-     Flags (applied to all documents):\n\
-     - nx: skip documents where the key/path already exists (JSON.SET NX)\n\
-     - xx: only update documents where the key/path already exists (JSON.SET XX)\n\
-     nx and xx are mutually exclusive.\n\n\
-     Returns a per-document result (OK or skipped) and a summary count. \
-     Not atomic — other clients may interleave between documents.",
-    {
-        /// Documents to set. Each requires key and value; path defaults to \"$\".
-        pub documents: Vec<JsonDocument>,
-        /// Only set documents where the key/path does not already exist
-        #[serde(default)]
-        pub nx: bool,
-        /// Only set documents where the key/path already exists
-        #[serde(default)]
-        pub xx: bool,
-    } => |conn, input| {
-        if input.documents.is_empty() {
-            return Ok(CallToolResult::text("No documents to set"));
-        }
-        if input.nx && input.xx {
-            return Err(tower_mcp::Error::tool(
-                "Cannot set both nx and xx: NX and XX are mutually exclusive",
-            ));
-        }
-
-        let mut pipe = redis::pipe();
-        for doc in &input.documents {
-            let mut cmd = redis::cmd("JSON.SET");
-            cmd.arg(&doc.key).arg(&doc.path).arg(&doc.value);
-            if input.nx {
-                cmd.arg("NX");
-            }
-            if input.xx {
-                cmd.arg("XX");
-            }
-            pipe.add_command(cmd);
-        }
-
-        let results: Vec<Option<String>> = pipe
-            .query_async(&mut conn)
-            .await
-            .tool_context("JSON.MSET pipeline failed")?;
-
-        let mut ok_count = 0usize;
-        let mut skipped_count = 0usize;
-        let mut lines = Vec::with_capacity(results.len());
-        for (doc, result) in input.documents.iter().zip(results.iter()) {
-            match result {
-                Some(_) => {
-                    ok_count += 1;
-                    lines.push(format!("OK       {}", doc.key));
-                }
-                None => {
-                    skipped_count += 1;
-                    lines.push(format!("skipped  {}", doc.key));
-                }
-            }
-        }
-
-        lines.push(String::new());
-        lines.push(format!(
-            "Summary: {} set, {} skipped (total {})",
-            ok_count,
-            skipped_count,
-            input.documents.len()
-        ));
-
-        Ok(CallToolResult::text(lines.join("\n")))
     }
 );
 


### PR DESCRIPTION
## Summary

Rather than adding a dedicated `json_mset` tool, this solves the root problems — discoverability and lack of per-result feedback — directly in `redis_bulk_load`:

- **Description update**: explicitly calls out JSON document seeding as a primary use case with a concrete example, including how to append `NX`/`XX` to args
- **`collect_results` flag** (default `false`): opt-in per-command result collection instead of fire-and-forget; returns index, command, key, and result for each command — useful for small batches where you need to verify NX/XX outcomes
- Reverts the `json_mset` additions from `json.rs`

## Why not a dedicated tool?

`redis_bulk_load` already handled batch JSON.SET — the gap was that agents didn't know to use it for that, and there was no way to see per-command results. Fixing those in the existing tool keeps the surface area smaller.

Closes #885