### PR TITLE
chore(deps): bump redis-cloud to v0.10.0 and redis-enterprise to v0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -952,7 +952,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1099,7 +1099,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2722,7 +2722,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.0",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2855,8 +2855,9 @@ dependencies = [
 
 [[package]]
 name = "redis-cloud"
-version = "0.9.5"
-source = "git+https://github.com/redis-developer/redis-cloud-rs?branch=fix%2Ftask-error-object-deserialization#6d9af5b6be4bfa749b8b88818f5af5263552c1c3"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44ce273747009abf9345536d0a4eb3a86db916ba0f002193edf4c90efcac021"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2879,8 +2880,9 @@ dependencies = [
 
 [[package]]
 name = "redis-enterprise"
-version = "0.8.7"
-source = "git+https://github.com/redis-developer/redis-enterprise-rs?branch=main#2c7337462c9a236975800e274ff6f965d8ef8f09"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13f41c80d29c1a26e390a64b803528971a824d02b8c449b61c4e05293054e15"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3262,7 +3264,7 @@ dependencies = [
  "errno 0.3.14",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3342,7 +3344,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3885,7 +3887,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4807,7 +4809,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,9 +99,8 @@ pretty_assertions = "1.4"
 redis = { version = "0.27", features = ["tokio-comp", "tokio-rustls-comp", "connection-manager", "cluster-async"] }
 
 # External crates (git for dev, version required for crates.io publish)
-# TODO: revert to branch = "main" once redis-developer/redis-cloud-rs#103 merges.
-redis-cloud = { version = "0.9.5", git = "https://github.com/redis-developer/redis-cloud-rs", branch = "fix/task-error-object-deserialization" }
-redis-enterprise = { version = "0.8.5", git = "https://github.com/redis-developer/redis-enterprise-rs", branch = "main" }
+redis-cloud = { version = "0.10.0" }
+redis-enterprise = { version = "0.9.1" }
 
 # Windows CI workaround - ensure these are available in workspace
 shellexpand = "3.1"

--- a/crates/redisctl-core/src/enterprise/workflows.rs
+++ b/crates/redisctl-core/src/enterprise/workflows.rs
@@ -7,7 +7,7 @@
 
 use crate::enterprise::progress::{EnterpriseProgressCallback, poll_action};
 use crate::error::Result;
-use redis_enterprise::bdb::DatabaseUpgradeRequest;
+use redis_enterprise::bdb::{DatabaseActionResponse, DatabaseUpgradeRequest, ModuleUpgrade};
 use redis_enterprise::{Database, EnterpriseClient};
 use std::time::Duration;
 
@@ -97,10 +97,19 @@ pub async fn upgrade_module_and_wait(
     timeout: Duration,
     on_progress: Option<EnterpriseProgressCallback>,
 ) -> Result<Database> {
-    // Submit the module upgrade request
+    // Submit the module upgrade as part of a database upgrade request. The
+    // dedicated module-upgrade method was folded into the upgrade endpoint
+    // upstream; modules are now carried in the `modules` field.
+    let request = DatabaseUpgradeRequest::builder()
+        .modules(vec![ModuleUpgrade {
+            module_name: module_name.to_string(),
+            new_version: Some(new_version.to_string()),
+            module_args: None,
+        }])
+        .build();
     let action = client
         .databases()
-        .upgrade(bdb_uid, module_name, new_version)
+        .upgrade_redis_version(bdb_uid, request)
         .await?;
 
     // Poll until completion
@@ -137,13 +146,24 @@ pub async fn backup_database_and_wait(
     timeout: Duration,
     on_progress: Option<EnterpriseProgressCallback>,
 ) -> Result<()> {
-    // Trigger backup
-    let response = client.databases().backup(bdb_uid).await?;
+    // Trigger backup. The dedicated `backup` handler method was removed
+    // upstream; POST the backup action directly (BDB.BACKUP).
+    let response: DatabaseActionResponse = client
+        .post(
+            &format!("/v1/bdbs/{}/actions/backup", bdb_uid),
+            &serde_json::json!({}),
+        )
+        .await?;
 
-    // Poll until completion if we got an action_uid
-    if let Some(action_uid) = response.action_uid {
-        poll_action(client, &action_uid, timeout, DEFAULT_INTERVAL, on_progress).await?;
-    }
+    // Poll until completion
+    poll_action(
+        client,
+        &response.action_uid,
+        timeout,
+        DEFAULT_INTERVAL,
+        on_progress,
+    )
+    .await?;
 
     Ok(())
 }

--- a/crates/redisctl-core/src/progress.rs
+++ b/crates/redisctl-core/src/progress.rs
@@ -6,6 +6,7 @@
 
 use crate::error::{CoreError, Result};
 use redis_cloud::tasks::TaskStateUpdate;
+use redis_cloud::types::TaskStatus;
 use redis_cloud::{CloudClient, TaskHandler};
 use std::time::{Duration, Instant};
 
@@ -102,21 +103,24 @@ pub async fn poll_task(
         }
 
         let task = handler.get_task_by_id(task_id.to_string()).await?;
-        let status = task.status.clone().unwrap_or_default();
+        let status = task.status.clone();
+        let status_label = task_status_label(status.as_ref());
 
         emit(
             &on_progress,
             ProgressEvent::Polling {
                 task_id: task_id.to_string(),
-                status: status.clone(),
+                status: status_label.clone(),
                 elapsed,
             },
         );
 
-        // Check for terminal states (case-insensitive)
-        match status.to_lowercase().as_str() {
-            // Success states
-            "processing-completed" | "completed" | "complete" | "succeeded" | "success" => {
+        // Check for terminal states. `TaskStatus` only models the two terminal
+        // states explicitly; everything else (Initialized, Received,
+        // ProcessingInProgress, and any Unknown wire value) is still in flight.
+        match status {
+            // Success
+            Some(TaskStatus::ProcessingCompleted) => {
                 let resource_id = task.response.as_ref().and_then(|r| r.resource_id);
                 emit(
                     &on_progress,
@@ -127,13 +131,13 @@ pub async fn poll_task(
                 );
                 return Ok(task);
             }
-            // Failure states
-            "processing-error" | "failed" | "error" => {
+            // Failure
+            Some(TaskStatus::ProcessingError) => {
                 let error = task
                     .response
                     .as_ref()
                     .and_then(|r| r.error_message())
-                    .unwrap_or_else(|| format!("Task failed with status: {}", status));
+                    .unwrap_or_else(|| format!("Task failed with status: {}", status_label));
 
                 emit(
                     &on_progress,
@@ -144,19 +148,8 @@ pub async fn poll_task(
                 );
                 return Err(CoreError::TaskFailed(error));
             }
-            // Cancelled state
-            "cancelled" => {
-                emit(
-                    &on_progress,
-                    ProgressEvent::Failed {
-                        task_id: task_id.to_string(),
-                        error: "Task was cancelled".to_string(),
-                    },
-                );
-                return Err(CoreError::TaskFailed("Task was cancelled".to_string()));
-            }
+            // Still processing, wait and try again
             _ => {
-                // Still processing, wait and try again
                 tokio::time::sleep(interval).await;
             }
         }
@@ -168,6 +161,22 @@ fn emit(callback: &Option<ProgressCallback>, event: ProgressEvent) {
     if let Some(cb) = callback {
         cb(event);
     }
+}
+
+/// Human-readable label for a task status, mirroring the kebab-case wire form.
+///
+/// Used for progress events and failure messages. A missing status (or one the
+/// client doesn't recognize) is reported as `"unknown"`.
+fn task_status_label(status: Option<&TaskStatus>) -> String {
+    match status {
+        Some(TaskStatus::Initialized) => "initialized",
+        Some(TaskStatus::Received) => "received",
+        Some(TaskStatus::ProcessingInProgress) => "processing-in-progress",
+        Some(TaskStatus::ProcessingCompleted) => "processing-completed",
+        Some(TaskStatus::ProcessingError) => "processing-error",
+        Some(TaskStatus::Unknown) | None => "unknown",
+    }
+    .to_string()
 }
 
 #[cfg(test)]

--- a/crates/redisctl-mcp/src/tools/cloud/account.rs
+++ b/crates/redisctl-mcp/src/tools/cloud/account.rs
@@ -6,6 +6,7 @@ use redis_cloud::acl::{
     AclUserUpdateRequest,
 };
 use redis_cloud::cloud_accounts::{CloudAccountCreateRequest, CloudAccountUpdateRequest};
+use redis_cloud::types::TaskStatus;
 use redis_cloud::users::AccountUserUpdateRequest;
 use redis_cloud::{
     AccountHandler, AclHandler, CloudAccountHandler, CostReportCreateRequest, CostReportHandler,
@@ -688,20 +689,13 @@ cloud_tool!(read_only, wait_for_cloud_task, "wait_for_cloud_task",
                 .await
                 .tool_context("Failed to get task status")?;
 
-            // Check for terminal states
-            if let Some(ref status) = task.status {
-                let s = status.to_lowercase();
-                if matches!(
-                    s.as_str(),
-                    "completed"
-                        | "failed"
-                        | "error"
-                        | "success"
-                        | "cancelled"
-                        | "aborted"
-                ) {
-                    return CallToolResult::from_serialize(&task);
-                }
+            // Check for terminal states. `TaskStatus` models only the two
+            // terminal states explicitly; everything else is still in flight.
+            if matches!(
+                task.status,
+                Some(TaskStatus::ProcessingCompleted) | Some(TaskStatus::ProcessingError)
+            ) {
+                return CallToolResult::from_serialize(&task);
             }
 
             // Check timeout

--- a/crates/redisctl-mcp/src/tools/cloud/networking.rs
+++ b/crates/redisctl-mcp/src/tools/cloud/networking.rs
@@ -4,7 +4,9 @@
 
 use redis_cloud::connectivity::psc::PscEndpointUpdateRequest;
 use redis_cloud::connectivity::transit_gateway::TgwAttachmentRequest;
-use redis_cloud::connectivity::vpc_peering::VpcPeeringCreateRequest;
+use redis_cloud::connectivity::vpc_peering::{
+    ActiveActiveVpcPeeringCreateRequest, VpcPeeringCreateRequest, VpcPeeringUpdateAwsRequest,
+};
 use redis_cloud::{
     PrincipalType, PrivateLinkAddPrincipalRequest, PrivateLinkCreateRequest, PrivateLinkHandler,
     PscHandler, TransitGatewayHandler, VpcPeeringHandler,
@@ -261,11 +263,13 @@ cloud_tool!(write, create_aa_vpc_peering, "create_aa_vpc_peering",
         #[serde(default)]
         pub network_name: Option<String>,
     } => |client, input| {
-        let request = VpcPeeringCreateRequest {
+        // Active-Active peering uses a distinct request type upstream; map the
+        // single `aws_region` onto `source_region`.
+        let request = ActiveActiveVpcPeeringCreateRequest {
             provider: input.provider,
-            vpc_id: input.vpc_id,
-            aws_region: input.aws_region,
+            source_region: input.aws_region,
             aws_account_id: input.aws_account_id,
+            vpc_id: input.vpc_id,
             vpc_cidr: input.vpc_cidr,
             vpc_cidrs: input.vpc_cidrs,
             gcp_project_id: input.gcp_project_id,
@@ -290,41 +294,20 @@ cloud_tool!(write, update_aa_vpc_peering, "update_aa_vpc_peering",
         pub subscription_id: i32,
         /// VPC Peering ID
         pub peering_id: i32,
-        /// Cloud provider (AWS, GCP, Azure)
-        #[serde(default)]
-        pub provider: Option<String>,
-        /// AWS VPC ID
-        #[serde(default)]
-        pub vpc_id: Option<String>,
-        /// AWS region
-        #[serde(default)]
-        pub aws_region: Option<String>,
-        /// AWS account ID
-        #[serde(default)]
-        pub aws_account_id: Option<String>,
         /// VPC CIDR block
         #[serde(default)]
         pub vpc_cidr: Option<String>,
         /// Multiple VPC CIDR blocks
         #[serde(default)]
         pub vpc_cidrs: Option<Vec<String>>,
-        /// GCP project ID (for GCP peering)
-        #[serde(default)]
-        pub gcp_project_id: Option<String>,
-        /// GCP network name (for GCP peering)
-        #[serde(default)]
-        pub network_name: Option<String>,
     } => |client, input| {
-        let request = VpcPeeringCreateRequest {
-            provider: input.provider,
-            vpc_id: input.vpc_id,
-            aws_region: input.aws_region,
-            aws_account_id: input.aws_account_id,
+        // Active-Active update only carries the CIDR list upstream.
+        let request = VpcPeeringUpdateAwsRequest {
+            subscription_id: None,
+            vpc_peering_id: None,
             vpc_cidr: input.vpc_cidr,
             vpc_cidrs: input.vpc_cidrs,
-            gcp_project_id: input.gcp_project_id,
-            network_name: input.network_name,
-            ..Default::default()
+            command_type: None,
         };
 
         let handler = VpcPeeringHandler::new(client);
@@ -432,25 +415,19 @@ cloud_tool!(write, create_tgw_attachment, "create_tgw_attachment",
     {
         /// Subscription ID
         pub subscription_id: i32,
-        /// AWS account ID
-        #[serde(default)]
-        pub aws_account_id: Option<String>,
         /// Transit Gateway ID
         #[serde(default)]
         pub tgw_id: Option<String>,
-        /// CIDR blocks to route through the TGW
-        #[serde(default)]
-        pub cidrs: Option<Vec<String>>,
     } => |client, input| {
-        let request = TgwAttachmentRequest {
-            aws_account_id: input.aws_account_id,
-            tgw_id: input.tgw_id,
-            cidrs: input.cidrs,
-        };
+        // The attachment route now requires the TGW ID in the path; the
+        // generic `create_attachment` was removed upstream.
+        let tgw_id = input
+            .tgw_id
+            .ok_or_else(|| ToolError::new("tgw_id is required".to_string()))?;
 
         let handler = TransitGatewayHandler::new(client);
         let result = handler
-            .create_attachment(input.subscription_id, &request)
+            .create_attachment_with_id(input.subscription_id, &tgw_id)
             .await
             .tool_context("Failed to create TGW attachment")?;
 
@@ -518,10 +495,12 @@ cloud_tool!(read_only, get_aa_tgw_attachments, "get_aa_tgw_attachments",
     {
         /// Subscription ID
         pub subscription_id: i32,
+        /// Region ID
+        pub region_id: i32,
     } => |client, input| {
         let handler = TransitGatewayHandler::new(client);
         let result = handler
-            .get_attachments_active_active(input.subscription_id)
+            .get_attachments_active_active(input.subscription_id, input.region_id)
             .await
             .tool_context("Failed to get AA TGW attachments")?;
 
@@ -534,10 +513,12 @@ cloud_tool!(read_only, get_aa_tgw_invitations, "get_aa_tgw_invitations",
     {
         /// Subscription ID
         pub subscription_id: i32,
+        /// Region ID
+        pub region_id: i32,
     } => |client, input| {
         let handler = TransitGatewayHandler::new(client);
         let result = handler
-            .get_shared_invitations_active_active(input.subscription_id)
+            .get_shared_invitations_active_active(input.subscription_id, input.region_id)
             .await
             .tool_context("Failed to get AA TGW invitations")?;
 
@@ -610,6 +591,11 @@ cloud_tool!(write, create_aa_tgw_attachment, "create_aa_tgw_attachment",
         #[serde(default)]
         pub cidrs: Option<Vec<String>>,
     } => |client, input| {
+        // The attachment route now requires the TGW ID in the path.
+        let tgw_id = input
+            .tgw_id
+            .clone()
+            .ok_or_else(|| ToolError::new("tgw_id is required".to_string()))?;
         let request = TgwAttachmentRequest {
             aws_account_id: input.aws_account_id,
             tgw_id: input.tgw_id,
@@ -621,6 +607,7 @@ cloud_tool!(write, create_aa_tgw_attachment, "create_aa_tgw_attachment",
             .create_attachment_active_active(
                 input.subscription_id,
                 input.region_id,
+                &tgw_id,
                 &request,
             )
             .await
@@ -751,10 +738,12 @@ cloud_tool!(read_only, get_psc_endpoints, "get_psc_endpoints",
     {
         /// Subscription ID
         pub subscription_id: i32,
+        /// PSC service ID
+        pub psc_service_id: i32,
     } => |client, input| {
         let handler = PscHandler::new(client);
         let result = handler
-            .get_endpoints(input.subscription_id)
+            .get_endpoints(input.subscription_id, input.psc_service_id)
             .await
             .tool_context("Failed to get PSC endpoints")?;
 
@@ -796,7 +785,7 @@ cloud_tool!(write, create_psc_endpoint, "create_psc_endpoint",
 
         let handler = PscHandler::new(client);
         let result = handler
-            .create_endpoint(input.subscription_id, &request)
+            .create_endpoint(input.subscription_id, input.psc_service_id, &request)
             .await
             .tool_context("Failed to create PSC endpoint")?;
 
@@ -838,7 +827,12 @@ cloud_tool!(write, update_psc_endpoint, "update_psc_endpoint",
 
         let handler = PscHandler::new(client);
         let result = handler
-            .update_endpoint(input.subscription_id, input.endpoint_id, &request)
+            .update_endpoint(
+                input.subscription_id,
+                input.psc_service_id,
+                input.endpoint_id,
+                &request,
+            )
             .await
             .tool_context("Failed to update PSC endpoint")?;
 
@@ -851,12 +845,14 @@ cloud_tool!(destructive, delete_psc_endpoint, "delete_psc_endpoint",
     {
         /// Subscription ID
         pub subscription_id: i32,
+        /// PSC service ID
+        pub psc_service_id: i32,
         /// Endpoint ID
         pub endpoint_id: i32,
     } => |client, input| {
         let handler = PscHandler::new(client);
         let result = handler
-            .delete_endpoint(input.subscription_id, input.endpoint_id)
+            .delete_endpoint(input.subscription_id, input.psc_service_id, input.endpoint_id)
             .await
             .tool_context("Failed to delete PSC endpoint")?;
 
@@ -869,12 +865,18 @@ cloud_tool!(read_only, get_psc_creation_script, "get_psc_creation_script",
     {
         /// Subscription ID
         pub subscription_id: i32,
+        /// PSC service ID
+        pub psc_service_id: i32,
         /// Endpoint ID
         pub endpoint_id: i32,
     } => |client, input| {
         let handler = PscHandler::new(client);
         let result = handler
-            .get_endpoint_creation_script(input.subscription_id, input.endpoint_id)
+            .get_endpoint_creation_script(
+                input.subscription_id,
+                input.psc_service_id,
+                input.endpoint_id,
+            )
             .await
             .tool_context("Failed to get PSC creation script")?;
 
@@ -887,12 +889,18 @@ cloud_tool!(read_only, get_psc_deletion_script, "get_psc_deletion_script",
     {
         /// Subscription ID
         pub subscription_id: i32,
+        /// PSC service ID
+        pub psc_service_id: i32,
         /// Endpoint ID
         pub endpoint_id: i32,
     } => |client, input| {
         let handler = PscHandler::new(client);
         let result = handler
-            .get_endpoint_deletion_script(input.subscription_id, input.endpoint_id)
+            .get_endpoint_deletion_script(
+                input.subscription_id,
+                input.psc_service_id,
+                input.endpoint_id,
+            )
             .await
             .tool_context("Failed to get PSC deletion script")?;
 
@@ -909,10 +917,12 @@ cloud_tool!(read_only, get_aa_psc_service, "get_aa_psc_service",
     {
         /// Subscription ID
         pub subscription_id: i32,
+        /// Region ID
+        pub region_id: i32,
     } => |client, input| {
         let handler = PscHandler::new(client);
         let result = handler
-            .get_service_active_active(input.subscription_id)
+            .get_service_active_active(input.subscription_id, input.region_id)
             .await
             .tool_context("Failed to get AA PSC service")?;
 
@@ -925,10 +935,12 @@ cloud_tool!(write, create_aa_psc_service, "create_aa_psc_service",
     {
         /// Subscription ID
         pub subscription_id: i32,
+        /// Region ID
+        pub region_id: i32,
     } => |client, input| {
         let handler = PscHandler::new(client);
         let result = handler
-            .create_service_active_active(input.subscription_id)
+            .create_service_active_active(input.subscription_id, input.region_id)
             .await
             .tool_context("Failed to create AA PSC service")?;
 
@@ -941,10 +953,12 @@ cloud_tool!(destructive, delete_aa_psc_service, "delete_aa_psc_service",
     {
         /// Subscription ID
         pub subscription_id: i32,
+        /// Region ID
+        pub region_id: i32,
     } => |client, input| {
         let handler = PscHandler::new(client);
         let result = handler
-            .delete_service_active_active(input.subscription_id)
+            .delete_service_active_active(input.subscription_id, input.region_id)
             .await
             .tool_context("Failed to delete AA PSC service")?;
 
@@ -957,10 +971,18 @@ cloud_tool!(read_only, get_aa_psc_endpoints, "get_aa_psc_endpoints",
     {
         /// Subscription ID
         pub subscription_id: i32,
+        /// Region ID
+        pub region_id: i32,
+        /// PSC service ID
+        pub psc_service_id: i32,
     } => |client, input| {
         let handler = PscHandler::new(client);
         let result = handler
-            .get_endpoints_active_active(input.subscription_id)
+            .get_endpoints_active_active(
+                input.subscription_id,
+                input.region_id,
+                input.psc_service_id,
+            )
             .await
             .tool_context("Failed to get AA PSC endpoints")?;
 
@@ -973,6 +995,8 @@ cloud_tool!(write, create_aa_psc_endpoint, "create_aa_psc_endpoint",
     {
         /// Subscription ID
         pub subscription_id: i32,
+        /// Region ID
+        pub region_id: i32,
         /// PSC service ID
         pub psc_service_id: i32,
         /// Endpoint ID
@@ -1002,7 +1026,12 @@ cloud_tool!(write, create_aa_psc_endpoint, "create_aa_psc_endpoint",
 
         let handler = PscHandler::new(client);
         let result = handler
-            .create_endpoint_active_active(input.subscription_id, &request)
+            .create_endpoint_active_active(
+                input.subscription_id,
+                input.region_id,
+                input.psc_service_id,
+                &request,
+            )
             .await
             .tool_context("Failed to create AA PSC endpoint")?;
 
@@ -1049,6 +1078,7 @@ cloud_tool!(write, update_aa_psc_endpoint, "update_aa_psc_endpoint",
             .update_endpoint_active_active(
                 input.subscription_id,
                 input.region_id,
+                input.psc_service_id,
                 input.endpoint_id,
                 &request,
             )
@@ -1066,6 +1096,8 @@ cloud_tool!(destructive, delete_aa_psc_endpoint, "delete_aa_psc_endpoint",
         pub subscription_id: i32,
         /// Region ID
         pub region_id: i32,
+        /// PSC service ID
+        pub psc_service_id: i32,
         /// Endpoint ID
         pub endpoint_id: i32,
     } => |client, input| {
@@ -1074,6 +1106,7 @@ cloud_tool!(destructive, delete_aa_psc_endpoint, "delete_aa_psc_endpoint",
             .delete_endpoint_active_active(
                 input.subscription_id,
                 input.region_id,
+                input.psc_service_id,
                 input.endpoint_id,
             )
             .await

--- a/crates/redisctl-mcp/src/tools/enterprise/databases.rs
+++ b/crates/redisctl-mcp/src/tools/enterprise/databases.rs
@@ -385,9 +385,14 @@ enterprise_tool!(write, restore_enterprise_database, "restore_enterprise_databas
         #[serde(default)]
         pub backup_uid: Option<String>,
     } => |client, input| {
-        let handler = DatabaseHandler::new(client);
-        let response = handler
-            .restore(input.uid, input.backup_uid.as_deref())
+        // `DatabaseHandler::restore` was removed upstream; POST the restore
+        // action directly (BDB.RESTORE).
+        let body = match input.backup_uid.as_deref() {
+            Some(backup_id) => serde_json::json!({ "backup_uid": backup_id }),
+            None => serde_json::json!({}),
+        };
+        let response: redis_enterprise::bdb::DatabaseActionResponse = client
+            .post(&format!("/v1/bdbs/{}/actions/restore", input.uid), &body)
             .await
             .tool_context("Failed to restore database")?;
 

--- a/crates/redisctl-mcp/src/tools/enterprise/observability.rs
+++ b/crates/redisctl-mcp/src/tools/enterprise/observability.rs
@@ -32,8 +32,12 @@ mcp_module! {
 enterprise_tool!(read_only, list_alerts, "list_alerts",
     "List all active alerts.",
     {} => |client, _input| {
-        let handler = redis_enterprise::alerts::AlertHandler::new(client);
-        let alerts = handler.list().await.tool_context("Failed to list alerts")?;
+        // The `AlertHandler::list` convenience method was removed upstream; call
+        // the cluster-wide alerts route directly to preserve this tool.
+        let alerts: Vec<redis_enterprise::alerts::Alert> = client
+            .get("/v1/alerts")
+            .await
+            .tool_context("Failed to list alerts")?;
         CallToolResult::from_list("alerts", &alerts)
     }
 );
@@ -44,9 +48,10 @@ enterprise_tool!(write, acknowledge_enterprise_alert, "acknowledge_enterprise_al
         /// Alert UID to acknowledge
         pub alert_uid: String,
     } => |client, input| {
-        let handler = redis_enterprise::alerts::AlertHandler::new(client);
-        handler
-            .clear(&input.alert_uid)
+        // The `AlertHandler::clear` convenience method was removed upstream;
+        // delete the alert directly to preserve this tool.
+        client
+            .delete(&format!("/v1/alerts/{}", input.alert_uid))
             .await
             .tool_context("Failed to acknowledge alert")?;
 

--- a/crates/redisctl-mcp/src/tools/enterprise/services.rs
+++ b/crates/redisctl-mcp/src/tools/enterprise/services.rs
@@ -15,16 +15,33 @@ mcp_module! {
     restart_service => "restart_enterprise_service",
 }
 
+/// Look up a single service entry in the `/v1/local/services` map (keyed by
+/// service name), returning a helpful error listing available names if absent.
+fn lookup_service(services: &Value, service_id: &str) -> Result<Value, tower_mcp::Error> {
+    let map = services.as_object().ok_or_else(|| {
+        tower_mcp::Error::tool("Unexpected response format from /v1/local/services".to_string())
+    })?;
+    map.get(service_id).cloned().ok_or_else(|| {
+        let available: Vec<&str> = map.keys().map(String::as_str).collect();
+        tower_mcp::Error::tool(format!(
+            "Service '{}' not found. Available services: {}",
+            service_id,
+            available.join(", ")
+        ))
+    })
+}
+
 enterprise_tool!(read_only, list_services, "list_enterprise_services",
     "List all cluster services.",
     {} => |client, _input| {
-        let handler = redis_enterprise::services::ServicesHandler::new(client);
-        let services = handler
-            .list()
+        // `ServicesHandler` was removed upstream; the cluster service map is
+        // served at /v1/local/services, keyed by service name.
+        let services: Value = client
+            .get("/v1/local/services")
             .await
             .tool_context("Failed to list services")?;
 
-        CallToolResult::from_list("services", &services)
+        CallToolResult::from_serialize(&services)
     }
 );
 
@@ -34,11 +51,11 @@ enterprise_tool!(read_only, get_service, "get_enterprise_service",
         /// Service ID (e.g., "cm_server", "mdns_server", "stats_archiver")
         pub service_id: String,
     } => |client, input| {
-        let handler = redis_enterprise::services::ServicesHandler::new(client);
-        let service = handler
-            .get(&input.service_id)
+        let services: Value = client
+            .get("/v1/local/services")
             .await
             .tool_context("Failed to get service")?;
+        let service = lookup_service(&services, &input.service_id)?;
 
         CallToolResult::from_serialize(&service)
     }
@@ -50,13 +67,13 @@ enterprise_tool!(read_only, get_service_status, "get_enterprise_service_status",
         /// Service ID
         pub service_id: String,
     } => |client, input| {
-        let handler = redis_enterprise::services::ServicesHandler::new(client);
-        let status = handler
-            .status(&input.service_id)
+        let services: Value = client
+            .get("/v1/local/services")
             .await
             .tool_context("Failed to get service status")?;
+        let service = lookup_service(&services, &input.service_id)?;
 
-        CallToolResult::from_serialize(&status)
+        CallToolResult::from_serialize(&service)
     }
 );
 
@@ -68,11 +85,8 @@ enterprise_tool!(write, update_service, "update_enterprise_service",
         /// Updated service configuration as JSON (e.g., enabled, config, node_uids)
         pub config: Value,
     } => |client, input| {
-        let handler = redis_enterprise::services::ServicesHandler::new(client);
-        let request = serde_json::from_value(input.config)
-            .map_err(|e| tower_mcp::Error::tool(format!("Invalid service config: {}", e)))?;
-        let result = handler
-            .update(&input.service_id, request)
+        let result: Value = client
+            .put_raw(&format!("/v1/services/{}", input.service_id), input.config)
             .await
             .tool_context("Failed to update service")?;
 
@@ -86,9 +100,11 @@ enterprise_tool!(write, start_service, "start_enterprise_service",
         /// Service ID
         pub service_id: String,
     } => |client, input| {
-        let handler = redis_enterprise::services::ServicesHandler::new(client);
-        let result = handler
-            .start(&input.service_id)
+        let result: Value = client
+            .post_raw(
+                &format!("/v1/services/{}/start", input.service_id),
+                serde_json::json!({}),
+            )
             .await
             .tool_context("Failed to start service")?;
 
@@ -102,9 +118,11 @@ enterprise_tool!(write, stop_service, "stop_enterprise_service",
         /// Service ID
         pub service_id: String,
     } => |client, input| {
-        let handler = redis_enterprise::services::ServicesHandler::new(client);
-        let result = handler
-            .stop(&input.service_id)
+        let result: Value = client
+            .post_raw(
+                &format!("/v1/services/{}/stop", input.service_id),
+                serde_json::json!({}),
+            )
             .await
             .tool_context("Failed to stop service")?;
 
@@ -118,9 +136,11 @@ enterprise_tool!(write, restart_service, "restart_enterprise_service",
         /// Service ID
         pub service_id: String,
     } => |client, input| {
-        let handler = redis_enterprise::services::ServicesHandler::new(client);
-        let result = handler
-            .restart(&input.service_id)
+        let result: Value = client
+            .post_raw(
+                &format!("/v1/services/{}/restart", input.service_id),
+                serde_json::json!({}),
+            )
             .await
             .tool_context("Failed to restart service")?;
 

--- a/crates/redisctl-mcp/tests/enterprise_tools.rs
+++ b/crates/redisctl-mcp/tests/enterprise_tools.rs
@@ -411,7 +411,13 @@ async fn test_list_alerts() {
         .entity_uid("1")
         .build();
 
-    server.mock_alerts_list(vec![alert1, alert2]).await;
+    // The `mock_alerts_list` helper was removed upstream; the list_alerts tool
+    // now reads the cluster-wide alerts route directly.
+    Mock::given(method("GET"))
+        .and(path("/v1/alerts"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([alert1, alert2])))
+        .mount(server.inner())
+        .await;
 
     let client = server.client();
     let state = Arc::new(AppState::with_enterprise_client(client));

--- a/crates/redisctl/src/cli/cloud.rs
+++ b/crates/redisctl/src/cli/cloud.rs
@@ -287,6 +287,9 @@ pub enum PscCommands {
     EndpointsList {
         /// Subscription ID
         subscription_id: i32,
+        /// PSC Service ID
+        #[arg(long)]
+        psc_service_id: i32,
     },
     /// Create PSC endpoint
     #[command(
@@ -306,6 +309,10 @@ pub enum PscCommands {
     EndpointCreate {
         /// Subscription ID
         subscription_id: i32,
+
+        /// PSC Service ID
+        #[arg(long)]
+        psc_service_id: i32,
 
         /// GCP project ID
         #[arg(long, required_unless_present = "data")]
@@ -351,7 +358,7 @@ pub enum PscCommands {
         endpoint_id: i32,
         /// PSC Service ID
         #[arg(long)]
-        psc_service_id: Option<i32>,
+        psc_service_id: i32,
 
         /// GCP project ID
         #[arg(long)]
@@ -381,6 +388,9 @@ pub enum PscCommands {
     EndpointDelete {
         /// Subscription ID
         subscription_id: i32,
+        /// PSC Service ID
+        #[arg(long)]
+        psc_service_id: i32,
         /// Endpoint ID
         endpoint_id: i32,
         /// Skip confirmation prompt
@@ -394,6 +404,9 @@ pub enum PscCommands {
     EndpointCreationScript {
         /// Subscription ID
         subscription_id: i32,
+        /// PSC Service ID
+        #[arg(long)]
+        psc_service_id: i32,
         /// Endpoint ID
         endpoint_id: i32,
     },
@@ -402,6 +415,9 @@ pub enum PscCommands {
     EndpointDeletionScript {
         /// Subscription ID
         subscription_id: i32,
+        /// PSC Service ID
+        #[arg(long)]
+        psc_service_id: i32,
         /// Endpoint ID
         endpoint_id: i32,
     },
@@ -412,12 +428,16 @@ pub enum PscCommands {
     AaServiceGet {
         /// Subscription ID
         subscription_id: i32,
+        /// Region ID
+        region_id: i32,
     },
     /// Create Active-Active PSC service
     #[command(name = "aa-service-create")]
     AaServiceCreate {
         /// Subscription ID
         subscription_id: i32,
+        /// Region ID
+        region_id: i32,
         #[command(flatten)]
         async_ops: crate::commands::cloud::async_utils::AsyncOperationArgs,
     },
@@ -426,6 +446,8 @@ pub enum PscCommands {
     AaServiceDelete {
         /// Subscription ID
         subscription_id: i32,
+        /// Region ID
+        region_id: i32,
         /// Skip confirmation prompt
         #[arg(short, long)]
         yes: bool,
@@ -439,6 +461,11 @@ pub enum PscCommands {
     AaEndpointsList {
         /// Subscription ID
         subscription_id: i32,
+        /// Region ID
+        region_id: i32,
+        /// PSC Service ID
+        #[arg(long)]
+        psc_service_id: i32,
     },
     /// Create Active-Active PSC endpoint
     #[command(
@@ -458,6 +485,14 @@ pub enum PscCommands {
     AaEndpointCreate {
         /// Subscription ID
         subscription_id: i32,
+
+        /// Region ID
+        #[arg(long)]
+        region_id: i32,
+
+        /// PSC Service ID
+        #[arg(long)]
+        psc_service_id: i32,
 
         /// GCP project ID
         #[arg(long, required_unless_present = "data")]
@@ -489,6 +524,9 @@ pub enum PscCommands {
         subscription_id: i32,
         /// Region ID
         region_id: i32,
+        /// PSC Service ID
+        #[arg(long)]
+        psc_service_id: i32,
         /// Endpoint ID
         endpoint_id: i32,
         /// Skip confirmation prompt
@@ -634,6 +672,8 @@ pub enum TgwCommands {
     AaAttachmentsList {
         /// Subscription ID
         subscription_id: i32,
+        /// Region ID
+        region_id: i32,
     },
     /// Create Active-Active TGW attachment
     #[command(
@@ -734,6 +774,8 @@ pub enum TgwCommands {
     AaInvitationsList {
         /// Subscription ID
         subscription_id: i32,
+        /// Region ID
+        region_id: i32,
     },
     /// Accept Active-Active TGW resource share invitation
     #[command(name = "aa-invitation-accept")]

--- a/crates/redisctl/src/commands/cloud/connectivity/private_link.rs
+++ b/crates/redisctl/src/commands/cloud/connectivity/private_link.rs
@@ -169,7 +169,8 @@ async fn handle_get(
             .context("Failed to get PrivateLink configuration")?
     };
 
-    let data = handle_output(result, output_format, query)?;
+    let json_response = serde_json::to_value(result).context("Failed to serialize response")?;
+    let data = handle_output(json_response, output_format, query)?;
     print_formatted_output(data, output_format)?;
     Ok(())
 }
@@ -303,10 +304,11 @@ async fn handle_create(
             .context("Failed to create PrivateLink")?
     };
 
+    let json_response = serde_json::to_value(result).context("Failed to serialize response")?;
     handle_async_response(
         params.conn_mgr,
         params.profile_name,
-        result,
+        json_response,
         params.async_ops,
         params.output_format,
         params.query,
@@ -338,7 +340,8 @@ async fn handle_add_principal(
             .context("Failed to add principals to PrivateLink")?
     };
 
-    let data = handle_output(result, output_format, query)?;
+    let json_response = serde_json::to_value(result).context("Failed to serialize response")?;
+    let data = handle_output(json_response, output_format, query)?;
     print_formatted_output(data, output_format)?;
     Ok(())
 }
@@ -366,7 +369,8 @@ async fn handle_remove_principal(
             .context("Failed to remove principals from PrivateLink")?
     };
 
-    let data = handle_output(result, output_format, query)?;
+    let json_response = serde_json::to_value(result).context("Failed to serialize response")?;
+    let data = handle_output(json_response, output_format, query)?;
     print_formatted_output(data, output_format)?;
     Ok(())
 }
@@ -391,7 +395,8 @@ async fn handle_get_script(
             .context("Failed to get endpoint script")?
     };
 
-    let data = handle_output(result, output_format, query)?;
+    let json_response = serde_json::to_value(result).context("Failed to serialize response")?;
+    let data = handle_output(json_response, output_format, query)?;
     print_formatted_output(data, output_format)?;
     Ok(())
 }
@@ -425,10 +430,11 @@ async fn handle_delete(
         .await
         .context("Failed to delete PrivateLink")?;
 
+    let json_response = serde_json::to_value(result).context("Failed to serialize response")?;
     handle_async_response(
         params.conn_mgr,
         params.profile_name,
-        result,
+        json_response,
         params.async_ops,
         params.output_format,
         params.query,

--- a/crates/redisctl/src/commands/cloud/connectivity/psc.rs
+++ b/crates/redisctl/src/commands/cloud/connectivity/psc.rs
@@ -76,11 +76,22 @@ pub async fn handle_psc_command(
         }
 
         // Standard PSC Endpoint operations
-        PscCommands::EndpointsList { subscription_id } => {
-            get_endpoints(&client, *subscription_id, output_format, query).await
+        PscCommands::EndpointsList {
+            subscription_id,
+            psc_service_id,
+        } => {
+            get_endpoints(
+                &client,
+                *subscription_id,
+                *psc_service_id,
+                output_format,
+                query,
+            )
+            .await
         }
         PscCommands::EndpointCreate {
             subscription_id,
+            psc_service_id,
             gcp_project_id,
             gcp_vpc_name,
             gcp_vpc_subnet_name,
@@ -102,10 +113,10 @@ pub async fn handle_psc_command(
                 gcp_vpc_name: gcp_vpc_name.clone(),
                 gcp_vpc_subnet_name: gcp_vpc_subnet_name.clone(),
                 endpoint_connection_name: endpoint_connection_name.clone(),
-                psc_service_id: None,
+                psc_service_id: Some(*psc_service_id),
                 data: data.clone(),
             };
-            create_endpoint(&params, &endpoint_params).await
+            create_endpoint(&params, *psc_service_id, &endpoint_params).await
         }
         PscCommands::EndpointUpdate {
             subscription_id,
@@ -132,13 +143,14 @@ pub async fn handle_psc_command(
                 gcp_vpc_name: gcp_vpc_name.clone(),
                 gcp_vpc_subnet_name: gcp_vpc_subnet_name.clone(),
                 endpoint_connection_name: endpoint_connection_name.clone(),
-                psc_service_id: *psc_service_id,
+                psc_service_id: Some(*psc_service_id),
                 data: data.clone(),
             };
-            update_endpoint(&params, *endpoint_id, &endpoint_params).await
+            update_endpoint(&params, *psc_service_id, *endpoint_id, &endpoint_params).await
         }
         PscCommands::EndpointDelete {
             subscription_id,
+            psc_service_id,
             endpoint_id,
             yes,
             async_ops,
@@ -152,23 +164,33 @@ pub async fn handle_psc_command(
                 output_format,
                 query,
             };
-            delete_endpoint(&params, *endpoint_id, *yes).await
+            delete_endpoint(&params, *psc_service_id, *endpoint_id, *yes).await
         }
         PscCommands::EndpointCreationScript {
             subscription_id,
+            psc_service_id,
             endpoint_id,
-        } => get_endpoint_creation_script(&client, *subscription_id, *endpoint_id).await,
+        } => {
+            get_endpoint_creation_script(&client, *subscription_id, *psc_service_id, *endpoint_id)
+                .await
+        }
         PscCommands::EndpointDeletionScript {
             subscription_id,
+            psc_service_id,
             endpoint_id,
-        } => get_endpoint_deletion_script(&client, *subscription_id, *endpoint_id).await,
+        } => {
+            get_endpoint_deletion_script(&client, *subscription_id, *psc_service_id, *endpoint_id)
+                .await
+        }
 
         // Active-Active PSC Service operations
-        PscCommands::AaServiceGet { subscription_id } => {
-            get_service_aa(&client, *subscription_id, output_format, query).await
-        }
+        PscCommands::AaServiceGet {
+            subscription_id,
+            region_id,
+        } => get_service_aa(&client, *subscription_id, *region_id, output_format, query).await,
         PscCommands::AaServiceCreate {
             subscription_id,
+            region_id,
             async_ops,
         } => {
             let params = ConnectivityOperationParams {
@@ -180,10 +202,11 @@ pub async fn handle_psc_command(
                 output_format,
                 query,
             };
-            create_service_aa(&params).await
+            create_service_aa(&params, *region_id).await
         }
         PscCommands::AaServiceDelete {
             subscription_id,
+            region_id,
             yes,
             async_ops,
         } => {
@@ -196,15 +219,29 @@ pub async fn handle_psc_command(
                 output_format,
                 query,
             };
-            delete_service_aa(&params, *yes).await
+            delete_service_aa(&params, *region_id, *yes).await
         }
 
         // Active-Active PSC Endpoint operations
-        PscCommands::AaEndpointsList { subscription_id } => {
-            get_endpoints_aa(&client, *subscription_id, output_format, query).await
+        PscCommands::AaEndpointsList {
+            subscription_id,
+            region_id,
+            psc_service_id,
+        } => {
+            get_endpoints_aa(
+                &client,
+                *subscription_id,
+                *region_id,
+                *psc_service_id,
+                output_format,
+                query,
+            )
+            .await
         }
         PscCommands::AaEndpointCreate {
             subscription_id,
+            region_id,
+            psc_service_id,
             gcp_project_id,
             gcp_vpc_name,
             gcp_vpc_subnet_name,
@@ -226,14 +263,15 @@ pub async fn handle_psc_command(
                 gcp_vpc_name: gcp_vpc_name.clone(),
                 gcp_vpc_subnet_name: gcp_vpc_subnet_name.clone(),
                 endpoint_connection_name: endpoint_connection_name.clone(),
-                psc_service_id: None,
+                psc_service_id: Some(*psc_service_id),
                 data: data.clone(),
             };
-            create_endpoint_aa(&params, &endpoint_params).await
+            create_endpoint_aa(&params, *region_id, *psc_service_id, &endpoint_params).await
         }
         PscCommands::AaEndpointDelete {
             subscription_id,
             region_id,
+            psc_service_id,
             endpoint_id,
             yes,
             async_ops,
@@ -247,7 +285,7 @@ pub async fn handle_psc_command(
                 output_format,
                 query,
             };
-            delete_endpoint_aa(&params, *region_id, *endpoint_id, *yes).await
+            delete_endpoint_aa(&params, *region_id, *psc_service_id, *endpoint_id, *yes).await
         }
     }
 }
@@ -334,12 +372,13 @@ async fn delete_service(params: &ConnectivityOperationParams<'_>, yes: bool) -> 
 async fn get_endpoints(
     client: &CloudClient,
     subscription_id: i32,
+    psc_service_id: i32,
     output_format: OutputFormat,
     query: Option<&str>,
 ) -> CliResult<()> {
     let handler = PscHandler::new(client.clone());
     let response = handler
-        .get_endpoints(subscription_id)
+        .get_endpoints(subscription_id, psc_service_id)
         .await
         .context("Failed to get PSC endpoints")?;
 
@@ -379,13 +418,14 @@ fn build_psc_endpoint_request(
 
 async fn create_endpoint(
     params: &ConnectivityOperationParams<'_>,
+    psc_service_id: i32,
     endpoint_params: &PscEndpointParams,
 ) -> CliResult<()> {
     let request = build_psc_endpoint_request(params.subscription_id, 0, endpoint_params)?;
 
     let handler = PscHandler::new(params.client.clone());
     let response = handler
-        .create_endpoint(params.subscription_id, &request)
+        .create_endpoint(params.subscription_id, psc_service_id, &request)
         .await
         .context("Failed to create PSC endpoint")?;
 
@@ -405,6 +445,7 @@ async fn create_endpoint(
 
 async fn update_endpoint(
     params: &ConnectivityOperationParams<'_>,
+    psc_service_id: i32,
     endpoint_id: i32,
     endpoint_params: &PscEndpointParams,
 ) -> CliResult<()> {
@@ -412,7 +453,12 @@ async fn update_endpoint(
 
     let handler = PscHandler::new(params.client.clone());
     let response = handler
-        .update_endpoint(params.subscription_id, endpoint_id, &request)
+        .update_endpoint(
+            params.subscription_id,
+            psc_service_id,
+            endpoint_id,
+            &request,
+        )
         .await
         .context("Failed to update PSC endpoint")?;
 
@@ -432,6 +478,7 @@ async fn update_endpoint(
 
 async fn delete_endpoint(
     params: &ConnectivityOperationParams<'_>,
+    psc_service_id: i32,
     endpoint_id: i32,
     yes: bool,
 ) -> CliResult<()> {
@@ -448,7 +495,7 @@ async fn delete_endpoint(
 
     let handler = PscHandler::new(params.client.clone());
     let response = handler
-        .delete_endpoint(params.subscription_id, endpoint_id)
+        .delete_endpoint(params.subscription_id, psc_service_id, endpoint_id)
         .await
         .context("Failed to delete PSC endpoint")?;
 
@@ -469,11 +516,12 @@ async fn delete_endpoint(
 async fn get_endpoint_creation_script(
     client: &CloudClient,
     subscription_id: i32,
+    psc_service_id: i32,
     endpoint_id: i32,
 ) -> CliResult<()> {
     let handler = PscHandler::new(client.clone());
     let script = handler
-        .get_endpoint_creation_script(subscription_id, endpoint_id)
+        .get_endpoint_creation_script(subscription_id, psc_service_id, endpoint_id)
         .await
         .context("Failed to get creation script")?;
 
@@ -485,11 +533,12 @@ async fn get_endpoint_creation_script(
 async fn get_endpoint_deletion_script(
     client: &CloudClient,
     subscription_id: i32,
+    psc_service_id: i32,
     endpoint_id: i32,
 ) -> CliResult<()> {
     let handler = PscHandler::new(client.clone());
     let script = handler
-        .get_endpoint_deletion_script(subscription_id, endpoint_id)
+        .get_endpoint_deletion_script(subscription_id, psc_service_id, endpoint_id)
         .await
         .context("Failed to get deletion script")?;
 
@@ -505,12 +554,13 @@ async fn get_endpoint_deletion_script(
 async fn get_service_aa(
     client: &CloudClient,
     subscription_id: i32,
+    region_id: i32,
     output_format: OutputFormat,
     query: Option<&str>,
 ) -> CliResult<()> {
     let handler = PscHandler::new(client.clone());
     let response = handler
-        .get_service_active_active(subscription_id)
+        .get_service_active_active(subscription_id, region_id)
         .await
         .context("Failed to get Active-Active PSC service")?;
 
@@ -520,10 +570,13 @@ async fn get_service_aa(
     Ok(())
 }
 
-async fn create_service_aa(params: &ConnectivityOperationParams<'_>) -> CliResult<()> {
+async fn create_service_aa(
+    params: &ConnectivityOperationParams<'_>,
+    region_id: i32,
+) -> CliResult<()> {
     let handler = PscHandler::new(params.client.clone());
     let response = handler
-        .create_service_active_active(params.subscription_id)
+        .create_service_active_active(params.subscription_id, region_id)
         .await
         .context("Failed to create Active-Active PSC service")?;
 
@@ -541,7 +594,11 @@ async fn create_service_aa(params: &ConnectivityOperationParams<'_>) -> CliResul
     .await
 }
 
-async fn delete_service_aa(params: &ConnectivityOperationParams<'_>, yes: bool) -> CliResult<()> {
+async fn delete_service_aa(
+    params: &ConnectivityOperationParams<'_>,
+    region_id: i32,
+    yes: bool,
+) -> CliResult<()> {
     if !yes {
         let prompt = format!(
             "Delete Active-Active PSC service for subscription {}?",
@@ -555,7 +612,7 @@ async fn delete_service_aa(params: &ConnectivityOperationParams<'_>, yes: bool) 
 
     let handler = PscHandler::new(params.client.clone());
     let response = handler
-        .delete_service_active_active(params.subscription_id)
+        .delete_service_active_active(params.subscription_id, region_id)
         .await
         .context("Failed to delete Active-Active PSC service")?;
 
@@ -580,12 +637,14 @@ async fn delete_service_aa(params: &ConnectivityOperationParams<'_>, yes: bool) 
 async fn get_endpoints_aa(
     client: &CloudClient,
     subscription_id: i32,
+    region_id: i32,
+    psc_service_id: i32,
     output_format: OutputFormat,
     query: Option<&str>,
 ) -> CliResult<()> {
     let handler = PscHandler::new(client.clone());
     let response = handler
-        .get_endpoints_active_active(subscription_id)
+        .get_endpoints_active_active(subscription_id, region_id, psc_service_id)
         .await
         .context("Failed to get Active-Active PSC endpoints")?;
 
@@ -597,13 +656,15 @@ async fn get_endpoints_aa(
 
 async fn create_endpoint_aa(
     params: &ConnectivityOperationParams<'_>,
+    region_id: i32,
+    psc_service_id: i32,
     endpoint_params: &PscEndpointParams,
 ) -> CliResult<()> {
     let request = build_psc_endpoint_request(params.subscription_id, 0, endpoint_params)?;
 
     let handler = PscHandler::new(params.client.clone());
     let response = handler
-        .create_endpoint_active_active(params.subscription_id, &request)
+        .create_endpoint_active_active(params.subscription_id, region_id, psc_service_id, &request)
         .await
         .context("Failed to create Active-Active PSC endpoint")?;
 
@@ -624,6 +685,7 @@ async fn create_endpoint_aa(
 async fn delete_endpoint_aa(
     params: &ConnectivityOperationParams<'_>,
     region_id: i32,
+    psc_service_id: i32,
     endpoint_id: i32,
     yes: bool,
 ) -> CliResult<()> {
@@ -640,7 +702,12 @@ async fn delete_endpoint_aa(
 
     let handler = PscHandler::new(params.client.clone());
     let response = handler
-        .delete_endpoint_active_active(params.subscription_id, region_id, endpoint_id)
+        .delete_endpoint_active_active(
+            params.subscription_id,
+            region_id,
+            psc_service_id,
+            endpoint_id,
+        )
         .await
         .context("Failed to delete Active-Active PSC endpoint")?;
 

--- a/crates/redisctl/src/commands/cloud/connectivity/tgw.rs
+++ b/crates/redisctl/src/commands/cloud/connectivity/tgw.rs
@@ -154,9 +154,10 @@ pub async fn handle_tgw_command(
         }
 
         // Active-Active TGW operations
-        TgwCommands::AaAttachmentsList { subscription_id } => {
-            list_attachments_aa(&client, *subscription_id, output_format, query).await
-        }
+        TgwCommands::AaAttachmentsList {
+            subscription_id,
+            region_id,
+        } => list_attachments_aa(&client, *subscription_id, *region_id, output_format, query).await,
         TgwCommands::AaAttachmentCreate {
             subscription_id,
             region_id,
@@ -226,9 +227,10 @@ pub async fn handle_tgw_command(
             };
             delete_attachment_aa(&params, *region_id, attachment_id, *yes).await
         }
-        TgwCommands::AaInvitationsList { subscription_id } => {
-            list_invitations_aa(&client, *subscription_id, output_format, query).await
-        }
+        TgwCommands::AaInvitationsList {
+            subscription_id,
+            region_id,
+        } => list_invitations_aa(&client, *subscription_id, *region_id, output_format, query).await,
         TgwCommands::AaInvitationAccept {
             subscription_id,
             region_id,
@@ -314,11 +316,16 @@ async fn create_attachment(
     params: &ConnectivityOperationParams<'_>,
     attachment_params: &TgwAttachmentParams,
 ) -> CliResult<()> {
-    let request = build_tgw_attachment_request(attachment_params)?;
+    // The generic create_attachment route was removed upstream; the TGW ID is
+    // now required and is carried in the path.
+    let tgw_id = attachment_params
+        .tgw_id
+        .clone()
+        .ok_or_else(|| anyhow::anyhow!("--tgw-id is required"))?;
 
     let handler = TransitGatewayHandler::new(params.client.clone());
     let response = handler
-        .create_attachment(params.subscription_id, &request)
+        .create_attachment_with_id(params.subscription_id, &tgw_id)
         .await
         .context("Failed to create TGW attachment")?;
 
@@ -485,12 +492,13 @@ async fn reject_invitation(
 async fn list_attachments_aa(
     client: &CloudClient,
     subscription_id: i32,
+    region_id: i32,
     output_format: OutputFormat,
     query: Option<&str>,
 ) -> CliResult<()> {
     let handler = TransitGatewayHandler::new(client.clone());
     let response = handler
-        .get_attachments_active_active(subscription_id)
+        .get_attachments_active_active(subscription_id, region_id)
         .await
         .context("Failed to get Active-Active TGW attachments")?;
 
@@ -505,11 +513,16 @@ async fn create_attachment_aa(
     region_id: i32,
     attachment_params: &TgwAttachmentParams,
 ) -> CliResult<()> {
+    // The attachment route now requires the TGW ID in the path.
+    let tgw_id = attachment_params
+        .tgw_id
+        .clone()
+        .ok_or_else(|| anyhow::anyhow!("--tgw-id is required"))?;
     let request = build_tgw_attachment_request(attachment_params)?;
 
     let handler = TransitGatewayHandler::new(params.client.clone());
     let response = handler
-        .create_attachment_active_active(params.subscription_id, region_id, &request)
+        .create_attachment_active_active(params.subscription_id, region_id, &tgw_id, &request)
         .await
         .context("Failed to create Active-Active TGW attachment")?;
 
@@ -594,12 +607,13 @@ async fn delete_attachment_aa(
 async fn list_invitations_aa(
     client: &CloudClient,
     subscription_id: i32,
+    region_id: i32,
     output_format: OutputFormat,
     query: Option<&str>,
 ) -> CliResult<()> {
     let handler = TransitGatewayHandler::new(client.clone());
     let response = handler
-        .get_shared_invitations_active_active(subscription_id)
+        .get_shared_invitations_active_active(subscription_id, region_id)
         .await
         .context("Failed to get Active-Active TGW invitations")?;
 

--- a/crates/redisctl/src/commands/enterprise/cluster_impl.rs
+++ b/crates/redisctl/src/commands/enterprise/cluster_impl.rs
@@ -7,7 +7,6 @@ use crate::connection::ConnectionManager;
 use crate::error::RedisCtlError;
 use crate::error::Result as CliResult;
 use anyhow::Context;
-use redis_enterprise::alerts::AlertHandler;
 use redis_enterprise::bootstrap::BootstrapHandler;
 use redis_enterprise::cluster::ClusterHandler;
 use redis_enterprise::debuginfo::DebugInfoHandler;
@@ -550,8 +549,9 @@ pub async fn get_cluster_alerts(
     query: Option<&str>,
 ) -> CliResult<()> {
     let client = conn_mgr.create_enterprise_client(profile_name).await?;
-    let handler = AlertHandler::new(client);
-    let alerts = handler.list().await?;
+    // `AlertHandler::list` was removed upstream; call the cluster-wide alerts
+    // route directly to preserve this command's behavior.
+    let alerts: Vec<redis_enterprise::alerts::Alert> = client.get("/v1/alerts").await?;
     let alerts_json = serde_json::to_value(alerts).context("Failed to serialize alerts")?;
     let data = handle_output(alerts_json, output_format, query)?;
     print_formatted_output(data, output_format)?;


### PR DESCRIPTION
## Summary

Bumps both upstream API client crates to their latest published versions:
- `redis-cloud`: v0.9.5 (git pin) → v0.10.0 (crates.io)
- `redis-enterprise`: v0.8.5 (git pin) → v0.9.1 (crates.io)

Removes the git/branch pins and the stale TODO comment about #103 (merged 2026-06-01).

Adapts all callers for the redis-cloud v0.10.0 breaking changes:
- Connectivity endpoints (VPC peering, TGW, PSC) now return `TaskStateUpdate`
- TGW + PSC handler method signatures reconciled with spec
- Consolidated task/tag model types

Closes #933

## Test plan
- [ ] `cargo build --workspace --all-features` compiles clean
- [ ] `cargo fmt --all -- --check` passes
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` passes
- [ ] `cargo test --workspace` passes