### PR TITLE
chore: finish move to redis/ org

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: redis-developer/redisctl
+  IMAGE_NAME: redis/redisctl
 
 jobs:
   docker:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -104,8 +104,8 @@ jobs:
             --exclude-path node_modules
             --exclude-path .git
             --exclude-path docs/site
-            --exclude "https://github.com/redis-developer/redisctl/pull/.*"
-            --exclude "https://github.com/redis-developer/redisctl/issues/.*"
+            --exclude "https://github.com/redis/redisctl/pull/.*"
+            --exclude "https://github.com/redis/redisctl/issues/.*"
             .
         continue-on-error: true # Don't fail CI for broken external links
 
@@ -185,4 +185,4 @@ jobs:
           external_repository: redis-field-engineering/redisctl-docs
           publish_branch: gh-pages
           publish_dir: ./docs/site
-          commit_message: "docs: update from redis-developer/redisctl@${{ github.sha }}"
+          commit_message: "docs: update from redis/redisctl@${{ github.sha }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -331,7 +331,7 @@ jobs:
         env:
           COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
         run: |
-          git clone "https://x-access-token:${COMMITTER_TOKEN}@github.com/redis-developer/homebrew-tap.git" tap
+          git clone "https://x-access-token:${COMMITTER_TOKEN}@github.com/redis/homebrew-tap.git" tap
           cd tap
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Please be respectful and constructive in all interactions.
 
 ### Finding Good First Issues
 
-New to the project? Look for issues labeled [`good first issue`](https://github.com/redis-developer/redisctl/labels/good%20first%20issue).
+New to the project? Look for issues labeled [`good first issue`](https://github.com/redis/redisctl/labels/good%20first%20issue).
 
 These issues are:
 - Well-defined with clear acceptance criteria
@@ -180,8 +180,8 @@ We use a manual release workflow with semantic versioning:
 
 ## Getting Help
 
-- Open a [Discussion](https://github.com/redis-developer/redisctl/discussions) for questions
-- Check existing [Issues](https://github.com/redis-developer/redisctl/issues)
+- Open a [Discussion](https://github.com/redis/redisctl/discussions) for questions
+- Check existing [Issues](https://github.com/redis/redisctl/issues)
 - Review [Documentation](https://docs.rs/redisctl)
 
 ## Recognition

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ edition = "2024"
 rust-version = "1.90"
 authors = ["Josh Rotenberg <josh.rotenberg@redis.com>"]
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/redis-developer/redisctl"
-homepage = "https://github.com/redis-developer/redisctl"
+repository = "https://github.com/redis/redisctl"
+homepage = "https://github.com/redis/redisctl"
 documentation = "https://docs.rs/redisctl"
 
 # Config for 'dist'

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 **Manage Redis Cloud, Redis Enterprise, and Redis databases from one tool** -- as a CLI for humans or an MCP server for AI agents.
 
 [![Crates.io](https://img.shields.io/crates/v/redisctl.svg)](https://crates.io/crates/redisctl)
-[![CI](https://github.com/redis-developer/redisctl/actions/workflows/ci.yml/badge.svg)](https://github.com/redis-developer/redisctl/actions/workflows/ci.yml)
-[![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](https://github.com/redis-developer/redisctl#license)
+[![CI](https://github.com/redis/redisctl/actions/workflows/ci.yml/badge.svg)](https://github.com/redis/redisctl/actions/workflows/ci.yml)
+[![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](https://github.com/redis/redisctl#license)
 
 redisctl replaces curl-and-jq scripts against the Redis Cloud and Enterprise REST APIs with a single binary that handles authentication, async polling, output formatting, and error handling. The same tool ships as an MCP server so AI assistants can manage Redis infrastructure directly.
 
@@ -27,12 +27,12 @@ redisctl replaces curl-and-jq scripts against the Redis Cloud and Enterprise RES
 
 ```bash
 # Homebrew (macOS/Linux)
-brew install redis-developer/homebrew-tap/redisctl
+brew install redis/homebrew-tap/redisctl
 
 # Cargo
 cargo install redisctl
 
-# Binary releases: https://github.com/redis-developer/redisctl/releases
+# Binary releases: https://github.com/redis/redisctl/releases
 ```
 
 ### Configure a Profile
@@ -111,7 +111,7 @@ See the [MCP configuration docs](https://redis-field-engineering.github.io/redis
         "-e", "REDIS_ENTERPRISE_URL=https://cluster:9443",
         "-e", "REDIS_ENTERPRISE_USER=admin@redis.local",
         "-e", "REDIS_ENTERPRISE_PASSWORD",
-        "ghcr.io/redis-developer/redisctl",
+        "ghcr.io/redis/redisctl",
         "redisctl-mcp"
       ]
     }
@@ -175,7 +175,7 @@ API client libraries (separate repositories):
 ## Contributing
 
 ```bash
-git clone https://github.com/redis-developer/redisctl.git
+git clone https://github.com/redis/redisctl.git
 cd redisctl
 cargo build --release
 cargo test --workspace

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,7 +12,7 @@ The release process produces artifacts for multiple destinations:
 | `redisctl` crate | crates.io | `release-plz.yml` |
 | `redisctl-mcp` crate | crates.io | `release-plz.yml` |
 | CLI binaries | GitHub Releases | `release.yml` |
-| Homebrew formula | redis-developer/homebrew-tap | `release.yml` |
+| Homebrew formula | redis/homebrew-tap | `release.yml` |
 | Docker images | ghcr.io | `docker.yml` |
 
 **Note:** The `redis-cloud` and `redis-enterprise` crates are maintained in separate repositories:
@@ -106,7 +106,7 @@ git_tag_name = "redisctl-v{{ version }}"
    - `x86_64-pc-windows-msvc` (Windows)
 3. **Build global artifacts:** Creates installers, checksums
 4. **Host phase:** Uploads artifacts, creates GitHub Release
-5. **Update Homebrew:** Updates formula in `redis-developer/homebrew-tap`
+5. **Update Homebrew:** Updates formula in `redis/homebrew-tap`
 
 **Configuration:** `Cargo.toml` under `[workspace.metadata.dist]`
 
@@ -119,7 +119,7 @@ git_tag_name = "redisctl-v{{ version }}"
 **What it does:**
 1. Extracts version from tag
 2. Builds multi-arch images (linux/amd64, linux/arm64)
-3. Pushes to `ghcr.io/redis-developer/redisctl` with tags:
+3. Pushes to `ghcr.io/redis/redisctl` with tags:
    - `latest`
    - `{version}` (e.g., `0.7.6`)
    - `{major}.{minor}` (e.g., `0.7`)
@@ -167,7 +167,7 @@ release-plz.yml (creates tags)
 ### Homebrew update fails
 - **Symptom:** GitHub Release exists but formula not updated
 - **Check:** `update-homebrew` job in release.yml
-- **Recovery:** Manually update the formula in `redis-developer/homebrew-tap`
+- **Recovery:** Manually update the formula in `redis/homebrew-tap`
 - **Common causes:**
   - `COMMITTER_TOKEN` secret expired/invalid
   - Download URL incorrect
@@ -203,7 +203,7 @@ After a release, verify:
 
 - [ ] **Docker:** Images available
   ```bash
-  docker pull ghcr.io/redis-developer/redisctl:{version}
+  docker pull ghcr.io/redis/redisctl:{version}
   ```
 
 ## Manual Release Steps
@@ -239,8 +239,8 @@ gh release create redisctl-v{version} \
 ### Build and Push Docker
 ```bash
 docker buildx build --platform linux/amd64,linux/arm64 \
-  -t ghcr.io/redis-developer/redisctl:{version} \
-  -t ghcr.io/redis-developer/redisctl:latest \
+  -t ghcr.io/redis/redisctl:{version} \
+  -t ghcr.io/redis/redisctl:latest \
   --push .
 ```
 

--- a/crates/redisctl/src/lib.rs
+++ b/crates/redisctl/src/lib.rs
@@ -78,7 +78,7 @@
 //!
 //! ## Documentation
 //!
-//! For complete documentation and examples, see the [GitHub repository](https://github.com/redis-developer/redisctl).
+//! For complete documentation and examples, see the [GitHub repository](https://github.com/redis/redisctl).
 
 // Internal modules for CLI functionality
 pub(crate) mod cli;

--- a/docker/docker-compose.enterprise-demo.yml
+++ b/docker/docker-compose.enterprise-demo.yml
@@ -77,7 +77,7 @@ services:
   # This is a high-level workflow that replaces multiple manual API calls.
   # ==============================================================================
   redis-enterprise-init:
-    image: ghcr.io/redis-developer/redisctl:latest
+    image: ghcr.io/redis/redisctl:latest
     container_name: redis-enterprise-init
     depends_on:
       redis-enterprise:
@@ -115,7 +115,7 @@ services:
   # Create first test database - basic ephemeral cache
   # Configuration: 100MB, no persistence, LRU eviction policy
   redis-enterprise-create-db1:
-    image: ghcr.io/redis-developer/redisctl:latest
+    image: ghcr.io/redis/redisctl:latest
     container_name: redis-enterprise-create-db1
     depends_on:
       redis-enterprise-init:
@@ -136,7 +136,7 @@ services:
   # Create second test database - persistent with AOF
   # Configuration: 200MB, AOF persistence, appendfsync-every-sec
   redis-enterprise-create-db2:
-    image: ghcr.io/redis-developer/redisctl:latest
+    image: ghcr.io/redis/redisctl:latest
     container_name: redis-enterprise-create-db2
     depends_on:
       redis-enterprise-init:
@@ -166,7 +166,7 @@ services:
   # List all databases to verify creation
   # 👤 HUMAN-FRIENDLY COMMAND
   redis-enterprise-list-dbs:
-    image: ghcr.io/redis-developer/redisctl:latest
+    image: ghcr.io/redis/redisctl:latest
     container_name: redis-enterprise-list-dbs
     depends_on:
       redis-enterprise-create-db1:
@@ -187,7 +187,7 @@ services:
   # Get cache database details with JMESPath filtering
   # 👤 HUMAN-FRIENDLY COMMAND (with filtering)
   redis-enterprise-get-cache-db:
-    image: ghcr.io/redis-developer/redisctl:latest
+    image: ghcr.io/redis/redisctl:latest
     container_name: redis-enterprise-get-cache-db
     depends_on:
       redis-enterprise-create-db1:
@@ -210,7 +210,7 @@ services:
   # Get persistent database details
   # 👤 HUMAN-FRIENDLY COMMAND (with filtering)
   redis-enterprise-get-persistent-db:
-    image: ghcr.io/redis-developer/redisctl:latest
+    image: ghcr.io/redis/redisctl:latest
     container_name: redis-enterprise-get-persistent-db
     depends_on:
       redis-enterprise-create-db2:
@@ -242,7 +242,7 @@ services:
   # Output: Basic cluster details (filtered for key fields)
   # 👤 HUMAN-FRIENDLY COMMAND
   redis-enterprise-cluster-info:
-    image: ghcr.io/redis-developer/redisctl:latest
+    image: ghcr.io/redis/redisctl:latest
     container_name: redis-enterprise-cluster-info
     depends_on:
       redis-enterprise-list-dbs:
@@ -261,7 +261,7 @@ services:
   # List nodes in the cluster
   # 👤 HUMAN-FRIENDLY COMMAND
   redis-enterprise-list-nodes:
-    image: ghcr.io/redis-developer/redisctl:latest
+    image: ghcr.io/redis/redisctl:latest
     container_name: redis-enterprise-list-nodes
     depends_on:
       redis-enterprise-cluster-info:
@@ -280,7 +280,7 @@ services:
   # Check cluster stats
   # 👤 HUMAN-FRIENDLY COMMAND
   redis-enterprise-stats:
-    image: ghcr.io/redis-developer/redisctl:latest
+    image: ghcr.io/redis/redisctl:latest
     container_name: redis-enterprise-stats
     depends_on:
       redis-enterprise-list-nodes:
@@ -307,7 +307,7 @@ services:
   # Get license information
   # 👤 HUMAN-FRIENDLY COMMAND
   redis-enterprise-license:
-    image: ghcr.io/redis-developer/redisctl:latest
+    image: ghcr.io/redis/redisctl:latest
     container_name: redis-enterprise-license
     depends_on:
       redis-enterprise-stats:
@@ -329,7 +329,7 @@ services:
   # Get detailed node information
   # 👤 HUMAN-FRIENDLY COMMAND
   redis-enterprise-node-details:
-    image: ghcr.io/redis-developer/redisctl:latest
+    image: ghcr.io/redis/redisctl:latest
     container_name: redis-enterprise-node-details
     depends_on:
       redis-enterprise-license:
@@ -348,7 +348,7 @@ services:
   # List all users
   # 👤 HUMAN-FRIENDLY COMMAND
   redis-enterprise-users:
-    image: ghcr.io/redis-developer/redisctl:latest
+    image: ghcr.io/redis/redisctl:latest
     container_name: redis-enterprise-users
     depends_on:
       redis-enterprise-node-details:
@@ -367,7 +367,7 @@ services:
   # Get cluster policy
   # 🔧 RAW API COMMAND
   redis-enterprise-policy:
-    image: ghcr.io/redis-developer/redisctl:latest
+    image: ghcr.io/redis/redisctl:latest
     container_name: redis-enterprise-policy
     depends_on:
       redis-enterprise-users:
@@ -386,7 +386,7 @@ services:
   # Check for any cluster alerts
   # 🔧 RAW API COMMAND
   redis-enterprise-alerts:
-    image: ghcr.io/redis-developer/redisctl:latest
+    image: ghcr.io/redis/redisctl:latest
     container_name: redis-enterprise-alerts
     depends_on:
       redis-enterprise-policy:
@@ -405,7 +405,7 @@ services:
   # Get comprehensive cluster information
   # 👤 HUMAN-FRIENDLY COMMAND
   redis-enterprise-cluster-full:
-    image: ghcr.io/redis-developer/redisctl:latest
+    image: ghcr.io/redis/redisctl:latest
     container_name: redis-enterprise-cluster-full
     depends_on:
       redis-enterprise-alerts:

--- a/docker/docker-compose.mcp-demo.yml
+++ b/docker/docker-compose.mcp-demo.yml
@@ -63,7 +63,7 @@ services:
   # ==============================================================================
   # Creates the cluster, admin user, and default database.
   redis-enterprise-init:
-    image: ghcr.io/redis-developer/redisctl:latest
+    image: ghcr.io/redis/redisctl:latest
     container_name: mcp-demo-init
     depends_on:
       redis-enterprise:
@@ -116,7 +116,7 @@ services:
   # Connects to the Enterprise cluster API and directly to the default
   # database for Redis data operations.
   mcp-server:
-    image: ghcr.io/redis-developer/redisctl:latest
+    image: ghcr.io/redis/redisctl:latest
     container_name: mcp-demo-server
     depends_on:
       seed-data:

--- a/docker/docker-compose.multi-cluster.yml
+++ b/docker/docker-compose.multi-cluster.yml
@@ -39,7 +39,7 @@ x-redis-enterprise-base: &redis-enterprise-base
     - multi-cluster-network
 
 x-redisctl-base: &redisctl-base
-  image: ghcr.io/redis-developer/redisctl:latest
+  image: ghcr.io/redis/redisctl:latest
   networks:
     - multi-cluster-network
 

--- a/docs/docs/cookbook/cloud/first-database.md
+++ b/docs/docs/cookbook/cloud/first-database.md
@@ -6,7 +6,7 @@ Go from zero to a running Redis database in 5 minutes.
 
 - Redis Cloud account ([sign up free](https://redis.com/try-free/))
 - API keys from Redis Cloud console (Access Management > API Keys)
-- redisctl installed (`brew install redis-developer/homebrew-tap/redisctl`)
+- redisctl installed (`brew install redis/homebrew-tap/redisctl`)
 
 !!! tip "Prefix optional"
     The `cloud` prefix is optional when your profile config is unambiguous. The examples below use the full form for copy-paste convenience in scripts. See [Platform Inference](../../common/profiles.md#platform-inference).

--- a/docs/docs/developer/contributing.md
+++ b/docs/docs/developer/contributing.md
@@ -12,7 +12,7 @@ How to contribute to redisctl.
 ### Clone and Build
 
 ```bash
-git clone https://github.com/redis-developer/redisctl
+git clone https://github.com/redis/redisctl
 cd redisctl
 cargo build
 ```
@@ -152,5 +152,5 @@ async fn test_database_list() {
 
 ## Questions?
 
-- [GitHub Issues](https://github.com/redis-developer/redisctl/issues)
-- [GitHub Discussions](https://github.com/redis-developer/redisctl/discussions)
+- [GitHub Issues](https://github.com/redis/redisctl/issues)
+- [GitHub Discussions](https://github.com/redis/redisctl/discussions)

--- a/docs/docs/developer/index.md
+++ b/docs/docs/developer/index.md
@@ -81,6 +81,6 @@ We welcome contributions:
 
 ## Links
 
-- [GitHub Repository](https://github.com/redis-developer/redisctl)
-- [Issue Tracker](https://github.com/redis-developer/redisctl/issues)
-- [Releases](https://github.com/redis-developer/redisctl/releases)
+- [GitHub Repository](https://github.com/redis/redisctl)
+- [Issue Tracker](https://github.com/redis/redisctl/issues)
+- [Releases](https://github.com/redis/redisctl/releases)

--- a/docs/docs/developer/libraries.md
+++ b/docs/docs/developer/libraries.md
@@ -8,7 +8,7 @@ Use the Redis API client libraries in your own Rust or Python projects.
 |-------|-------------|---------|------------|
 | `redis-cloud` | Redis Cloud API client | [docs](https://docs.rs/redis-cloud) | [redis-cloud-rs](https://github.com/redis-developer/redis-cloud-rs) |
 | `redis-enterprise` | Redis Enterprise API client | [docs](https://docs.rs/redis-enterprise) | [redis-enterprise-rs](https://github.com/redis-developer/redis-enterprise-rs) |
-| `redisctl-core` | Profile and credential management | [docs](https://docs.rs/redisctl-core) | [redisctl](https://github.com/redis-developer/redisctl) |
+| `redisctl-core` | Profile and credential management | [docs](https://docs.rs/redisctl-core) | [redisctl](https://github.com/redis/redisctl) |
 
 **Note:** `redis-cloud` and `redis-enterprise` are maintained in separate repositories and also provide Python bindings via PyPI.
 
@@ -208,6 +208,6 @@ async fn collect_metrics(client: &RedisEnterpriseClient) -> anyhow::Result<()> {
 - [pypi.org/project/redis-enterprise](https://pypi.org/project/redis-enterprise/)
 
 **GitHub:**
-- [redis-developer/redisctl](https://github.com/redis-developer/redisctl)
+- [redis/redisctl](https://github.com/redis/redisctl)
 - [redis-developer/redis-cloud-rs](https://github.com/redis-developer/redis-cloud-rs)
 - [redis-developer/redis-enterprise-rs](https://github.com/redis-developer/redis-enterprise-rs)

--- a/docs/docs/getting-started/docker.md
+++ b/docs/docs/getting-started/docker.md
@@ -5,7 +5,7 @@ Run redisctl without installing anything.
 ## Quick Start
 
 ```bash
-docker run ghcr.io/redis-developer/redisctl --help
+docker run ghcr.io/redis/redisctl --help
 ```
 
 !!! note "Explicit prefixes in Docker"
@@ -19,7 +19,7 @@ docker run ghcr.io/redis-developer/redisctl --help
 docker run --rm \
   -e REDIS_CLOUD_API_KEY \
   -e REDIS_CLOUD_SECRET_KEY \
-  ghcr.io/redis-developer/redisctl cloud subscription list
+  ghcr.io/redis/redisctl cloud subscription list
 ```
 
 ### Mount Config File
@@ -29,7 +29,7 @@ If you have a local configuration:
 ```bash
 docker run --rm \
   -v ~/.config/redisctl:/root/.config/redisctl:ro \
-  ghcr.io/redis-developer/redisctl --profile prod cloud subscription list
+  ghcr.io/redis/redisctl --profile prod cloud subscription list
 ```
 
 ## Convenient Aliases
@@ -42,7 +42,7 @@ Add to your shell profile (`~/.bashrc`, `~/.zshrc`, etc.):
     alias redisctl-cloud='docker run --rm \
       -e REDIS_CLOUD_API_KEY \
       -e REDIS_CLOUD_SECRET_KEY \
-      ghcr.io/redis-developer/redisctl'
+      ghcr.io/redis/redisctl'
 
     # Usage
     redisctl-cloud cloud subscription list
@@ -56,7 +56,7 @@ Add to your shell profile (`~/.bashrc`, `~/.zshrc`, etc.):
       -e REDIS_ENTERPRISE_USER \
       -e REDIS_ENTERPRISE_PASSWORD \
       -e REDIS_ENTERPRISE_INSECURE \
-      ghcr.io/redis-developer/redisctl'
+      ghcr.io/redis/redisctl'
 
     # Usage
     redisctl-enterprise enterprise cluster get
@@ -67,7 +67,7 @@ Add to your shell profile (`~/.bashrc`, `~/.zshrc`, etc.):
     ``` bash
     alias redisctl='docker run --rm \
       -v ~/.config/redisctl:/root/.config/redisctl:ro \
-      ghcr.io/redis-developer/redisctl'
+      ghcr.io/redis/redisctl'
 
     # Usage
     redisctl --profile prod cloud database list
@@ -83,7 +83,7 @@ docker run --rm \
   -e REDIS_ENTERPRISE_USER \
   -e REDIS_ENTERPRISE_PASSWORD \
   -v $(pwd)/output:/output \
-  ghcr.io/redis-developer/redisctl \
+  ghcr.io/redis/redisctl \
   enterprise support-package cluster --output-dir /output
 ```
 
@@ -105,7 +105,7 @@ Pass credentials as environment variables. The password is pulled from your host
         "-e", "REDIS_ENTERPRISE_URL=https://cluster:9443",
         "-e", "REDIS_ENTERPRISE_USER=admin@redis.local",
         "-e", "REDIS_ENTERPRISE_PASSWORD",
-        "ghcr.io/redis-developer/redisctl",
+        "ghcr.io/redis/redisctl",
         "redisctl-mcp"
       ]
     }
@@ -125,7 +125,7 @@ Mount your existing redisctl config directory for profile-based auth:
       "args": [
         "run", "-i", "--rm",
         "-v", "~/.config/redisctl:/root/.config/redisctl:ro",
-        "ghcr.io/redis-developer/redisctl",
+        "ghcr.io/redis/redisctl",
         "redisctl-mcp", "--profile", "my-profile"
       ]
     }
@@ -149,7 +149,7 @@ For clusters running on localhost (e.g. Docker Compose demos), use `--network ho
         "-e", "REDIS_ENTERPRISE_USER=admin@redis.local",
         "-e", "REDIS_ENTERPRISE_PASSWORD",
         "-e", "REDIS_ENTERPRISE_INSECURE=true",
-        "ghcr.io/redis-developer/redisctl",
+        "ghcr.io/redis/redisctl",
         "redisctl-mcp"
       ]
     }
@@ -170,13 +170,13 @@ docker run -i --rm \
   -e REDIS_ENTERPRISE_URL \
   -e REDIS_ENTERPRISE_USER \
   -e REDIS_ENTERPRISE_PASSWORD \
-  ghcr.io/redis-developer/redisctl \
+  ghcr.io/redis/redisctl \
   redisctl-mcp
 
 # With mounted config
 docker run -i --rm \
   -v ~/.config/redisctl:/root/.config/redisctl:ro \
-  ghcr.io/redis-developer/redisctl \
+  ghcr.io/redis/redisctl \
   redisctl-mcp --profile my-profile
 ```
 
@@ -193,7 +193,7 @@ docker run -i --rm \
 
 ```bash
 # Pin to specific version
-docker run ghcr.io/redis-developer/redisctl:0.7.7 --version
+docker run ghcr.io/redis/redisctl:0.7.7 --version
 ```
 
 ## CI/CD Example
@@ -205,6 +205,6 @@ docker run ghcr.io/redis-developer/redisctl:0.7.7 --version
     docker run --rm \
       -e REDIS_CLOUD_API_KEY=${{ secrets.REDIS_CLOUD_API_KEY }} \
       -e REDIS_CLOUD_SECRET_KEY=${{ secrets.REDIS_CLOUD_SECRET_KEY }} \
-      ghcr.io/redis-developer/redisctl \
+      ghcr.io/redis/redisctl \
       cloud database list --subscription-id ${{ vars.SUBSCRIPTION_ID }} -o json
 ```

--- a/docs/docs/getting-started/index.md
+++ b/docs/docs/getting-started/index.md
@@ -13,7 +13,7 @@ Get up and running with redisctl in minutes.
     No installation required. Run commands immediately.
 
     ``` bash
-    docker run ghcr.io/redis-developer/redisctl --help
+    docker run ghcr.io/redis/redisctl --help
     ```
 
     [:octicons-arrow-right-24: Docker guide](docker.md)

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -7,7 +7,7 @@ Multiple ways to install redisctl depending on your platform and preferences.
 The easiest way to install on macOS or Linux:
 
 ```bash
-brew install redis-developer/homebrew-tap/redisctl
+brew install redis/homebrew-tap/redisctl
 ```
 
 To upgrade:
@@ -21,13 +21,13 @@ brew upgrade redisctl
 Run without installing anything:
 
 ```bash
-docker run ghcr.io/redis-developer/redisctl --help
+docker run ghcr.io/redis/redisctl --help
 ```
 
 For frequent use, create an alias:
 
 ```bash
-alias redisctl='docker run --rm -e REDIS_CLOUD_API_KEY -e REDIS_CLOUD_SECRET_KEY ghcr.io/redis-developer/redisctl'
+alias redisctl='docker run --rm -e REDIS_CLOUD_API_KEY -e REDIS_CLOUD_SECRET_KEY ghcr.io/redis/redisctl'
 ```
 
 See the [Docker guide](docker.md) for more details.
@@ -48,33 +48,33 @@ cargo install redisctl --features secure-storage
 
 ## Binary Downloads
 
-Download pre-built binaries from [GitHub Releases](https://github.com/redis-developer/redisctl/releases/latest).
+Download pre-built binaries from [GitHub Releases](https://github.com/redis/redisctl/releases/latest).
 
 === "Linux (x86_64)"
 
     ``` bash
-    curl -L https://github.com/redis-developer/redisctl/releases/latest/download/redisctl-x86_64-unknown-linux-gnu.tar.xz | tar xJ
+    curl -L https://github.com/redis/redisctl/releases/latest/download/redisctl-x86_64-unknown-linux-gnu.tar.xz | tar xJ
     sudo mv redisctl /usr/local/bin/
     ```
 
 === "Linux (ARM64)"
 
     ``` bash
-    curl -L https://github.com/redis-developer/redisctl/releases/latest/download/redisctl-aarch64-unknown-linux-gnu.tar.xz | tar xJ
+    curl -L https://github.com/redis/redisctl/releases/latest/download/redisctl-aarch64-unknown-linux-gnu.tar.xz | tar xJ
     sudo mv redisctl /usr/local/bin/
     ```
 
 === "macOS (Intel)"
 
     ``` bash
-    curl -L https://github.com/redis-developer/redisctl/releases/latest/download/redisctl-x86_64-apple-darwin.tar.xz | tar xJ
+    curl -L https://github.com/redis/redisctl/releases/latest/download/redisctl-x86_64-apple-darwin.tar.xz | tar xJ
     sudo mv redisctl /usr/local/bin/
     ```
 
 === "macOS (Apple Silicon)"
 
     ``` bash
-    curl -L https://github.com/redis-developer/redisctl/releases/latest/download/redisctl-aarch64-apple-darwin.tar.xz | tar xJ
+    curl -L https://github.com/redis/redisctl/releases/latest/download/redisctl-aarch64-apple-darwin.tar.xz | tar xJ
     sudo mv redisctl /usr/local/bin/
     ```
 

--- a/docs/docs/getting-started/quickstart.md
+++ b/docs/docs/getting-started/quickstart.md
@@ -15,7 +15,7 @@ export REDIS_CLOUD_SECRET_KEY="your-secret-key"
 docker run --rm \
   -e REDIS_CLOUD_API_KEY \
   -e REDIS_CLOUD_SECRET_KEY \
-  ghcr.io/redis-developer/redisctl cloud subscription list
+  ghcr.io/redis/redisctl cloud subscription list
 ```
 
 !!! tip "Getting API Keys"
@@ -36,7 +36,7 @@ docker run --rm \
   -e REDIS_ENTERPRISE_USER \
   -e REDIS_ENTERPRISE_PASSWORD \
   -e REDIS_ENTERPRISE_INSECURE \
-  ghcr.io/redis-developer/redisctl enterprise cluster get
+  ghcr.io/redis/redisctl enterprise cluster get
 ```
 
 That's it! You just ran your first redisctl command.

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -122,13 +122,13 @@ graph LR
 === "Homebrew"
 
     ``` bash
-    brew install redis-developer/homebrew-tap/redisctl
+    brew install redis/homebrew-tap/redisctl
     ```
 
 === "Docker"
 
     ``` bash
-    docker run ghcr.io/redis-developer/redisctl --help
+    docker run ghcr.io/redis/redisctl --help
     ```
 
 === "Cargo"
@@ -141,7 +141,7 @@ graph LR
 
     ``` bash
     # Download from GitHub Releases
-    curl -L https://github.com/redis-developer/redisctl/releases/latest/download/redisctl-x86_64-unknown-linux-gnu.tar.gz | tar xz
+    curl -L https://github.com/redis/redisctl/releases/latest/download/redisctl-x86_64-unknown-linux-gnu.tar.gz | tar xz
     ```
 
 [:octicons-arrow-right-24: Full installation guide](getting-started/installation.md)
@@ -173,7 +173,7 @@ graph LR
 
     MIT licensed. Contributions welcome.
 
-    [GitHub](https://github.com/redis-developer/redisctl)
+    [GitHub](https://github.com/redis/redisctl)
 
 -   :material-book:{ .lg } __API Docs__
 

--- a/docs/docs/mcp/getting-started.md
+++ b/docs/docs/mcp/getting-started.md
@@ -10,12 +10,12 @@ The MCP server is a separate binary called `redisctl-mcp`. Install it using one 
 
 ```bash
 # macOS / Linux
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/redis-developer/redisctl/releases/latest/download/redisctl-mcp-installer.sh | sh
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/redis/redisctl/releases/latest/download/redisctl-mcp-installer.sh | sh
 ```
 
 ```powershell
 # Windows
-powershell -ExecutionPolicy Bypass -c "irm https://github.com/redis-developer/redisctl/releases/latest/download/redisctl-mcp-installer.ps1 | iex"
+powershell -ExecutionPolicy Bypass -c "irm https://github.com/redis/redisctl/releases/latest/download/redisctl-mcp-installer.ps1 | iex"
 ```
 
 ### Cargo
@@ -26,7 +26,7 @@ cargo install redisctl-mcp
 
 ### Binary Downloads
 
-Download pre-built binaries from [GitHub Releases](https://github.com/redis-developer/redisctl/releases/latest).
+Download pre-built binaries from [GitHub Releases](https://github.com/redis/redisctl/releases/latest).
 
 ### Docker (Zero-Install)
 
@@ -42,7 +42,7 @@ No local install required. Pass credentials via environment variables and point 
         "-e", "REDIS_ENTERPRISE_URL=https://cluster:9443",
         "-e", "REDIS_ENTERPRISE_USER=admin@redis.local",
         "-e", "REDIS_ENTERPRISE_PASSWORD",
-        "ghcr.io/redis-developer/redisctl",
+        "ghcr.io/redis/redisctl",
         "redisctl-mcp"
       ]
     }

--- a/docs/docs/presentation/index.md
+++ b/docs/docs/presentation/index.md
@@ -55,7 +55,7 @@ Need a one-liner?
 
 ```bash
 # Show installation
-brew install redis-developer/homebrew-tap/redisctl
+brew install redis/homebrew-tap/redisctl
 
 # Configure profile
 redisctl profile set demo \

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,8 +1,8 @@
 site_name: redisctl
 site_description: The CLI and MCP Server for Redis
 site_url: https://redis-field-engineering.github.io/redisctl-docs
-repo_url: https://github.com/redis-developer/redisctl
-repo_name: redis-developer/redisctl
+repo_url: https://github.com/redis/redisctl
+repo_name: redis/redisctl
 edit_uri: edit/main/mkdocs-site/docs/
 
 theme:
@@ -92,9 +92,9 @@ markdown_extensions:
 extra:
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/redis-developer/redisctl
+      link: https://github.com/redis/redisctl
     - icon: fontawesome/brands/docker
-      link: https://github.com/redis-developer/redisctl/pkgs/container/redisctl
+      link: https://github.com/redis/redisctl/pkgs/container/redisctl
   generator: false
 
 extra_css:

--- a/skills/redisctl-setup/SKILL.md
+++ b/skills/redisctl-setup/SKILL.md
@@ -19,7 +19,7 @@ brew install redis-developer/tap/redisctl
 cargo install redisctl
 
 # Docker
-docker run --rm -it ghcr.io/redis-developer/redisctl --help
+docker run --rm -it ghcr.io/redis/redisctl --help
 ```
 
 ## Profile Setup


### PR DESCRIPTION
## Summary

The repo was transferred from `github.com/redis-developer/redisctl` to `github.com/redis/redisctl`, and the Homebrew tap was transferred from `redis-developer/homebrew-tap` to `redis/homebrew-tap`. GitHub's redirects still resolve the old URLs today, but the redirects are provisional and don't survive subsequent org renames or namespace collisions — so this PR finishes the move by rewriting every live reference.

**92 replacements across 24 files.**

## Critical fixes

### Homebrew formula was being pushed to the wrong (stale) tap

`.github/workflows/release.yml` `update-homebrew` job was cloning `redis-developer/homebrew-tap.git` to push formula updates. That repo has been stale since 2026-03-19 (the move), while `redis/homebrew-tap` has been the live tap since then. **Recent `redisctl-v*` releases were silently writing formulas to the wrong tap**, which is why `brew install redis-developer/homebrew-tap/redisctl` was handing out an old binary. Updated the workflow to clone `redis/homebrew-tap`.

`README.md` was also pointing users at the stale tap (`brew install redis-developer/homebrew-tap/redisctl`); now `redis/homebrew-tap/redisctl`.

### GHCR image namespace

`.github/workflows/docker.yml` `IMAGE_NAME` updated from `redis-developer/redisctl` to `redis/redisctl`. Future workflow runs publish to the new GHCR namespace. The package follows the repo transfer at GHCR, so existing `ghcr.io/redis-developer/redisctl:*` pulls still resolve via the same redirect that backs the GitHub repo URL.

`docker/docker-compose.*.yml` — **18 image references** across the three bundled compose stacks switched to `ghcr.io/redis/redisctl`.

## What else this touches

**Crate metadata**
- `Cargo.toml`: `repository` and `homepage` fields
- The three per-crate `Cargo.toml`s inherit from workspace, so no per-crate edits needed
- `crates/redisctl/src/lib.rs`: one rustdoc URL

**Documentation**
- `docs/mkdocs.yml`: `repo_url`, `repo_name`, social-link URLs
- `docs/docs/*.md`: 47 references across getting-started, MCP, developer, cookbook, and presentation sections (clone URLs, release download URLs, GHCR image references, link-checker excludes)
- `README.md`, `CONTRIBUTING.md`, `RELEASE.md`, `skills/redisctl-setup/SKILL.md`: all live URL references

## What this intentionally does NOT touch

Historical `crates/*/CHANGELOG.md` entries. Those are release-plz output; the old compare URLs still resolve via GitHub's redirect, and rewriting them would churn release history. The next release-plz run will use the new URL automatically via `Cargo.toml.repository`.

## Test plan

- [x] `cargo check --workspace` — clean
- [x] `cargo doc -p redisctl -p redisctl-core --no-deps` with `RUSTDOCFLAGS="-D warnings"` — clean for the two crates this PR touches. (`redisctl-mcp` has unrelated pre-existing rustdoc warnings already addressed in #924.)
- [x] Manual grep confirms zero live `redis-developer/redisctl` or `redis-developer/homebrew-tap` references outside historical CHANGELOGs.

## Verification after merge

The next `redisctl-v*` release will be the first one to write a formula to `redis/homebrew-tap`. Worth confirming:

- `update-homebrew` job in `release.yml` completes successfully
- The new formula appears at `redis/homebrew-tap`
- `brew tap redis/homebrew-tap && brew install redisctl` resolves to the new tag
