### PR TITLE
test(mcp): cover all redis_seed data types and error paths

### DIFF
--- a/crates/redisctl-mcp/tests/redis_stack_tools.rs
+++ b/crates/redisctl-mcp/tests/redis_stack_tools.rs
@@ -471,6 +471,11 @@ async fn test_bulk_seed_tools() {
 
     cleanup(&mut conn, "bulk_").await;
     cleanup(&mut conn, "seed_user:").await;
+    cleanup(&mut conn, "seed_str:").await;
+    cleanup(&mut conn, "seed_list:").await;
+    cleanup(&mut conn, "seed_set:").await;
+    cleanup(&mut conn, "seed_zs:").await;
+    cleanup(&mut conn, "seed_json:").await;
 
     // redis_bulk_load -- 3 SET commands
     let text = call_tool_text(
@@ -531,8 +536,151 @@ async fn test_bulk_seed_tools() {
     .await;
     assert!(text.contains("1"), "json_get bulk_json:1: {}", text);
 
+    // redis_seed -- string type with value_pattern + ttl
+    let text = call_tool_text(
+        &redis::seed(state.clone()),
+        json!({
+            "data_type": "string",
+            "key_pattern": "seed_str:{i}",
+            "count": 3,
+            "value_pattern": "val_{i}",
+            "ttl": 3600
+        }),
+    )
+    .await;
+    assert!(text.contains("3"), "seed string: {}", text);
+
+    let value: String = ::redis::cmd("GET")
+        .arg("seed_str:0")
+        .query_async(&mut conn)
+        .await
+        .unwrap();
+    assert_eq!(value, "val_0", "seed string value");
+    let ttl: i64 = ::redis::cmd("TTL")
+        .arg("seed_str:0")
+        .query_async(&mut conn)
+        .await
+        .unwrap();
+    assert!(ttl > 0, "seed string ttl should be positive: {}", ttl);
+
+    // redis_seed -- list type with member_pattern
+    let text = call_tool_text(
+        &redis::seed(state.clone()),
+        json!({
+            "data_type": "list",
+            "key_pattern": "seed_list:{i}",
+            "count": 3,
+            "member_pattern": "item_{i}"
+        }),
+    )
+    .await;
+    assert!(text.contains("3"), "seed list: {}", text);
+
+    let members: Vec<String> = ::redis::cmd("LRANGE")
+        .arg("seed_list:1")
+        .arg(0)
+        .arg(-1)
+        .query_async(&mut conn)
+        .await
+        .unwrap();
+    assert_eq!(members, vec!["item_1".to_string()], "seed list members");
+
+    // redis_seed -- set type with member_pattern
+    let text = call_tool_text(
+        &redis::seed(state.clone()),
+        json!({
+            "data_type": "set",
+            "key_pattern": "seed_set:{i}",
+            "count": 3,
+            "member_pattern": "item_{i}"
+        }),
+    )
+    .await;
+    assert!(text.contains("3"), "seed set: {}", text);
+
+    let members: Vec<String> = ::redis::cmd("SMEMBERS")
+        .arg("seed_set:2")
+        .query_async(&mut conn)
+        .await
+        .unwrap();
+    assert_eq!(members, vec!["item_2".to_string()], "seed set members");
+
+    // redis_seed -- sorted_set type with member_pattern
+    let text = call_tool_text(
+        &redis::seed(state.clone()),
+        json!({
+            "data_type": "sorted_set",
+            "key_pattern": "seed_zs:{i}",
+            "count": 2,
+            "member_pattern": "member_{i}"
+        }),
+    )
+    .await;
+    assert!(text.contains("2"), "seed sorted_set: {}", text);
+
+    let members: Vec<String> = ::redis::cmd("ZRANGE")
+        .arg("seed_zs:0")
+        .arg(0)
+        .arg(-1)
+        .query_async(&mut conn)
+        .await
+        .unwrap();
+    assert_eq!(
+        members,
+        vec!["member_0".to_string()],
+        "seed sorted_set members"
+    );
+
+    // redis_seed -- json type with value_pattern
+    let text = call_tool_text(
+        &redis::seed(state.clone()),
+        json!({
+            "data_type": "json",
+            "key_pattern": "seed_json:{i}",
+            "count": 2,
+            "value_pattern": "{\"id\":{i}}"
+        }),
+    )
+    .await;
+    assert!(text.contains("2"), "seed json: {}", text);
+
+    let doc = call_tool_text(
+        &redis::json_get(state.clone()),
+        json!({"key": "seed_json:1"}),
+    )
+    .await;
+    assert!(doc.contains("1"), "seed json get seed_json:1: {}", doc);
+
+    // Error path: hash type without field_values
+    let result = redis::seed(state.clone())
+        .call(json!({
+            "data_type": "hash",
+            "key_pattern": "seed_err:{i}",
+            "count": 1
+        }))
+        .await;
+    assert!(
+        result.is_error,
+        "seed hash without field_values should error"
+    );
+
+    // Error path: invalid data_type
+    let result = redis::seed(state.clone())
+        .call(json!({
+            "data_type": "bogus",
+            "key_pattern": "seed_err:{i}",
+            "count": 1
+        }))
+        .await;
+    assert!(result.is_error, "seed with invalid data_type should error");
+
     cleanup(&mut conn, "bulk_").await;
     cleanup(&mut conn, "seed_user:").await;
+    cleanup(&mut conn, "seed_str:").await;
+    cleanup(&mut conn, "seed_list:").await;
+    cleanup(&mut conn, "seed_set:").await;
+    cleanup(&mut conn, "seed_zs:").await;
+    cleanup(&mut conn, "seed_json:").await;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Closes #999.

`test_bulk_seed_tools` in `crates/redisctl-mcp/tests/redis_stack_tools.rs` previously tested `redis_seed` only with the `hash` data type. The tool supports six data types (`string`, `hash`, `sorted_set`, `set`, `list`, `json`); the other five were untested, along with the `ttl` parameter and the missing-required-field error paths.

## Changes

Expand `test_bulk_seed_tools` to cover:

1. `string` with `value_pattern` + `ttl` — verifies `GET` value and `TTL > 0`
2. `list` with `member_pattern` — verifies `LRANGE`
3. `set` with `member_pattern` — verifies `SMEMBERS`
4. `sorted_set` with `member_pattern` — verifies `ZRANGE`
5. `json` with `value_pattern` — verifies via `redis_json_get`
6. Error path: `hash` type without `field_values` returns a tool error
7. Error path: invalid `data_type` returns a tool error

Cleanup calls for the new key prefixes (`seed_str:`, `seed_list:`, `seed_set:`, `seed_zs:`, `seed_json:`) were added at the start and end of the test.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p redisctl-mcp --tests --all-features -- -D warnings`
- `cargo test -p redisctl-mcp --test redis_stack_tools test_bulk_seed_tools -- --ignored` passes against a live Redis Stack container (all new assertions verified)

The test remains `#[ignore = "Requires Docker"]`, consistent with the rest of the Stack suite.