### PR TITLE
fix(auth): support Redis Cloud secret env var alias

### DIFF
--- a/crates/redisctl-core/src/config/config.rs
+++ b/crates/redisctl-core/src/config/config.rs
@@ -181,7 +181,10 @@ impl Profile {
                         ConfigError::CredentialError(format!("Failed to resolve API key: {}", e))
                     })?;
                 let resolved_secret = store
-                    .get_credential(api_secret, Some("REDIS_CLOUD_API_SECRET"))
+                    .get_credential_with_env_vars(
+                        api_secret,
+                        vec!["REDIS_CLOUD_SECRET_KEY", "REDIS_CLOUD_API_SECRET"],
+                    )
                     .map_err(|e| {
                         ConfigError::CredentialError(format!("Failed to resolve API secret: {}", e))
                     })?;

--- a/crates/redisctl-core/src/config/credential.rs
+++ b/crates/redisctl-core/src/config/credential.rs
@@ -109,15 +109,21 @@ impl CredentialStore {
     /// Retrieve a credential value
     ///
     /// Resolution order:
-    /// 1. Check environment variable (if env_var provided)
+    /// 1. Check environment variables in order (if env vars provided)
     /// 2. If value starts with "keyring:", retrieve from keyring
     /// 3. Otherwise, return the value as-is (plaintext)
     pub fn get_credential(&self, value: &str, env_var: Option<&str>) -> Result<String> {
-        // First check environment variable if provided
-        if let Some(var) = env_var
-            && let Ok(env_value) = env::var(var)
-        {
-            return Ok(env_value);
+        self.get_credential_with_env_vars(value, env_var.into_iter().collect())
+    }
+
+    /// Retrieve a credential value with support for multiple environment variable aliases.
+    ///
+    /// Environment variables are checked in order, and the first set value wins.
+    pub fn get_credential_with_env_vars(&self, value: &str, env_vars: Vec<&str>) -> Result<String> {
+        for var in env_vars {
+            if let Ok(env_value) = env::var(var) {
+                return Ok(env_value);
+            }
         }
 
         // Check if this is a keyring reference
@@ -225,6 +231,48 @@ mod tests {
 
         unsafe {
             env::remove_var("TEST_CREDENTIAL");
+        }
+    }
+
+    #[test]
+    fn test_env_var_alias_override_uses_first_available() {
+        unsafe {
+            env::set_var("TEST_CREDENTIAL_ALIAS_2", "alias-value");
+        }
+
+        let store = CredentialStore::new();
+        let result = store
+            .get_credential_with_env_vars(
+                "config-value",
+                vec!["TEST_CREDENTIAL_ALIAS_1", "TEST_CREDENTIAL_ALIAS_2"],
+            )
+            .unwrap();
+        assert_eq!(result, "alias-value");
+
+        unsafe {
+            env::remove_var("TEST_CREDENTIAL_ALIAS_2");
+        }
+    }
+
+    #[test]
+    fn test_env_var_alias_override_prefers_first_set() {
+        unsafe {
+            env::set_var("TEST_CREDENTIAL_ALIAS_1", "preferred-value");
+            env::set_var("TEST_CREDENTIAL_ALIAS_2", "fallback-value");
+        }
+
+        let store = CredentialStore::new();
+        let result = store
+            .get_credential_with_env_vars(
+                "config-value",
+                vec!["TEST_CREDENTIAL_ALIAS_1", "TEST_CREDENTIAL_ALIAS_2"],
+            )
+            .unwrap();
+        assert_eq!(result, "preferred-value");
+
+        unsafe {
+            env::remove_var("TEST_CREDENTIAL_ALIAS_1");
+            env::remove_var("TEST_CREDENTIAL_ALIAS_2");
         }
     }
 

--- a/crates/redisctl-mcp/README.md
+++ b/crates/redisctl-mcp/README.md
@@ -128,7 +128,7 @@ default_enterprise_profile = "enterprise-dev"
 [profiles.cloud-prod]
 type = "cloud"
 api_key = "${REDIS_CLOUD_API_KEY}"
-api_secret = "${REDIS_CLOUD_API_SECRET}"
+api_secret = "${REDIS_CLOUD_SECRET_KEY}"
 
 [profiles.enterprise-dev]
 type = "enterprise"
@@ -145,7 +145,7 @@ For OAuth/HTTP mode or when not using profiles:
 ```bash
 # Redis Cloud
 export REDIS_CLOUD_API_KEY=your-key
-export REDIS_CLOUD_API_SECRET=your-secret
+export REDIS_CLOUD_SECRET_KEY=your-secret
 
 # Redis Enterprise
 export REDIS_ENTERPRISE_URL=https://cluster:9443

--- a/crates/redisctl-mcp/src/state.rs
+++ b/crates/redisctl-mcp/src/state.rs
@@ -15,6 +15,13 @@ use tokio::sync::RwLock;
 
 use crate::policy::{Policy, SafetyTier};
 
+#[cfg(feature = "cloud")]
+fn cloud_api_secret_from_env() -> Result<String> {
+    std::env::var("REDIS_CLOUD_SECRET_KEY")
+        .or_else(|_| std::env::var("REDIS_CLOUD_API_SECRET"))
+        .context("REDIS_CLOUD_SECRET_KEY or REDIS_CLOUD_API_SECRET not set")
+}
+
 /// How credentials are resolved
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
@@ -224,8 +231,7 @@ impl AppState {
                 // In OAuth mode, credentials come from environment variables
                 let api_key =
                     std::env::var("REDIS_CLOUD_API_KEY").context("REDIS_CLOUD_API_KEY not set")?;
-                let api_secret = std::env::var("REDIS_CLOUD_API_SECRET")
-                    .context("REDIS_CLOUD_API_SECRET not set")?;
+                let api_secret = cloud_api_secret_from_env()?;
 
                 CloudClient::builder()
                     .api_key(api_key)
@@ -596,6 +602,45 @@ impl AppState {
             }),
             #[cfg(feature = "database")]
             aliases: RwLock::new(HashMap::new()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "cloud")]
+    use super::cloud_api_secret_from_env;
+
+    #[cfg(feature = "cloud")]
+    #[test]
+    fn cloud_secret_env_prefers_canonical_name() {
+        unsafe {
+            std::env::set_var("REDIS_CLOUD_SECRET_KEY", "canonical-secret");
+            std::env::set_var("REDIS_CLOUD_API_SECRET", "alias-secret");
+        }
+
+        let result = cloud_api_secret_from_env().unwrap();
+        assert_eq!(result, "canonical-secret");
+
+        unsafe {
+            std::env::remove_var("REDIS_CLOUD_SECRET_KEY");
+            std::env::remove_var("REDIS_CLOUD_API_SECRET");
+        }
+    }
+
+    #[cfg(feature = "cloud")]
+    #[test]
+    fn cloud_secret_env_falls_back_to_alias() {
+        unsafe {
+            std::env::remove_var("REDIS_CLOUD_SECRET_KEY");
+            std::env::set_var("REDIS_CLOUD_API_SECRET", "alias-secret");
+        }
+
+        let result = cloud_api_secret_from_env().unwrap();
+        assert_eq!(result, "alias-secret");
+
+        unsafe {
+            std::env::remove_var("REDIS_CLOUD_API_SECRET");
         }
     }
 }

--- a/crates/redisctl/src/connection.rs
+++ b/crates/redisctl/src/connection.rs
@@ -146,7 +146,9 @@ impl ConnectionManager {
             None
         };
         let env_api_secret = if use_env_vars {
-            std::env::var("REDIS_CLOUD_SECRET_KEY").ok()
+            std::env::var("REDIS_CLOUD_SECRET_KEY")
+                .ok()
+                .or_else(|| std::env::var("REDIS_CLOUD_API_SECRET").ok())
         } else {
             None
         };
@@ -160,7 +162,9 @@ impl ConnectionManager {
             debug!("Found REDIS_CLOUD_API_KEY environment variable");
         }
         if env_api_secret.is_some() {
-            debug!("Found REDIS_CLOUD_SECRET_KEY environment variable");
+            debug!(
+                "Found Redis Cloud secret environment variable (REDIS_CLOUD_SECRET_KEY or REDIS_CLOUD_API_SECRET)"
+            );
         }
         if env_api_url.is_some() {
             debug!("Found REDIS_CLOUD_API_URL environment variable");

--- a/crates/redisctl/src/lib.rs
+++ b/crates/redisctl/src/lib.rs
@@ -24,7 +24,7 @@
 //! For Redis Cloud:
 //! ```bash
 //! export REDIS_CLOUD_API_KEY="your-api-key"
-//! export REDIS_CLOUD_API_SECRET="your-api-secret"
+//! export REDIS_CLOUD_SECRET_KEY="your-api-secret"
 //! ```
 //!
 //! For Redis Enterprise:

--- a/crates/redisctl/tests/cli_integration_mocked_tests.rs
+++ b/crates/redisctl/tests/cli_integration_mocked_tests.rs
@@ -1064,3 +1064,34 @@ async fn test_env_vars_work_without_config_file() {
         .success()
         .stdout(predicate::str::contains("env credentials used"));
 }
+
+#[tokio::test]
+async fn test_cloud_api_secret_alias_works_without_config_file() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/test"))
+        .and(header("x-api-key", "env-api-key"))
+        .and(header("x-api-secret-key", "env-api-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "message": "env alias credentials used"
+        })))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let mut cmd = Command::cargo_bin("redisctl").unwrap();
+
+    cmd.env("REDIS_CLOUD_API_KEY", "env-api-key");
+    cmd.env("REDIS_CLOUD_API_SECRET", "env-api-secret");
+    cmd.env_remove("REDIS_CLOUD_SECRET_KEY");
+    cmd.env("REDIS_CLOUD_API_URL", mock_server.uri());
+
+    cmd.arg("api")
+        .arg("cloud")
+        .arg("get")
+        .arg("/test")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("env alias credentials used"));
+}

--- a/docs/docs/developer/python.md
+++ b/docs/docs/developer/python.md
@@ -89,7 +89,7 @@ CloudClient(
 | Variable | Description |
 |----------|-------------|
 | `REDIS_CLOUD_API_KEY` | API key |
-| `REDIS_CLOUD_API_SECRET` | API secret |
+| `REDIS_CLOUD_SECRET_KEY` | API secret |
 | `REDIS_CLOUD_BASE_URL` | Base URL (optional) |
 
 ## EnterpriseClient API

--- a/docs/docs/reference/environment-variables.md
+++ b/docs/docs/reference/environment-variables.md
@@ -8,6 +8,8 @@ Complete reference of environment variables supported by redisctl.
 |----------|-------------|---------|
 | `REDIS_CLOUD_API_KEY` | API account key | `A3qcymrvqpn9rr...` |
 | `REDIS_CLOUD_SECRET_KEY` | API secret key | `S3s8ecrrnaguqk...` |
+
+`REDIS_CLOUD_API_SECRET` is still accepted as a compatibility alias, but `REDIS_CLOUD_SECRET_KEY` is the canonical name used by the CLI and docs.
 | `REDIS_CLOUD_API_URL` | API endpoint (optional) | `https://api.redislabs.com/v1` |
 
 ## Redis Enterprise


### PR DESCRIPTION
## Summary

- standardize on `REDIS_CLOUD_SECRET_KEY` as the canonical Redis Cloud secret env var
- keep `REDIS_CLOUD_API_SECRET` working as a compatibility alias in CLI, core config resolution, and MCP OAuth env handling
- add regression tests for alias lookup and update the docs that still presented the alias as primary

## Testing

- `cargo test -p redisctl-core`
- `cargo test -p redisctl-mcp`
- `cargo test -p redisctl`
- `cargo clippy --all-targets --all-features -- -D warnings`

Closes #908
