### PR TITLE
docs: fix config paths, MSRV, file paths, and library version examples

### DIFF
--- a/docs/docs/developer/contributing.md
+++ b/docs/docs/developer/contributing.md
@@ -6,7 +6,7 @@ How to contribute to redisctl.
 
 ### Prerequisites
 
-- Rust 1.75+ (edition 2024)
+- Rust 1.90+ (edition 2024)
 - Git
 
 ### Clone and Build
@@ -106,10 +106,10 @@ crates/
 
 ## Adding a New Command
 
-1. Add command enum in `crates/redisctl/src/cli.rs`
-2. Implement handler in `src/commands/`
-3. Add to command routing in `src/main.rs`
-4. Add tests in `tests/`
+1. Add command enum in `crates/redisctl/src/cli/mod.rs` (top-level) or the relevant domain file: `src/cli/cloud.rs` (Cloud), `src/cli/enterprise.rs` (Enterprise)
+2. Implement handler in `crates/redisctl/src/commands/` (subdirs: `cloud/`, `enterprise/`)
+3. Add to command routing in `crates/redisctl/src/main.rs`
+4. Add tests in `crates/redisctl/tests/`
 5. Update documentation
 
 ## Testing
@@ -146,7 +146,7 @@ async fn test_database_list() {
 
 ## Documentation
 
-- User docs: `mkdocs-site/docs/`
+- User docs: `docs/docs/`
 - API docs: Inline rustdoc comments
 - Build docs: `cargo doc --workspace`
 

--- a/docs/docs/developer/libraries.md
+++ b/docs/docs/developer/libraries.md
@@ -21,7 +21,7 @@ Redis Cloud API client with full type coverage. Maintained at [github.com/redis-
 **Rust:**
 ```toml
 [dependencies]
-redis-cloud = "0.8"
+redis-cloud = "0.10"
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -64,7 +64,7 @@ Redis Enterprise REST API client. Maintained at [github.com/redis-developer/redi
 **Rust:**
 ```toml
 [dependencies]
-redis-enterprise = "0.7"
+redis-enterprise = "0.9"
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -109,7 +109,7 @@ Core library for config, workflows, and shared logic.
 
 ```toml
 [dependencies]
-redisctl-core = "0.8"
+redisctl-core = "0.11"
 ```
 
 ### Example

--- a/docs/docs/mcp/getting-started.md
+++ b/docs/docs/mcp/getting-started.md
@@ -148,7 +148,7 @@ REDIS_URL=redis://localhost:6379 redisctl-mcp --profile my-profile
 
 #### Option 2: Database Profile (Recommended for Regular Use)
 
-Configure a database profile in your redisctl config file (`~/.config/redisctl/config.toml` or `~/Library/Application Support/redisctl/config.toml` on macOS):
+Configure a database profile in your redisctl config file (`~/.config/redisctl/config.toml` or `~/Library/Application Support/com.redis.redisctl/config.toml` on macOS):
 
 ```toml
 # Default database profile to use when none specified

--- a/docs/docs/reference/config-file.md
+++ b/docs/docs/reference/config-file.md
@@ -109,7 +109,7 @@ Every profile requires a `deployment_type` field (`cloud`, `enterprise`, or `dat
 | `password` | Redis password (optional) |
 | `username` | Redis ACL username (optional, default: `default`) |
 | `tls` | Enable TLS (`true`/`false`, default: `true`) |
-| `db` | Redis database number (optional, default: `0`) |
+| `database` | Redis database number (optional, default: `0`) |
 
 ### Global Settings
 


### PR DESCRIPTION
## Summary

Three documentation accuracy fixes.

### Fix 1 — Config paths and TOML field name (#956)

- `docs/docs/reference/config-file.md`: `db` → `database` in the Database profile table (the actual Rust struct field is `database`, not `db`)
- `docs/docs/mcp/getting-started.md`: fix macOS config path from `~/Library/Application Support/redisctl/config.toml` to `~/Library/Application Support/com.redis.redisctl/config.toml` (matches `ProjectDirs::from("com", "redis", "redisctl")`)

### Fix 2 — MSRV and contributing guide paths (#960)

- `docs/docs/developer/contributing.md`: MSRV `1.75+` → `1.90+` (matches `rust-version = "1.90"` in workspace `Cargo.toml`)
- Fix "Adding a New Command" step referencing non-existent `src/cli.rs` → correct paths (`src/cli/mod.rs`, `src/cli/cloud.rs`, `src/cli/enterprise.rs`) with full `crates/redisctl/` prefixes
- Fix user docs path `mkdocs-site/docs/` → `docs/docs/`

### Fix 3 — Stale library version examples (#961)

- `docs/docs/developer/libraries.md`: update version pins
  - `redis-cloud = "0.8"` → `"0.10"` (current workspace: `0.10.0`)
  - `redis-enterprise = "0.7"` → `"0.9"` (current workspace: `0.9.1`)
  - `redisctl-core = "0.8"` → `"0.11"` (current workspace version: `0.11.0`)

Closes #956, #960, #961