### PR TITLE
docs: update Cloud and Enterprise CLI command reference to match current surface (closes #958)

### DIFF
--- a/docs/docs/cloud/commands/index.md
+++ b/docs/docs/cloud/commands/index.md
@@ -12,13 +12,13 @@ All Redis Cloud CLI commands.
 | [fixed-database](fixed-databases.md) | Manage Essentials databases |
 | [user](access-control.md) | User management |
 | [acl](access-control.md) | Access control lists |
-| [account](billing.md) | Account operations |
-| [payment-method](billing.md) | Payment method management |
+| account | Account operations |
+| payment-method | Payment method management |
 | [cost-report](cost-report.md) | Cost reporting (Beta) |
 | [connectivity](networking.md) | Network connectivity operations (VPC, PSC, TGW) |
-| [provider-account](networking.md) | Cloud provider account operations |
+| provider-account | Cloud provider account operations |
 | [task](tasks.md) | Async task monitoring |
-| [workflow](tasks.md) | Workflow operations for multi-step tasks |
+| workflow | Workflow operations for multi-step tasks |
 
 ## Getting Help
 

--- a/docs/docs/cloud/commands/index.md
+++ b/docs/docs/cloud/commands/index.md
@@ -10,10 +10,15 @@ All Redis Cloud CLI commands.
 | [database](databases.md) | Manage Pro databases |
 | [fixed-subscription](fixed-subscriptions.md) | Manage Essentials subscriptions |
 | [fixed-database](fixed-databases.md) | Manage Essentials databases |
-| [acl](access-control.md) | Access control lists |
 | [user](access-control.md) | User management |
+| [acl](access-control.md) | Access control lists |
+| [account](billing.md) | Account operations |
+| [payment-method](billing.md) | Payment method management |
+| [cost-report](cost-report.md) | Cost reporting (Beta) |
+| [connectivity](networking.md) | Network connectivity operations (VPC, PSC, TGW) |
+| [provider-account](networking.md) | Cloud provider account operations |
 | [task](tasks.md) | Async task monitoring |
-| [peering](networking.md) | VPC peering |
+| [workflow](tasks.md) | Workflow operations for multi-step tasks |
 
 ## Getting Help
 

--- a/docs/docs/enterprise/commands/index.md
+++ b/docs/docs/enterprise/commands/index.md
@@ -11,8 +11,8 @@ All Redis Enterprise CLI commands.
 | [database](databases.md) | Database management |
 | [cluster](cluster.md) | Cluster configuration and operations |
 | [node](nodes.md) | Node operations |
-| [shard](databases.md) | Shard management operations |
-| [endpoint](databases.md) | Endpoint operations |
+| shard | Shard management operations |
+| endpoint | Endpoint operations |
 
 ### Access
 
@@ -21,59 +21,59 @@ All Redis Enterprise CLI commands.
 | [user](access-control.md) | User management |
 | [role](access-control.md) | Role management |
 | [acl](access-control.md) | ACL operations |
-| [ldap](access-control.md) | LDAP integration |
-| [ldap-mappings](access-control.md) | LDAP mappings management |
-| [auth](access-control.md) | Authentication and sessions |
+| ldap | LDAP integration |
+| ldap-mappings | LDAP mappings management |
+| auth | Authentication and sessions |
 
 ### Monitoring
 
 | Command Group | Description |
 |---------------|-------------|
-| [stats](monitoring.md) | Statistics and metrics |
-| [status](monitoring.md) | Comprehensive cluster status (cluster, nodes, databases, shards) |
 | [alerts](monitoring.md) | Alert management |
+| stats | Statistics and metrics |
+| status | Comprehensive cluster status (cluster, nodes, databases, shards) |
 | [logs](monitoring.md) | Log operations |
 | [diagnostics](monitoring.md) | Diagnostics operations |
-| [debug-info](monitoring.md) | Debug info collection |
+| debug-info | Debug info collection |
 
 ### Admin
 
 | Command Group | Description |
 |---------------|-------------|
-| [license](cluster.md) | License management |
-| [module](databases.md) | Module management |
-| [proxy](cluster.md) | Proxy management |
-| [services](cluster.md) | Service management |
-| [cm-settings](cluster.md) | Cluster manager settings |
-| [suffix](cluster.md) | DNS suffix management |
+| license | License management |
+| module | Module management |
+| proxy | Proxy management |
+| services | Service management |
+| cm-settings | Cluster manager settings |
+| suffix | DNS suffix management |
 
 ### Advanced
 
 | Command Group | Description |
 |---------------|-------------|
 | [crdb](active-active.md) | Active-Active database (CRDB) operations |
-| [crdb-task](active-active.md) | CRDB task operations |
-| [bdb-group](databases.md) | Database group operations |
-| [migration](databases.md) | Migration operations |
-| [bootstrap](cluster.md) | Bootstrap and initialization operations |
-| [job-scheduler](cluster.md) | Job scheduler operations |
+| crdb-task | CRDB task operations |
+| bdb-group | Database group operations |
+| migration | Migration operations |
+| bootstrap | Bootstrap and initialization operations |
+| job-scheduler | Job scheduler operations |
 
 ### Troubleshooting
 
 | Command Group | Description |
 |---------------|-------------|
-| [support-package](monitoring.md) | Support package generation for troubleshooting |
-| [ocsp](cluster.md) | OCSP certificate validation |
-| [usage-report](monitoring.md) | Usage report operations |
-| [local](cluster.md) | Local node operations |
+| support-package | Support package generation for troubleshooting |
+| ocsp | OCSP certificate validation |
+| usage-report | Usage report operations |
+| local | Local node operations |
 
 ### Other
 
 | Command Group | Description |
 |---------------|-------------|
-| [action](tasks.md) | Action (task) operations |
-| [workflow](tasks.md) | Workflow operations for multi-step tasks |
-| [jsonschema](cluster.md) | JSON schema operations |
+| action | Action (task) operations |
+| workflow | Workflow operations for multi-step tasks |
+| jsonschema | JSON schema operations |
 
 ## Getting Help
 

--- a/docs/docs/enterprise/commands/index.md
+++ b/docs/docs/enterprise/commands/index.md
@@ -4,15 +4,76 @@ All Redis Enterprise CLI commands.
 
 ## Command Reference
 
+### Core
+
 | Command Group | Description |
 |---------------|-------------|
-| [cluster](cluster.md) | Cluster configuration |
 | [database](databases.md) | Database management |
+| [cluster](cluster.md) | Cluster configuration and operations |
 | [node](nodes.md) | Node operations |
+| [shard](databases.md) | Shard management operations |
+| [endpoint](databases.md) | Endpoint operations |
+
+### Access
+
+| Command Group | Description |
+|---------------|-------------|
 | [user](access-control.md) | User management |
 | [role](access-control.md) | Role management |
-| [alert](monitoring.md) | Alert configuration |
-| [crdb](active-active.md) | Active-Active databases |
+| [acl](access-control.md) | ACL operations |
+| [ldap](access-control.md) | LDAP integration |
+| [ldap-mappings](access-control.md) | LDAP mappings management |
+| [auth](access-control.md) | Authentication and sessions |
+
+### Monitoring
+
+| Command Group | Description |
+|---------------|-------------|
+| [stats](monitoring.md) | Statistics and metrics |
+| [status](monitoring.md) | Comprehensive cluster status (cluster, nodes, databases, shards) |
+| [alerts](monitoring.md) | Alert management |
+| [logs](monitoring.md) | Log operations |
+| [diagnostics](monitoring.md) | Diagnostics operations |
+| [debug-info](monitoring.md) | Debug info collection |
+
+### Admin
+
+| Command Group | Description |
+|---------------|-------------|
+| [license](cluster.md) | License management |
+| [module](databases.md) | Module management |
+| [proxy](cluster.md) | Proxy management |
+| [services](cluster.md) | Service management |
+| [cm-settings](cluster.md) | Cluster manager settings |
+| [suffix](cluster.md) | DNS suffix management |
+
+### Advanced
+
+| Command Group | Description |
+|---------------|-------------|
+| [crdb](active-active.md) | Active-Active database (CRDB) operations |
+| [crdb-task](active-active.md) | CRDB task operations |
+| [bdb-group](databases.md) | Database group operations |
+| [migration](databases.md) | Migration operations |
+| [bootstrap](cluster.md) | Bootstrap and initialization operations |
+| [job-scheduler](cluster.md) | Job scheduler operations |
+
+### Troubleshooting
+
+| Command Group | Description |
+|---------------|-------------|
+| [support-package](monitoring.md) | Support package generation for troubleshooting |
+| [ocsp](cluster.md) | OCSP certificate validation |
+| [usage-report](monitoring.md) | Usage report operations |
+| [local](cluster.md) | Local node operations |
+
+### Other
+
+| Command Group | Description |
+|---------------|-------------|
+| [action](tasks.md) | Action (task) operations |
+| [workflow](tasks.md) | Workflow operations for multi-step tasks |
+| [jsonschema](cluster.md) | JSON schema operations |
 
 ## Getting Help
 


### PR DESCRIPTION
## Summary

- **Cloud index**: remove nonexistent `peering` entry, replace with `connectivity (conn)`; add 5 missing command groups (`account`, `payment-method`, `cost-report`, `provider-account`, `workflow`)
- **Enterprise index**: expand from 7 entries to 35 entries covering the full command surface exposed by `redisctl enterprise --help`, organized into the same category sections (`Core`, `Access`, `Monitoring`, `Admin`, `Advanced`, `Troubleshooting`, `Other`)

Both changes were derived directly from `cargo run --bin redisctl -- cloud --help` and `cargo run --bin redisctl -- enterprise --help` to ensure accuracy.

Closes #958