### PR TITLE
test(mcp): add missing serde_helpers coverage for opt_i64 string branch and opt_usize number form

### DIFF
--- a/crates/redisctl-mcp/src/serde_helpers.rs
+++ b/crates/redisctl-mcp/src/serde_helpers.rs
@@ -245,6 +245,12 @@ mod tests {
     }
 
     #[test]
+    fn opt_i64_present_negative_string() {
+        let t: TestOptI64 = serde_json::from_value(json!({"val": "-5"})).unwrap();
+        assert_eq!(t.val, Some(-5));
+    }
+
+    #[test]
     fn u64_from_number() {
         let t: TestU64 = serde_json::from_value(json!({"val": 100})).unwrap();
         assert_eq!(t.val, 100);
@@ -284,6 +290,12 @@ mod tests {
         assert_eq!(t.val, None);
         let t: TestOptUsize = serde_json::from_value(json!({"val": "1000"})).unwrap();
         assert_eq!(t.val, Some(1000));
+    }
+
+    #[test]
+    fn opt_usize_present_number() {
+        let t: TestOptUsize = serde_json::from_value(json!({"val": 50})).unwrap();
+        assert_eq!(t.val, Some(50));
     }
 
     #[test]


### PR DESCRIPTION
Closes #1000

## Summary

- Add `opt_i64_present_negative_string` test: exercises the `string_or_opt_i64` deserializer with a negative string (`"-5"` → `Some(-5)`), previously untested
- Add `opt_usize_present_number` test: exercises the `string_or_opt_usize` deserializer with a native JSON number (`50` → `Some(50)`), previously untested

No production or tool code changes — test module only.

## Test plan

- [ ] `cargo test --lib -p redisctl-mcp` passes (all serde_helpers tests green)
- [ ] `cargo fmt --all` clean
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean