### PR TITLE
docs(skills): fix networking skill — correct all subcommand names and arg syntax (closes #963)

### DIFF
--- a/skills/redisctl-networking/SKILL.md
+++ b/skills/redisctl-networking/SKILL.md
@@ -5,80 +5,156 @@ description: Configure network connectivity for Redis Cloud deployments via the 
 
 ## Overview
 
-Set up private network connectivity between your infrastructure and Redis Cloud deployments. Supports VPC Peering, Transit Gateway, Private Service Connect (GCP), and AWS PrivateLink.
+Set up private network connectivity between your infrastructure and Redis Cloud deployments. All networking commands live under `redisctl cloud connectivity`. Supports VPC Peering, Transit Gateway (AWS), Private Service Connect (GCP), and AWS PrivateLink.
 
 ## VPC Peering
 
+VPC peering uses `--subscription <ID>` as a named flag. There is no generic `list` subcommand — use `get` to retrieve the current peering configuration, or `list-aa` for Active-Active subscriptions.
+
 ```bash
-# List VPC peering connections
-redisctl cloud connectivity vpc-peering list --subscription-id 12345
+# Get VPC peering details for a subscription
+redisctl cloud connectivity vpc-peering get --subscription 12345
 
-# Get peering details
-redisctl cloud connectivity vpc-peering get --subscription-id 12345 --id 1
+# Create an AWS VPC peering connection
+redisctl cloud connectivity vpc-peering create --subscription 12345 \
+  --region us-east-1 \
+  --aws-account-id 123456789012 \
+  --vpc-id vpc-abc123 \
+  --vpc-cidr 10.0.0.0/16
 
-# Create a peering connection
-redisctl cloud connectivity vpc-peering create \
-  --subscription-id 12345 \
-  --data '{
-    "region": "us-east-1",
-    "aws_account_id": "123456789012",
-    "vpc_id": "vpc-abc123",
-    "vpc_cidr": "10.0.0.0/16"
-  }'
+# Create a GCP VPC peering connection
+redisctl cloud connectivity vpc-peering create --subscription 12345 \
+  --gcp-project-id my-gcp-project \
+  --gcp-network-name my-vpc-network
+
+# Update an existing peering connection
+redisctl cloud connectivity vpc-peering update --subscription 12345
 
 # Delete a peering connection
-redisctl cloud connectivity vpc-peering delete --subscription-id 12345 --id 1
+redisctl cloud connectivity vpc-peering delete --subscription 12345 --peering-id 1
+
+# Active-Active: list VPC peerings
+redisctl cloud connectivity vpc-peering list-aa --subscription 12345
 ```
 
 ## Transit Gateway (AWS)
 
+TGW commands take the subscription ID as a **positional argument** (not a flag).
+
 ```bash
 # List TGW attachments
-redisctl cloud connectivity tgw list --subscription-id 12345
+redisctl cloud connectivity tgw attachments-list 12345
 
 # Create a TGW attachment
-redisctl cloud connectivity tgw create \
-  --subscription-id 12345 \
-  --data '{...}'
+redisctl cloud connectivity tgw attachment-create 12345 \
+  --aws-account-id 123456789012 \
+  --tgw-id tgw-abc123 \
+  --cidr 10.0.0.0/16
 
-# Accept a TGW invitation
-redisctl cloud connectivity tgw accept --subscription-id 12345 --id 1
+# Update TGW attachment CIDRs
+redisctl cloud connectivity tgw attachment-update 12345
+
+# Delete a TGW attachment
+redisctl cloud connectivity tgw attachment-delete 12345
+
+# List pending resource share invitations
+redisctl cloud connectivity tgw invitations-list 12345
+
+# Accept a TGW resource share invitation
+redisctl cloud connectivity tgw invitation-accept 12345 <invitation-id>
+
+# Reject a TGW resource share invitation
+redisctl cloud connectivity tgw invitation-reject 12345 <invitation-id>
+```
+
+Active-Active TGW commands follow the same positional-arg pattern:
+
+```bash
+redisctl cloud connectivity tgw aa-attachments-list 12345
+redisctl cloud connectivity tgw aa-attachment-create 12345 --tgw-id tgw-abc123
+redisctl cloud connectivity tgw aa-invitations-list 12345
+redisctl cloud connectivity tgw aa-invitation-accept 12345 <invitation-id>
 ```
 
 ## Private Service Connect (GCP)
 
+PSC commands take the subscription ID as a **positional argument**. `endpoints-list` and `endpoint-create` also require `--psc-service-id`.
+
 ```bash
+# Get PSC service details for a subscription
+redisctl cloud connectivity psc service-get 12345
+
+# Create a PSC service
+redisctl cloud connectivity psc service-create 12345
+
+# Delete a PSC service
+redisctl cloud connectivity psc service-delete 12345
+
 # List PSC endpoints
-redisctl cloud connectivity psc list --subscription-id 12345
+redisctl cloud connectivity psc endpoints-list 12345 --psc-service-id <service-id>
 
 # Create a PSC endpoint
-redisctl cloud connectivity psc create \
-  --subscription-id 12345 \
-  --data '{...}'
+redisctl cloud connectivity psc endpoint-create 12345 \
+  --psc-service-id <service-id> \
+  --gcp-project-id my-project \
+  --gcp-vpc-name my-vpc \
+  --gcp-vpc-subnet-name my-subnet \
+  --endpoint-connection-name redis-psc
 
-# Get connection scripts
-redisctl cloud connectivity psc scripts --subscription-id 12345 --id 1
+# Get the endpoint creation script
+redisctl cloud connectivity psc endpoint-creation-script 12345 <endpoint-id> \
+  --psc-service-id <service-id>
+
+# Get the endpoint deletion script
+redisctl cloud connectivity psc endpoint-deletion-script 12345 <endpoint-id> \
+  --psc-service-id <service-id>
+
+# Delete a PSC endpoint
+redisctl cloud connectivity psc endpoint-delete 12345 \
+  --psc-service-id <service-id>
 ```
 
 ## AWS PrivateLink
 
-```bash
-# List PrivateLink endpoints
-redisctl cloud connectivity privatelink list --subscription-id 12345
+PrivateLink uses `--subscription <ID>` as a named flag. There is no `list` subcommand — use `get` to retrieve the current configuration.
 
-# Create a PrivateLink endpoint
-redisctl cloud connectivity privatelink create \
-  --subscription-id 12345 \
-  --data '{...}'
+```bash
+# Get PrivateLink configuration
+redisctl cloud connectivity privatelink get --subscription 12345
+
+# Create a PrivateLink service (with an initial principal)
+redisctl cloud connectivity privatelink create --subscription 12345 \
+  --share-name my-redis-share \
+  --principal 123456789012 \
+  --type aws-account
+
+# Add additional AWS principals to an existing PrivateLink
+redisctl cloud connectivity privatelink add-principal --subscription 12345 \
+  --principal 123456789012 \
+  --type aws-account
+
+# Remove a principal from PrivateLink
+redisctl cloud connectivity privatelink remove-principal --subscription 12345 \
+  --principal 123456789012 \
+  --type aws-account
+
+# Get the VPC endpoint creation script
+redisctl cloud connectivity privatelink get-script --subscription 12345
+
+# Delete PrivateLink configuration
+redisctl cloud connectivity privatelink delete --subscription 12345
 ```
 
 ## Cloud Provider Accounts
 
-Required for some networking operations:
+Required for some networking operations (e.g., AWS VPC peering, TGW):
 
 ```bash
 # List provider accounts
 redisctl cloud provider-account list
+
+# Get provider account details
+redisctl cloud provider-account get
 
 # Create a provider account
 redisctl cloud provider-account create --data '{...}'
@@ -86,8 +162,10 @@ redisctl cloud provider-account create --data '{...}'
 
 ## Tips
 
-- VPC peering requires matching CIDR ranges -- ensure no overlap with Redis Cloud VPC
+- VPC peering requires matching CIDR ranges — ensure no overlap with Redis Cloud VPC
 - Transit Gateway and PrivateLink are AWS-only features
 - Private Service Connect is GCP-only
-- Most connectivity operations are async -- use `redisctl cloud task wait` after creation
-- Active-Active subscriptions have separate connectivity endpoints per region
+- Most connectivity operations are async — use `redisctl cloud task wait` after creation
+- Active-Active subscriptions have separate connectivity commands with an `aa-` prefix
+- Use `--wait` on create/delete commands to block until the operation completes
+- Use `--output json` or `--output table` to control output format


### PR DESCRIPTION
## Summary

- Rewrites `skills/redisctl-networking/SKILL.md` to use correct CLI syntax throughout
- Fixes the subcommand path: `redisctl cloud vpc-peering` → `redisctl cloud connectivity vpc-peering`
- Replaces non-existent `list`/`create`/`accept` subcommands with actual ones (`attachments-list`, `attachment-create`, `invitation-accept`, etc.)
- Fixes `--subscription-id` → `--subscription` (flag) and positional `<SUBSCRIPTION_ID>` arg patterns where applicable
- Adds coverage for PSC service operations, TGW invitations, PrivateLink scripting, principal management

## Test plan

- [ ] Every command in the skill matches output of `cargo run --bin redisctl -- cloud connectivity <subgroup> --help`
- [ ] No `--subscription-id` flag references remain (replaced with `--subscription` or positional arg)
- [ ] All sections (VPC Peering, TGW, PSC, PrivateLink) updated with real subcommand names

Closes #963