### PR TITLE
test(mcp): add ft_profile, synonym, alias, and JSON array tool tests (closes #962)

### DIFF
--- a/crates/redisctl-mcp/tests/redis_stack_tools.rs
+++ b/crates/redisctl-mcp/tests/redis_stack_tools.rs
@@ -633,3 +633,371 @@ async fn test_alias_tools() {
 
     cleanup(&mut conn, "alias_doc:").await;
 }
+
+// ============================================================================
+// Search: profile, synonyms, dictionaries, aliases (RediSearch)
+// ============================================================================
+
+#[tokio::test]
+#[ignore = "Requires Docker"]
+async fn test_ft_profile() {
+    let ctx = get_redis_stack()
+        .await
+        .expect("Failed to get Redis Stack container");
+    let full_state = make_full_state(ctx.port);
+    let state = make_state(ctx.port);
+    let mut conn = get_conn(ctx.port).await;
+
+    cleanup(&mut conn, "ftpro_doc:").await;
+    let _: Result<(), _> = ::redis::cmd("FT.DROPINDEX")
+        .arg("ftpro_idx")
+        .query_async::<()>(&mut conn)
+        .await;
+
+    // Index a single document.
+    let _: () = ::redis::cmd("JSON.SET")
+        .arg("ftpro_doc:1")
+        .arg("$")
+        .arg("{\"title\":\"Redis Search Profiling Guide\"}")
+        .query_async(&mut conn)
+        .await
+        .unwrap();
+
+    // redis_ft_create -- minimal TEXT index on the JSON title.
+    let text = call_tool_text(
+        &redis::ft_create(full_state.clone()),
+        json!({
+            "index": "ftpro_idx",
+            "on": "JSON",
+            "prefixes": ["ftpro_doc:"],
+            "schema": [
+                {"name": "$.title", "alias": "title", "field_type": "TEXT"}
+            ]
+        }),
+    )
+    .await;
+    assert!(
+        text.contains("Created") || text.contains("OK"),
+        "ft_create: {}",
+        text
+    );
+
+    // Give the indexer a moment to settle before profiling.
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    // redis_ft_profile -- profile a SEARCH query.
+    let text = call_tool_text(
+        &redis::ft_profile(state.clone()),
+        json!({"index": "ftpro_idx", "command": "SEARCH", "query": "redis"}),
+    )
+    .await;
+    assert!(
+        text.contains("Profile for SEARCH"),
+        "ft_profile header: {}",
+        text
+    );
+    // The result/profile sections are rendered as "[0]:" and "[1]:" markers.
+    assert!(
+        text.contains("[0]:"),
+        "ft_profile results section: {}",
+        text
+    );
+    assert!(
+        text.contains("[1]:"),
+        "ft_profile profile section: {}",
+        text
+    );
+
+    let _: Result<(), _> = ::redis::cmd("FT.DROPINDEX")
+        .arg("ftpro_idx")
+        .query_async::<()>(&mut conn)
+        .await;
+    cleanup(&mut conn, "ftpro_doc:").await;
+}
+
+#[tokio::test]
+#[ignore = "Requires Docker"]
+async fn test_ft_synonym_and_dict() {
+    let ctx = get_redis_stack()
+        .await
+        .expect("Failed to get Redis Stack container");
+    let full_state = make_full_state(ctx.port);
+    let state = make_state(ctx.port);
+    let mut conn = get_conn(ctx.port).await;
+
+    cleanup(&mut conn, "ftsyn_doc:").await;
+    let _: Result<(), _> = ::redis::cmd("FT.DROPINDEX")
+        .arg("ftsyn_idx")
+        .query_async::<()>(&mut conn)
+        .await;
+    // Clear any leftover dictionary terms from a previous run.
+    let _: Result<i64, _> = ::redis::cmd("FT.DICTDEL")
+        .arg("ftsyn_dict")
+        .arg("foo")
+        .arg("bar")
+        .query_async(&mut conn)
+        .await;
+
+    // redis_ft_create -- minimal TEXT index (synonyms are index-scoped).
+    let text = call_tool_text(
+        &redis::ft_create(full_state.clone()),
+        json!({
+            "index": "ftsyn_idx",
+            "on": "JSON",
+            "prefixes": ["ftsyn_doc:"],
+            "schema": [
+                {"name": "$.title", "alias": "title", "field_type": "TEXT"}
+            ]
+        }),
+    )
+    .await;
+    assert!(
+        text.contains("Created") || text.contains("OK"),
+        "ft_create: {}",
+        text
+    );
+
+    // redis_ft_synupdate -- add a synonym group.
+    let text = call_tool_text(
+        &redis::ft_synupdate(full_state.clone()),
+        json!({
+            "index": "ftsyn_idx",
+            "group_id": "speed_group",
+            "terms": ["fast", "quick", "speedy"]
+        }),
+    )
+    .await;
+    assert!(
+        text.contains("Updated synonym group"),
+        "ft_synupdate: {}",
+        text
+    );
+
+    // redis_ft_syndump -- the group terms appear.
+    let text = call_tool_text(
+        &redis::ft_syndump(state.clone()),
+        json!({"index": "ftsyn_idx"}),
+    )
+    .await;
+    assert!(
+        text.contains("speed_group") || text.contains("fast"),
+        "ft_syndump: {}",
+        text
+    );
+
+    // redis_ft_dictadd -- add dictionary terms.
+    let text = call_tool_text(
+        &redis::ft_dictadd(full_state.clone()),
+        json!({"dict": "ftsyn_dict", "terms": ["foo", "bar"]}),
+    )
+    .await;
+    assert!(text.contains("Added"), "ft_dictadd: {}", text);
+
+    // redis_ft_dictdump -- both terms present.
+    let text = call_tool_text(
+        &redis::ft_dictdump(state.clone()),
+        json!({"dict": "ftsyn_dict"}),
+    )
+    .await;
+    assert!(text.contains("foo"), "ft_dictdump foo: {}", text);
+
+    // redis_ft_dictdel -- remove "foo".
+    let text = call_tool_text(
+        &redis::ft_dictdel(full_state.clone()),
+        json!({"dict": "ftsyn_dict", "terms": ["foo"]}),
+    )
+    .await;
+    assert!(text.contains("Removed"), "ft_dictdel: {}", text);
+
+    // redis_ft_dictdump -- "bar" remains, "foo" is gone.
+    let text = call_tool_text(
+        &redis::ft_dictdump(state.clone()),
+        json!({"dict": "ftsyn_dict"}),
+    )
+    .await;
+    assert!(text.contains("bar"), "ft_dictdump bar: {}", text);
+    assert!(!text.contains("foo"), "ft_dictdump foo gone: {}", text);
+
+    // Clean up the dictionary and index.
+    let _: Result<i64, _> = ::redis::cmd("FT.DICTDEL")
+        .arg("ftsyn_dict")
+        .arg("bar")
+        .query_async(&mut conn)
+        .await;
+    let _: Result<(), _> = ::redis::cmd("FT.DROPINDEX")
+        .arg("ftsyn_idx")
+        .query_async::<()>(&mut conn)
+        .await;
+    cleanup(&mut conn, "ftsyn_doc:").await;
+}
+
+#[tokio::test]
+#[ignore = "Requires Docker"]
+async fn test_ft_alias_management() {
+    let ctx = get_redis_stack()
+        .await
+        .expect("Failed to get Redis Stack container");
+    let full_state = make_full_state(ctx.port);
+    let state = make_state(ctx.port);
+    let mut conn = get_conn(ctx.port).await;
+
+    cleanup(&mut conn, "ftalias_doc:").await;
+    for idx in ["ft_alias_src_idx", "ft_alias_dst_idx"] {
+        let _: Result<(), _> = ::redis::cmd("FT.DROPINDEX")
+            .arg(idx)
+            .query_async::<()>(&mut conn)
+            .await;
+    }
+    // Best-effort drop of a stale alias from a previous run.
+    let _: Result<(), _> = ::redis::cmd("FT.ALIASDEL")
+        .arg("ft_alias_test")
+        .query_async::<()>(&mut conn)
+        .await;
+
+    // Index a document so searches via the alias return a hit.
+    let _: () = ::redis::cmd("JSON.SET")
+        .arg("ftalias_doc:1")
+        .arg("$")
+        .arg("{\"title\":\"Redis Alias Guide\"}")
+        .query_async(&mut conn)
+        .await
+        .unwrap();
+
+    // redis_ft_create -- source index.
+    let schema = json!([
+        {"name": "$.title", "alias": "title", "field_type": "TEXT"}
+    ]);
+    let text = call_tool_text(
+        &redis::ft_create(full_state.clone()),
+        json!({
+            "index": "ft_alias_src_idx",
+            "on": "JSON",
+            "prefixes": ["ftalias_doc:"],
+            "schema": schema.clone()
+        }),
+    )
+    .await;
+    assert!(
+        text.contains("Created") || text.contains("OK"),
+        "ft_create src: {}",
+        text
+    );
+
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    // redis_ft_aliasadd -- point alias at the source index.
+    let text = call_tool_text(
+        &redis::ft_aliasadd(full_state.clone()),
+        json!({"alias": "ft_alias_test", "index": "ft_alias_src_idx"}),
+    )
+    .await;
+    assert!(text.contains("Added alias"), "ft_aliasadd: {}", text);
+
+    // redis_ft_search -- search via the alias should resolve to the source index.
+    let text = call_tool_text(
+        &redis::ft_search(state.clone()),
+        json!({"index": "ft_alias_test", "query": "redis"}),
+    )
+    .await;
+    assert!(
+        text.contains("Total results") && !text.contains("Total results: 0"),
+        "ft_search via alias: {}",
+        text
+    );
+
+    // redis_ft_create -- destination index (same schema).
+    let text = call_tool_text(
+        &redis::ft_create(full_state.clone()),
+        json!({
+            "index": "ft_alias_dst_idx",
+            "on": "JSON",
+            "prefixes": ["ftalias_doc:"],
+            "schema": schema
+        }),
+    )
+    .await;
+    assert!(
+        text.contains("Created") || text.contains("OK"),
+        "ft_create dst: {}",
+        text
+    );
+
+    // redis_ft_aliasupdate -- repoint the alias.
+    let text = call_tool_text(
+        &redis::ft_aliasupdate(full_state.clone()),
+        json!({"alias": "ft_alias_test", "index": "ft_alias_dst_idx"}),
+    )
+    .await;
+    assert!(text.contains("Updated alias"), "ft_aliasupdate: {}", text);
+
+    // redis_ft_aliasdel -- remove the alias.
+    let text = call_tool_text(
+        &redis::ft_aliasdel(full_state.clone()),
+        json!({"alias": "ft_alias_test"}),
+    )
+    .await;
+    assert!(text.contains("Deleted alias"), "ft_aliasdel: {}", text);
+
+    for idx in ["ft_alias_src_idx", "ft_alias_dst_idx"] {
+        let _: Result<(), _> = ::redis::cmd("FT.DROPINDEX")
+            .arg(idx)
+            .query_async::<()>(&mut conn)
+            .await;
+    }
+    cleanup(&mut conn, "ftalias_doc:").await;
+}
+
+// ============================================================================
+// JSON array mutation tools (RedisJSON)
+// ============================================================================
+
+#[tokio::test]
+#[ignore = "Requires Docker"]
+async fn test_json_array_tools() {
+    let ctx = get_redis_stack()
+        .await
+        .expect("Failed to get Redis Stack container");
+    let state = make_full_state(ctx.port);
+    let mut conn = get_conn(ctx.port).await;
+
+    cleanup(&mut conn, "jarr_doc:").await;
+
+    // Seed a document with an array at $.nums.
+    let _: () = ::redis::cmd("JSON.SET")
+        .arg("jarr_doc:1")
+        .arg("$")
+        .arg("{\"nums\":[10,20,30,40,50]}")
+        .query_async(&mut conn)
+        .await
+        .unwrap();
+
+    // redis_json_arrinsert -- insert 99 at the front -> new length 6.
+    let text = call_tool_text(
+        &redis::json_arrinsert(state.clone()),
+        json!({"key": "jarr_doc:1", "path": "$.nums", "index": 0, "values": ["99"]}),
+    )
+    .await;
+    assert!(text.contains("6"), "json_arrinsert: {}", text);
+
+    // redis_json_arrpop -- pop the last element. Uses a legacy path (".nums")
+    // because the tool deserializes the reply into a scalar String; a "$" path
+    // returns a wrapped array that would not deserialize.
+    let text = call_tool_text(
+        &redis::json_arrpop(state.clone()),
+        json!({"key": "jarr_doc:1", "path": ".nums"}),
+    )
+    .await;
+    assert!(text.contains("Popped:"), "json_arrpop: {}", text);
+    assert!(text.contains("50"), "json_arrpop value: {}", text);
+
+    // redis_json_arrtrim -- trim to indices 0..=1 -> new length 2.
+    let text = call_tool_text(
+        &redis::json_arrtrim(state.clone()),
+        json!({"key": "jarr_doc:1", "path": "$.nums", "start": 0, "stop": 1}),
+    )
+    .await;
+    assert!(text.contains("Trimmed array"), "json_arrtrim: {}", text);
+    assert!(text.contains("2"), "json_arrtrim length: {}", text);
+
+    cleanup(&mut conn, "jarr_doc:").await;
+}

--- a/skills/redisctl-cloud-management/SKILL.md
+++ b/skills/redisctl-cloud-management/SKILL.md
@@ -14,42 +14,39 @@ Manage the full lifecycle of Redis Cloud resources: subscriptions, databases, us
 redisctl cloud subscription list
 
 # Get subscription details
-redisctl cloud subscription get --id 12345
+redisctl cloud subscription get 12345
 
 # Create a subscription (JSON input)
 redisctl cloud subscription create --data '{...}'
 
 # Update a subscription
-redisctl cloud subscription update --id 12345 --data '{...}'
+redisctl cloud subscription update 12345 --data '{...}'
 
 # Delete a subscription
-redisctl cloud subscription delete --id 12345
+redisctl cloud subscription delete 12345
 ```
 
 ## Databases
 
 ```bash
-# List databases in a subscription
-redisctl cloud database list --subscription-id 12345
+# List databases (optionally filtered by subscription)
+redisctl cloud database list
+redisctl cloud database list --subscription 12345
 
-# Get database details
-redisctl cloud database get --subscription-id 12345 --id 67890
+# Get database details (format: subscription_id:database_id)
+redisctl cloud database get 12345:67890
 
 # Create a database
-redisctl cloud database create --subscription-id 12345 --data '{...}'
+redisctl cloud database create --subscription 12345 --name mydb --memory 1
 
 # Update a database
-redisctl cloud database update --subscription-id 12345 --id 67890 --data '{...}'
+redisctl cloud database update 12345:67890 --memory 10
 
 # Delete a database
-redisctl cloud database delete --subscription-id 12345 --id 67890
-
-# Pause/recover a database
-redisctl cloud database pause --subscription-id 12345 --id 67890
-redisctl cloud database recover --subscription-id 12345 --id 67890
+redisctl cloud database delete 12345:67890
 
 # Backup a database
-redisctl cloud database backup --subscription-id 12345 --id 67890
+redisctl cloud database backup 12345:67890
 ```
 
 ## Essentials / Fixed Tier
@@ -58,8 +55,8 @@ For smaller, fixed-price databases:
 
 ```bash
 redisctl cloud fixed-subscription list
-redisctl cloud fixed-database list --subscription-id 12345
-redisctl cloud fixed-database create --subscription-id 12345 --data '{...}'
+redisctl cloud fixed-database list 12345
+redisctl cloud fixed-database create 12345 --name mydb
 ```
 
 ## Task Tracking
@@ -71,10 +68,10 @@ Cloud operations are async. Track tasks:
 redisctl cloud task list
 
 # Get task status
-redisctl cloud task get --id <task-id>
+redisctl cloud task get <task-id>
 
 # Wait for a task to complete
-redisctl cloud task wait --id <task-id>
+redisctl cloud task wait <task-id>
 ```
 
 ## Workflows
@@ -93,7 +90,7 @@ redisctl cloud workflow subscription-setup
 redisctl cloud cost-report generate --start 2026-01-01 --end 2026-01-31
 
 # Download a generated report
-redisctl cloud cost-report download --id <report-id>
+redisctl cloud cost-report download <report-id>
 
 # Generate and download in one step
 redisctl cloud cost-report export --start 2026-01-01 --end 2026-01-31
@@ -105,18 +102,25 @@ redisctl cloud cost-report export --start 2026-01-01 --end 2026-01-31
 # Get account details
 redisctl cloud account get
 
-# List/manage users
+# List/manage users (no create — users are managed via the Redis Cloud console)
 redisctl cloud user list
-redisctl cloud user create --data '{...}'
+redisctl cloud user get <user-id>
+redisctl cloud user update <user-id> --data '{...}'
+redisctl cloud user delete <user-id>
 
-# ACL management
-redisctl cloud acl list
-redisctl cloud acl create --data '{...}'
+# ACL management — granular subcommands
+redisctl cloud acl list-redis-rules
+redisctl cloud acl create-redis-rule --data '{...}'
+redisctl cloud acl list-roles
+redisctl cloud acl create-role --data '{...}'
+redisctl cloud acl list-acl-users
+redisctl cloud acl create-acl-user --data '{...}'
 ```
 
 ## Tips
 
 - Use `--profile <name>` to target a specific Cloud profile
 - Use `--output json` for machine-readable output
-- Most create/update commands accept `--data` with a JSON payload or `--file` for a JSON file
-- Task IDs are returned from async operations -- use `cloud task wait` to block until completion
+- Most create/update commands accept `--data` with a JSON payload
+- Task IDs are returned from async operations — use `cloud task wait` to block until completion
+- Database IDs use the format `subscription_id:database_id` for most operations


### PR DESCRIPTION
## Summary

Adds integration tests for 12 previously-untested MCP tools in `crates/redisctl-mcp/tests/redis_stack_tools.rs`:

- **RediSearch**: `ft_profile`, `ft_synupdate`, `ft_syndump`, `ft_dictadd`, `ft_dictdel`, `ft_dictdump`, `ft_aliasadd`, `ft_aliasupdate`, `ft_aliasdel`
- **RedisJSON arrays**: `json_arrinsert`, `json_arrpop`, `json_arrtrim`

## Test plan

- [ ] `test_ft_profile` — creates an index, runs a profiled search, asserts profiling breakdown in output
- [ ] `test_ft_synonym_and_dict` — synonym add/dump and dictionary add/del/dump round-trips
- [ ] `test_ft_alias_management` — alias add, search via alias, update, delete lifecycle
- [ ] `test_json_array_tools` — arrinsert, arrpop, arrtrim on a JSON array

All tests use `#[ignore = "Requires Docker"]` and the shared `get_redis_stack()` fixture.

Closes #962