### PR TITLE
ci(release): remove one-time OIDC unwedge publish job

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -9,8 +9,6 @@ on:
   push:
     branches:
       - main
-  # TEMPORARY: manual trigger for the one-time unwedge publish (manual-publish job below).
-  workflow_dispatch:
 
 concurrency:
   group: release-plz
@@ -19,9 +17,6 @@ concurrency:
 jobs:
   release-plz:
     name: Release-plz
-    # Normal operation runs on push to main only. workflow_dispatch is reserved
-    # for the one-time manual-publish job below.
-    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     environment: crates-io
     steps:
@@ -40,49 +35,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           # Uses OIDC Trusted Publishing - no CARGO_REGISTRY_TOKEN needed
           # Trusted publishers configured on crates.io for all workspace crates
-
-  # ---------------------------------------------------------------------------
-  # TEMPORARY (remove after use): one-time manual publish to unwedge crates.io.
-  #
-  # Background: redisctl-core 0.11.0 published, but redisctl/redisctl-mcp stayed
-  # at 0.10.1 (org-move-era trusted-publisher gap, since corrected). release-plz
-  # now refuses to auto-publish 0.11.0 because the redisctl-v0.11.0 tag already
-  # exists ("run cargo publish manually"), and the require-trusted-publishing
-  # policy rejects local API-token publishes. So 0.11.0 can only ship via an
-  # OIDC publish from a workflow named release-plz.yml (what the publisher trusts).
-  #
-  # This job checks out the faithful 0.11.0 source (the tag), mints an OIDC token,
-  # and publishes redisctl + redisctl-mcp so crates.io reaches 0.11.0 across all
-  # three crates and release-plz unwedges. cargo publish ignores git tags, so the
-  # existing tags / GitHub releases are untouched.
-  #
-  # Run once: gh workflow run release-plz.yml
-  # Then delete this job and the workflow_dispatch trigger above.
-  # ---------------------------------------------------------------------------
-  manual-publish:
-    name: Manual publish (one-time unwedge)
-    if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    environment: crates-io
-    steps:
-      - name: Checkout v0.11.0 source
-        uses: actions/checkout@v4
-        with:
-          ref: redisctl-v0.11.0
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Authenticate to crates.io (OIDC trusted publishing)
-        uses: rust-lang/crates-io-auth-action@v1
-        id: auth
-
-      - name: Publish redisctl 0.11.0
-        run: cargo publish -p redisctl
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
-
-      - name: Publish redisctl-mcp 0.11.0
-        run: cargo publish -p redisctl-mcp
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
Removes the temporary `manual-publish` job + `workflow_dispatch` trigger added in #1016. Their one-time purpose is done: crates.io is now synced at **0.11.0** across all three crates (`redisctl`, `redisctl-mcp`, `redisctl-core`), published via OIDC trusted publishing.

`release-plz.yml` is restored to its normal push-triggered form. Surgical — touches only the workflow file (no `git revert`, so #1015's `Cargo.toml` changes are untouched).

## After this merges

release-plz runs on the push, now **unwedged** (registry 0.11.0 == manifest 0.11.0 == tag), sees #1015's `fix:` and opens **`chore: release v0.11.1`** → merging that tags `redisctl-v0.11.1` → cargo-dist builds all 5 targets incl. `x86_64-unknown-linux-musl` → GitHub release carries the musl binary.