### PR TITLE
ci(release): one-time OIDC publish to unwedge crates.io 0.11.0

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -9,6 +9,8 @@ on:
   push:
     branches:
       - main
+  # TEMPORARY: manual trigger for the one-time unwedge publish (manual-publish job below).
+  workflow_dispatch:
 
 concurrency:
   group: release-plz
@@ -17,6 +19,9 @@ concurrency:
 jobs:
   release-plz:
     name: Release-plz
+    # Normal operation runs on push to main only. workflow_dispatch is reserved
+    # for the one-time manual-publish job below.
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     environment: crates-io
     steps:
@@ -35,3 +40,49 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           # Uses OIDC Trusted Publishing - no CARGO_REGISTRY_TOKEN needed
           # Trusted publishers configured on crates.io for all workspace crates
+
+  # ---------------------------------------------------------------------------
+  # TEMPORARY (remove after use): one-time manual publish to unwedge crates.io.
+  #
+  # Background: redisctl-core 0.11.0 published, but redisctl/redisctl-mcp stayed
+  # at 0.10.1 (org-move-era trusted-publisher gap, since corrected). release-plz
+  # now refuses to auto-publish 0.11.0 because the redisctl-v0.11.0 tag already
+  # exists ("run cargo publish manually"), and the require-trusted-publishing
+  # policy rejects local API-token publishes. So 0.11.0 can only ship via an
+  # OIDC publish from a workflow named release-plz.yml (what the publisher trusts).
+  #
+  # This job checks out the faithful 0.11.0 source (the tag), mints an OIDC token,
+  # and publishes redisctl + redisctl-mcp so crates.io reaches 0.11.0 across all
+  # three crates and release-plz unwedges. cargo publish ignores git tags, so the
+  # existing tags / GitHub releases are untouched.
+  #
+  # Run once: gh workflow run release-plz.yml
+  # Then delete this job and the workflow_dispatch trigger above.
+  # ---------------------------------------------------------------------------
+  manual-publish:
+    name: Manual publish (one-time unwedge)
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    environment: crates-io
+    steps:
+      - name: Checkout v0.11.0 source
+        uses: actions/checkout@v4
+        with:
+          ref: redisctl-v0.11.0
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Authenticate to crates.io (OIDC trusted publishing)
+        uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+
+      - name: Publish redisctl 0.11.0
+        run: cargo publish -p redisctl
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+
+      - name: Publish redisctl-mcp 0.11.0
+        run: cargo publish -p redisctl-mcp
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
## Problem

`redisctl-core` published 0.11.0, but `redisctl` and `redisctl-mcp` are stuck at **0.10.1** on crates.io. This wedges release-plz on every run:

> local package `redisctl` has a greater version (0.11.0) ... but the git tag redisctl-v0.11.0 exists. Consider running `cargo publish` manually.

Chicken-and-egg: release-plz won't auto-publish 0.11.0 (tag exists), and the **require-trusted-publishing** policy on crates.io rejects local API-token `cargo publish` (`403`). So 0.11.0 can only be published by an **OIDC publish from a workflow named `release-plz.yml`** — the workflow the trusted publishers accept.

Trusted publishers verified correct for all three crates: `redis/redisctl` · `release-plz.yml` · `crates-io`.

## What this does

Adds a **temporary**, `workflow_dispatch`-gated `manual-publish` job that:
1. checks out the faithful 0.11.0 source (the `redisctl-v0.11.0` tag — verified to have no git-pinned deps),
2. mints an OIDC token via `rust-lang/crates-io-auth-action`,
3. `cargo publish -p redisctl` + `cargo publish -p redisctl-mcp` with it.

The existing `release-plz` job is gated to `push`, so dispatch runs **only** the publish. `cargo publish` verify-builds before upload (fails safe) and ignores git tags, so the existing tags / GitHub releases are untouched.

## How to use (one-time)

1. Merge this PR.
2. `gh workflow run release-plz.yml`
3. Confirm crates.io shows `redisctl` 0.11.0 + `redisctl-mcp` 0.11.0.
4. **Revert this commit** (remove the `manual-publish` job + `workflow_dispatch`).

## After

crates.io synced at 0.11.0 → release-plz unwedges → #1015 (`fix:`) drives **0.11.1** → cargo-dist builds all 5 targets incl. `x86_64-unknown-linux-musl` → GitHub release carries the musl binary.