### PR TITLE
fix(enterprise): resolve services get/status from /v1/local/services

### DIFF
--- a/crates/redisctl/src/commands/enterprise/services.rs
+++ b/crates/redisctl/src/commands/enterprise/services.rs
@@ -147,16 +147,32 @@ async fn handle_services_get(
 ) -> Result<(), RedisCtlError> {
     let client = conn_mgr.create_enterprise_client(profile_name).await?;
 
-    let endpoint = format!("/v1/services/{}", service);
     let response = client
-        .get::<Value>(&endpoint)
+        .get::<Value>("/v1/local/services")
         .await
-        .context(format!("Failed to get service {}", service))?;
+        .map_err(RedisCtlError::from)?;
+
+    let services_map = response
+        .as_object()
+        .ok_or_else(|| RedisCtlError::ApiError {
+            message: "Unexpected response format from /v1/local/services".to_string(),
+        })?;
+
+    let entry = services_map.get(service).ok_or_else(|| {
+        let available: Vec<&str> = services_map.keys().map(String::as_str).collect();
+        RedisCtlError::InvalidInput {
+            message: format!(
+                "Service '{}' not found. Available services: {}",
+                service,
+                available.join(", ")
+            ),
+        }
+    })?;
 
     let result = if let Some(q) = query {
-        utils::apply_jmespath(&response, q)?
+        utils::apply_jmespath(entry, q)?
     } else {
-        response
+        entry.clone()
     };
 
     utils::print_formatted_output(result, output_format)
@@ -240,16 +256,32 @@ async fn handle_services_status(
 ) -> Result<(), RedisCtlError> {
     let client = conn_mgr.create_enterprise_client(profile_name).await?;
 
-    let endpoint = format!("/v1/services/{}/status", service);
     let response = client
-        .get::<Value>(&endpoint)
+        .get::<Value>("/v1/local/services")
         .await
-        .context(format!("Failed to get status for service {}", service))?;
+        .map_err(RedisCtlError::from)?;
+
+    let services_map = response
+        .as_object()
+        .ok_or_else(|| RedisCtlError::ApiError {
+            message: "Unexpected response format from /v1/local/services".to_string(),
+        })?;
+
+    let entry = services_map.get(service).ok_or_else(|| {
+        let available: Vec<&str> = services_map.keys().map(String::as_str).collect();
+        RedisCtlError::InvalidInput {
+            message: format!(
+                "Service '{}' not found. Available services: {}",
+                service,
+                available.join(", ")
+            ),
+        }
+    })?;
 
     let result = if let Some(q) = query {
-        utils::apply_jmespath(&response, q)?
+        utils::apply_jmespath(entry, q)?
     } else {
-        response
+        entry.clone()
     };
 
     utils::print_formatted_output(result, output_format)
@@ -326,5 +358,98 @@ mod tests {
         }
 
         TestCli::command().debug_assert();
+    }
+
+    /// Helper that mimics the extraction logic shared by handle_services_get and
+    /// handle_services_status: look up a service name in the /v1/local/services object.
+    fn extract_service_entry<'a>(
+        response: &'a Value,
+        service: &str,
+    ) -> Result<&'a Value, RedisCtlError> {
+        let services_map = response
+            .as_object()
+            .ok_or_else(|| RedisCtlError::ApiError {
+                message: "Unexpected response format from /v1/local/services".to_string(),
+            })?;
+
+        services_map.get(service).ok_or_else(|| {
+            let available: Vec<&str> = services_map.keys().map(String::as_str).collect();
+            RedisCtlError::InvalidInput {
+                message: format!(
+                    "Service '{}' not found. Available services: {}",
+                    service,
+                    available.join(", ")
+                ),
+            }
+        })
+    }
+
+    fn sample_services_response() -> Value {
+        serde_json::json!({
+            "cm_server": {
+                "start_time": "2025-06-01T00:00:00Z",
+                "status": "RUNNING",
+                "uptime": "0:02:18"
+            },
+            "ccs": {
+                "start_time": "2025-06-01T00:00:01Z",
+                "status": "RUNNING",
+                "uptime": "0:02:17"
+            }
+        })
+    }
+
+    #[test]
+    fn test_get_extracts_known_service() {
+        let response = sample_services_response();
+        let entry = extract_service_entry(&response, "cm_server").unwrap();
+        assert_eq!(entry["status"], "RUNNING");
+        assert_eq!(entry["uptime"], "0:02:18");
+    }
+
+    #[test]
+    fn test_status_extracts_known_service() {
+        let response = sample_services_response();
+        let entry = extract_service_entry(&response, "ccs").unwrap();
+        assert_eq!(entry["status"], "RUNNING");
+    }
+
+    #[test]
+    fn test_get_unknown_service_returns_invalid_input_error() {
+        let response = sample_services_response();
+        let err = extract_service_entry(&response, "nope").unwrap_err();
+        match err {
+            RedisCtlError::InvalidInput { message } => {
+                assert!(
+                    message.contains("nope"),
+                    "error should mention the service name"
+                );
+                assert!(
+                    message.contains("cm_server") || message.contains("ccs"),
+                    "error should list available services"
+                );
+            }
+            other => panic!("expected InvalidInput, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_get_reads_from_local_services_object() {
+        // Verify that both get and status derive data from the flat map at /v1/local/services,
+        // not from a per-service endpoint.  The sample response is a JSON object (not array),
+        // matching what the real API returns.
+        let response = sample_services_response();
+        assert!(
+            response.as_object().is_some(),
+            "/v1/local/services must be a JSON object keyed by service name"
+        );
+        // Every entry should have a 'status' field
+        for (name, entry) in response.as_object().unwrap() {
+            assert!(
+                entry.get("status").is_some(),
+                "service '{}' is missing the 'status' field",
+                name
+            );
+        }
     }
 }


### PR DESCRIPTION
## Root cause

`services get <name>` and `services status <name>` were issuing GET requests to `/v1/services/{name}` and `/v1/services/{name}/status` respectively. Those per-service endpoints **do not exist** on the Redis Enterprise REST API — they always return 404. The only source of per-service data is the `/v1/local/services` object (an object keyed by service name), which `services list` already calls correctly.

## Fix

Rework `handle_services_get` and `handle_services_status` to:

1. Fetch `/v1/local/services` (same call as `handle_services_list`).
2. Extract the entry for the requested service name from the returned JSON object.
3. Apply the optional JMESPath `query` and `output_format` to the extracted entry, consistent with the rest of the file.

If the requested service name is not a key in the object, a `RedisCtlError::InvalidInput` is returned that names the missing service and lists all available service names.

## Live verification (against a real cluster)

```
$ enterprise services get cm_server -o json
{
  "start_time": "2026-06-01T16:44:09Z",
  "status": "RUNNING",
  "uptime": "0:21:27"
}

$ enterprise services status cm_server -o json
{
  "start_time": "2026-06-01T16:44:09Z",
  "status": "RUNNING",
  "uptime": "0:21:27"
}

$ enterprise services get nope -o json
error: Invalid input: Service 'nope' not found. Available services: alert_mgr,
  authentication_service, call_home_agent, ccs, cluster_api, ... (40 services listed)
```

## Quality gates

- `cargo fmt --all` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p redisctl` — all pass (5 new unit tests in `services::tests`)

## New tests

- `test_get_extracts_known_service` — verifies the extraction returns the correct entry
- `test_status_extracts_known_service` — same for status path
- `test_get_unknown_service_returns_invalid_input_error` — verifies not-found error names the service and lists available ones
- `test_get_reads_from_local_services_object` — asserts the API response is a flat JSON object (not an array), matching the `/v1/local/services` contract

## Follow-up note

`handle_services_update`, `handle_services_restart`, `handle_services_enable`, and `handle_services_disable` also target `/v1/services/{name}` paths that are likely equally nonexistent on the real API. These are out of scope for this fix but should be investigated and corrected in a follow-up PR.

Closes #920