### PR TITLE
chore: release v0.11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2908,7 +2908,7 @@ dependencies = [
 
 [[package]]
 name = "redisctl"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2958,7 +2958,7 @@ dependencies = [
 
 [[package]]
 name = "redisctl-core"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "clap",
  "directories",
@@ -2979,7 +2979,7 @@ dependencies = [
 
 [[package]]
 name = "redisctl-mcp"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ default-members = [
 version = "0.4.1"
 
 [workspace.package]
-version = "0.11.0"
+version = "0.11.1"
 edition = "2024"
 rust-version = "1.90"
 authors = ["Josh Rotenberg <josh.rotenberg@redis.com>"]

--- a/crates/redisctl-mcp/CHANGELOG.md
+++ b/crates/redisctl-mcp/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1](https://github.com/redis/redisctl/compare/redisctl-mcp-v0.11.0...redisctl-mcp-v0.11.1) - 2026-06-11
+
+### Other
+
+- *(mcp)* add mock tests for enterprise observability gaps (closes #995) ([#1020](https://github.com/redis/redisctl/pull/1020))
+- *(mcp)* add missing opt_i64 string and opt_usize number test coverage ([#1019](https://github.com/redis/redisctl/pull/1019))
+- *(mcp)* add mock tests for enterprise RBAC tools ([#1007](https://github.com/redis/redisctl/pull/1007))
+- *(mcp)* add mock tests for enterprise cluster write and destructive tools ([#1006](https://github.com/redis/redisctl/pull/1006))
+- *(mcp)* cover redis_object_freq error and LFU happy paths (closes #996) ([#1005](https://github.com/redis/redisctl/pull/1005))
+- *(mcp)* cover cloud subscription write/destructive/read-only tools ([#1004](https://github.com/redis/redisctl/pull/1004))
+- *(mcp)* add mock tests for enterprise database write/destructive tools and CRDB tools ([#1003](https://github.com/redis/redisctl/pull/1003))
+- *(mcp)* cover redis_hexpire and redis_zremrangebyscore (closes #993) ([#1002](https://github.com/redis/redisctl/pull/1002))
+
 ## [0.11.0](https://github.com/redis-developer/redisctl/compare/redisctl-mcp-v0.10.1...redisctl-mcp-v0.11.0) - 2026-03-20
 
 ### Added

--- a/crates/redisctl-mcp/Cargo.toml
+++ b/crates/redisctl-mcp/Cargo.toml
@@ -21,7 +21,7 @@ tower-mcp = { version = "0.8.2", features = ["http", "oauth", "dynamic-tools"] }
 schemars = "1.2"
 
 # Internal crates
-redisctl-core = { version = "0.11.0", path = "../redisctl-core" }
+redisctl-core = { version = "0.11.1", path = "../redisctl-core" }
 
 # External API clients (optional, gated by features)
 redis-cloud = { workspace = true, optional = true }

--- a/crates/redisctl/CHANGELOG.md
+++ b/crates/redisctl/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1](https://github.com/redis/redisctl/compare/redisctl-v0.11.0...redisctl-v0.11.1) - 2026-06-11
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.11.0](https://github.com/redis-developer/redisctl/compare/redisctl-v0.10.1...redisctl-v0.11.0) - 2026-03-20
 
 ### Fixed

--- a/crates/redisctl/Cargo.toml
+++ b/crates/redisctl/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 
 
 [dependencies]
-redisctl-core = { version = "0.11.0", path = "../redisctl-core" }
+redisctl-core = { version = "0.11.1", path = "../redisctl-core" }
 redis-cloud = { workspace = true, features = ["tower-integration"] }
 redis-enterprise = { workspace = true, features = ["tower-integration"] }
 files-sdk = { workspace = true, optional = true }


### PR DESCRIPTION



## 🤖 New release

* `redisctl-core`: 0.11.0 -> 0.11.1
* `redisctl`: 0.11.0 -> 0.11.1 (✓ API compatible changes)
* `redisctl-mcp`: 0.11.0 -> 0.11.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `redisctl-core`

<blockquote>

## [0.11.0](https://github.com/redis-developer/redisctl/compare/redisctl-core-v0.10.1...redisctl-core-v0.11.0) - 2026-03-20

### Fixed

- *(auth)* support Redis Cloud secret env var alias ([#913](https://github.com/redis-developer/redisctl/pull/913))
</blockquote>

## `redisctl`

<blockquote>

## [0.11.1](https://github.com/redis/redisctl/compare/redisctl-v0.11.0...redisctl-v0.11.1) - 2026-06-11

### Other

- update Cargo.toml dependencies
</blockquote>

## `redisctl-mcp`

<blockquote>

## [0.11.1](https://github.com/redis/redisctl/compare/redisctl-mcp-v0.11.0...redisctl-mcp-v0.11.1) - 2026-06-11

### Other

- *(mcp)* add mock tests for enterprise observability gaps (closes #995) ([#1020](https://github.com/redis/redisctl/pull/1020))
- *(mcp)* add missing opt_i64 string and opt_usize number test coverage ([#1019](https://github.com/redis/redisctl/pull/1019))
- *(mcp)* add mock tests for enterprise RBAC tools ([#1007](https://github.com/redis/redisctl/pull/1007))
- *(mcp)* add mock tests for enterprise cluster write and destructive tools ([#1006](https://github.com/redis/redisctl/pull/1006))
- *(mcp)* cover redis_object_freq error and LFU happy paths (closes #996) ([#1005](https://github.com/redis/redisctl/pull/1005))
- *(mcp)* cover cloud subscription write/destructive/read-only tools ([#1004](https://github.com/redis/redisctl/pull/1004))
- *(mcp)* add mock tests for enterprise database write/destructive tools and CRDB tools ([#1003](https://github.com/redis/redisctl/pull/1003))
- *(mcp)* cover redis_hexpire and redis_zremrangebyscore (closes #993) ([#1002](https://github.com/redis/redisctl/pull/1002))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).