### PR TITLE
fix(deps): bump anyhow to 1.0.104 (RUSTSEC-2026-0190)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,9 +120,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "approx"


### PR DESCRIPTION
## Summary

Closes #1033.

`anyhow` `1.0.100` is affected by [RUSTSEC-2026-0190](https://rustsec.org/advisories/RUSTSEC-2026-0190.html), "Unsoundness in `Error::downcast_mut()`". `Cargo.toml` already pins `anyhow = "1.0"`, so this is a lockfile-only update.

## Changes

`cargo update -p anyhow`: `1.0.100` -> `1.0.104`. `Cargo.lock` is the only file touched.

## Validation

| Gate | Result |
| --- | --- |
| `cargo fmt --all -- --check` | pass |
| `cargo clippy --all-targets --all-features -- -D warnings` | pass |
| `cargo test --all-features` | pass, 0 failures |
| RUSTSEC-2026-0190 in `cargo audit` / `cargo deny check advisories` | cleared |

## Remaining advisory failures are unrelated and pre-existing

`cargo audit` and `cargo deny check advisories` still fail on this branch, but not because of `anyhow`. Two other advisories are present, both already on `main` at the same versions:

| Advisory | Crate | Kind | Path |
| --- | --- | --- | --- |
| [RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204) | `crossbeam-epoch` 0.9.18 | vulnerability, fixed in >=0.9.20 | dev-only: `criterion` -> `rayon` -> `rayon-core` -> `crossbeam-deque` |
| [RUSTSEC-2026-0205](https://rustsec.org/advisories/RUSTSEC-2026-0205) | `scc` 2.4.0 | unsoundness warning | transitive |

Both are outside the scope of #1033 and need their own change. This PR does not make the Security Audit or Cargo Deny checks green on its own.
