### PR TITLE
fix(cloud): surface object-shaped task errors on --wait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2856,7 +2856,7 @@ dependencies = [
 [[package]]
 name = "redis-cloud"
 version = "0.9.5"
-source = "git+https://github.com/redis-developer/redis-cloud-rs?branch=main#bbd0beb3f84ed0e71126c274fbdefb05899d1264"
+source = "git+https://github.com/redis-developer/redis-cloud-rs?branch=fix%2Ftask-error-object-deserialization#6d9af5b6be4bfa749b8b88818f5af5263552c1c3"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,8 @@ pretty_assertions = "1.4"
 redis = { version = "0.27", features = ["tokio-comp", "tokio-rustls-comp", "connection-manager", "cluster-async"] }
 
 # External crates (git for dev, version required for crates.io publish)
-redis-cloud = { version = "0.9.5", git = "https://github.com/redis-developer/redis-cloud-rs", branch = "main" }
+# TODO: revert to branch = "main" once redis-developer/redis-cloud-rs#103 merges.
+redis-cloud = { version = "0.9.5", git = "https://github.com/redis-developer/redis-cloud-rs", branch = "fix/task-error-object-deserialization" }
 redis-enterprise = { version = "0.8.5", git = "https://github.com/redis-developer/redis-enterprise-rs", branch = "main" }
 
 # Windows CI workaround - ensure these are available in workspace

--- a/crates/redisctl-core/src/progress.rs
+++ b/crates/redisctl-core/src/progress.rs
@@ -132,7 +132,7 @@ pub async fn poll_task(
                 let error = task
                     .response
                     .as_ref()
-                    .and_then(|r| r.error.clone())
+                    .and_then(|r| r.error_message())
                     .unwrap_or_else(|| format!("Task failed with status: {}", status));
 
                 emit(
@@ -167,5 +167,64 @@ pub async fn poll_task(
 fn emit(callback: &Option<ProgressCallback>, event: ProgressEvent) {
     if let Some(cb) = callback {
         cb(event);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn test_client(uri: String) -> CloudClient {
+        CloudClient::builder()
+            .api_key("test-key".to_string())
+            .api_secret("test-secret".to_string())
+            .base_url(uri)
+            .build()
+            .unwrap()
+    }
+
+    // Regression: a failed task whose `response.error` is a structured object
+    // (e.g. a failed database backup) must surface the human-readable
+    // description, not fail to deserialize. See redis-cloud-rs
+    // ProcessorResponse::error_message.
+    #[tokio::test]
+    async fn poll_task_surfaces_object_error_description() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/tasks/task-backup"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "taskId": "task-backup",
+                "commandType": "DATABASE_BACKUP",
+                "status": "processing-error",
+                "response": {
+                    "error": {
+                        "type": "BACKUP_FAILED",
+                        "status": "400 BAD_REQUEST",
+                        "description": "Remote backup location is not configured"
+                    }
+                }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = test_client(mock_server.uri());
+        let result = poll_task(
+            &client,
+            "task-backup",
+            Duration::from_secs(5),
+            Duration::from_millis(10),
+            None,
+        )
+        .await;
+
+        match result {
+            Err(CoreError::TaskFailed(msg)) => {
+                assert_eq!(msg, "Remote backup location is not configured");
+            }
+            other => panic!("expected TaskFailed with description, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
## Problem

`redisctl cloud database backup <id> --wait` (and any `--wait` on a Cloud task that fails this way) errored with:

```
ERROR redisctl: API error: Cloud API error: Connection error: Failed to deserialize field 'response.error': invalid type: map, expected a string
```

The label "Connection error" is misleading — it was actually a **deserialization failure while polling the task**. On some failures the Cloud API returns `response.error` as a structured object (`{type, status, description}`), but `redis-cloud-rs` typed it as `Option<String>`, so polling blew up before the real error could be shown.

## Fix

- Bump `redis-cloud` to the branch from redis-developer/redis-cloud-rs#103, where `ProcessorResponse.error` is `Option<Value>` and a new `error_message()` helper extracts a readable string from either the string or object shape.
- `redisctl-core/progress.rs`: use `error_message()` in `poll_task` so the actual failure (e.g. *"Remote backup location is not configured"*) is reported via `ProgressEvent::Failed` / `CoreError::TaskFailed`.
- Add a `poll_task` regression test with a mocked failed-backup task carrying an object error.

`cargo fmt`, `cargo clippy --workspace --all-targets -D warnings`, and `cargo test --workspace` all pass.

## ⚠️ Merge order

Depends on redis-developer/redis-cloud-rs#103. The `Cargo.toml` dep is temporarily pinned to that fix branch (`branch = "fix/task-error-object-deserialization"`). **Once #103 merges, revert the pin back to `branch = "main"`** (TODO noted inline) and re-run `cargo update -p redis-cloud`.