### PR TITLE
chore: release v0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2907,7 +2907,7 @@ dependencies = [
 
 [[package]]
 name = "redisctl"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2957,7 +2957,7 @@ dependencies = [
 
 [[package]]
 name = "redisctl-core"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "clap",
  "directories",
@@ -2978,7 +2978,7 @@ dependencies = [
 
 [[package]]
 name = "redisctl-mcp"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ default-members = [
 version = "0.3.1"
 
 [workspace.package]
-version = "0.10.1"
+version = "0.11.0"
 edition = "2024"
 rust-version = "1.90"
 authors = ["Josh Rotenberg <josh.rotenberg@redis.com>"]

--- a/crates/redisctl-core/CHANGELOG.md
+++ b/crates/redisctl-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0](https://github.com/redis-developer/redisctl/compare/redisctl-core-v0.10.1...redisctl-core-v0.11.0) - 2026-03-20
+
+### Fixed
+
+- *(auth)* support Redis Cloud secret env var alias ([#913](https://github.com/redis-developer/redisctl/pull/913))
+
 ## [0.2.0](https://github.com/redis-developer/redisctl/compare/redisctl-core-v0.1.0...redisctl-core-v0.2.0) - 2026-02-28
 
 ### Added

--- a/crates/redisctl-mcp/CHANGELOG.md
+++ b/crates/redisctl-mcp/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0](https://github.com/redis-developer/redisctl/compare/redisctl-mcp-v0.10.1...redisctl-mcp-v0.11.0) - 2026-03-20
+
+### Added
+
+- *(mcp)* cluster-aware connections + client_name ([#906](https://github.com/redis-developer/redisctl/pull/906))
+
+### Fixed
+
+- *(auth)* support Redis Cloud secret env var alias ([#913](https://github.com/redis-developer/redisctl/pull/913))
+- *(mcp)* preserve raw tool denies in synthesized policy ([#912](https://github.com/redis-developer/redisctl/pull/912))
+
 ## [0.10.1](https://github.com/redis-developer/redisctl/compare/redisctl-mcp-v0.10.0...redisctl-mcp-v0.10.1) - 2026-03-19
 
 ### Other

--- a/crates/redisctl-mcp/Cargo.toml
+++ b/crates/redisctl-mcp/Cargo.toml
@@ -21,7 +21,7 @@ tower-mcp = { version = "0.8.2", features = ["http", "oauth", "dynamic-tools"] }
 schemars = "1.2"
 
 # Internal crates
-redisctl-core = { version = "0.10.1", path = "../redisctl-core" }
+redisctl-core = { version = "0.11.0", path = "../redisctl-core" }
 
 # External API clients (optional, gated by features)
 redis-cloud = { workspace = true, optional = true }

--- a/crates/redisctl/CHANGELOG.md
+++ b/crates/redisctl/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0](https://github.com/redis-developer/redisctl/compare/redisctl-v0.10.1...redisctl-v0.11.0) - 2026-03-20
+
+### Fixed
+
+- *(auth)* support Redis Cloud secret env var alias ([#913](https://github.com/redis-developer/redisctl/pull/913))
+
+### Other
+
+- *(readme)* fix MCP policy example ([#915](https://github.com/redis-developer/redisctl/pull/915))
+
 ## [0.10.1](https://github.com/redis-developer/redisctl/compare/redisctl-v0.10.0...redisctl-v0.10.1) - 2026-03-19
 
 ### Fixed

--- a/crates/redisctl/Cargo.toml
+++ b/crates/redisctl/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 
 
 [dependencies]
-redisctl-core = { version = "0.10.1", path = "../redisctl-core" }
+redisctl-core = { version = "0.11.0", path = "../redisctl-core" }
 redis-cloud = { workspace = true, features = ["tower-integration"] }
 redis-enterprise = { workspace = true, features = ["tower-integration"] }
 files-sdk = { workspace = true, optional = true }


### PR DESCRIPTION



## 🤖 New release

* `redisctl-core`: 0.10.1 -> 0.11.0 (✓ API compatible changes)
* `redisctl`: 0.10.1 -> 0.11.0 (✓ API compatible changes)
* `redisctl-mcp`: 0.10.1 -> 0.11.0 (⚠ API breaking changes)

### ⚠ `redisctl-mcp` breaking changes

```text
--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/method_parameter_count_changed.ron

Failed in:
  redisctl_mcp::state::AppState::new now takes 5 parameters instead of 3, in /tmp/.tmpOvWxgU/redisctl/crates/redisctl-mcp/src/state.rs:75
  redisctl_mcp::AppState::new now takes 5 parameters instead of 3, in /tmp/.tmpOvWxgU/redisctl/crates/redisctl-mcp/src/state.rs:75
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `redisctl-core`

<blockquote>

## [0.11.0](https://github.com/redis-developer/redisctl/compare/redisctl-core-v0.10.1...redisctl-core-v0.11.0) - 2026-03-20

### Fixed

- *(auth)* support Redis Cloud secret env var alias ([#913](https://github.com/redis-developer/redisctl/pull/913))
</blockquote>

## `redisctl`

<blockquote>

## [0.11.0](https://github.com/redis-developer/redisctl/compare/redisctl-v0.10.1...redisctl-v0.11.0) - 2026-03-20

### Fixed

- *(auth)* support Redis Cloud secret env var alias ([#913](https://github.com/redis-developer/redisctl/pull/913))

### Other

- *(readme)* fix MCP policy example ([#915](https://github.com/redis-developer/redisctl/pull/915))
</blockquote>

## `redisctl-mcp`

<blockquote>

## [0.11.0](https://github.com/redis-developer/redisctl/compare/redisctl-mcp-v0.10.1...redisctl-mcp-v0.11.0) - 2026-03-20

### Added

- *(mcp)* cluster-aware connections + client_name ([#906](https://github.com/redis-developer/redisctl/pull/906))

### Fixed

- *(auth)* support Redis Cloud secret env var alias ([#913](https://github.com/redis-developer/redisctl/pull/913))
- *(mcp)* preserve raw tool denies in synthesized policy ([#912](https://github.com/redis-developer/redisctl/pull/912))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).