### PR TITLE
test(mcp): add enterprise proxy and services tool tests (closes #955)

### DIFF
--- a/crates/redisctl-mcp/tests/enterprise_tools.rs
+++ b/crates/redisctl-mcp/tests/enterprise_tools.rs
@@ -832,3 +832,288 @@ async fn test_get_module() {
     assert_eq!(result["semantic_version"], "2.6.0");
     assert_eq!(result["author"], "Redis Ltd.");
 }
+
+// ============================================================================
+// Proxy Tests
+// ============================================================================
+
+#[tokio::test]
+async fn test_list_enterprise_proxies() {
+    let server = MockEnterpriseServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/proxies"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            {"uid": 1, "status": "active", "port": 12000},
+            {"uid": 2, "status": "active", "port": 12001}
+        ])))
+        .mount(server.inner())
+        .await;
+
+    let client = server.client();
+    let state = Arc::new(AppState::with_enterprise_client(client));
+    let tool = enterprise::list_proxies(state);
+
+    let result = call_tool_json(&tool, json!({})).await;
+
+    let proxies = result["proxies"]
+        .as_array()
+        .expect("expected proxies array");
+    assert_eq!(proxies.len(), 2);
+    assert_eq!(proxies[0]["uid"], 1);
+}
+
+#[tokio::test]
+async fn test_get_enterprise_proxy() {
+    let server = MockEnterpriseServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/proxies/1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "uid": 1,
+            "status": "active",
+            "port": 12000,
+            "max_connections": 1000
+        })))
+        .mount(server.inner())
+        .await;
+
+    let client = server.client();
+    let state = Arc::new(AppState::with_enterprise_client(client));
+    let tool = enterprise::get_proxy(state);
+
+    let result = call_tool_json(&tool, json!({"uid": 1})).await;
+
+    assert_eq!(result["uid"], 1);
+    assert_eq!(result["status"], "active");
+}
+
+#[tokio::test]
+async fn test_get_enterprise_proxy_stats() {
+    let server = MockEnterpriseServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/proxies/1/stats"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "uid": 1,
+            "intervals": [
+                {"interval": "1sec", "timestamps": [1705314600], "values": [5000]}
+            ]
+        })))
+        .mount(server.inner())
+        .await;
+
+    let client = server.client();
+    let state = Arc::new(AppState::with_enterprise_client(client));
+    let tool = enterprise::get_proxy_stats(state);
+
+    let result = call_tool_json(&tool, json!({"uid": 1})).await;
+
+    assert_eq!(result["uid"], 1);
+    assert!(result.get("intervals").is_some());
+}
+
+#[tokio::test]
+async fn test_update_enterprise_proxy() {
+    let server = MockEnterpriseServer::start().await;
+
+    Mock::given(method("PUT"))
+        .and(path("/v1/proxies/1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "uid": 1,
+            "status": "active",
+            "max_connections": 2000
+        })))
+        .mount(server.inner())
+        .await;
+
+    let client = server.client();
+    let mut state = AppState::with_enterprise_client(client);
+    state.policy = AppState::test_write_policy();
+    let state = Arc::new(state);
+    let tool = enterprise::update_proxy(state);
+
+    let result = call_tool_json(
+        &tool,
+        json!({
+            "uid": 1,
+            "updates": {"max_connections": 2000}
+        }),
+    )
+    .await;
+
+    assert_eq!(result["uid"], 1);
+    assert_eq!(result["max_connections"], 2000);
+}
+
+// ============================================================================
+// Services Tests
+// ============================================================================
+
+#[tokio::test]
+async fn test_list_enterprise_services() {
+    let server = MockEnterpriseServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/local/services"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "cm_server": {"service_id": "cm_server", "name": "cm_server", "enabled": true},
+            "mdns_server": {"service_id": "mdns_server", "name": "mdns_server", "enabled": true}
+        })))
+        .mount(server.inner())
+        .await;
+
+    let client = server.client();
+    let state = Arc::new(AppState::with_enterprise_client(client));
+    let tool = enterprise::list_services(state);
+
+    let result = call_tool_json(&tool, json!({})).await;
+
+    assert!(result.get("cm_server").is_some());
+    assert!(result.get("mdns_server").is_some());
+}
+
+#[tokio::test]
+async fn test_get_enterprise_service() {
+    let server = MockEnterpriseServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/local/services"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "cm_server": {"service_id": "cm_server", "name": "cm_server", "enabled": true}
+        })))
+        .mount(server.inner())
+        .await;
+
+    let client = server.client();
+    let state = Arc::new(AppState::with_enterprise_client(client));
+    let tool = enterprise::get_service(state);
+
+    let result = call_tool_json(&tool, json!({"service_id": "cm_server"})).await;
+
+    assert_eq!(result["service_id"], "cm_server");
+    assert_eq!(result["enabled"], true);
+}
+
+#[tokio::test]
+async fn test_get_enterprise_service_status() {
+    let server = MockEnterpriseServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/local/services"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "cm_server": {"service_id": "cm_server", "name": "cm_server", "enabled": true}
+        })))
+        .mount(server.inner())
+        .await;
+
+    let client = server.client();
+    let state = Arc::new(AppState::with_enterprise_client(client));
+    let tool = enterprise::get_service_status(state);
+
+    let result = call_tool_json(&tool, json!({"service_id": "cm_server"})).await;
+
+    assert_eq!(result["service_id"], "cm_server");
+    assert_eq!(result["enabled"], true);
+}
+
+#[tokio::test]
+async fn test_update_enterprise_service() {
+    let server = MockEnterpriseServer::start().await;
+
+    Mock::given(method("PUT"))
+        .and(path("/v1/services/cm_server"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "service_id": "cm_server",
+            "enabled": false
+        })))
+        .mount(server.inner())
+        .await;
+
+    let client = server.client();
+    let mut state = AppState::with_enterprise_client(client);
+    state.policy = AppState::test_write_policy();
+    let state = Arc::new(state);
+    let tool = enterprise::update_service(state);
+
+    let result = call_tool_json(
+        &tool,
+        json!({
+            "service_id": "cm_server",
+            "config": {"enabled": false}
+        }),
+    )
+    .await;
+
+    assert_eq!(result["service_id"], "cm_server");
+    assert_eq!(result["enabled"], false);
+}
+
+#[tokio::test]
+async fn test_start_enterprise_service() {
+    let server = MockEnterpriseServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/services/cm_server/start"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "status": "ok"
+        })))
+        .mount(server.inner())
+        .await;
+
+    let client = server.client();
+    let mut state = AppState::with_enterprise_client(client);
+    state.policy = AppState::test_write_policy();
+    let state = Arc::new(state);
+    let tool = enterprise::start_service(state);
+
+    let result = call_tool_json(&tool, json!({"service_id": "cm_server"})).await;
+
+    assert_eq!(result["status"], "ok");
+}
+
+#[tokio::test]
+async fn test_stop_enterprise_service() {
+    let server = MockEnterpriseServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/services/cm_server/stop"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "status": "ok"
+        })))
+        .mount(server.inner())
+        .await;
+
+    let client = server.client();
+    let mut state = AppState::with_enterprise_client(client);
+    state.policy = AppState::test_write_policy();
+    let state = Arc::new(state);
+    let tool = enterprise::stop_service(state);
+
+    let result = call_tool_json(&tool, json!({"service_id": "cm_server"})).await;
+
+    assert_eq!(result["status"], "ok");
+}
+
+#[tokio::test]
+async fn test_restart_enterprise_service() {
+    let server = MockEnterpriseServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/services/cm_server/restart"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "status": "ok"
+        })))
+        .mount(server.inner())
+        .await;
+
+    let client = server.client();
+    let mut state = AppState::with_enterprise_client(client);
+    state.policy = AppState::test_write_policy();
+    let state = Arc::new(state);
+    let tool = enterprise::restart_service(state);
+
+    let result = call_tool_json(&tool, json!({"service_id": "cm_server"})).await;
+
+    assert_eq!(result["status"], "ok");
+}


### PR DESCRIPTION
## Summary

Adds wiremock-based MCP tool tests for two enterprise modules with zero coverage:
- `proxy.rs` (4 tools): `list_proxies`, `get_proxy`, `get_proxy_stats`, `update_proxy`
- `services.rs` (7 tools): `list_services`, `get_service`, `get_service_status`, `update_service`, `start_service`, `stop_service`, `restart_service`

All 11 tools get at least one test asserting the correct HTTP method, path, and basic response shape.

## Approach

Follows the established wiremock pattern in `enterprise_tools.rs`. Each test:
1. Starts a `MockEnterpriseServer`
2. Mounts a `Mock` for the expected HTTP method + path
3. Calls the tool via `call_tool_json`
4. Asserts on the response shape

For read tools: mock GET and assert on returned fields.  
For write tools (PUT/POST): mock the mutating method/path and assert the response shape.

## Test coverage added

- `test_list_enterprise_proxies` — GET /v1/proxies
- `test_get_enterprise_proxy` — GET /v1/proxies/{uid}
- `test_get_enterprise_proxy_stats` — GET /v1/proxies/{uid}/stats
- `test_update_enterprise_proxy` — PUT /v1/proxies/{uid}
- `test_list_enterprise_services` — GET /v1/local/services
- `test_get_enterprise_service` — GET /v1/local/services (map lookup)
- `test_get_enterprise_service_status` — GET /v1/local/services (map lookup)
- `test_update_enterprise_service` — PUT /v1/services/{service_id}
- `test_start_enterprise_service` — POST /v1/services/{service_id}/start
- `test_stop_enterprise_service` — POST /v1/services/{service_id}/stop
- `test_restart_enterprise_service` — POST /v1/services/{service_id}/restart

Closes #955 (partial — proxy and services modules; remaining modules tracked in the parent issue).