### PR TITLE
docs: post-0.11.1 cleanup (version example, edit_uri, musl comment)

### DIFF
--- a/crates/redisctl/Cargo.toml
+++ b/crates/redisctl/Cargo.toml
@@ -73,8 +73,8 @@ full = ["cloud", "enterprise", "upload"]
 cloud = []
 enterprise = []
 upload = ["dep:files-sdk"]
-# Note: secure-storage may not work on musl targets due to keyring native dependencies
-# Build with --no-default-features --features full for musl
+# secure-storage uses keyring (linux-keyutils on Linux — pure Rust, no C deps), which
+# builds for x86_64-unknown-linux-musl; the default-feature musl binary ships in releases.
 secure-storage = ["redisctl-core/secure-storage", "dep:keyring"]
 
 [dev-dependencies]

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -91,7 +91,7 @@ redisctl --version
 Expected output:
 
 ```
-redisctl 0.10.1
+redisctl 0.11.1
 ```
 
 ## Shell Completions

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -3,7 +3,7 @@ site_description: The CLI and MCP Server for Redis
 site_url: https://redis-field-engineering.github.io/redisctl-docs
 repo_url: https://github.com/redis/redisctl
 repo_name: redis/redisctl
-edit_uri: edit/main/mkdocs-site/docs/
+edit_uri: edit/main/docs/docs/
 
 theme:
   name: material


### PR DESCRIPTION
Release fix-forward cleanups surfaced by the 0.11.1 pre-flight audit:

- **installation.md** — `--version` example `0.10.1` → `0.11.1`
- **mkdocs.yml** — `edit_uri` pointed at a non-existent `mkdocs-site/docs/`; corrected to `docs/docs/` so the docs 'edit' links resolve
- **crates/redisctl/Cargo.toml** — the "secure-storage may not work on musl" note is disproven by the 0.11.1 release (the default-feature musl binary builds + ships; keyring resolves to pure-Rust `linux-keyutils`). Comment corrected.

All `docs:`-type / comment-only — no behavior change, non-bumping.