### PR TITLE
fix(mcp): add tier context to Fixed tool descriptions, clarify Enterprise memory_size unit

### DIFF
--- a/crates/redisctl-mcp/src/tools/cloud/fixed.rs
+++ b/crates/redisctl-mcp/src/tools/cloud/fixed.rs
@@ -58,7 +58,8 @@ mcp_module! {
 // ============================================================================
 
 cloud_tool!(read_only, list_fixed_subscriptions, "list_fixed_subscriptions",
-    "List all Fixed/Essentials subscriptions.",
+    "List all Fixed/Essentials tier subscriptions (pre-configured plans). \
+     Use list_subscriptions for Pro subscriptions.",
     {} => |client, _input| {
         let handler = FixedSubscriptionHandler::new(client);
         let subscriptions = handler
@@ -71,7 +72,8 @@ cloud_tool!(read_only, list_fixed_subscriptions, "list_fixed_subscriptions",
 );
 
 cloud_tool!(read_only, get_fixed_subscription, "get_fixed_subscription",
-    "Get subscription details by ID.",
+    "Get details for a Fixed/Essentials subscription by ID. \
+     Use get_subscription for Pro subscriptions.",
     {
         /// Fixed subscription ID
         pub subscription_id: i32,
@@ -175,7 +177,8 @@ cloud_tool!(destructive, delete_fixed_subscription, "delete_fixed_subscription",
 );
 
 cloud_tool!(read_only, list_fixed_plans, "list_fixed_plans",
-    "List available Fixed/Essentials plans.",
+    "List available Fixed/Essentials plans by size, region, and price. \
+     Call this before create_fixed_subscription to discover available plan IDs.",
     {
         /// Cloud provider filter (e.g., "AWS", "GCP", "Azure")
         #[serde(default)]
@@ -247,7 +250,8 @@ cloud_tool!(read_only, get_fixed_redis_versions, "get_fixed_redis_versions",
 // ============================================================================
 
 cloud_tool!(read_only, list_fixed_databases, "list_fixed_databases",
-    "List databases in a subscription.",
+    "List databases in a Fixed/Essentials subscription. \
+     Use list_databases for Pro subscriptions.",
     {
         /// Fixed subscription ID
         pub subscription_id: i32,
@@ -269,7 +273,8 @@ cloud_tool!(read_only, list_fixed_databases, "list_fixed_databases",
 );
 
 cloud_tool!(read_only, get_fixed_database, "get_fixed_database",
-    "Get database details by ID.",
+    "Get details for a database in a Fixed/Essentials subscription by ID. \
+     Use get_database for Pro subscriptions.",
     {
         /// Fixed subscription ID
         pub subscription_id: i32,
@@ -462,7 +467,7 @@ cloud_tool!(destructive, delete_fixed_database, "delete_fixed_database",
 // ============================================================================
 
 cloud_tool!(read_only, get_fixed_database_backup_status, "get_fixed_database_backup_status",
-    "Get latest backup status for a database.",
+    "Get latest backup status for a Fixed/Essentials database.",
     {
         /// Fixed subscription ID
         pub subscription_id: i32,

--- a/crates/redisctl-mcp/src/tools/enterprise/databases.rs
+++ b/crates/redisctl-mcp/src/tools/enterprise/databases.rs
@@ -246,11 +246,13 @@ enterprise_tool!(write, import_enterprise_database, "import_enterprise_database"
 enterprise_tool!(write, create_enterprise_database, "create_enterprise_database",
     "Create a new database on the Enterprise cluster. \
      Prerequisites: 1) get_cluster -- verify the cluster is healthy and has capacity. \
-     2) list_enterprise_databases -- review existing databases.",
+     2) get_enterprise_cluster_policy -- check the default Redis version and rack-awareness settings. \
+     3) list_enterprise_databases -- check name uniqueness and review existing databases.",
     {
         /// Database name
         pub name: String,
-        /// Memory size in bytes (e.g., 1073741824 for 1GB)
+        /// Memory size in **bytes** (not GB — unlike Cloud tools). Example: 1073741824 = 1 GB.
+        /// IMPORTANT: passing a value in GB (e.g., 1.0) will create a 1-byte database.
         pub memory_size: Option<u64>,
         /// Port number (optional, cluster will assign if not specified)
         pub port: Option<u16>,


### PR DESCRIPTION
## Summary

- Fixes Fixed/Essentials tier tool descriptions (#949): adds tier context to all list/get tools so agents know these are for the Essentials tier and can cross-reference to the Pro equivalents
- Fixes Enterprise `create_enterprise_database` (#948): expands prerequisite chain and adds a prominent bytes-not-GB warning to `memory_size`

## Changes

### Fixed/Essentials tier (`cloud/fixed.rs`)

- `list_fixed_subscriptions`: clarify this is for Fixed/Essentials tier (pre-configured plans), cross-reference Pro
- `get_fixed_subscription`: clarify tier, cross-reference Pro equivalent
- `list_fixed_databases`: clarify tier, cross-reference Pro equivalent
- `get_fixed_database`: clarify tier, cross-reference Pro equivalent
- `list_fixed_plans`: emphasize this is how you discover plan sizes/regions before creating
- `get_fixed_database_backup_status`: add tier context

### Enterprise databases (`enterprise/databases.rs`)

- `create_enterprise_database`: expand prerequisite chain (add `get_enterprise_cluster_policy`)
- `memory_size` field doc: add prominent "IMPORTANT: in **bytes**, not GB — unlike Cloud tools" note

Closes #948, Closes #949