### PR TITLE
test(core): serialize credential alias env-var tests to fix parallel race

### DIFF
--- a/crates/redisctl-core/src/config/credential.rs
+++ b/crates/redisctl-core/src/config/credential.rs
@@ -235,6 +235,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(credential_alias_env)]
     fn test_env_var_alias_override_uses_first_available() {
         unsafe {
             env::set_var("TEST_CREDENTIAL_ALIAS_2", "alias-value");
@@ -255,6 +256,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(credential_alias_env)]
     fn test_env_var_alias_override_prefers_first_set() {
         unsafe {
             env::set_var("TEST_CREDENTIAL_ALIAS_1", "preferred-value");


### PR DESCRIPTION
## Summary

Same race-condition pattern as [#926](https://github.com/redis/redisctl/pull/926), this time in `redisctl-core/src/config/credential.rs`. Two tests share `TEST_CREDENTIAL_ALIAS_1` and `TEST_CREDENTIAL_ALIAS_2`:

- `test_env_var_alias_override_uses_first_available` — sets only `_ALIAS_2`, expects result `"alias-value"`
- `test_env_var_alias_override_prefers_first_set` — sets `_ALIAS_1="preferred-value"` and `_ALIAS_2="fallback-value"`, expects result `"preferred-value"`

When they run in parallel, whichever test loses the race ends up reading a state set by the other and fails.

## Reproduction

```
for i in 1 2 3 4 5; do
  cargo test -p redisctl-core --lib config::credential::tests
done
```

Failed 1 of 5 runs on `main` prior to the fix. Surfaced on [#924](https://github.com/redis/redisctl/pull/924)'s CI after the `rand`/`tar` Cargo.lock churn changed test scheduling enough to make the race fire more reliably.

## Fix

Annotate both tests with `#[serial_test::serial(credential_alias_env)]` to put them in the same named serialization group. Mirrors the #926 pattern. `serial_test` is already a redisctl-core dev-dep — `config/config.rs` uses it for the same reason.

The third env-var test in this module (`test_env_var_override`) uses `TEST_CREDENTIAL`, doesn't share state with the alias tests, and stays parallelizable.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p redisctl-core --lib config::credential::tests` — 5 consecutive parallel runs, all green
- [x] Reproduced the failure on `main` before the fix