### PR TITLE
fix(mcp): wire destination_region for create_aa_vpc_peering tool

### DIFF
--- a/crates/redisctl-mcp/src/state.rs
+++ b/crates/redisctl-mcp/src/state.rs
@@ -529,6 +529,27 @@ impl AppState {
         ))
     }
 
+    /// Create a read-write policy for tests that exercise write tools
+    pub fn test_write_policy() -> Arc<Policy> {
+        Arc::new(Policy::new(
+            crate::policy::PolicyConfig {
+                tier: SafetyTier::ReadWrite,
+                ..Default::default()
+            },
+            std::collections::HashMap::new(),
+            "test".to_string(),
+        ))
+    }
+
+    /// Create test state with a pre-configured Cloud client and write access
+    /// enabled, for tests that exercise write tools.
+    #[cfg(feature = "cloud")]
+    pub fn with_cloud_client_write(client: CloudClient) -> Self {
+        let mut state = Self::with_cloud_client(client);
+        state.policy = Self::test_write_policy();
+        state
+    }
+
     /// Create test state with a pre-configured Cloud client
     #[cfg(feature = "cloud")]
     pub fn with_cloud_client(client: CloudClient) -> Self {

--- a/crates/redisctl-mcp/src/tools/cloud/networking.rs
+++ b/crates/redisctl-mcp/src/tools/cloud/networking.rs
@@ -234,7 +234,7 @@ cloud_tool!(read_only, get_aa_vpc_peering, "get_aa_vpc_peering",
 );
 
 cloud_tool!(write, create_aa_vpc_peering, "create_aa_vpc_peering",
-    "Create an Active-Active VPC peering connection.",
+    "Create an Active-Active VPC peering connection. Use aws_region for the source region and destination_region for the target region (AWS cross-region peering).",
     {
         /// Subscription ID
         pub subscription_id: i32,
@@ -244,9 +244,12 @@ cloud_tool!(write, create_aa_vpc_peering, "create_aa_vpc_peering",
         /// AWS VPC ID
         #[serde(default)]
         pub vpc_id: Option<String>,
-        /// AWS region
+        /// AWS source region
         #[serde(default)]
         pub aws_region: Option<String>,
+        /// AWS destination region for cross-region Active-Active VPC peering (AWS only)
+        #[serde(default)]
+        pub destination_region: Option<String>,
         /// AWS account ID
         #[serde(default)]
         pub aws_account_id: Option<String>,
@@ -263,11 +266,13 @@ cloud_tool!(write, create_aa_vpc_peering, "create_aa_vpc_peering",
         #[serde(default)]
         pub network_name: Option<String>,
     } => |client, input| {
-        // Active-Active peering uses a distinct request type upstream; map the
-        // single `aws_region` onto `source_region`.
+        // Active-Active peering uses a distinct request type upstream; map
+        // `aws_region` onto `source_region` and the optional
+        // `destination_region` for AWS cross-region peering.
         let request = ActiveActiveVpcPeeringCreateRequest {
             provider: input.provider,
             source_region: input.aws_region,
+            destination_region: input.destination_region,
             aws_account_id: input.aws_account_id,
             vpc_id: input.vpc_id,
             vpc_cidr: input.vpc_cidr,

--- a/crates/redisctl-mcp/tests/cloud_tools.rs
+++ b/crates/redisctl-mcp/tests/cloud_tools.rs
@@ -8,7 +8,8 @@ use redis_cloud::testing::{
 };
 use serde_json::json;
 use tower_mcp::Tool;
-use wiremock::ResponseTemplate;
+use wiremock::matchers::{body_partial_json, method, path};
+use wiremock::{Mock, ResponseTemplate};
 
 // Import the tools and state from the MCP crate
 use redisctl_mcp::state::AppState;
@@ -453,4 +454,49 @@ async fn test_get_session_logs() {
     assert!(result.get("entries").is_some());
     let entries = result["entries"].as_array().unwrap();
     assert_eq!(entries.len(), 2);
+}
+
+// ============================================================================
+// Networking Tests
+// ============================================================================
+
+#[tokio::test]
+async fn test_create_aa_vpc_peering_destination_region() {
+    let server = MockCloudServer::start().await;
+
+    // The mock only matches when the request body carries both the source and
+    // destination regions, so a successful call proves `destination_region`
+    // was wired through to the upstream request.
+    Mock::given(method("POST"))
+        .and(path("/subscriptions/123/regions/peerings"))
+        .and(body_partial_json(json!({
+            "sourceRegion": "us-east-1",
+            "destinationRegion": "us-west-2"
+        })))
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({
+            "taskId": "task-aa-001",
+            "commandType": "CREATE_AA_VPC_PEERING",
+            "status": "processing-in-progress"
+        })))
+        .mount(server.inner())
+        .await;
+
+    let client = server.client();
+    let state = Arc::new(AppState::with_cloud_client_write(client));
+    let tool = cloud::create_aa_vpc_peering(state);
+
+    let result = call_tool_json(
+        &tool,
+        json!({
+            "subscription_id": 123,
+            "provider": "AWS",
+            "aws_region": "us-east-1",
+            "destination_region": "us-west-2",
+            "aws_account_id": "123456789012",
+            "vpc_id": "vpc-abcdef01"
+        }),
+    )
+    .await;
+
+    assert_eq!(result["taskId"], "task-aa-001");
 }


### PR DESCRIPTION
## Summary

Closes #938.

- Adds `destination_region` as an optional parameter to the `create_aa_vpc_peering` MCP tool
- Wires it through to `ActiveActiveVpcPeeringCreateRequest::destination_region` in the upstream `redis-cloud` v0.10.0 API
- Updates the tool description to document both `aws_region` (source) and `destination_region` (target) for cross-region AWS Active-Active VPC peering
- Adds a mock assertion test covering the new field

## Test plan

- [ ] `cargo fmt --all` passes
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` passes
- [ ] `cargo test --workspace` passes including new `test_create_aa_vpc_peering_destination_region` test