### PR TITLE
fix(enterprise): use ?dry_run query param for database create --dry-run

### DIFF
--- a/crates/redisctl/src/commands/enterprise/database_impl.rs
+++ b/crates/redisctl/src/commands/enterprise/database_impl.rs
@@ -470,7 +470,7 @@ pub async fn create_database(
     }
 
     let path = if dry_run {
-        "/v1/bdbs/dry-run"
+        "/v1/bdbs?dry_run"
     } else {
         "/v1/bdbs"
     };

--- a/crates/redisctl/tests/cli_integration_mocked_tests.rs
+++ b/crates/redisctl/tests/cli_integration_mocked_tests.rs
@@ -2,7 +2,7 @@ use assert_cmd::Command;
 use predicates::prelude::*;
 use serde_json::json;
 use tempfile::TempDir;
-use wiremock::matchers::{header, method, path};
+use wiremock::matchers::{header, method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 /// Helper to create a test command with isolated config
@@ -1094,4 +1094,49 @@ async fn test_cloud_api_secret_alias_works_without_config_file() {
         .assert()
         .success()
         .stdout(predicate::str::contains("env alias credentials used"));
+}
+
+/// Regression test for #916: `enterprise database create --dry-run` must POST to
+/// `/v1/bdbs?dry_run` (query-string flag), NOT `/v1/bdbs/dry-run` (non-existent path).
+#[tokio::test]
+async fn test_enterprise_database_create_dry_run_uses_query_param() {
+    let temp_dir = TempDir::new().unwrap();
+    let mock_server = MockServer::start().await;
+
+    create_enterprise_profile(&temp_dir, &mock_server.uri()).unwrap();
+
+    // The validated BDB object the real API returns on dry-run success.
+    let bdb_response = json!({
+        "uid": 0,
+        "name": "dryrun-db",
+        "type": "redis",
+        "memory_size": 1073741824,
+        "status": "active"
+    });
+
+    // Assert that the request goes to /v1/bdbs with ?dry_run — NOT /v1/bdbs/dry-run.
+    Mock::given(method("POST"))
+        .and(path("/v1/bdbs"))
+        .and(query_param("dry_run", ""))
+        .respond_with(ResponseTemplate::new(200).set_body_json(bdb_response))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    test_cmd(&temp_dir)
+        .args([
+            "enterprise",
+            "database",
+            "create",
+            "--data",
+            r#"{"name":"dryrun-db","type":"redis","memory_size":1073741824}"#,
+            "--dry-run",
+            "-o",
+            "json",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("dryrun-db"));
+
+    // MockServer verifies the `.expect(1)` constraint on drop.
 }


### PR DESCRIPTION
## Summary

- **Root cause**: `enterprise database create --dry-run` was POSTing to `/v1/bdbs/dry-run`, a path that does not exist on the Redis Enterprise REST API, returning HTTP 404.
- **Fix**: Changed the dry-run branch to use `/v1/bdbs?dry_run` (query-string flag on the normal create endpoint). Verified against the API spec: `POST /v1/bdbs?dry_run` returns HTTP 200 with the validated BDB object and creates nothing.
- **Test**: Added `test_enterprise_database_create_dry_run_uses_query_param` in `cli_integration_mocked_tests.rs` using wiremock to assert the request hits `POST /v1/bdbs` with `query_param("dry_run", "")`, not the old `/v1/bdbs/dry-run` path.

## Live verification

Against a real Enterprise cluster (`https://localhost:9443`):

```
$ cargo run -p redisctl -- enterprise database create --data @/tmp/db916.json --dry-run -o json
{
  "name": "dryrun-db-916",
  "type": "redis",
  "uid": 3,
  "status": "pending",
  "version": "8.4.0",
  ...  (full BDB validation object, HTTP 200)
}
```

Followed by:
```
$ cargo run -p redisctl -- enterprise database list -q "[].name"
[
  "default-db",
  "repro-db"
]
```

No `dryrun-db-916` in the list — confirmed nothing was created.

## Test plan

- [x] `cargo fmt --all` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `test_enterprise_database_create_dry_run_uses_query_param` passes (wiremock asserts correct endpoint)
- [x] Live cluster verification: HTTP 200 BDB validation object returned, no database created

Closes #916