### PR TITLE
ci(release): add workflow_dispatch trigger to release-plz

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -9,6 +9,9 @@ on:
   push:
     branches:
       - main
+  # Manual trigger: re-run release-plz on demand (e.g. to refresh the release PR
+  # or publish a version the push trigger missed) without needing a new commit.
+  workflow_dispatch:
 
 concurrency:
   group: release-plz


### PR DESCRIPTION
Adds a `workflow_dispatch` trigger to `release-plz.yml` so it can be re-run manually (refresh the release PR, or publish a version the push trigger missed) without a new commit. Push-to-main trigger unchanged.

Merging this also serves as the push that re-triggers release-plz now that RELEASE_TOKEN's org approval has landed — expect it to open the `chore: release v0.11.1` PR.