### PR TITLE
test(mcp): serialize cloud_secret_env tests to fix parallel race

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2991,6 +2991,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "serial_test",
  "thiserror 2.0.17",
  "tokio",
  "toml",

--- a/crates/redisctl-mcp/Cargo.toml
+++ b/crates/redisctl-mcp/Cargo.toml
@@ -70,4 +70,5 @@ wiremock = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }
 redis = { workspace = true }
+serial_test = { workspace = true }
 docker-wrapper = { git = "https://github.com/joshrotenberg/docker-wrapper", features = ["testing", "template-redis"] }

--- a/crates/redisctl-mcp/src/state.rs
+++ b/crates/redisctl-mcp/src/state.rs
@@ -613,6 +613,7 @@ mod tests {
 
     #[cfg(feature = "cloud")]
     #[test]
+    #[serial_test::serial(cloud_secret_env)]
     fn cloud_secret_env_prefers_canonical_name() {
         unsafe {
             std::env::set_var("REDIS_CLOUD_SECRET_KEY", "canonical-secret");
@@ -630,6 +631,7 @@ mod tests {
 
     #[cfg(feature = "cloud")]
     #[test]
+    #[serial_test::serial(cloud_secret_env)]
     fn cloud_secret_env_falls_back_to_alias() {
         unsafe {
             std::env::remove_var("REDIS_CLOUD_SECRET_KEY");


### PR DESCRIPTION
## Summary

Both `state::tests::cloud_secret_env_prefers_canonical_name` and `state::tests::cloud_secret_env_falls_back_to_alias` (added in [#913](https://github.com/redis/redisctl/pull/913)) mutate the same process-wide env vars — `REDIS_CLOUD_SECRET_KEY` and `REDIS_CLOUD_API_SECRET`. `cargo test` runs in parallel by default, so when one test sets `REDIS_CLOUD_SECRET_KEY=canonical-secret` and the other expects that key to be unset, whichever wins the race gets the wrong env state and fails.

This surfaced on [#924](https://github.com/redis/redisctl/pull/924)'s CI as:

```
state::tests::cloud_secret_env_falls_back_to_alias
  left:  "canonical-secret"
  right: "alias-secret"
```

Reproduced locally on `main` — the failing test alternates between the two depending on scheduling. With this fix, five consecutive parallel runs all pass.

## Fix

Annotate both tests with `#[serial_test::serial(cloud_secret_env)]` to put them in the same named serialization group. `serial_test` is already a workspace dev-dep used by `redisctl-core/src/config/config.rs` for exactly the same reason (env var mutation in tests). This PR just adds it to `redisctl-mcp`'s dev-deps and applies the standard pattern.

The named group means we only serialize these two against each other, not against unrelated tests — so we don't lose parallelism overall.

## Why this matters now

It's the only real failure blocking PR #924 (deps bump). Once this lands and #924 rebases, both #924 and #925 (org-move) go green.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p redisctl-mcp --features cloud --lib state::tests::cloud_secret` — 5 consecutive parallel runs, all green
- [x] Reproduced the failure on `main` prior to the fix; both branches of the race observed (`prefers_canonical_name` failing one run, `falls_back_to_alias` failing the next).
