### PR TITLE
chore(deps): bump redis-enterprise + redis-cloud to refreshed main; adapt callers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,9 +236,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.4"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7b6141e96a8c160799cc2d5adecd5cbbe5054cb8c7c4af53da0f83bb7ad256"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -247,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.37.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c34dda4df7017c8db52132f0f8a2e0f8161649d15723ed63fc00c82d0f2081a"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -952,7 +952,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1099,7 +1099,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1576,7 +1576,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -1885,7 +1885,7 @@ dependencies = [
  "json-patch",
  "md-5",
  "nanoid",
- "rand 0.8.5",
+ "rand 0.8.6",
  "regex",
  "rphonetic",
  "rust-stemmers",
@@ -2198,7 +2198,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
 dependencies = [
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -2682,7 +2682,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -2699,7 +2699,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.3",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2720,9 +2720,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2742,9 +2742,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -2753,9 +2753,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -2839,7 +2839,7 @@ dependencies = [
  "num-bigint",
  "percent-encoding",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rustls",
  "rustls-native-certs 0.7.3",
  "rustls-pemfile",
@@ -2856,7 +2856,7 @@ dependencies = [
 [[package]]
 name = "redis-cloud"
 version = "0.9.5"
-source = "git+https://github.com/redis-developer/redis-cloud-rs?branch=main#989a32c1aac960945a4742e07da4dff07911d0ef"
+source = "git+https://github.com/redis-developer/redis-cloud-rs?branch=main#bbd0beb3f84ed0e71126c274fbdefb05899d1264"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2880,7 +2880,7 @@ dependencies = [
 [[package]]
 name = "redis-enterprise"
 version = "0.8.7"
-source = "git+https://github.com/redis-developer/redis-enterprise-rs?branch=main#c4c93428482759d0c3c4ae6ba47880c0e1178482"
+source = "git+https://github.com/redis-developer/redis-enterprise-rs?branch=main#2c7337462c9a236975800e274ff6f965d8ef8f09"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3262,7 +3262,7 @@ dependencies = [
  "errno 0.3.14",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3342,7 +3342,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3353,9 +3353,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.7"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10b3f4191e8a80e6b43eebabfac91e5dcecebb27a71f04e820c47ec41d314bf"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3866,9 +3866,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -3885,7 +3885,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4289,7 +4289,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24656d6d6429e311738f9f3f64269e7c0cadda32fb1dc0d18e1ad843740f77fd"
 dependencies = [
  "futures",
- "rand 0.9.2",
+ "rand 0.9.4",
  "thiserror 2.0.17",
  "tokio",
  "tower",
@@ -4394,7 +4394,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.4",
  "sha1",
  "thiserror 2.0.17",
  "utf-8",
@@ -4444,7 +4444,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
 dependencies = [
- "rand 0.9.2",
+ "rand 0.9.4",
  "web-time",
 ]
 
@@ -4807,7 +4807,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/crates/redisctl-core/src/enterprise/progress.rs
+++ b/crates/redisctl-core/src/enterprise/progress.rs
@@ -16,9 +16,17 @@ pub enum EnterpriseProgressEvent {
     Started { action_uid: String },
     /// Polling iteration with current status
     Polling {
+        /// Action UID being polled.
         action_uid: String,
+        /// Current status string (e.g. `"running"`, `"completed"`).
         status: String,
-        progress: Option<f32>,
+        /// Percent complete as reported by the API.
+        ///
+        /// Typed as `Option<String>` because the Redis Enterprise REST
+        /// API emits this as a string (e.g. `"100"`), not a float.
+        /// Callers that need a numeric value can `.parse::<f32>().ok()`.
+        progress: Option<String>,
+        /// Time since polling started.
         elapsed: Duration,
     },
     /// Action completed successfully
@@ -106,7 +114,7 @@ pub async fn poll_action(
             EnterpriseProgressEvent::Polling {
                 action_uid: action_uid.to_string(),
                 status: status.clone(),
-                progress: action.progress,
+                progress: action.progress.clone(),
                 elapsed,
             },
         );

--- a/crates/redisctl-mcp/src/tools/enterprise/rbac.rs
+++ b/crates/redisctl-mcp/src/tools/enterprise/rbac.rs
@@ -86,7 +86,10 @@ enterprise_tool!(write, create_enterprise_user, "create_enterprise_user",
         let request = CreateUserRequest {
             email: input.email,
             password: input.password,
-            role: input.role,
+            // `role` is now Option<String> in redis-enterprise so RBAC-only
+            // clusters can pass role_uids without a role. The MCP tool
+            // still treats role as required at the schema level.
+            role: Some(input.role),
             name: input.name,
             email_alerts: input.email_alerts,
             bdbs_email_alerts: None,

--- a/crates/redisctl-mcp/tests/enterprise_tools.rs
+++ b/crates/redisctl-mcp/tests/enterprise_tools.rs
@@ -521,8 +521,12 @@ async fn test_get_all_databases_stats() {
 async fn test_get_shard_stats() {
     let server = MockEnterpriseServer::start().await;
 
+    // The documented Enterprise REST API path is `/v1/shards/stats/{uid}`,
+    // not `/v1/shards/{uid}/stats`. The handler was corrected to match
+    // the spec in redis-enterprise-rs#71; this test mounts the correct
+    // path so the tool round-trips against a realistic mock.
     Mock::given(method("GET"))
-        .and(path("/v1/shards/1/stats"))
+        .and(path("/v1/shards/stats/1"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "intervals": [
                 {"time": "2024-01-15T10:30:00Z", "metrics": {"used_memory": 512000}}


### PR DESCRIPTION
## Summary

Picks up the 2026-05 refresh of both client crates that landed across ~25 PRs in `redis-enterprise-rs` and ~10 PRs in `redis-cloud-rs`. Both deps are pinned via `branch = "main"` so this is a `cargo update -p redis-enterprise -p redis-cloud` plus the small caller-side adaptations the breaking changes required.

## What landed upstream

### `redis-enterprise-rs`

- **All 10 Tier-1 issues (#58–#67) closed.** Surgical bug fixes (crdb `PATCH`, bdb flush path, nodes `execute_action` URL, ocsp `POST`), six wrapper-decode fixes (actions, crdb, bdb_groups, bootstrap, proxies, cluster_alerts), type corrections (Action `progress`/`node_uid` as `String`, Proxy `maxmemory_clients` widened to `u64`).
- cluster + nodes gained `check()` endpoints; users RBAC made `role` `Optional` so `role_uids` can be used alone.
- Stats / crdb_tasks correctness fixes — shard stats path corrected from `/v1/shards/{uid}/stats` to `/v1/shards/stats/{uid}`; `crdb_tasks` cancel now POSTs to `/actions/cancel`.
- Live-integration smoke tests added.
- Route-coverage test against `docs/api-inventory.csv`.
- Full rustdoc pass: **490 missing-docs errors → 0**, `#![deny(missing_docs)]` enforced.
- `aws-lc-sys` / `rustls-webpki` bumped past six RUSTSEC advisories.

### `redis-cloud-rs`

- All Tier-1 surgical bug fixes (FixedDatabaseHandler::list, GET /tasks decode, VPC peering wire keys, `activatedOn`, `credit_card_ends_with` String).
- ConnectivityHandler delegation methods documented.
- Rustdoc pass: **378 missing-docs errors → 0**, lint enforced.
- `aws-lc-sys` / `rustls-webpki` bumped.

## Caller adaptations

| File | Change |
|---|---|
| `crates/redisctl-core/src/enterprise/progress.rs` | `EnterpriseProgressEvent::Polling.progress` widens to `Option<String>` to match the enterprise crate's `Action.progress`. `.clone()` added on the assignment since `String` isn't `Copy`. |
| `crates/redisctl-mcp/src/tools/enterprise/rbac.rs` | `create_enterprise_user` wraps the tool's required `role` input in `Some(...)`. The MCP tool schema still treats role as required; RBAC-only via `role_uids` is a follow-up. |
| `crates/redisctl-mcp/tests/enterprise_tools.rs` | `test_get_shard_stats` mounts `/v1/shards/stats/{uid}` (spec-correct) instead of `/v1/shards/{uid}/stats`. |

## Drive-by clippy fixes

`crates/redisctl-mcp/src/tools/redis/diagnostics.rs` hit `clippy::unnecessary_sort_by` after the rust-clippy update; both call sites converted to `sort_by_key(|entry| std::cmp::Reverse(entry.1))`.

## Issues likely auto-resolved (needs live verification)

The upstream enterprise refresh fixed multiple decode/path bugs that match the symptoms reported in:

- #917 usage-report get fails to parse live response
- #919 endpoint availability fails against local demo cluster
- #920 services get/status fails for cm_server
- #921 diagnostics list-checks returns 404
- #916 enterprise database create --dry-run returns 404

Each needs a live re-run after this lands to confirm.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — ~1000+ tests pass, none failing
