### PR TITLE
feat(mcp): add session-scoped command aliases

### DIFF
--- a/crates/redisctl-mcp/src/state.rs
+++ b/crates/redisctl-mcp/src/state.rs
@@ -1,6 +1,5 @@
 //! Application state and credential resolution
 
-#[cfg(any(feature = "cloud", feature = "enterprise", feature = "database"))]
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -55,6 +54,9 @@ pub struct AppState {
     /// Cached API clients (keyed by profile name, "_default" for default)
     #[allow(dead_code)]
     clients: RwLock<CachedClients>,
+    /// Session-scoped command aliases (name → list of command arg arrays)
+    #[cfg(feature = "database")]
+    aliases: RwLock<HashMap<String, Vec<Vec<String>>>>,
 }
 
 impl AppState {
@@ -90,6 +92,8 @@ impl AppState {
                 #[cfg(feature = "database")]
                 database: HashMap::new(),
             }),
+            #[cfg(feature = "database")]
+            aliases: RwLock::new(HashMap::new()),
         })
     }
 
@@ -406,6 +410,36 @@ impl AppState {
     pub fn is_destructive_allowed(&self) -> bool {
         matches!(self.policy.global_tier(), SafetyTier::Full)
     }
+
+    /// Store a named command alias (session-scoped, in-memory only).
+    #[cfg(feature = "database")]
+    pub async fn set_alias(&self, name: String, commands: Vec<Vec<String>>) {
+        let mut aliases = self.aliases.write().await;
+        aliases.insert(name, commands);
+    }
+
+    /// Retrieve a named command alias.
+    #[cfg(feature = "database")]
+    pub async fn get_alias(&self, name: &str) -> Option<Vec<Vec<String>>> {
+        let aliases = self.aliases.read().await;
+        aliases.get(name).cloned()
+    }
+
+    /// List all aliases with their command counts.
+    #[cfg(feature = "database")]
+    pub async fn list_aliases(&self) -> Vec<(String, usize)> {
+        let aliases = self.aliases.read().await;
+        let mut entries: Vec<_> = aliases.iter().map(|(k, v)| (k.clone(), v.len())).collect();
+        entries.sort_by(|a, b| a.0.cmp(&b.0));
+        entries
+    }
+
+    /// Delete a named alias. Returns true if it existed.
+    #[cfg(feature = "database")]
+    pub async fn delete_alias(&self, name: &str) -> bool {
+        let mut aliases = self.aliases.write().await;
+        aliases.remove(name).is_some()
+    }
 }
 
 impl Clone for AppState {
@@ -425,6 +459,8 @@ impl Clone for AppState {
                 #[cfg(feature = "database")]
                 database: HashMap::new(),
             }),
+            #[cfg(feature = "database")]
+            aliases: RwLock::new(HashMap::new()),
         }
     }
 }
@@ -459,6 +495,8 @@ impl AppState {
                 #[cfg(feature = "database")]
                 database: HashMap::new(),
             }),
+            #[cfg(feature = "database")]
+            aliases: RwLock::new(HashMap::new()),
         }
     }
 
@@ -480,6 +518,8 @@ impl AppState {
                 #[cfg(feature = "database")]
                 database: HashMap::new(),
             }),
+            #[cfg(feature = "database")]
+            aliases: RwLock::new(HashMap::new()),
         }
     }
 
@@ -502,6 +542,8 @@ impl AppState {
                 #[cfg(feature = "database")]
                 database: HashMap::new(),
             }),
+            #[cfg(feature = "database")]
+            aliases: RwLock::new(HashMap::new()),
         }
     }
 }

--- a/crates/redisctl-mcp/src/tools/macros.rs
+++ b/crates/redisctl-mcp/src/tools/macros.rs
@@ -96,6 +96,49 @@ macro_rules! database_tool {
         }
     };
 
+    // --- Stateful variant: exposes state as a user-provided identifier ---
+
+    (@impl_stateful $safety_method:ident, $guard:ident, $fn_name:ident, $tool_name:literal, $description:expr,
+     { $($(#[$field_meta:meta])* pub $field_name:ident : $field_type:ty),* $(,)? }
+     => |$state:ident, $conn:ident, $input:ident| $body:block
+    ) => {
+        pastey::paste! {
+            #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+            pub struct [<$fn_name:camel Input>] {
+                /// Optional Redis URL (overrides profile, uses configured URL if not provided)
+                #[serde(default)]
+                pub url: Option<String>,
+                /// Optional profile name to resolve connection from (uses default profile if not set)
+                #[serde(default)]
+                pub profile: Option<String>,
+                $(
+                    $(#[$field_meta])*
+                    pub $field_name: $field_type,
+                )*
+            }
+
+            pub fn $fn_name(state: std::sync::Arc<crate::state::AppState>) -> tower_mcp::Tool {
+                tower_mcp::ToolBuilder::new($tool_name)
+                    .description($description)
+                    .$safety_method()
+                    .extractor_handler(
+                        state,
+                        |tower_mcp::extract::State($state): tower_mcp::extract::State<std::sync::Arc<crate::state::AppState>>,
+                         tower_mcp::extract::Json(mut $input): tower_mcp::extract::Json<[<$fn_name:camel Input>]>| async move {
+                            database_tool!(@guard $guard $state);
+                            #[allow(unused_mut)]
+                            let mut $conn = super::get_connection(
+                                $input.url.take(), $input.profile.as_deref(), &$state
+                            ).await?;
+                            let $state = &$state;
+                            $body
+                        },
+                    )
+                    .build()
+            }
+        }
+    };
+
     // --- Public entry points ---
 
     (read_only, $($rest:tt)*) => {
@@ -106,6 +149,17 @@ macro_rules! database_tool {
     };
     (destructive, $($rest:tt)*) => {
         database_tool!(@impl destructive, destructive_guard, $($rest)*);
+    };
+
+    // Stateful variants — handler receives |state, conn, input| instead of |conn, input|
+    (read_only_stateful, $($rest:tt)*) => {
+        database_tool!(@impl_stateful read_only_safe, no_guard, $($rest)*);
+    };
+    (write_stateful, $($rest:tt)*) => {
+        database_tool!(@impl_stateful non_destructive, write_guard, $($rest)*);
+    };
+    (destructive_stateful, $($rest:tt)*) => {
+        database_tool!(@impl_stateful destructive, destructive_guard, $($rest)*);
     };
 }
 pub(crate) use database_tool;

--- a/crates/redisctl-mcp/src/tools/redis/aliases.rs
+++ b/crates/redisctl-mcp/src/tools/redis/aliases.rs
@@ -1,0 +1,133 @@
+//! Command alias tools — save and replay named Redis command sequences
+
+use tower_mcp::{CallToolResult, ResultExt};
+
+use crate::tools::macros::{database_tool, mcp_module};
+
+/// A command entry for defining an alias.
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct AliasCommand {
+    /// Redis command arguments (e.g. ["SET", "key", "value"] or ["JSON.SET", "doc:1", "$", "{}"])
+    pub args: Vec<String>,
+}
+
+mcp_module! {
+    alias_set => "redis_alias_set",
+    alias_run => "redis_alias_run",
+    alias_list => "redis_alias_list",
+    alias_delete => "redis_alias_delete"
+}
+
+database_tool!(write_stateful, alias_set, "redis_alias_set",
+    "Save a named command alias for this session. The alias stores a sequence of Redis commands \
+     that can be replayed with redis_alias_run.\n\n\
+     Use this to capture a repeatable workflow (e.g. seed + query, write + verify round-trip) \
+     and replay it without reconstructing the commands each time.\n\n\
+     Aliases are session-scoped (in-memory only) and are lost when the MCP server restarts.",
+    {
+        /// Alias name (e.g. "seed-users", "health-check")
+        pub name: String,
+        /// Commands to store. Each command is an args array (e.g. [\"SET\", \"k\", \"v\"]).
+        pub commands: Vec<AliasCommand>,
+    } => |state, _conn, input| {
+        if input.commands.is_empty() {
+            return Err(tower_mcp::Error::tool("commands must not be empty"));
+        }
+        for (i, cmd) in input.commands.iter().enumerate() {
+            if cmd.args.is_empty() {
+                return Err(tower_mcp::Error::tool(format!(
+                    "command at index {} has empty args", i
+                )));
+            }
+        }
+
+        let command_count = input.commands.len();
+        let commands: Vec<Vec<String>> = input.commands.into_iter().map(|c| c.args).collect();
+        state.set_alias(input.name.clone(), commands).await;
+
+        Ok(CallToolResult::text(format!(
+            "Alias '{}' saved with {} command(s)", input.name, command_count
+        )))
+    }
+);
+
+database_tool!(read_only_stateful, alias_run, "redis_alias_run",
+    "Run a previously saved command alias. Executes the stored commands in order via a \
+     Redis pipeline and returns per-command results.\n\n\
+     Use redis_alias_list to see available aliases.",
+    {
+        /// Alias name to run
+        pub name: String,
+    } => |state, conn, input| {
+        let commands = state.get_alias(&input.name).await
+            .ok_or_else(|| tower_mcp::Error::tool(format!(
+                "Alias '{}' not found. Use redis_alias_list to see available aliases.", input.name
+            )))?;
+
+        let mut pipe = redis::pipe();
+        for cmd_args in &commands {
+            let mut cmd = redis::cmd(&cmd_args[0]);
+            for arg in &cmd_args[1..] {
+                cmd.arg(arg);
+            }
+            pipe.add_command(cmd);
+        }
+
+        let results: Vec<redis::Value> = pipe
+            .query_async(&mut conn)
+            .await
+            .tool_context(format!("Alias '{}' pipeline failed", input.name))?;
+
+        let mut lines = Vec::with_capacity(results.len() + 2);
+        for (i, (cmd_args, result)) in commands.iter().zip(results.iter()).enumerate() {
+            let label = cmd_args.first().map(|s| s.as_str()).unwrap_or("?");
+            let key = cmd_args.get(1).map(|s| s.as_str()).unwrap_or("");
+            let result_str = super::format_value(result);
+            lines.push(format!("[{:>4}] {:<12} {}  →  {}", i, label, key, result_str));
+        }
+        lines.push(String::new());
+        lines.push(format!("Alias '{}': {} command(s) executed", input.name, results.len()));
+
+        Ok(CallToolResult::text(lines.join("\n")))
+    }
+);
+
+database_tool!(read_only_stateful, alias_list, "redis_alias_list",
+    "List all saved command aliases for this session.",
+    {
+    } => |state, _conn, _input| {
+        let entries = state.list_aliases().await;
+
+        if entries.is_empty() {
+            return Ok(CallToolResult::text(
+                "No aliases saved. Use redis_alias_set to create one."
+            ));
+        }
+
+        let lines: Vec<String> = entries.iter()
+            .map(|(name, count)| format!("  {:<24} {} command(s)", name, count))
+            .collect();
+
+        Ok(CallToolResult::text(format!(
+            "Aliases ({}):\n{}",
+            entries.len(),
+            lines.join("\n")
+        )))
+    }
+);
+
+database_tool!(write_stateful, alias_delete, "redis_alias_delete",
+    "Delete a saved command alias.",
+    {
+        /// Alias name to delete
+        pub name: String,
+    } => |state, _conn, input| {
+        if state.delete_alias(&input.name).await {
+            Ok(CallToolResult::text(format!("Deleted alias '{}'", input.name)))
+        } else {
+            Ok(CallToolResult::text(format!(
+                "Alias '{}' not found", input.name
+            )))
+        }
+    }
+);

--- a/crates/redisctl-mcp/src/tools/redis/mod.rs
+++ b/crates/redisctl-mcp/src/tools/redis/mod.rs
@@ -1,5 +1,6 @@
 //! Direct Redis database tools
 
+mod aliases;
 mod bulk;
 mod diagnostics;
 mod json;
@@ -9,6 +10,8 @@ mod search;
 mod server;
 mod structures;
 
+#[allow(unused_imports)]
+pub use aliases::*;
 #[allow(unused_imports)]
 pub use bulk::*;
 #[allow(unused_imports)]
@@ -67,6 +70,10 @@ pub const SUB_MODULES: &[SubModule] = &[
         name: "raw",
         tool_names: raw::TOOL_NAMES,
     },
+    SubModule {
+        name: "aliases",
+        tool_names: aliases::TOOL_NAMES,
+    },
 ];
 
 /// Get all Database tool names as owned strings.
@@ -96,6 +103,7 @@ pub fn sub_router(name: &str, state: Arc<AppState>) -> Option<McpRouter> {
         "search" => Some(search::router(state)),
         "bulk" => Some(bulk::router(state)),
         "raw" => Some(raw::router(state)),
+        "aliases" => Some(aliases::router(state)),
         _ => None,
     }
 }
@@ -178,5 +186,6 @@ pub fn router(state: Arc<AppState>) -> McpRouter {
         .merge(json::router(state.clone()))
         .merge(search::router(state.clone()))
         .merge(bulk::router(state.clone()))
-        .merge(raw::router(state))
+        .merge(raw::router(state.clone()))
+        .merge(aliases::router(state))
 }


### PR DESCRIPTION
## Summary

Adds four new tools for saving and replaying named Redis command sequences within an MCP session:

| Tool | Description |
|------|-------------|
| `redis_alias_set` | Save a named alias from an explicit command list |
| `redis_alias_run` | Replay a stored alias via pipeline, returns per-command results |
| `redis_alias_list` | List all session aliases with command counts |
| `redis_alias_delete` | Remove an alias |

Aliases are stored in-memory on `AppState` (session-scoped, lost on restart). This lets agents capture repeatable workflows (seed + query, write + verify round-trip) and replay them without reconstructing commands each time.

## Implementation

- Alias store: `RwLock<HashMap<String, Vec<Vec<String>>>>` on `AppState`, same pattern as `CachedClients`
- New `database_tool!` macro variants (`read_only_stateful`, `write_stateful`, `destructive_stateful`) that expose `AppState` to the handler body, working around macro hygiene limitations
- New `aliases` sub-module in the database toolset

## Use cases

- Prototype application read/write paths interactively
- Re-run a seeding sequence after `FLUSHDB` without rebuilding commands
- Encode a "health check" pattern (PING + FT.INFO + key count) as a replayable alias
- Demonstrate a workflow in a live session without writing scripts

Closes #887