### PR TITLE
fix(enterprise): handle non-JSON usage-report response

### DIFF
--- a/crates/redisctl/src/commands/enterprise/usage_report.rs
+++ b/crates/redisctl/src/commands/enterprise/usage_report.rs
@@ -59,18 +59,36 @@ async fn handle_usage_report_command_impl(
 
     match command {
         UsageReportCommands::Get => {
-            let response: serde_json::Value = client
-                .get("/v1/usage_report")
+            let body = client
+                .get_text("/v1/usage_report")
                 .await
                 .map_err(RedisCtlError::from)?;
 
-            let output_data = if let Some(q) = query {
-                super::utils::apply_jmespath(&response, q)?
+            // Try JSON first; if the body is non-JSON (e.g. a bare MD5 checksum
+            // returned by demo clusters with no usage data), emit a clear message.
+            let body_trimmed = body.trim();
+            if let Ok(json_val) = serde_json::from_str::<serde_json::Value>(body_trimmed) {
+                let output_data = if let Some(q) = query {
+                    super::utils::apply_jmespath(&json_val, q)?
+                } else {
+                    json_val
+                };
+                super::utils::print_formatted_output(output_data, output_format)?;
+            } else if is_md5_hex(body_trimmed) {
+                // Bare MD5 checksum = cluster has no usage data yet
+                println!(
+                    "usage-report: cluster returned a checksum ({body_trimmed}) with no report \
+                     data — this cluster has not yet accrued any usage. \
+                     No report to display."
+                );
+            } else if body_trimmed.is_empty() {
+                println!(
+                    "usage-report: endpoint returned an empty body — no usage data available."
+                );
             } else {
-                response
-            };
-
-            super::utils::print_formatted_output(output_data, output_format)?;
+                // Unknown non-JSON shape; surface the raw text so the user can act on it
+                println!("usage-report: endpoint returned non-JSON content:\n{body_trimmed}");
+            }
         }
         UsageReportCommands::Export { output, format } => {
             let response: serde_json::Value = client
@@ -169,6 +187,11 @@ fn json_to_csv(data: &serde_json::Value) -> CliResult<String> {
     Ok(csv)
 }
 
+/// Returns true if `s` looks like a bare MD5 hex digest (32 hex chars).
+fn is_md5_hex(s: &str) -> bool {
+    s.len() == 32 && s.chars().all(|c| c.is_ascii_hexdigit())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -231,5 +254,14 @@ mod tests {
         assert!(csv.contains("\"db2\""));
         assert!(csv.contains("1024"));
         assert!(csv.contains("2048"));
+    }
+
+    #[test]
+    fn test_is_md5_hex() {
+        assert!(is_md5_hex("d41d8cd98f00b204e9800998ecf8427e"));
+        assert!(is_md5_hex("D41D8CD98F00B204E9800998ECF8427E"));
+        assert!(!is_md5_hex("not-a-checksum"));
+        assert!(!is_md5_hex(""));
+        assert!(!is_md5_hex("d41d8cd98f00b204e9800998ecf8427")); // 31 chars, too short
     }
 }


### PR DESCRIPTION
Closes #917

## Problem

`redisctl enterprise usage-report get` fails against live Enterprise demo clusters with:
```
API error: Parse error: Failed to deserialize field '.': expected value at line 1 column 1
```

The `/v1/usage_report` endpoint on demo clusters (with no accrued usage data) returns `text/html` with an MD5 checksum (`d41d8cd98f00b204e9800998ecf8427e`) rather than JSON. The client's `handle_response` tries to deserialize this as JSON and panics.

## Fix

Switch from `client.get::<serde_json::Value>()` (JSON-only) to `client.get_text()` + opportunistic JSON parse:
- If the body parses as JSON → behave exactly as before
- If the body is a bare MD5 hex checksum → emit a clear diagnostic: "usage-report endpoint returned a checksum — cluster has no usage data yet"  
- Otherwise → surface the raw body as text so the user sees something actionable

Also add a unit test covering the checksum-body case.

## Test plan

- [ ] Unit test: non-JSON / checksum body path returns a clear message instead of a parse error
- [ ] `cargo fmt --all && cargo clippy --all-targets --all-features -- -D warnings` pass
- [ ] `cargo test --workspace` pass