### PR TITLE
fix(deps): bump quinn-proto to 0.11.15 (RUSTSEC-2026-0185)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2692,9 +2692,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
Clears the **Security Audit** failure now blocking the 0.11.2 release (#1024).

- **RUSTSEC-2026-0185** — remote memory exhaustion in `quinn-proto` from unbounded out-of-order stream reassembly (DoS). Newly published advisory.
- Fixed in **quinn-proto 0.11.15**; this is a lock-only transitive bump (0.11.14 → 0.11.15).
- `cargo audit` clean locally after the bump (0 matches for RUSTSEC-2026-0185).

Real vuln with a published patch one version away, so bumping (not ignoring). Once merged, release-plz refreshes #1024 off the patched lock and its Security Audit goes green.