### PR TITLE
docs: update redis-developer → redis org references

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -73,7 +73,7 @@ markdown_extensions:
   - pymdownx.keys
   - pymdownx.magiclink:
       repo_url_shorthand: true
-      user: redis-developer
+      user: redis
       repo: redisctl
   - pymdownx.mark
   - pymdownx.smartsymbols

--- a/skills/redisctl-setup/SKILL.md
+++ b/skills/redisctl-setup/SKILL.md
@@ -13,7 +13,7 @@ Choose one method:
 
 ```bash
 # Homebrew (macOS/Linux)
-brew install redis-developer/tap/redisctl
+brew install redis/homebrew-tap/redisctl
 
 # Cargo (from source)
 cargo install redisctl


### PR DESCRIPTION
## Summary

- Fix `pymdownx.magiclink` user in `docs/mkdocs.yml`: `redis-developer` → `redis` (affects auto-expanded issue/PR shorthand links in docs)
- Fix Homebrew tap URL in `skills/redisctl-setup/SKILL.md`: `redis-developer/tap` → `redis/homebrew-tap`

API client lib references (`redis-developer/redis-cloud-rs`, `redis-developer/redis-enterprise-rs`) are intentionally left as-is — those repos live under `redis-developer/` and did not move.

Closes stragglers from the org move in #925.

## Test plan
- [ ] `mkdocs build` passes (or at minimum `markdown lint` CI check passes)
- [ ] Homebrew tap URL `redis/homebrew-tap` is valid (confirmed: https://github.com/redis/homebrew-tap)