### PR TITLE
feat(mcp): add zremrangebyscore + hexpire tools, Cloud provisioning + Enterprise health skills

### DIFF
--- a/crates/redisctl-mcp/skills/cloud-database-provisioning/SKILL.md
+++ b/crates/redisctl-mcp/skills/cloud-database-provisioning/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: cloud-database-provisioning
+description: Provision a Redis Cloud database end-to-end — Essentials (fixed plan) or Pro (custom) — using Redis Cloud MCP tools
+---
+
+You are a Redis Cloud provisioning assistant. Guide the user through creating a Redis Cloud subscription and database from scratch, handling the full async task lifecycle.
+
+## Workflow
+
+### Step 1: Verify authentication
+
+Call `get_account` to confirm credentials are configured and the account is accessible. Note the account ID and name for later steps.
+
+If `get_account` fails, tell the user to configure their Redis Cloud API key:
+
+```
+redisctl cloud auth --key <API-KEY> --secret <SECRET>
+```
+
+### Step 2: Choose subscription type
+
+Ask the user (or infer from context):
+
+- **Essentials** (fixed plans): managed infrastructure, quickest to provision. Best for development, testing, or small production workloads.
+- **Pro** (custom): dedicated infrastructure, supports advanced modules, Multi-AZ, Active-Active replication. Best for production workloads with specific performance or HA requirements.
+
+If unsure, default to Essentials and note that migration to Pro is possible later.
+
+### Step 3a: Provision Essentials (fixed plan)
+
+**3a-1. List available plans**
+
+Call `list_fixed_plans` to see available plan tiers. Present the options as a table:
+
+| Plan ID | Name | Memory | Max Throughput | Provider | Region | Price/Month |
+|---------|------|--------|----------------|----------|--------|-------------|
+
+**3a-2. Create the subscription**
+
+Call `create_fixed_subscription` with:
+- `name`: descriptive name (e.g. `my-app-dev`)
+- `plan_id`: from the chosen plan
+- `redis_version` (optional): call `get_fixed_redis_versions` to see supported versions
+
+**3a-3. Verify subscription is active**
+
+Call `get_fixed_subscription` with the returned subscription ID. Check that `status == "active"`. If not yet active, wait a few seconds and retry (the subscription should activate quickly for Essentials).
+
+**3a-4. Create the database**
+
+Call `create_fixed_database` with:
+- `subscription_id`: from step 3a-2
+- `name`: database name (e.g. `my-app-db`)
+- `password` (optional): set a password, or omit for the default
+
+**3a-5. Retrieve connection info**
+
+Call `get_fixed_database` to get the database endpoint and port. Report to the user:
+
+```
+Host: <endpoint>
+Port: <port>
+Password: <configured or default>
+```
+
+### Step 3b: Provision Pro (custom)
+
+**3b-1. Gather requirements**
+
+Ask the user:
+- Cloud provider and region — call `get_regions` to list options
+- Memory size (GB) and throughput (ops/sec, optional)
+- Required modules — call `get_modules` to list available modules
+- High availability requirements (replication, Multi-AZ)
+
+**3b-2. Create the subscription**
+
+Call `create_subscription` with the gathered parameters. This starts an asynchronous provisioning task (typically takes 5-15 minutes).
+
+**3b-3. Wait for the task to complete**
+
+Call `wait_for_cloud_task` with the task ID returned from `create_subscription`. This polls until the task reaches a terminal state (default timeout: 300s).
+
+If the task timeout is reached before completion, call `get_task` directly with the task ID to continue checking status.
+
+If the task fails, report the error details from the task response.
+
+**3b-4. Verify database is active**
+
+After the subscription is created, it includes a default database. Call `get_database` with the subscription ID and database ID (typically 1 for the first database). Check that `status == "active"`.
+
+**3b-5. Retrieve connection info**
+
+Report the public endpoint, port, and any configured password to the user.
+
+### Step 4: Smoke test (optional)
+
+If the user wants to verify connectivity, suggest:
+
+```bash
+redis-cli -h <endpoint> -p <port> -a <password> PING
+```
+
+Or use the `redis_ping` MCP tool if a database profile is configured for this new database.
+
+## Decision table
+
+| Scenario | Recommendation |
+|----------|---------------|
+| Development / testing | Essentials (free tier if available) |
+| Small production (< 1 GB, < 1000 ops/s) | Essentials paid |
+| Production with modules (Search, JSON, etc.) | Pro |
+| Multi-AZ or high availability required | Pro |
+| Active-Active (multi-region) | Pro |
+| Uncertain | Start with Essentials; migrate to Pro when needed |
+
+## Common issues
+
+- **Pro task timeout**: Pro subscriptions typically take 5-15 minutes to provision. If `wait_for_cloud_task` times out, use `get_task` with the task ID to continue polling.
+- **Plan not available in region**: call `list_fixed_plans` and check the `region` field to find plans in the target region.
+- **Subscription limit reached**: check `get_account` for subscription limits; delete an unused subscription first if needed.
+- **Database not active after creation**: for Pro databases, the database transitions through `pending` to `active`; poll `get_database` every 10-15 seconds until active.

--- a/crates/redisctl-mcp/skills/enterprise-health-check/SKILL.md
+++ b/crates/redisctl-mcp/skills/enterprise-health-check/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: enterprise-health-check
+description: Comprehensive pre-operation health check for a Redis Enterprise cluster — verify cluster state, node health, license status, and active alerts before making changes
+---
+
+You are a Redis Enterprise cluster health checker. Before any significant cluster operation (upgrade, scaling, configuration change, maintenance), run this workflow to establish a go/no-go baseline.
+
+## Workflow
+
+### Step 1: Cluster state
+
+Call `get_cluster` to get:
+- Cluster name and FQDN
+- Redis Enterprise software version
+- Cluster state
+
+**Go condition**: `state == "active"`. Any other state (`degraded`, `recovery`, etc.) is a **NO-GO** — do not proceed with the planned operation.
+
+### Step 2: Node health
+
+**2a. List all nodes**
+
+Call `list_nodes` to get all cluster nodes. For each node, note:
+- Node ID
+- Status (`active` or other)
+- Role (primary/replica if shown)
+- Address
+
+**2b. Check each non-active node**
+
+If any node shows a status other than `active`, call `get_node` with that node ID to get detailed status. Report the details.
+
+**Go condition**: all nodes must show `status == "active"`. Any inactive or unreachable node is a **NO-GO**.
+
+### Step 3: License check
+
+**3a. Call `get_license`** to check:
+- License expiry date
+- Maximum shards allowed
+
+**3b. Call `get_license_usage`** to check:
+- Current shard count in use
+- Shard usage percentage
+
+**Go condition**:
+- License expiry is more than 14 days away (warn if < 30 days)
+- Shard usage is below 90% of the licensed maximum
+
+Report shard headroom: `licensed - used = available shards`.
+
+### Step 4: Active alerts
+
+Call `list_alerts` to get all active alerts for the cluster.
+
+Classify alerts by severity:
+- **Critical alerts** (memory, connectivity, node down, license): **NO-GO** — must be resolved before proceeding
+- **Warning alerts** (high memory, replication lag, slow performance): proceed with caution; document in change record
+- **Info alerts**: note for awareness
+
+If no alerts are active, confirm: "No active alerts."
+
+### Step 5: Database status
+
+Call `list_enterprise_databases` to get all databases. For each database, check:
+- `status` field — must be `active`
+- Note database name, memory size, and shard count for context
+
+**Go condition**: all databases must be `active`. A database in `pending`, `recovery`, or error state is a **NO-GO**.
+
+### Step 6: Health summary
+
+Present a go/no-go table:
+
+| Check | Status | Details |
+|-------|--------|---------|
+| Cluster state | ✓ active / ✗ <state> | <version> |
+| All nodes active | ✓ N/N active / ✗ N/M active | IDs of inactive nodes |
+| License valid | ✓ expires <date> / ✗ expires <date> | <used>/<max> shards |
+| No critical alerts | ✓ clean / ✗ N critical | Alert names |
+| All databases active | ✓ N/N active / ✗ N/M active | IDs of inactive databases |
+
+**Overall: GO / NO-GO**
+
+If all checks pass: "Cluster is healthy. Safe to proceed with the planned operation."
+
+If any check fails: "Cluster has issues. Resolve the NO-GO conditions before proceeding."
+
+## Thresholds
+
+| Metric | Warning | NO-GO |
+|--------|---------|-------|
+| License expiry | < 30 days | < 7 days |
+| Shard usage | > 80% of licensed | > 95% of licensed |
+| Inactive nodes | 1 node (warn) | 2+ nodes, or primary node |
+| Inactive databases | Any database not active | Any database in error/recovery |
+| Active critical alerts | N/A | Any critical alert present |
+
+## When to run this skill
+
+Run before:
+- Redis Enterprise version upgrades
+- Cluster scaling (adding/removing nodes)
+- Database configuration changes (resizing, module additions)
+- Maintenance windows
+- Active-Active cluster topology changes
+- Any operation that requires cluster quorum
+
+Do NOT run during an active incident — this skill is a pre-flight check, not an incident response tool. For active incidents, use `list_alerts` and `get_node` directly.

--- a/crates/redisctl-mcp/src/tools/redis/structures.rs
+++ b/crates/redisctl-mcp/src/tools/redis/structures.rs
@@ -1,7 +1,8 @@
 //! Data structure Redis tools (hgetall, lrange, smembers, zrange, xinfo_stream, xrange, xlen,
 //! pubsub_channels, pubsub_numsub, hset, hdel, lpush, rpush, lpop, rpop, sadd, srem, zadd,
-//! zrem, xadd, xtrim, hget, hmget, hlen, hexists, hkeys, hvals, hincrby, scard, sismember,
-//! sunion, sinter, sdiff, zcard, zscore, zrank, zcount, zrangebyscore, llen, lindex)
+//! zrem, xadd, xtrim, hget, hmget, hlen, hexists, hkeys, hvals, hincrby, hexpire, scard,
+//! sismember, sunion, sinter, sdiff, zcard, zscore, zrank, zcount, zrangebyscore,
+//! zremrangebyscore, llen, lindex)
 
 use std::collections::HashMap;
 
@@ -61,6 +62,7 @@ mcp_module! {
     hkeys => "redis_hkeys",
     hvals => "redis_hvals",
     hincrby => "redis_hincrby",
+    hexpire => "redis_hexpire",
     scard => "redis_scard",
     sismember => "redis_sismember",
     sunion => "redis_sunion",
@@ -71,6 +73,7 @@ mcp_module! {
     zrank => "redis_zrank",
     zcount => "redis_zcount",
     zrangebyscore => "redis_zrangebyscore",
+    zremrangebyscore => "redis_zremrangebyscore",
     llen => "redis_llen",
     lindex => "redis_lindex",
 }
@@ -899,6 +902,34 @@ database_tool!(read_only, zrangebyscore, "redis_zrangebyscore",
     }
 );
 
+database_tool!(write, zremrangebyscore, "redis_zremrangebyscore",
+    "Remove all members from a sorted set with scores between min and max (inclusive). \
+     Use \"-inf\"/\"+inf\" for unbounded. Returns the number of removed members.\n\n\
+     Tip: use with timestamp scores to implement sliding-window cleanup \
+     (e.g. ZREMRANGEBYSCORE key -inf {now - window}).",
+    {
+        /// Sorted set key
+        pub key: String,
+        /// Minimum score (use "-inf" for no lower bound)
+        pub min: String,
+        /// Maximum score (use "+inf" for no upper bound)
+        pub max: String,
+    } => |conn, input| {
+        let removed: i64 = redis::cmd("ZREMRANGEBYSCORE")
+            .arg(&input.key)
+            .arg(&input.min)
+            .arg(&input.max)
+            .query_async(&mut conn)
+            .await
+            .tool_context("ZREMRANGEBYSCORE failed")?;
+
+        Ok(CallToolResult::text(format!(
+            "Removed {} member(s) from '{}' with scores in [{}, {}]",
+            removed, input.key, input.min, input.max
+        )))
+    }
+);
+
 // --- P1 List read tools ---
 
 database_tool!(read_only, llen, "redis_llen",
@@ -1385,6 +1416,81 @@ database_tool!(write, hincrby, "redis_hincrby",
         Ok(CallToolResult::text(format!(
             "{}.{}: {}",
             input.key, input.field, value
+        )))
+    }
+);
+
+database_tool!(write, hexpire, "redis_hexpire",
+    "Set a TTL (in seconds) on one or more hash fields (Redis 7.4+). \
+     Each field expires independently; when a field expires it is automatically deleted.\n\n\
+     Optional condition:\n\
+     - NX: set expiry only if the field has no expiry\n\
+     - XX: set expiry only if the field already has an expiry\n\
+     - GT: set expiry only if new TTL is greater than current TTL\n\
+     - LT: set expiry only if new TTL is less than current TTL\n\n\
+     Per-field result codes: 2 = field already expired/deleted, 1 = expiry set, \
+     0 = condition not met, -2 = field does not exist.",
+    {
+        /// Hash key
+        pub key: String,
+        /// TTL in seconds
+        #[serde(deserialize_with = "serde_helpers::string_or_i64::deserialize")]
+        pub seconds: i64,
+        /// Fields to set TTL on
+        pub fields: Vec<String>,
+        /// Optional condition: NX, XX, GT, or LT
+        #[serde(default)]
+        pub condition: Option<String>,
+    } => |conn, input| {
+        if let Some(ref cond) = input.condition {
+            let cond_upper = cond.to_uppercase();
+            if !matches!(cond_upper.as_str(), "NX" | "XX" | "GT" | "LT") {
+                return Err(tower_mcp::Error::tool(format!(
+                    "invalid condition '{}': must be NX, XX, GT, or LT",
+                    cond
+                )));
+            }
+        }
+
+        let mut cmd = redis::cmd("HEXPIRE");
+        cmd.arg(&input.key).arg(input.seconds);
+
+        if let Some(ref cond) = input.condition {
+            cmd.arg(cond.to_uppercase());
+        }
+
+        cmd.arg("FIELDS").arg(input.fields.len());
+        for field in &input.fields {
+            cmd.arg(field);
+        }
+
+        let results: Vec<i64> = cmd
+            .query_async(&mut conn)
+            .await
+            .tool_context("HEXPIRE failed")?;
+
+        let summary: Vec<String> = input
+            .fields
+            .iter()
+            .zip(results.iter())
+            .map(|(field, &code)| {
+                let status = match code {
+                    2 => "field already expired/deleted",
+                    1 => "expiry set",
+                    0 => "condition not met",
+                    -2 => "field not found",
+                    _ => "unknown result",
+                };
+                format!("  {}: {}", field, status)
+            })
+            .collect();
+
+        Ok(CallToolResult::text(format!(
+            "HEXPIRE '{}' ({}s) on {} field(s):\n{}",
+            input.key,
+            input.seconds,
+            input.fields.len(),
+            summary.join("\n")
         )))
     }
 );


### PR DESCRIPTION
## Summary

Closes #966, closes #967 (partial — implements `cloud-database-provisioning` and `enterprise-health-check` skills).

### Part 1: Missing MCP tools (#966)

Adds two Redis MCP tools that `data-modeling-advisor` skill references but didn't exist:

- **`redis_zremrangebyscore`** — `ZREMRANGEBYSCORE` write tool; removes sorted set members with scores in a given range. Supports `-inf`/`+inf` bounds. Returns removed count.
- **`redis_hexpire`** — `HEXPIRE` write tool (Redis 7.4+); sets per-field TTL on hash fields. Supports NX/XX/GT/LT condition options. Returns per-field result codes.

The `data-modeling-advisor` skill already referenced these tool names correctly — no skill edit needed once the tools exist.

### Part 2: New Cloud and Enterprise MCP skills (#967 partial)

Adds two workflow skill files following the agentskills.io format:

- **`cloud-database-provisioning/SKILL.md`** — End-to-end Redis Cloud provisioning for both Essentials (fixed plans) and Pro subscriptions. Covers auth verification, plan selection, async task polling, and connection endpoint retrieval.
- **`enterprise-health-check/SKILL.md`** — Pre-operation cluster health assessment. Checks cluster state, node health, license expiry/shard usage, active alerts, and database status. Produces a go/no-go table with explicit thresholds.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` passes (clean)
- [x] `cargo test --workspace --lib` passes (118 passed, 0 failed)
- [x] `redis_zremrangebyscore` and `redis_hexpire` registered in `mcp_module!` — verified in `test_database_tools_build`
- [x] `data-modeling-advisor` skill tool names now resolve to real tools