### PR TITLE
ci: ignore RUSTSEC-2026-0173 (proc-macro-error2 unmaintained)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -5,4 +5,7 @@ ignore = [
     # rustls-pemfile is unmaintained but still used by redis crate
     # This is a transitive dependency we cannot directly update
     "RUSTSEC-2025-0134",
+    # proc-macro-error2 is unmaintained (pulled via tabled -> tabled_derive); no safe upgrade
+    # available. Benign EOL notice, not a vulnerability. Revisit when tabled drops it.
+    "RUSTSEC-2026-0173",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -18,6 +18,9 @@ ignore = [
     # Tracking: https://github.com/redis-rs/redis-rs/issues/1234
     # This is a transitive dependency we cannot directly update
     "RUSTSEC-2025-0134",
+    # proc-macro-error2 is unmaintained (pulled via tabled -> tabled_derive); no safe upgrade
+    # available. Benign EOL notice, not a vulnerability. Revisit when tabled drops it.
+    "RUSTSEC-2026-0173",
 ]
 
 [licenses]


### PR DESCRIPTION
proc-macro-error2 is pulled transitively via tabled -> tabled_derive and flagged unmaintained (RUSTSEC-2026-0173) -- not a vulnerability, no safe upgrade available. Ignored in deny.toml (cargo-deny) and .cargo/audit.toml (cargo-audit) to green the Cargo Deny and Security Audit workflows. Revisit when tabled drops it.