### PR TITLE
fix(enterprise): tolerate empty 200 body in endpoint availability

### DIFF
--- a/crates/redisctl/src/commands/enterprise/endpoint.rs
+++ b/crates/redisctl/src/commands/enterprise/endpoint.rs
@@ -68,13 +68,24 @@ async fn handle_endpoint_command_impl(
             super::utils::print_formatted_output(output_data, output_format)?;
         }
         EndpointCommands::Availability { bdb_uid } => {
-            let response: serde_json::Value = client
-                .get(&format!("/v1/local/bdbs/{}/endpoint/availability", bdb_uid))
+            let text = client
+                .get_text(&format!("/v1/local/bdbs/{}/endpoint/availability", bdb_uid))
                 .await
+                .map_err(RedisCtlError::from)
                 .context(format!(
                     "Failed to check endpoint availability for database {}",
                     bdb_uid
                 ))?;
+
+            let response: serde_json::Value = if text.trim().is_empty() {
+                // HTTP 200 with empty body means the endpoint is available.
+                serde_json::json!({ "bdb_uid": bdb_uid, "available": true })
+            } else {
+                match serde_json::from_str::<serde_json::Value>(&text) {
+                    Ok(v) => v,
+                    Err(_) => serde_json::json!({ "bdb_uid": bdb_uid, "raw": text }),
+                }
+            };
 
             let output_data = if let Some(q) = query {
                 super::utils::apply_jmespath(&response, q)?
@@ -114,5 +125,75 @@ mod tests {
         } else {
             panic!("Expected Availability command");
         }
+    }
+
+    /// Verify the body-parsing logic used in the Availability arm:
+    /// - empty body  → synthesized `{ bdb_uid, available: true }`
+    /// - valid JSON  → parsed value passed through
+    /// - non-JSON    → wrapped in `{ bdb_uid, raw: <text> }`
+    #[test]
+    fn test_availability_body_synthesis_empty() {
+        let bdb_uid: u64 = 1;
+        let text = "";
+        let result: serde_json::Value = if text.trim().is_empty() {
+            serde_json::json!({ "bdb_uid": bdb_uid, "available": true })
+        } else {
+            match serde_json::from_str::<serde_json::Value>(text) {
+                Ok(v) => v,
+                Err(_) => serde_json::json!({ "bdb_uid": bdb_uid, "raw": text }),
+            }
+        };
+        assert_eq!(result["bdb_uid"], 1);
+        assert_eq!(result["available"], true);
+    }
+
+    #[test]
+    fn test_availability_body_synthesis_whitespace_only() {
+        let bdb_uid: u64 = 42;
+        let text = "   \n  ";
+        let result: serde_json::Value = if text.trim().is_empty() {
+            serde_json::json!({ "bdb_uid": bdb_uid, "available": true })
+        } else {
+            match serde_json::from_str::<serde_json::Value>(text) {
+                Ok(v) => v,
+                Err(_) => serde_json::json!({ "bdb_uid": bdb_uid, "raw": text }),
+            }
+        };
+        assert_eq!(result["bdb_uid"], 42);
+        assert_eq!(result["available"], true);
+    }
+
+    #[test]
+    fn test_availability_body_synthesis_json_body() {
+        let bdb_uid: u64 = 5;
+        let text = r#"{"status":"unavailable","reason":"recovering"}"#;
+        let result: serde_json::Value = if text.trim().is_empty() {
+            serde_json::json!({ "bdb_uid": bdb_uid, "available": true })
+        } else {
+            match serde_json::from_str::<serde_json::Value>(text) {
+                Ok(v) => v,
+                Err(_) => serde_json::json!({ "bdb_uid": bdb_uid, "raw": text }),
+            }
+        };
+        assert_eq!(result["status"], "unavailable");
+        assert_eq!(result["reason"], "recovering");
+        // Not synthesized — original keys are preserved
+        assert!(result.get("bdb_uid").is_none());
+    }
+
+    #[test]
+    fn test_availability_body_synthesis_non_json_body() {
+        let bdb_uid: u64 = 7;
+        let text = "endpoint not ready";
+        let result: serde_json::Value = if text.trim().is_empty() {
+            serde_json::json!({ "bdb_uid": bdb_uid, "available": true })
+        } else {
+            match serde_json::from_str::<serde_json::Value>(text) {
+                Ok(v) => v,
+                Err(_) => serde_json::json!({ "bdb_uid": bdb_uid, "raw": text }),
+            }
+        };
+        assert_eq!(result["bdb_uid"], 7);
+        assert_eq!(result["raw"], "endpoint not ready");
     }
 }

--- a/crates/redisctl/tests/cli_integration_mocked_tests.rs
+++ b/crates/redisctl/tests/cli_integration_mocked_tests.rs
@@ -1065,6 +1065,40 @@ async fn test_env_vars_work_without_config_file() {
         .stdout(predicate::str::contains("env credentials used"));
 }
 
+/// Regression test for https://github.com/redis/redisctl/issues/919
+///
+/// When the endpoint is available the API returns HTTP 200 with an empty
+/// body.  The old typed `client.get::<Value>()` tried to JSON-deserialise
+/// that empty body and failed.  The fix uses `get_text` + synthesises the
+/// result, so the command must succeed and output `"available": true`.
+#[tokio::test]
+async fn test_enterprise_endpoint_availability_empty_200_body() {
+    let temp_dir = TempDir::new().unwrap();
+    let mock_server = MockServer::start().await;
+
+    create_enterprise_profile(&temp_dir, &mock_server.uri()).unwrap();
+
+    // Simulate the real cluster behaviour: 200 OK with zero bytes.
+    Mock::given(method("GET"))
+        .and(path("/v1/local/bdbs/1/endpoint/availability"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    test_cmd(&temp_dir)
+        .arg("enterprise")
+        .arg("endpoint")
+        .arg("availability")
+        .arg("1")
+        .arg("-o")
+        .arg("json")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("available"))
+        .stdout(predicate::str::contains("true"));
+}
+
 #[tokio::test]
 async fn test_cloud_api_secret_alias_works_without_config_file() {
     let mock_server = MockServer::start().await;


### PR DESCRIPTION
## Summary

- Fixes `redisctl enterprise endpoint availability <bdb_uid>` crashing with _"Failed to check endpoint availability"_ even when the endpoint is available (issue #919).
- Root cause: `GET /v1/local/bdbs/{uid}/endpoint/availability` returns **HTTP 200 with an empty body** when the endpoint is available. The previous typed `client.get::<serde_json::Value>()` call tried to JSON-deserialise that empty body and failed.
- Fix: switch to `client.get_text()` (returns raw body for any 2xx, errors on non-2xx), then synthesise a JSON result when the body is empty/whitespace-only, pass through parsed JSON if non-empty, or wrap plain text in a `raw` field.

## Changes

- `crates/redisctl/src/commands/enterprise/endpoint.rs` — `Availability` arm now uses `get_text` + body-synthesis logic; 4 new unit tests covering empty, whitespace-only, JSON, and non-JSON bodies.
- `crates/redisctl/tests/cli_integration_mocked_tests.rs` — regression test `test_enterprise_endpoint_availability_empty_200_body` that mocks the real cluster behaviour (200 with no body) and asserts the command succeeds with `"available": true`.

## Note on deeper fix

The underlying `redis-enterprise` crate's `handle_response` could be made tolerant of empty bodies for typed deserialisation; that is a separate upstream concern and is not addressed here.

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test -p redisctl` — all pass (new unit tests + new mock integration test)
- [x] Live cluster: `cargo run -p redisctl -- enterprise endpoint availability 1 -o json` returns `{"available":true,"bdb_uid":1}` instead of the previous error

Closes #919