### PR TITLE
docs(readme): fix MCP policy example

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,13 @@ The `cloud`/`enterprise` prefix is optional -- the CLI infers the platform from 
 }
 ```
 
-**Read-only by default.** Write and destructive operations require explicit opt-in via a policy file (`redisctl-mcp.toml`):
+**Read-only by default.** Write and destructive operations require explicit opt-in via a policy file (`mcp-policy.toml`):
 
 ```toml
-tier = "standard"  # read-only (default) | standard (read-write) | full (destructive)
+tier = "read-write"  # read-only (default) | read-write | full
 ```
+
+See the [MCP configuration docs](https://redis-field-engineering.github.io/redisctl-docs/mcp/configuration/) for the full policy schema and precedence rules.
 
 ### Zero-Install with Docker
 


### PR DESCRIPTION
## Summary

- fix the README's MCP policy example so it matches the actual filename and accepted tier values
- replace the stale `redisctl-mcp.toml` / `standard` example with `mcp-policy.toml` / `read-write`
- link readers to the MCP configuration docs for the canonical policy reference

## Testing

- docs-only change; reviewed against `docs/docs/mcp/configuration.md`

Closes #909
