### PR TITLE
docs(skills): fix enterprise-admin and enterprise-ops skill command syntax (closes #964, closes #965)

### DIFF
--- a/docs/docs/developer/contributing.md
+++ b/docs/docs/developer/contributing.md
@@ -6,7 +6,7 @@ How to contribute to redisctl.
 
 ### Prerequisites
 
-- Rust 1.75+ (edition 2024)
+- Rust 1.90+ (edition 2024)
 - Git
 
 ### Clone and Build
@@ -106,10 +106,10 @@ crates/
 
 ## Adding a New Command
 
-1. Add command enum in `crates/redisctl/src/cli.rs`
-2. Implement handler in `src/commands/`
-3. Add to command routing in `src/main.rs`
-4. Add tests in `tests/`
+1. Add command enum in `crates/redisctl/src/cli/mod.rs` (top-level) or the relevant domain file: `src/cli/cloud.rs` (Cloud), `src/cli/enterprise.rs` (Enterprise)
+2. Implement handler in `crates/redisctl/src/commands/` (subdirs: `cloud/`, `enterprise/`)
+3. Add to command routing in `crates/redisctl/src/main.rs`
+4. Add tests in `crates/redisctl/tests/`
 5. Update documentation
 
 ## Testing
@@ -146,7 +146,7 @@ async fn test_database_list() {
 
 ## Documentation
 
-- User docs: `mkdocs-site/docs/`
+- User docs: `docs/docs/`
 - API docs: Inline rustdoc comments
 - Build docs: `cargo doc --workspace`
 

--- a/docs/docs/developer/libraries.md
+++ b/docs/docs/developer/libraries.md
@@ -21,7 +21,7 @@ Redis Cloud API client with full type coverage. Maintained at [github.com/redis-
 **Rust:**
 ```toml
 [dependencies]
-redis-cloud = "0.8"
+redis-cloud = "0.10"
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -64,7 +64,7 @@ Redis Enterprise REST API client. Maintained at [github.com/redis-developer/redi
 **Rust:**
 ```toml
 [dependencies]
-redis-enterprise = "0.7"
+redis-enterprise = "0.9"
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -109,7 +109,7 @@ Core library for config, workflows, and shared logic.
 
 ```toml
 [dependencies]
-redisctl-core = "0.8"
+redisctl-core = "0.11"
 ```
 
 ### Example

--- a/docs/docs/mcp/getting-started.md
+++ b/docs/docs/mcp/getting-started.md
@@ -148,7 +148,7 @@ REDIS_URL=redis://localhost:6379 redisctl-mcp --profile my-profile
 
 #### Option 2: Database Profile (Recommended for Regular Use)
 
-Configure a database profile in your redisctl config file (`~/.config/redisctl/config.toml` or `~/Library/Application Support/redisctl/config.toml` on macOS):
+Configure a database profile in your redisctl config file (`~/.config/redisctl/config.toml` or `~/Library/Application Support/com.redis.redisctl/config.toml` on macOS):
 
 ```toml
 # Default database profile to use when none specified

--- a/docs/docs/reference/config-file.md
+++ b/docs/docs/reference/config-file.md
@@ -109,7 +109,7 @@ Every profile requires a `deployment_type` field (`cloud`, `enterprise`, or `dat
 | `password` | Redis password (optional) |
 | `username` | Redis ACL username (optional, default: `default`) |
 | `tls` | Enable TLS (`true`/`false`, default: `true`) |
-| `db` | Redis database number (optional, default: `0`) |
+| `database` | Redis database number (optional, default: `0`) |
 
 ### Global Settings
 

--- a/skills/redisctl-enterprise-admin/SKILL.md
+++ b/skills/redisctl-enterprise-admin/SKILL.md
@@ -13,30 +13,30 @@ Advanced cluster administration tasks: access control, security, licensing, main
 
 ```bash
 redisctl enterprise user list
-redisctl enterprise user get --id 1
+redisctl enterprise user get 1
 redisctl enterprise user create --data '{...}'
-redisctl enterprise user update --id 1 --data '{...}'
-redisctl enterprise user delete --id 1
+redisctl enterprise user update 1 --data '{...}'
+redisctl enterprise user delete 1
 ```
 
 ### Roles
 
 ```bash
 redisctl enterprise role list
-redisctl enterprise role get --id 1
+redisctl enterprise role get 1
 redisctl enterprise role create --data '{...}'
-redisctl enterprise role update --id 1 --data '{...}'
-redisctl enterprise role delete --id 1
+redisctl enterprise role update 1 --data '{...}'
+redisctl enterprise role delete 1
 ```
 
 ### ACLs
 
 ```bash
 redisctl enterprise acl list
-redisctl enterprise acl get --id 1
+redisctl enterprise acl get 1
 redisctl enterprise acl create --data '{...}'
-redisctl enterprise acl update --id 1 --data '{...}'
-redisctl enterprise acl delete --id 1
+redisctl enterprise acl update 1 --data '{...}'
+redisctl enterprise acl delete 1
 ```
 
 ## LDAP Integration
@@ -54,8 +54,8 @@ redisctl enterprise ldap test
 # Manage LDAP role mappings
 redisctl enterprise ldap-mappings list
 redisctl enterprise ldap-mappings create --data '{...}'
-redisctl enterprise ldap-mappings update --id 1 --data '{...}'
-redisctl enterprise ldap-mappings delete --id 1
+redisctl enterprise ldap-mappings update 1 --data '{...}'
+redisctl enterprise ldap-mappings delete 1
 ```
 
 ## Cluster Configuration
@@ -88,16 +88,26 @@ redisctl enterprise cluster disable-maintenance-mode
 # Get current license info
 redisctl enterprise license get
 
-# Update license
-redisctl enterprise license update --file license.key
+# Upload a license file
+redisctl enterprise license upload --file license.key
+
+# Update license with a key string or JSON data
+redisctl enterprise license update --license-key <KEY>
+redisctl enterprise license update --data @license.json
+
+# Validate, check expiry, and view licensed features/usage
+redisctl enterprise license validate
+redisctl enterprise license expiry
+redisctl enterprise license features
+redisctl enterprise license usage
 ```
 
 ## Proxy Management
 
 ```bash
 redisctl enterprise proxy list
-redisctl enterprise proxy get --id 1
-redisctl enterprise proxy update --id 1 --data '{...}'
+redisctl enterprise proxy get <UID>
+redisctl enterprise proxy update <UID> --data '{...}'
 ```
 
 ## Service Management
@@ -111,19 +121,31 @@ redisctl enterprise services update --name <service> --data '{...}'
 ## Diagnostics
 
 ```bash
-# Cluster diagnostics
-redisctl enterprise diagnostics cluster
+# Get / update diagnostics configuration
+redisctl enterprise diagnostics get
+redisctl enterprise diagnostics update --data '{...}'
 
-# Node diagnostics
-redisctl enterprise diagnostics node
+# Run diagnostic checks
+redisctl enterprise diagnostics run
 
-# Debug info collection
-redisctl enterprise debug-info
+# List available checks and reports
+redisctl enterprise diagnostics list-checks
+redisctl enterprise diagnostics list-reports
+
+# Get the last or a specific diagnostic report
+redisctl enterprise diagnostics last-report
+redisctl enterprise diagnostics get-report <ID>
 
 # Support package for Redis support
-redisctl enterprise support-package create
-redisctl enterprise support-package status --id <pkg-id>
-redisctl enterprise support-package download --id <pkg-id>
+redisctl enterprise support-package cluster
+redisctl enterprise support-package database
+redisctl enterprise support-package node
+
+# Check status of an async support-package generation task
+redisctl enterprise support-package status <task-id>
+
+# List previously generated support packages
+redisctl enterprise support-package list
 ```
 
 ## Tips

--- a/skills/redisctl-enterprise-ops/SKILL.md
+++ b/skills/redisctl-enterprise-ops/SKILL.md
@@ -27,16 +27,16 @@ redisctl enterprise status --brief
 redisctl enterprise database list
 
 # Get database details
-redisctl enterprise database get --id 1
+redisctl enterprise database get 1
 
 # Create a database
 redisctl enterprise database create --data '{...}'
 
 # Update a database
-redisctl enterprise database update --id 1 --data '{...}'
+redisctl enterprise database update 1 --data '{...}'
 
 # Delete a database
-redisctl enterprise database delete --id 1
+redisctl enterprise database delete 1
 ```
 
 ## Active-Active (CRDB)
@@ -46,17 +46,17 @@ redisctl enterprise database delete --id 1
 redisctl enterprise crdb list
 
 # Get CRDB details
-redisctl enterprise crdb get --id <guid>
+redisctl enterprise crdb get <guid>
 
 # Create a CRDB
 redisctl enterprise crdb create --data '{...}'
 
 # Update a CRDB
-redisctl enterprise crdb update --id <guid> --data '{...}'
+redisctl enterprise crdb update <guid> --data '{...}'
 
 # Check CRDB task status
 redisctl enterprise crdb-task list
-redisctl enterprise crdb-task get --id <task-id>
+redisctl enterprise crdb-task get <task-id>
 ```
 
 ## Stats and Metrics
@@ -71,24 +71,21 @@ redisctl enterprise stats node
 # Per-database stats
 redisctl enterprise stats database
 
-# Per-shard stats
-redisctl enterprise stats shard
+# Per-shard stats (by database)
+redisctl enterprise stats database-shards
 ```
 
 ## Logs and Alerts
 
 ```bash
-# View cluster logs
-redisctl enterprise logs cluster
-
-# View node-specific logs
-redisctl enterprise logs node
+# View cluster event logs
+redisctl enterprise logs list
 
 # List alerts
 redisctl enterprise alerts list
 
 # Get alert details
-redisctl enterprise alerts get --id <alert-id>
+redisctl enterprise alerts get <UID>
 ```
 
 ## Module Management
@@ -98,7 +95,7 @@ redisctl enterprise alerts get --id <alert-id>
 redisctl enterprise module list
 
 # Get module details
-redisctl enterprise module get --id <module-id>
+redisctl enterprise module get <UID>
 ```
 
 ## Nodes and Shards
@@ -108,13 +105,13 @@ redisctl enterprise module get --id <module-id>
 redisctl enterprise node list
 
 # Get node details
-redisctl enterprise node get --id 1
+redisctl enterprise node get 1
 
 # List shards
 redisctl enterprise shard list
 
 # Get shard details
-redisctl enterprise shard get --id 1
+redisctl enterprise shard get <UID>
 ```
 
 ## Tips


### PR DESCRIPTION
## Summary

Fix broken CLI examples in two enterprise skills. All commands verified against actual `--help` output before writing.

### enterprise-admin (#964)
- `diagnostics cluster` / `diagnostics node` (nonexistent) replaced with real subcommands: `run`, `list-checks`, `last-report`, `get-report <ID>`, `list-reports`
- `support-package create` replaced with `cluster`/`database`/`node` forms
- `support-package status --id <pkg-id>` fixed to positional `status <task-id>`
- `support-package download` (nonexistent) replaced with `support-package list`
- `license update --file license.key` fixed to `license upload --file license.key`
- All `--id` flags in user/role/acl/proxy/ldap-mappings sections fixed to positional args

### enterprise-ops (#965)
- All `--id <N>` flags fixed to positional `<ID>` for database, node, shard, crdb, crdb-task, and module commands
- `stats shard` fixed to `stats database-shards`
- `logs cluster` / `logs node` fixed to `logs list`
- `alerts get --id <uid>` fixed to positional `alerts get <UID>`