### PR TITLE
fix(cli): restore upload to default features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1120,15 +1120,16 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "files-sdk"
-version = "0.3.1"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e1b158d0e399fe9f99e4b6ba8ba979b0536e0133a4c1270ac3386f00104336e"
+checksum = "31761b878a03696bd2a5260dda6ed5584a9a9c45ff95518fb19cbae81cade8de"
 dependencies = [
  "async-stream",
  "futures",
  "reqwest 0.12.23",
  "serde",
  "serde_json",
+ "serde_path_to_error",
  "thiserror 2.0.17",
  "tokio",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ default-members = [
 
 # External dependencies (not part of workspace)
 [workspace.dependencies.files-sdk]
-version = "0.3.1"
+version = "0.4.1"
 
 [workspace.package]
 version = "0.11.0"

--- a/crates/redisctl/Cargo.toml
+++ b/crates/redisctl/Cargo.toml
@@ -69,7 +69,7 @@ pager = "0.16"
 # Conditional dependencies for feature-gated binaries
 [features]
 default = ["full", "secure-storage"]
-full = ["cloud", "enterprise"]
+full = ["cloud", "enterprise", "upload"]
 cloud = []
 enterprise = []
 upload = ["dep:files-sdk"]


### PR DESCRIPTION
## What

Restore the `upload` feature to the default (`full`) feature set.

## Why

`upload` was temporarily removed from `full` (build(dist) #1013) so the
newly-added `x86_64-unknown-linux-musl` target would build openssl-free —
`files-sdk` 0.3.1 pulled `reqwest`'s `native-tls`, which can't cross-compile
to musl. `files-sdk` 0.4.1 switches to rustls
(`default-features = false`, `rustls-tls`), so `upload` can return to the
default build.

## Verification

- `files-sdk` bumped 0.3.1 → 0.4.1 (rustls).
- `full = ["cloud", "enterprise", "upload"]`.
- `cargo tree -p redisctl --target x86_64-unknown-linux-musl -e no-dev -i openssl-sys` → **empty** (and same for `native-tls`). The shipped binary stays static-link clean; the only openssl in the full tree is via the `docker-wrapper` dev-dependency, which the release binary excludes.
- `cargo clippy -p redisctl --features upload --all-targets -- -D warnings` clean; fmt clean.

## Release note

This is the bumping change that lets release-plz cut the next patch — whose
GitHub release will carry the first `x86_64-unknown-linux-musl` binary
(glibc-independent, runs on older/locked-down Linux).