### PR TITLE
fix(mcp): use sort_by_key for descending sorts in diagnostics

### DIFF
--- a/crates/redisctl-mcp/src/tools/redis/diagnostics.rs
+++ b/crates/redisctl-mcp/src/tools/redis/diagnostics.rs
@@ -338,7 +338,7 @@ database_tool!(read_only, hotkeys, "redis_hotkeys",
         }
 
         // Sort by memory descending and take top N
-        key_sizes.sort_by(|a, b| b.1.cmp(&a.1));
+        key_sizes.sort_by_key(|entry| std::cmp::Reverse(entry.1));
         key_sizes.truncate(TOP_N);
 
         // Build output
@@ -414,7 +414,7 @@ database_tool!(read_only, connection_summary, "redis_connection_summary",
             }
         }
         let mut ip_list: Vec<_> = ip_counts.into_iter().collect();
-        ip_list.sort_by(|a, b| b.1.cmp(&a.1));
+        ip_list.sort_by_key(|entry| std::cmp::Reverse(entry.1));
         ip_list.truncate(10);
 
         // Idle connections (idle > 60s)


### PR DESCRIPTION
## Summary

Two descending-sort sites in `crates/redisctl-mcp/src/tools/redis/diagnostics.rs` trip `clippy::unnecessary_sort_by` under the current rust-clippy:

| Line | Before | After |
|---|---|---|
| 341 | `key_sizes.sort_by(\|a, b\| b.1.cmp(&a.1))` | `key_sizes.sort_by_key(\|entry\| std::cmp::Reverse(entry.1))` |
| 417 | `ip_list.sort_by(\|a, b\| b.1.cmp(&a.1))` | `ip_list.sort_by_key(\|entry\| std::cmp::Reverse(entry.1))` |

Equivalent behaviour (descending sort on `.1`), expressed in the form clippy now prefers.

This is the single clippy warning blocking the **Quick Checks** job on PRs [#924](https://github.com/redis/redisctl/pull/924) (deps bump) and [#925](https://github.com/redis/redisctl/pull/925) (org move). When Quick Checks fails, Build / Unit Tests / Integration Tests / Code Coverage all get gated to `skipping`, which makes both PRs look much more broken than they are.

Pairs with #926 (test race fix) — together they clear the cascading CI failures on main and unblock #924 / #925.

## Test plan

- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo check --workspace` — clean