### PR TITLE
chore: migrate to redis-cloud 0.11.0 (handle breaking changes)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2857,8 +2857,6 @@ dependencies = [
 [[package]]
 name = "redis-cloud"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44ce273747009abf9345536d0a4eb3a86db916ba0f002193edf4c90efcac021"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2856,7 +2856,9 @@ dependencies = [
 
 [[package]]
 name = "redis-cloud"
-version = "0.10.0"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054296b735edff9bd77d097b6897846ab3f72549a05f920675400a2b8ea602e6"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ pretty_assertions = "1.4"
 redis = { version = "0.27", features = ["tokio-comp", "tokio-rustls-comp", "connection-manager", "cluster-async"] }
 
 # External crates (git for dev, version required for crates.io publish)
-redis-cloud = { version = "0.10.0" }
+redis-cloud = { version = "0.11" }
 redis-enterprise = { version = "0.9.1" }
 
 # Windows CI workaround - ensure these are available in workspace
@@ -120,8 +120,3 @@ debug = true
 [profile.dist]
 inherits = "release"
 lto = "thin"
-
-# DRY-RUN ONLY (remove before PR): build against local redis-cloud 0.11 until
-# v0.11.0 is published to crates.io.
-[patch.crates-io]
-redis-cloud = { path = "../redis-cloud-rs" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,3 +120,8 @@ debug = true
 [profile.dist]
 inherits = "release"
 lto = "thin"
+
+# DRY-RUN ONLY (remove before PR): build against local redis-cloud 0.11 until
+# v0.11.0 is published to crates.io.
+[patch.crates-io]
+redis-cloud = { path = "../redis-cloud-rs" }

--- a/crates/redisctl-core/src/cloud/workflows.rs
+++ b/crates/redisctl-core/src/cloud/workflows.rs
@@ -10,7 +10,7 @@ use redis_cloud::databases::{
     DatabaseUpdateRequest,
 };
 use redis_cloud::subscriptions::{
-    BaseSubscriptionUpdateRequest, Subscription, SubscriptionCreateRequest,
+    Subscription, SubscriptionCreateRequest, SubscriptionUpdateRequest,
 };
 use redis_cloud::{CloudClient, DatabaseHandler, SubscriptionHandler};
 use std::time::Duration;
@@ -440,14 +440,13 @@ pub async fn create_subscription_and_wait(
 /// # Example
 ///
 /// ```rust,ignore
-/// use redis_cloud::subscriptions::BaseSubscriptionUpdateRequest;
+/// use redis_cloud::subscriptions::SubscriptionUpdateRequest;
 /// use redisctl_core::cloud::update_subscription_and_wait;
 /// use std::time::Duration;
 ///
-/// let request = BaseSubscriptionUpdateRequest {
-///     subscription_id: None,
-///     command_type: None,
-/// };
+/// let request = SubscriptionUpdateRequest::builder()
+///     .name("renamed-subscription")
+///     .build();
 ///
 /// let subscription = update_subscription_and_wait(
 ///     &client,
@@ -460,7 +459,7 @@ pub async fn create_subscription_and_wait(
 pub async fn update_subscription_and_wait(
     client: &CloudClient,
     subscription_id: i32,
-    request: &BaseSubscriptionUpdateRequest,
+    request: &SubscriptionUpdateRequest,
     timeout: Duration,
     on_progress: Option<ProgressCallback>,
 ) -> Result<Subscription> {

--- a/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs
+++ b/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs
@@ -743,6 +743,7 @@ cloud_tool!(write, update_subscription, "update_subscription",
             payment_method: input.payment_method.clone(),
             subscription_id: None,
             command_type: None,
+            public_endpoint_access: None,
         };
 
         let result: TaskStateUpdate = client

--- a/crates/redisctl-mcp/tests/cloud_tools.rs
+++ b/crates/redisctl-mcp/tests/cloud_tools.rs
@@ -1466,7 +1466,7 @@ async fn test_get_database_certificate_request_shape() {
     Mock::given(method("GET"))
         .and(path("/subscriptions/123/databases/1001/certificate"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "publicCertificatePemString": "-----BEGIN CERTIFICATE-----\nMIIBx...\n-----END CERTIFICATE-----"
+            "publicCertificatePEMString": "-----BEGIN CERTIFICATE-----\nMIIBx...\n-----END CERTIFICATE-----"
         })))
         .mount(server.inner())
         .await;
@@ -1485,7 +1485,7 @@ async fn test_get_database_certificate_request_shape() {
     .await;
 
     assert!(
-        result.get("publicCertificatePemString").is_some(),
+        result.get("publicCertificatePEMString").is_some(),
         "Expected certificate PEM in response, got: {result}"
     );
 }


### PR DESCRIPTION
Migrates the workspace to **redis-cloud 0.11.0** (a breaking minor over our `0.10.0` dep). Finalizes #1026.

## Changes
- `Cargo.toml`: `redis-cloud` `0.10.0` → `0.11`; removed the temporary `[patch.crates-io] → ../redis-cloud-rs` (0.11.0 is now published).
- **Breaking-change fixes** (commit `42f0302`):
  - `redisctl-core/src/cloud/workflows.rs` — `update_subscription_and_wait` now uses `SubscriptionUpdateRequest` (the removed `BaseSubscriptionUpdateRequest`) — redis-developer/redis-cloud-rs#134
  - `redisctl-mcp` `update_subscription` tool — added `public_endpoint_access: None` (new field on `SubscriptionUpdateRequest`) — #134
  - `redisctl-mcp/tests/cloud_tools.rs` — cert test field casing `publicCertificatePemString` → `publicCertificatePEMString` — #143

## Validation (against published crates.io 0.11.0)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo test --workspace --lib` — 120 passed, 0 failed
- Full suite (incl. Docker integration) runs in CI here.

## Not affected
CLI `update_subscription` uses `put_raw` (raw JSON); the DB response-model nesting (#127) and `Subscription.pricing` rename (#129) don't touch request-building/raw-JSON paths.

Follow-up: **#1027** surfaces the now-captured 0.11 response fields (tags/plans were returning empty) — additive, lands after this.

Closes #1026