### PR TITLE
feat(core): add Cloud OIDC + SM auth library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2960,20 +2960,26 @@ dependencies = [
 name = "redisctl-core"
 version = "0.11.1"
 dependencies = [
+ "base64 0.22.1",
  "clap",
  "directories",
+ "getrandom 0.3.3",
  "keyring",
  "redis-cloud",
  "redis-enterprise",
+ "reqwest 0.13.1",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "serial_test",
+ "sha2",
  "shellexpand",
  "tempfile",
  "thiserror 2.0.17",
  "tokio",
  "toml",
  "tracing",
+ "url",
  "wiremock",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,8 @@ async-trait = "0.1"
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls", "multipart"] }
 url = "2.5"
 base64 = "0.22"
+sha2 = "0.10"
+getrandom = "0.3"
 urlencoding = "2.1"
 chrono = { version = "0.4", features = ["serde"] }
 

--- a/crates/redisctl-core/Cargo.toml
+++ b/crates/redisctl-core/Cargo.toml
@@ -24,6 +24,14 @@ thiserror = { workspace = true }
 # Async runtime
 tokio = { workspace = true }
 
+# HTTP client + PKCE for the Okta OIDC flows (device authorization / auth-code loopback)
+reqwest = { workspace = true }
+serde_urlencoded = { workspace = true }
+url = { workspace = true }
+base64 = { workspace = true }
+sha2 = { workspace = true }
+getrandom = { workspace = true }
+
 # Logging
 tracing = { workspace = true }
 

--- a/crates/redisctl-core/src/auth/auth_code_loopback.rs
+++ b/crates/redisctl-core/src/auth/auth_code_loopback.rs
@@ -1,0 +1,412 @@
+//! OIDC Authorization Code + PKCE via a loopback redirect (RFC 8252) — the interactive
+//! human login. The CLI opens the browser to the Okta sign-in page and self-hosts a
+//! one-shot `127.0.0.1` listener to catch the redirect; **no callback page is hosted
+//! anywhere** and the authorization code never leaves the machine.
+//!
+//! Flow: bind a loopback port → build PKCE (S256) + `state` → hand the authorize URL to the
+//! caller's `open_browser` → wait for the redirect on the listener → validate `state` →
+//! exchange the code (+ `code_verifier`) for tokens. Converges on the same [`TokenSet`] and
+//! token-endpoint plumbing as the device flow.
+
+use std::net::Ipv4Addr;
+use std::time::Duration;
+
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use sha2::{Digest, Sha256};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use url::Url;
+
+use super::{AuthError, TokenSet, default_http_client, endpoint, form_body, post_token, token_set};
+
+const AUTH_CODE_GRANT: &str = "authorization_code";
+/// Loopback ports tried in order. Each `http://127.0.0.1:PORT/callback` must be registered
+/// as a redirect URI on the Okta app (or the app configured to allow any loopback port).
+const DEFAULT_PORTS: &[u16] = &[8899, 8898, 8900];
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(300);
+/// Deadline for reading the request line *after* a connection is accepted, so a local client
+/// that connects but never finishes the request can't hang the login indefinitely.
+const REQUEST_READ_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Authorization-code-with-PKCE client using a loopback redirect.
+#[derive(Clone)]
+pub struct LoopbackFlowClient {
+    issuer: Url,
+    client_id: String,
+    http: reqwest::Client,
+    ports: Vec<u16>,
+    redirect_host: String,
+    redirect_path: String,
+    timeout: Duration,
+}
+
+impl LoopbackFlowClient {
+    /// Build a client for the given issuer and public client id, with sensible loopback
+    /// defaults (`127.0.0.1`, ports 8899/8898/8900, `/callback`, 5-minute timeout).
+    pub fn new(issuer: Url, client_id: impl Into<String>) -> Self {
+        Self {
+            issuer,
+            client_id: client_id.into(),
+            http: default_http_client(),
+            ports: DEFAULT_PORTS.to_vec(),
+            redirect_host: "127.0.0.1".to_string(),
+            redirect_path: "/callback".to_string(),
+            timeout: DEFAULT_TIMEOUT,
+        }
+    }
+
+    /// Use a caller-provided reqwest client.
+    pub fn with_http_client(mut self, http: reqwest::Client) -> Self {
+        self.http = http;
+        self
+    }
+
+    /// Override the candidate loopback ports (e.g. `[0]` for an ephemeral port in tests).
+    pub fn with_ports(mut self, ports: Vec<u16>) -> Self {
+        self.ports = ports;
+        self
+    }
+
+    /// Override how long to wait for the browser redirect.
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+
+    /// Run the interactive login. `open_browser` is invoked with the authorize URL (the
+    /// caller opens it or prints it); the method then blocks on the loopback redirect.
+    pub async fn login<F>(&self, scopes: &[&str], open_browser: F) -> Result<TokenSet, AuthError>
+    where
+        F: FnOnce(&str),
+    {
+        let (listener, port) = self.bind().await?;
+        let redirect_uri = format!(
+            "http://{}:{}{}",
+            self.redirect_host, port, self.redirect_path
+        );
+
+        let pkce = Pkce::generate()?;
+        let state = random_urlsafe(16)?;
+        let url = self.authorize_url(&redirect_uri, scopes, &pkce.challenge, &state);
+
+        open_browser(&url);
+
+        let code = self.wait_for_callback(listener, &state).await?;
+        self.exchange_code(&code, &pkce.verifier, &redirect_uri)
+            .await
+    }
+
+    async fn bind(&self) -> Result<(TcpListener, u16), AuthError> {
+        for &port in &self.ports {
+            if let Ok(listener) = TcpListener::bind((Ipv4Addr::LOCALHOST, port)).await {
+                let actual = listener
+                    .local_addr()
+                    .map_err(|e| AuthError::Protocol(format!("could not read local address: {e}")))?
+                    .port();
+                return Ok((listener, actual));
+            }
+        }
+        Err(AuthError::Protocol(format!(
+            "could not bind a loopback port (tried {:?})",
+            self.ports
+        )))
+    }
+
+    fn authorize_url(
+        &self,
+        redirect_uri: &str,
+        scopes: &[&str],
+        challenge: &str,
+        state: &str,
+    ) -> String {
+        let scope = scopes.join(" ");
+        let query = form_body(&[
+            ("client_id", self.client_id.as_str()),
+            ("response_type", "code"),
+            ("scope", scope.as_str()),
+            ("redirect_uri", redirect_uri),
+            ("state", state),
+            ("code_challenge", challenge),
+            ("code_challenge_method", "S256"),
+            ("prompt", "login"),
+        ]);
+        format!("{}?{}", endpoint(&self.issuer, "v1/authorize"), query)
+    }
+
+    async fn wait_for_callback(
+        &self,
+        listener: TcpListener,
+        expected_state: &str,
+    ) -> Result<String, AuthError> {
+        let accepted = tokio::time::timeout(self.timeout, listener.accept())
+            .await
+            .map_err(|_| {
+                AuthError::Protocol("timed out waiting for the browser redirect".into())
+            })?;
+        let (mut stream, _) =
+            accepted.map_err(|e| AuthError::Protocol(format!("accept failed: {e}")))?;
+
+        let target = tokio::time::timeout(REQUEST_READ_TIMEOUT, read_request_target(&mut stream))
+            .await
+            .map_err(|_| {
+                AuthError::Protocol("timed out reading the browser redirect request".into())
+            })??;
+        write_ok_page(&mut stream).await;
+
+        // The request target is a path+query; parse it against a dummy base to read the query.
+        let parsed = Url::parse(&format!("http://localhost{target}"))
+            .map_err(|e| AuthError::Protocol(format!("could not parse callback URL: {e}")))?;
+        let (mut code, mut state, mut error, mut error_desc) = (None, None, None, None);
+        for (k, v) in parsed.query_pairs() {
+            match k.as_ref() {
+                "code" => code = Some(v.into_owned()),
+                "state" => state = Some(v.into_owned()),
+                "error" => error = Some(v.into_owned()),
+                "error_description" => error_desc = Some(v.into_owned()),
+                _ => {}
+            }
+        }
+
+        if let Some(err) = error {
+            return match err.as_str() {
+                "access_denied" => Err(AuthError::Denied),
+                other => Err(AuthError::Protocol(format!(
+                    "authorization error {other}: {}",
+                    error_desc.unwrap_or_default()
+                ))),
+            };
+        }
+        if state.as_deref() != Some(expected_state) {
+            return Err(AuthError::Protocol(
+                "state mismatch on callback (possible CSRF or stale login)".into(),
+            ));
+        }
+        code.ok_or_else(|| {
+            AuthError::Protocol("callback did not include an authorization code".into())
+        })
+    }
+
+    async fn exchange_code(
+        &self,
+        code: &str,
+        verifier: &str,
+        redirect_uri: &str,
+    ) -> Result<TokenSet, AuthError> {
+        let tr = post_token(
+            &self.http,
+            &endpoint(&self.issuer, "v1/token"),
+            &[
+                ("client_id", self.client_id.as_str()),
+                ("grant_type", AUTH_CODE_GRANT),
+                ("code", code),
+                ("redirect_uri", redirect_uri),
+                ("code_verifier", verifier),
+            ],
+        )
+        .await?;
+        if let Some(err) = tr.error.as_deref() {
+            return Err(AuthError::Protocol(format!(
+                "token exchange failed ({err}): {}",
+                tr.description()
+            )));
+        }
+        token_set(tr)
+    }
+}
+
+/// A PKCE verifier/challenge pair (S256).
+struct Pkce {
+    verifier: String,
+    challenge: String,
+}
+
+impl Pkce {
+    fn generate() -> Result<Self, AuthError> {
+        let verifier = random_urlsafe(32)?; // 32 bytes -> 43-char base64url (valid PKCE length)
+        let challenge = URL_SAFE_NO_PAD.encode(Sha256::digest(verifier.as_bytes()));
+        Ok(Self {
+            verifier,
+            challenge,
+        })
+    }
+}
+
+/// `n` random bytes, base64url-no-pad encoded — used for the PKCE verifier and `state`.
+fn random_urlsafe(n: usize) -> Result<String, AuthError> {
+    let mut buf = vec![0u8; n];
+    getrandom::fill(&mut buf)
+        .map_err(|e| AuthError::Protocol(format!("secure RNG unavailable: {e}")))?;
+    Ok(URL_SAFE_NO_PAD.encode(&buf))
+}
+
+/// Read the HTTP request line's target (the path+query) from the loopback connection.
+async fn read_request_target(stream: &mut TcpStream) -> Result<String, AuthError> {
+    let mut buf = Vec::with_capacity(1024);
+    let mut chunk = [0u8; 1024];
+    loop {
+        let n = stream
+            .read(&mut chunk)
+            .await
+            .map_err(|e| AuthError::Protocol(format!("reading callback request failed: {e}")))?;
+        if n == 0 {
+            break;
+        }
+        buf.extend_from_slice(&chunk[..n]);
+        if buf.windows(4).any(|w| w == b"\r\n\r\n") || buf.len() > 16 * 1024 {
+            break;
+        }
+    }
+    let text = String::from_utf8_lossy(&buf);
+    let request_line = text.lines().next().unwrap_or_default();
+    // e.g. "GET /callback?code=...&state=... HTTP/1.1"
+    request_line
+        .split_whitespace()
+        .nth(1)
+        .map(|s| s.to_string())
+        .ok_or_else(|| AuthError::Protocol("malformed callback request line".into()))
+}
+
+/// Write a minimal "you can close this tab" page and close the connection.
+async fn write_ok_page(stream: &mut TcpStream) {
+    const BODY: &str = "<html><body style=\"font-family:sans-serif\">\
+        <h2>Signed in - you can close this tab.</h2></body></html>";
+    let response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\n\
+         Content-Length: {}\r\nConnection: close\r\n\r\n{}",
+        BODY.len(),
+        BODY
+    );
+    let _ = stream.write_all(response.as_bytes()).await;
+    let _ = stream.flush().await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[test]
+    fn pkce_challenge_matches_verifier() {
+        let p = Pkce::generate().unwrap();
+        assert!((43..=128).contains(&p.verifier.len()));
+        let expected = URL_SAFE_NO_PAD.encode(Sha256::digest(p.verifier.as_bytes()));
+        assert_eq!(p.challenge, expected);
+    }
+
+    #[test]
+    fn random_urlsafe_is_urlsafe_and_unique() {
+        let a = random_urlsafe(16).unwrap();
+        let b = random_urlsafe(16).unwrap();
+        assert_ne!(a, b);
+        assert!(!a.contains('+') && !a.contains('/') && !a.contains('='));
+    }
+
+    fn client_with_issuer(issuer: &str) -> LoopbackFlowClient {
+        LoopbackFlowClient::new(Url::parse(issuer).unwrap(), "cid")
+    }
+
+    #[test]
+    fn authorize_url_has_required_params() {
+        let c = client_with_issuer("https://issuer.example/oauth2/default");
+        let url = c.authorize_url(
+            "http://127.0.0.1:8899/callback",
+            &["openid", "email"],
+            "CHALLENGE",
+            "STATE",
+        );
+        assert!(url.starts_with("https://issuer.example/oauth2/default/v1/authorize?"));
+        let parsed = Url::parse(&url).unwrap();
+        let q: HashMap<_, _> = parsed.query_pairs().into_owned().collect();
+        assert_eq!(q["client_id"], "cid");
+        assert_eq!(q["response_type"], "code");
+        assert_eq!(q["code_challenge_method"], "S256");
+        assert_eq!(q["code_challenge"], "CHALLENGE");
+        assert_eq!(q["state"], "STATE");
+        assert_eq!(q["redirect_uri"], "http://127.0.0.1:8899/callback");
+        assert_eq!(q["scope"], "openid email");
+        assert_eq!(q["prompt"], "login");
+    }
+
+    async fn ephemeral(server: &MockServer) -> LoopbackFlowClient {
+        LoopbackFlowClient::new(Url::parse(&server.uri()).unwrap(), "cid")
+            .with_ports(vec![0])
+            .with_timeout(Duration::from_secs(5))
+    }
+
+    /// Simulate the browser: read redirect_uri + state from the authorize URL and GET the
+    /// callback with the given extra query.
+    fn simulate_browser(url: &str, extra: &str) {
+        let parsed = Url::parse(url).unwrap();
+        let q: HashMap<_, _> = parsed.query_pairs().into_owned().collect();
+        let cb = format!("{}?{}&state={}", q["redirect_uri"], extra, q["state"]);
+        tokio::spawn(async move {
+            let _ = reqwest::get(&cb).await;
+        });
+    }
+
+    #[tokio::test]
+    async fn login_happy_path() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "AT",
+                "id_token": "IT",
+                "refresh_token": "RT",
+                "expires_in": 3600
+            })))
+            .mount(&server)
+            .await;
+
+        let token = ephemeral(&server)
+            .await
+            .login(&["openid"], |url| simulate_browser(url, "code=THECODE"))
+            .await
+            .unwrap();
+        assert_eq!(token.access_token, "AT");
+        assert_eq!(token.refresh_token.as_deref(), Some("RT"));
+    }
+
+    #[tokio::test]
+    async fn login_state_mismatch_is_error() {
+        let server = MockServer::start().await;
+        let res = ephemeral(&server)
+            .await
+            .login(&["openid"], |url| {
+                // GET the callback with a wrong state (ignore the real one)
+                let parsed = Url::parse(url).unwrap();
+                let q: HashMap<_, _> = parsed.query_pairs().into_owned().collect();
+                let cb = format!("{}?code=X&state=WRONG", q["redirect_uri"]);
+                tokio::spawn(async move {
+                    let _ = reqwest::get(&cb).await;
+                });
+            })
+            .await;
+        assert!(matches!(res, Err(AuthError::Protocol(_))));
+    }
+
+    #[tokio::test]
+    async fn login_access_denied_maps_to_denied() {
+        let server = MockServer::start().await;
+        let res = ephemeral(&server)
+            .await
+            .login(&["openid"], |url| {
+                simulate_browser(url, "error=access_denied")
+            })
+            .await;
+        assert!(matches!(res, Err(AuthError::Denied)));
+    }
+
+    #[tokio::test]
+    async fn login_times_out_without_callback() {
+        let server = MockServer::start().await;
+        let res = ephemeral(&server)
+            .await
+            .with_timeout(Duration::from_millis(150))
+            .login(&["openid"], |_url| { /* browser never redirects */ })
+            .await;
+        assert!(matches!(res, Err(AuthError::Protocol(_))));
+    }
+}

--- a/crates/redisctl-core/src/auth/auth_code_loopback.rs
+++ b/crates/redisctl-core/src/auth/auth_code_loopback.rs
@@ -3,10 +3,15 @@
 //! one-shot `127.0.0.1` listener to catch the redirect; **no callback page is hosted
 //! anywhere** and the authorization code never leaves the machine.
 //!
-//! Flow: bind a loopback port → build PKCE (S256) + `state` → hand the authorize URL to the
-//! caller's `open_browser` → wait for the redirect on the listener → validate `state` →
-//! exchange the code (+ `code_verifier`) for tokens. Converges on the same [`TokenSet`] and
-//! token-endpoint plumbing as the device flow.
+//! Sequence:
+//! 1. Bind a loopback port on 127.0.0.1 (the redirect target; no page is hosted anywhere).
+//! 2. Build a PKCE S256 verifier/challenge + a random `state`.
+//! 3. Hand the `/v1/authorize` URL to the caller's `open_browser`; the user signs in.
+//! 4. Catch the browser's redirect to `127.0.0.1/callback?code&state` on the listener.
+//! 5. Validate `state` (CSRF guard) and extract the code.
+//! 6. Exchange the code (+ `code_verifier`) at `/v1/token` for a `TokenSet`.
+//!
+//! Converges on the same [`TokenSet`] and token-endpoint plumbing as the device flow.
 
 use std::net::Ipv4Addr;
 use std::time::Duration;

--- a/crates/redisctl-core/src/auth/authenticator.rs
+++ b/crates/redisctl-core/src/auth/authenticator.rs
@@ -87,12 +87,9 @@ impl CloudAuthenticator {
     }
 
     /// Device-authorization-grant client for headless / agent logins.
-    pub fn device_flow(&self) -> DeviceFlowClient {
-        DeviceFlowClient::with_http_client(
-            self.issuer.clone(),
-            self.client_id.clone(),
-            self.http.clone(),
-        )
+    pub fn device(&self) -> DeviceFlowClient {
+        DeviceFlowClient::new(self.issuer.clone(), self.client_id.clone())
+            .with_http_client(self.http.clone())
     }
 
     /// Auth-code + PKCE loopback client for interactive human logins.
@@ -101,9 +98,10 @@ impl CloudAuthenticator {
             .with_http_client(self.http.clone())
     }
 
-    /// Refresh an Okta refresh token for a fresh token set (Okta rotates it).
+    /// Refresh an Okta refresh token for a fresh token set (Okta rotates it). The grant is
+    /// flow-agnostic, so it goes straight through `oidc` rather than a specific flow client.
     pub async fn refresh(&self, refresh_token: &str) -> Result<TokenSet, AuthError> {
-        self.device_flow().refresh(refresh_token).await
+        super::oidc::refresh(&self.http, &self.issuer, &self.client_id, refresh_token).await
     }
 
     /// Given tokens from a flow, run the SM exchange and mint a CAPI key named `key_name`.
@@ -115,13 +113,16 @@ impl CloudAuthenticator {
         let mut sm = SmApiClient::with_http_client(self.sm_api_url.clone(), self.http.clone());
         // Google/GitHub logins must not send Sm-Id-Token (SSO-only); see sm_api docs.
         sm.login(&tokens.access_token, None).await?;
-        let user = sm.current_user().await?;
+        let user = sm.fetch_current_user().await?;
         sm.ensure_capi_enabled().await?;
         // Pick the account matching the logged-in user's current_account_id. /accounts list
         // order isn't guaranteed, so taking the first entry could mint a key for the wrong
         // account in a multi-account org. Fall back to the first only when it's absent/unknown.
-        let account = select_account(sm.accounts().await?, user.current_account_id.as_deref())
-            .ok_or_else(|| AuthError::Protocol("no accounts associated with this login".into()))?;
+        let account = select_account(
+            sm.fetch_accounts().await?,
+            user.current_account_id.as_deref(),
+        )
+        .ok_or_else(|| AuthError::Protocol("no accounts associated with this login".into()))?;
         let api_key = account.api_access_key.ok_or_else(|| {
             AuthError::Protocol("account has no CAPI access key after enabling CAPI".into())
         })?;
@@ -129,7 +130,7 @@ impl CloudAuthenticator {
         // Best-effort: count our keys so the CLI can warn about sprawl (D5). Never fail login
         // over this — a listing error just means no warning.
         let redisctl_key_count = sm
-            .list_capi_keys()
+            .fetch_capi_keys()
             .await
             .map(|keys| keys.iter().filter(|n| n.starts_with("redisctl-")).count())
             .unwrap_or(0);

--- a/crates/redisctl-core/src/auth/authenticator.rs
+++ b/crates/redisctl-core/src/auth/authenticator.rs
@@ -1,0 +1,325 @@
+//! Orchestrates a full `cloud auth login`: build the OIDC flow clients, and after a flow
+//! yields tokens, run the SM exchange and mint a CAPI key.
+//!
+//! Returns [`MintedCredentials`] for the caller to persist (see
+//! `config::Config::apply_cloud_login`). Persistence lives in the config layer so this stays
+//! free of file/keyring I/O and easy to test. The flow itself (device polling with progress,
+//! or loopback with a browser) is driven by the CLI using [`CloudAuthenticator::device_flow`]
+//! / [`CloudAuthenticator::loopback`].
+
+use url::Url;
+
+use super::sm_api::{SmAccount, SmApiClient};
+use super::{AuthError, DeviceFlowClient, LoopbackFlowClient, TokenSet, default_http_client};
+
+/// Result of a completed login: a Redis Cloud CAPI key pair plus context, ready to persist.
+///
+/// Secret fields are redacted from `Debug`.
+#[derive(Clone)]
+pub struct MintedCredentials {
+    pub account_id: Option<String>,
+    pub email: Option<String>,
+    /// Account-level CAPI key (`x-api-key`).
+    pub api_key: String,
+    /// Minted user secret (`x-api-secret-key`).
+    pub api_secret: String,
+    /// CAPI base URL to record in the resulting cloud profile.
+    pub api_url: String,
+    /// Okta refresh token (rotating) to persist for silent re-auth, if the IdP issued one.
+    pub refresh_token: Option<String>,
+    /// Name of the minted `redisctl-*` CAPI key (visible/revocable in the console).
+    pub capi_key_name: String,
+    /// How many `redisctl-*` CAPI keys the account has after this mint (best-effort; 0 if the
+    /// listing failed). The CLI warns when this grows, since each login mints a new key (D5).
+    pub redisctl_key_count: usize,
+}
+
+impl std::fmt::Debug for MintedCredentials {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MintedCredentials")
+            .field("account_id", &self.account_id)
+            .field("email", &self.email)
+            .field("api_key", &"<redacted>")
+            .field("api_secret", &"<redacted>")
+            .field("api_url", &self.api_url)
+            .field(
+                "refresh_token",
+                &self.refresh_token.as_ref().map(|_| "<redacted>"),
+            )
+            .field("capi_key_name", &self.capi_key_name)
+            .field("redisctl_key_count", &self.redisctl_key_count)
+            .finish()
+    }
+}
+
+/// Ties the OIDC endpoints (Okta) and the SM API together for one environment.
+#[derive(Clone)]
+pub struct CloudAuthenticator {
+    issuer: Url,
+    client_id: String,
+    sm_api_url: Url,
+    capi_url: String,
+    http: reqwest::Client,
+}
+
+impl CloudAuthenticator {
+    /// Build for one environment. `issuer`/`client_id` drive the Okta flows, `sm_api_url` the
+    /// key-minting exchange, and `capi_url` is recorded in the resulting profile.
+    pub fn new(
+        issuer: Url,
+        client_id: impl Into<String>,
+        sm_api_url: Url,
+        capi_url: impl Into<String>,
+    ) -> Self {
+        Self {
+            issuer,
+            client_id: client_id.into(),
+            sm_api_url,
+            capi_url: capi_url.into(),
+            http: default_http_client(),
+        }
+    }
+
+    /// Use a caller-provided reqwest client (tests / shared client).
+    pub fn with_http_client(mut self, http: reqwest::Client) -> Self {
+        self.http = http;
+        self
+    }
+
+    /// Device-authorization-grant client for headless / agent logins.
+    pub fn device_flow(&self) -> DeviceFlowClient {
+        DeviceFlowClient::with_http_client(
+            self.issuer.clone(),
+            self.client_id.clone(),
+            self.http.clone(),
+        )
+    }
+
+    /// Auth-code + PKCE loopback client for interactive human logins.
+    pub fn loopback(&self) -> LoopbackFlowClient {
+        LoopbackFlowClient::new(self.issuer.clone(), self.client_id.clone())
+            .with_http_client(self.http.clone())
+    }
+
+    /// Refresh an Okta refresh token for a fresh token set (Okta rotates it).
+    pub async fn refresh(&self, refresh_token: &str) -> Result<TokenSet, AuthError> {
+        self.device_flow().refresh(refresh_token).await
+    }
+
+    /// Given tokens from a flow, run the SM exchange and mint a CAPI key named `key_name`.
+    pub async fn complete_login(
+        &self,
+        tokens: &TokenSet,
+        key_name: &str,
+    ) -> Result<MintedCredentials, AuthError> {
+        let mut sm = SmApiClient::with_http_client(self.sm_api_url.clone(), self.http.clone());
+        // Google/GitHub logins must not send Sm-Id-Token (SSO-only); see sm_api docs.
+        sm.login(&tokens.access_token, None).await?;
+        let user = sm.current_user().await?;
+        sm.ensure_capi_enabled().await?;
+        // Pick the account matching the logged-in user's current_account_id. /accounts list
+        // order isn't guaranteed, so taking the first entry could mint a key for the wrong
+        // account in a multi-account org. Fall back to the first only when it's absent/unknown.
+        let account = select_account(sm.accounts().await?, user.current_account_id.as_deref())
+            .ok_or_else(|| AuthError::Protocol("no accounts associated with this login".into()))?;
+        let api_key = account.api_access_key.ok_or_else(|| {
+            AuthError::Protocol("account has no CAPI access key after enabling CAPI".into())
+        })?;
+        let minted = sm.mint_capi_key(key_name, user.user_account()?).await?;
+        // Best-effort: count our keys so the CLI can warn about sprawl (D5). Never fail login
+        // over this — a listing error just means no warning.
+        let redisctl_key_count = sm
+            .list_capi_keys()
+            .await
+            .map(|keys| keys.iter().filter(|n| n.starts_with("redisctl-")).count())
+            .unwrap_or(0);
+        Ok(MintedCredentials {
+            account_id: user.current_account_id,
+            email: user.email,
+            api_key,
+            api_secret: minted.secret_key,
+            api_url: self.capi_url.clone(),
+            refresh_token: tokens.refresh_token.clone(),
+            capi_key_name: minted.name,
+            redisctl_key_count,
+        })
+    }
+}
+
+/// Choose the account matching `current_account_id` (the logged-in user context); fall back to
+/// the first account only when the id is absent or not present in the list.
+fn select_account(accounts: Vec<SmAccount>, current_account_id: Option<&str>) -> Option<SmAccount> {
+    let target = current_account_id.and_then(|s| s.parse::<u64>().ok());
+    let idx = target
+        .and_then(|id| accounts.iter().position(|a| a.id == id))
+        .unwrap_or(0);
+    accounts.into_iter().nth(idx)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn account(id: u64) -> SmAccount {
+        serde_json::from_value(serde_json::json!({
+            "id": id, "api_access_key": format!("KEY-{id}")
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn select_account_prefers_current_account_id() {
+        let accts = vec![account(111), account(222), account(333)];
+        // Matches the user's current account, not the first in the list.
+        let chosen = select_account(accts, Some("222")).unwrap();
+        assert_eq!(chosen.id, 222);
+    }
+
+    #[test]
+    fn select_account_falls_back_to_first_when_absent_or_unknown() {
+        assert_eq!(
+            select_account(vec![account(111), account(222)], None)
+                .unwrap()
+                .id,
+            111
+        );
+        // current_account_id present but not in the list → first (defensive fallback).
+        assert_eq!(
+            select_account(vec![account(111), account(222)], Some("999"))
+                .unwrap()
+                .id,
+            111
+        );
+        assert!(select_account(vec![], Some("1")).is_none());
+    }
+
+    #[test]
+    fn debug_redacts_secrets() {
+        let creds = MintedCredentials {
+            account_id: Some("42".to_string()),
+            email: Some("u@example.com".to_string()),
+            api_key: "AKEY-visible-should-not-appear".to_string(),
+            api_secret: "SECRET-should-not-appear".to_string(),
+            api_url: "https://api.example.com/v1".to_string(),
+            refresh_token: Some("RT-should-not-appear".to_string()),
+            capi_key_name: "redisctl-cli-1".to_string(),
+            redisctl_key_count: 3,
+        };
+        let dbg = format!("{creds:?}");
+        assert!(dbg.contains("<redacted>"));
+        assert!(!dbg.contains("AKEY-visible-should-not-appear"));
+        assert!(!dbg.contains("SECRET-should-not-appear"));
+        assert!(!dbg.contains("RT-should-not-appear"));
+        // Non-secret fields remain visible for diagnostics.
+        assert!(dbg.contains("u@example.com"));
+        assert!(dbg.contains("redisctl-cli-1"));
+    }
+
+    #[tokio::test]
+    async fn complete_login_runs_the_full_exchange() {
+        let server = MockServer::start().await;
+        let mount = |m: &str, p: &'static str, body: serde_json::Value, cookie: bool| {
+            let mut tmpl = ResponseTemplate::new(200).set_body_json(body);
+            if cookie {
+                tmpl = tmpl.append_header("Set-Cookie", "JSESSIONID=SID; Path=/");
+            }
+            Mock::given(method(m)).and(path(p)).respond_with(tmpl)
+        };
+        mount("POST", "/login", serde_json::json!({}), true)
+            .mount(&server)
+            .await;
+        mount(
+            "GET",
+            "/csrf",
+            serde_json::json!({"csrfToken": {"csrf_token": "C"}}),
+            false,
+        )
+        .mount(&server)
+        .await;
+        mount(
+            "GET",
+            "/users/me",
+            serde_json::json!({"id": "114429", "current_account_id": "112117", "email": "u@e.com"}),
+            false,
+        )
+        .mount(&server)
+        .await;
+        mount(
+            "POST",
+            "/accounts/cloud-api/cloudApiAccessKey",
+            serde_json::json!({"cloudApiAccessKey": {"accessKey": "ACCT"}}),
+            false,
+        )
+        .mount(&server)
+        .await;
+        mount(
+            "GET",
+            "/accounts",
+            serde_json::json!({"accounts": [{"id": 112117, "api_access_key": "ACCT-KEY"}]}),
+            false,
+        )
+        .mount(&server)
+        .await;
+        mount(
+            "POST",
+            "/accounts/cloud-api/cloudApiKeys",
+            serde_json::json!({"name": "redisctl-test", "secret_key": "SECRET"}),
+            false,
+        )
+        .mount(&server)
+        .await;
+
+        let auth = CloudAuthenticator::new(
+            Url::parse("https://issuer.example/oauth2/default").unwrap(),
+            "cid",
+            Url::parse(&server.uri()).unwrap(),
+            "https://capi.example/v1",
+        );
+        let tokens = TokenSet {
+            access_token: "AT".into(),
+            id_token: "IT".into(),
+            refresh_token: Some("RT".into()),
+            expires_in: 3600,
+        };
+
+        let creds = auth.complete_login(&tokens, "redisctl-test").await.unwrap();
+        assert_eq!(creds.api_key, "ACCT-KEY");
+        assert_eq!(creds.api_secret, "SECRET");
+        assert_eq!(creds.api_url, "https://capi.example/v1");
+        assert_eq!(creds.account_id.as_deref(), Some("112117"));
+        assert_eq!(creds.email.as_deref(), Some("u@e.com"));
+        assert_eq!(creds.refresh_token.as_deref(), Some("RT"));
+        assert_eq!(creds.capi_key_name, "redisctl-test");
+        // secrets must not leak via Debug
+        let dbg = format!("{creds:?}");
+        assert!(!dbg.contains("SECRET") && !dbg.contains("ACCT-KEY") && !dbg.contains("RT"));
+    }
+
+    #[tokio::test]
+    async fn complete_login_errors_when_login_rejected() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/login"))
+            .respond_with(ResponseTemplate::new(401).append_header("Set-Cookie", "JSESSIONID=S"))
+            .mount(&server)
+            .await;
+        let auth = CloudAuthenticator::new(
+            Url::parse("https://issuer.example/oauth2/default").unwrap(),
+            "cid",
+            Url::parse(&server.uri()).unwrap(),
+            "https://capi.example/v1",
+        );
+        let tokens = TokenSet {
+            access_token: "AT".into(),
+            id_token: String::new(),
+            refresh_token: None,
+            expires_in: 3600,
+        };
+        assert!(matches!(
+            auth.complete_login(&tokens, "k").await,
+            Err(AuthError::Protocol(_))
+        ));
+    }
+}

--- a/crates/redisctl-core/src/auth/device_flow.rs
+++ b/crates/redisctl-core/src/auth/device_flow.rs
@@ -1,0 +1,375 @@
+//! OIDC Device Authorization Grant (RFC 8628) client for the Redis Cloud Okta tenant.
+//!
+//! Three requests against the issuer:
+//! - `POST {issuer}/v1/device/authorize` — start; returns the user code + verification URI.
+//! - `POST {issuer}/v1/token` (device-code grant) — polled until approved/expired/denied.
+//! - `POST {issuer}/v1/token` (refresh-token grant) — exchange a refresh token for a new set.
+//!
+//! The caller owns the polling loop (so the CLI can print progress and honor `--timeout`);
+//! [`DeviceFlowClient::poll_once`] performs a single attempt.
+
+use serde::Deserialize;
+use url::Url;
+
+use super::{
+    AuthError, TokenSet, default_http_client, endpoint, form_body, post_token, token_set, truncate,
+};
+
+const DEVICE_CODE_GRANT: &str = "urn:ietf:params:oauth:grant-type:device_code";
+const REFRESH_TOKEN_GRANT: &str = "refresh_token";
+/// RFC 8628 default poll interval when the server omits one.
+const DEFAULT_INTERVAL: u64 = 5;
+
+/// Device-authorization-grant client bound to one Okta issuer + public client id.
+#[derive(Clone)]
+pub struct DeviceFlowClient {
+    issuer: Url,
+    client_id: String,
+    http: reqwest::Client,
+}
+
+/// The device-authorization response — what `auth login` surfaces to the developer.
+///
+/// `device_code` is retained to poll the token endpoint; it is a secret and is never printed.
+#[derive(Clone)]
+pub struct DeviceAuthorization {
+    pub device_code: String,
+    pub user_code: String,
+    pub verification_uri: String,
+    pub verification_uri_complete: Option<String>,
+    pub expires_in: u64,
+    pub interval: u64,
+}
+
+/// Outcome of a single token-endpoint poll. The caller decides when to poll again.
+#[derive(Debug)]
+pub enum PollOutcome {
+    /// Still waiting on the user; sleep `interval` and poll again.
+    Pending,
+    /// Server asked us to back off; increase the interval, then keep polling.
+    SlowDown,
+    /// Approved — tokens issued.
+    Ready(TokenSet),
+}
+
+#[derive(Deserialize)]
+struct DeviceAuthzResponse {
+    device_code: String,
+    user_code: String,
+    verification_uri: String,
+    verification_uri_complete: Option<String>,
+    expires_in: u64,
+    interval: Option<u64>,
+}
+
+impl DeviceFlowClient {
+    /// Build a client for the given issuer (e.g.
+    /// `https://<your-okta-issuer>/oauth2/default`) and public client id.
+    pub fn new(issuer: Url, client_id: impl Into<String>) -> Self {
+        Self::with_http_client(issuer, client_id, default_http_client())
+    }
+
+    /// Build with a caller-provided reqwest client (used by tests and callers that want to
+    /// share a client / set a custom user agent).
+    pub fn with_http_client(
+        issuer: Url,
+        client_id: impl Into<String>,
+        http: reqwest::Client,
+    ) -> Self {
+        Self {
+            issuer,
+            client_id: client_id.into(),
+            http,
+        }
+    }
+
+    /// Start device authorization: `POST /v1/device/authorize`.
+    pub async fn start(&self, scopes: &[&str]) -> Result<DeviceAuthorization, AuthError> {
+        let scope = scopes.join(" ");
+        let resp = self
+            .http
+            .post(endpoint(&self.issuer, "v1/device/authorize"))
+            .header(
+                reqwest::header::CONTENT_TYPE,
+                "application/x-www-form-urlencoded",
+            )
+            .body(form_body(&[
+                ("client_id", self.client_id.as_str()),
+                ("scope", scope.as_str()),
+            ]))
+            .send()
+            .await?;
+        let status = resp.status();
+        let body = resp.text().await?;
+        if !status.is_success() {
+            return Err(AuthError::Protocol(format!(
+                "device authorize returned {status}: {}",
+                truncate(&body)
+            )));
+        }
+        let d: DeviceAuthzResponse = serde_json::from_str(&body).map_err(|e| {
+            AuthError::Protocol(format!("could not parse device-authorize response: {e}"))
+        })?;
+        Ok(DeviceAuthorization {
+            device_code: d.device_code,
+            user_code: d.user_code,
+            verification_uri: d.verification_uri,
+            verification_uri_complete: d.verification_uri_complete,
+            expires_in: d.expires_in,
+            interval: d.interval.unwrap_or(DEFAULT_INTERVAL),
+        })
+    }
+
+    /// One poll of the token endpoint with the device-code grant. The caller owns the loop.
+    ///
+    /// The OAuth device flow returns HTTP 400 with an `error` body for the pending/slow-down/
+    /// error cases, so we read and parse the body regardless of status.
+    pub async fn poll_once(&self, device_code: &str) -> Result<PollOutcome, AuthError> {
+        let tr = post_token(
+            &self.http,
+            &endpoint(&self.issuer, "v1/token"),
+            &[
+                ("client_id", self.client_id.as_str()),
+                ("grant_type", DEVICE_CODE_GRANT),
+                ("device_code", device_code),
+            ],
+        )
+        .await?;
+
+        if let Some(err) = tr.error.as_deref() {
+            return match err {
+                "authorization_pending" => Ok(PollOutcome::Pending),
+                "slow_down" => Ok(PollOutcome::SlowDown),
+                "expired_token" => Err(AuthError::Expired),
+                "access_denied" => Err(AuthError::Denied),
+                other => Err(AuthError::Protocol(format!(
+                    "token endpoint error {other}: {}",
+                    tr.description()
+                ))),
+            };
+        }
+        Ok(PollOutcome::Ready(token_set(tr)?))
+    }
+
+    /// Exchange a refresh token for a fresh token set (Okta rotates the refresh token).
+    pub async fn refresh(&self, refresh_token: &str) -> Result<TokenSet, AuthError> {
+        let tr = post_token(
+            &self.http,
+            &endpoint(&self.issuer, "v1/token"),
+            &[
+                ("client_id", self.client_id.as_str()),
+                ("grant_type", REFRESH_TOKEN_GRANT),
+                ("refresh_token", refresh_token),
+            ],
+        )
+        .await?;
+        if let Some(err) = tr.error.as_deref() {
+            return Err(AuthError::Protocol(format!(
+                "refresh failed ({err}): {}",
+                tr.description()
+            )));
+        }
+        token_set(tr)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn client(server: &MockServer) -> DeviceFlowClient {
+        DeviceFlowClient::new(Url::parse(&server.uri()).unwrap(), "test-client")
+    }
+
+    async fn mount_token(server: &MockServer, status: u16, body: serde_json::Value) {
+        Mock::given(method("POST"))
+            .and(path("/v1/token"))
+            .respond_with(ResponseTemplate::new(status).set_body_json(body))
+            .mount(server)
+            .await;
+    }
+
+    #[tokio::test]
+    async fn start_parses_device_authorization() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/device/authorize"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "device_code": "DC",
+                "user_code": "WDJB-MJHT",
+                "verification_uri": "https://x/activate",
+                "verification_uri_complete": "https://x/activate?user_code=WDJB-MJHT",
+                "expires_in": 600,
+                "interval": 5
+            })))
+            .mount(&server)
+            .await;
+
+        let d = client(&server)
+            .start(&["openid", "offline_access"])
+            .await
+            .unwrap();
+        assert_eq!(d.device_code, "DC");
+        assert_eq!(d.user_code, "WDJB-MJHT");
+        assert_eq!(d.interval, 5);
+        assert_eq!(
+            d.verification_uri_complete.as_deref(),
+            Some("https://x/activate?user_code=WDJB-MJHT")
+        );
+    }
+
+    #[tokio::test]
+    async fn start_defaults_interval_when_absent() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/device/authorize"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "device_code": "DC",
+                "user_code": "U",
+                "verification_uri": "https://x",
+                "expires_in": 600
+            })))
+            .mount(&server)
+            .await;
+
+        let d = client(&server).start(&["openid"]).await.unwrap();
+        assert_eq!(d.interval, DEFAULT_INTERVAL);
+    }
+
+    #[tokio::test]
+    async fn poll_pending() {
+        let server = MockServer::start().await;
+        mount_token(
+            &server,
+            400,
+            serde_json::json!({"error": "authorization_pending"}),
+        )
+        .await;
+        assert!(matches!(
+            client(&server).poll_once("DC").await.unwrap(),
+            PollOutcome::Pending
+        ));
+    }
+
+    #[tokio::test]
+    async fn poll_slow_down() {
+        let server = MockServer::start().await;
+        mount_token(&server, 400, serde_json::json!({"error": "slow_down"})).await;
+        assert!(matches!(
+            client(&server).poll_once("DC").await.unwrap(),
+            PollOutcome::SlowDown
+        ));
+    }
+
+    #[tokio::test]
+    async fn poll_ready_returns_tokens() {
+        let server = MockServer::start().await;
+        mount_token(
+            &server,
+            200,
+            serde_json::json!({
+                "access_token": "AT",
+                "id_token": "IT",
+                "refresh_token": "RT",
+                "expires_in": 3600
+            }),
+        )
+        .await;
+
+        match client(&server).poll_once("DC").await.unwrap() {
+            PollOutcome::Ready(t) => {
+                assert_eq!(t.access_token, "AT");
+                assert_eq!(t.id_token, "IT");
+                assert_eq!(t.refresh_token.as_deref(), Some("RT"));
+                assert_eq!(t.expires_in, 3600);
+            }
+            other => panic!("expected Ready, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn poll_expired_maps_to_error() {
+        let server = MockServer::start().await;
+        mount_token(&server, 400, serde_json::json!({"error": "expired_token"})).await;
+        assert!(matches!(
+            client(&server).poll_once("DC").await,
+            Err(AuthError::Expired)
+        ));
+    }
+
+    #[tokio::test]
+    async fn poll_denied_maps_to_error() {
+        let server = MockServer::start().await;
+        mount_token(&server, 400, serde_json::json!({"error": "access_denied"})).await;
+        assert!(matches!(
+            client(&server).poll_once("DC").await,
+            Err(AuthError::Denied)
+        ));
+    }
+
+    #[tokio::test]
+    async fn poll_unknown_error_is_protocol() {
+        let server = MockServer::start().await;
+        mount_token(
+            &server,
+            400,
+            serde_json::json!({"error": "weird", "error_description": "nope"}),
+        )
+        .await;
+        assert!(matches!(
+            client(&server).poll_once("DC").await,
+            Err(AuthError::Protocol(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn poll_malformed_body_is_protocol() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("not json"))
+            .mount(&server)
+            .await;
+        assert!(matches!(
+            client(&server).poll_once("DC").await,
+            Err(AuthError::Protocol(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn refresh_returns_rotated_token() {
+        let server = MockServer::start().await;
+        mount_token(
+            &server,
+            200,
+            serde_json::json!({
+                "access_token": "AT2",
+                "refresh_token": "RT2",
+                "expires_in": 3600
+            }),
+        )
+        .await;
+
+        let t = client(&server).refresh("RT1").await.unwrap();
+        assert_eq!(t.access_token, "AT2");
+        // Okta rotates the refresh token — the caller must persist the new one.
+        assert_eq!(t.refresh_token.as_deref(), Some("RT2"));
+    }
+
+    #[tokio::test]
+    async fn refresh_error_is_protocol() {
+        let server = MockServer::start().await;
+        mount_token(
+            &server,
+            400,
+            serde_json::json!({"error": "invalid_grant", "error_description": "expired"}),
+        )
+        .await;
+        assert!(matches!(
+            client(&server).refresh("RT1").await,
+            Err(AuthError::Protocol(_))
+        ));
+    }
+}

--- a/crates/redisctl-core/src/auth/device_flow.rs
+++ b/crates/redisctl-core/src/auth/device_flow.rs
@@ -1,12 +1,12 @@
 //! OIDC Device Authorization Grant (RFC 8628) client for the Redis Cloud Okta tenant.
 //!
-//! Three requests against the issuer:
+//! Two requests against the issuer:
 //! - `POST {issuer}/v1/device/authorize` — start; returns the user code + verification URI.
 //! - `POST {issuer}/v1/token` (device-code grant) — polled until approved/expired/denied.
-//! - `POST {issuer}/v1/token` (refresh-token grant) — exchange a refresh token for a new set.
 //!
 //! The caller owns the polling loop (so the CLI can print progress and honor `--timeout`);
-//! [`DeviceFlowClient::poll_once`] performs a single attempt.
+//! [`DeviceFlowClient::poll_once`] performs a single attempt. Refreshing a token is
+//! flow-agnostic and lives in [`super::oidc::refresh`].
 
 use serde::Deserialize;
 use url::Url;
@@ -16,7 +16,6 @@ use super::{
 };
 
 const DEVICE_CODE_GRANT: &str = "urn:ietf:params:oauth:grant-type:device_code";
-const REFRESH_TOKEN_GRANT: &str = "refresh_token";
 /// RFC 8628 default poll interval when the server omits one.
 const DEFAULT_INTERVAL: u64 = 5;
 
@@ -35,7 +34,10 @@ pub struct DeviceFlowClient {
 pub struct DeviceAuthorization {
     pub device_code: String,
     pub user_code: String,
+    /// The page the user opens and then *types* the `user_code` into.
     pub verification_uri: String,
+    /// The same page with the `user_code` pre-embedded (optional per RFC 8628), so the user
+    /// can just open it and confirm — no manual code entry. Prefer this when present.
     pub verification_uri_complete: Option<String>,
     pub expires_in: u64,
     pub interval: u64,
@@ -52,6 +54,9 @@ pub enum PollOutcome {
     Ready(TokenSet),
 }
 
+/// Raw `/device/authorize` wire response. Kept separate from the public [`DeviceAuthorization`]
+/// so the wire shape (`interval` optional per RFC 8628) stays isolated from the resolved public
+/// type (`interval` defaulted); `start()` maps one to the other.
 #[derive(Deserialize)]
 struct DeviceAuthzResponse {
     device_code: String,
@@ -66,21 +71,17 @@ impl DeviceFlowClient {
     /// Build a client for the given issuer (e.g.
     /// `https://<your-okta-issuer>/oauth2/default`) and public client id.
     pub fn new(issuer: Url, client_id: impl Into<String>) -> Self {
-        Self::with_http_client(issuer, client_id, default_http_client())
-    }
-
-    /// Build with a caller-provided reqwest client (used by tests and callers that want to
-    /// share a client / set a custom user agent).
-    pub fn with_http_client(
-        issuer: Url,
-        client_id: impl Into<String>,
-        http: reqwest::Client,
-    ) -> Self {
         Self {
             issuer,
             client_id: client_id.into(),
-            http,
+            http: default_http_client(),
         }
+    }
+
+    /// Use a caller-provided reqwest client (tests / shared client / custom user agent).
+    pub fn with_http_client(mut self, http: reqwest::Client) -> Self {
+        self.http = http;
+        self
     }
 
     /// Start device authorization: `POST /v1/device/authorize`.
@@ -149,27 +150,6 @@ impl DeviceFlowClient {
             };
         }
         Ok(PollOutcome::Ready(token_set(tr)?))
-    }
-
-    /// Exchange a refresh token for a fresh token set (Okta rotates the refresh token).
-    pub async fn refresh(&self, refresh_token: &str) -> Result<TokenSet, AuthError> {
-        let tr = post_token(
-            &self.http,
-            &endpoint(&self.issuer, "v1/token"),
-            &[
-                ("client_id", self.client_id.as_str()),
-                ("grant_type", REFRESH_TOKEN_GRANT),
-                ("refresh_token", refresh_token),
-            ],
-        )
-        .await?;
-        if let Some(err) = tr.error.as_deref() {
-            return Err(AuthError::Protocol(format!(
-                "refresh failed ({err}): {}",
-                tr.description()
-            )));
-        }
-        token_set(tr)
     }
 }
 
@@ -334,41 +314,6 @@ mod tests {
             .await;
         assert!(matches!(
             client(&server).poll_once("DC").await,
-            Err(AuthError::Protocol(_))
-        ));
-    }
-
-    #[tokio::test]
-    async fn refresh_returns_rotated_token() {
-        let server = MockServer::start().await;
-        mount_token(
-            &server,
-            200,
-            serde_json::json!({
-                "access_token": "AT2",
-                "refresh_token": "RT2",
-                "expires_in": 3600
-            }),
-        )
-        .await;
-
-        let t = client(&server).refresh("RT1").await.unwrap();
-        assert_eq!(t.access_token, "AT2");
-        // Okta rotates the refresh token — the caller must persist the new one.
-        assert_eq!(t.refresh_token.as_deref(), Some("RT2"));
-    }
-
-    #[tokio::test]
-    async fn refresh_error_is_protocol() {
-        let server = MockServer::start().await;
-        mount_token(
-            &server,
-            400,
-            serde_json::json!({"error": "invalid_grant", "error_description": "expired"}),
-        )
-        .await;
-        assert!(matches!(
-            client(&server).refresh("RT1").await,
             Err(AuthError::Protocol(_))
         ));
     }

--- a/crates/redisctl-core/src/auth/mod.rs
+++ b/crates/redisctl-core/src/auth/mod.rs
@@ -1,0 +1,168 @@
+//! Cloud authentication: OIDC flows that bootstrap a Redis Cloud CAPI key.
+//!
+//! `cloud auth login` is a credential *bootstrapper*: obtain Okta tokens, exchange them with
+//! the SM API, mint a CAPI key, and hand it to the config layer to persist as a normal cloud
+//! profile. This module holds the OIDC token-acquisition clients plus the SM exchange.
+//!
+//! Two front doors, one back end:
+//! - [`device_flow::DeviceFlowClient`] — device authorization grant (headless / agent).
+//! - [`auth_code_loopback::LoopbackFlowClient`] — auth-code + PKCE via a loopback redirect
+//!   (interactive human login).
+//!
+//! Both yield a [`TokenSet`] and share the token-endpoint plumbing below. No JWT/JWKS
+//! validation happens here — the SM API is the verifier of the token downstream.
+
+pub mod auth_code_loopback;
+pub mod authenticator;
+pub mod device_flow;
+pub mod sm_api;
+
+pub use auth_code_loopback::LoopbackFlowClient;
+pub use authenticator::{CloudAuthenticator, MintedCredentials};
+pub use device_flow::{DeviceAuthorization, DeviceFlowClient, PollOutcome};
+pub use sm_api::{CapiKey, SmAccount, SmApiClient, SmUser};
+
+use serde::Deserialize;
+use thiserror::Error;
+use url::Url;
+
+/// OIDC tokens returned by any login flow (device flow or auth-code loopback).
+///
+/// `Debug` is hand-written so token material never lands in logs, panics, or `{:?}` output.
+#[derive(Clone)]
+pub struct TokenSet {
+    pub access_token: String,
+    pub id_token: String,
+    pub refresh_token: Option<String>,
+    /// Access-token lifetime in seconds (0 if the IdP omitted it).
+    pub expires_in: u64,
+}
+
+impl std::fmt::Debug for TokenSet {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TokenSet")
+            .field("access_token", &"<redacted>")
+            .field("id_token", &"<redacted>")
+            .field(
+                "refresh_token",
+                &self.refresh_token.as_ref().map(|_| "<redacted>"),
+            )
+            .field("expires_in", &self.expires_in)
+            .finish()
+    }
+}
+
+/// Errors from the OIDC token-acquisition flows.
+///
+/// Exit-code mapping is applied at the CLI layer in the error-contract work unit;
+/// here we only classify the failure.
+#[derive(Debug, Error)]
+pub enum AuthError {
+    /// The device/authorization code expired before the user approved (`expired_token`).
+    #[error("the login code expired before it was approved; start login again")]
+    Expired,
+
+    /// The user denied the authorization request (`access_denied`).
+    #[error("the login request was denied")]
+    Denied,
+
+    /// Network/transport failure talking to the identity provider.
+    #[error("network error contacting the identity provider: {0}")]
+    Network(#[from] reqwest::Error),
+
+    /// The identity provider returned something unexpected or unparseable.
+    #[error("unexpected identity-provider response: {0}")]
+    Protocol(String),
+}
+
+// ---------------------------------------------------------------------------
+// Shared OIDC plumbing used by both flows.
+// ---------------------------------------------------------------------------
+
+/// Raw token-endpoint response — either the token fields or an OAuth `error` object.
+#[derive(Deserialize)]
+pub(crate) struct TokenResponse {
+    pub(crate) access_token: Option<String>,
+    pub(crate) id_token: Option<String>,
+    pub(crate) refresh_token: Option<String>,
+    pub(crate) expires_in: Option<u64>,
+    pub(crate) error: Option<String>,
+    pub(crate) error_description: Option<String>,
+}
+
+impl TokenResponse {
+    /// The `error_description`, or a placeholder — for building error messages.
+    pub(crate) fn description(&self) -> &str {
+        self.error_description
+            .as_deref()
+            .unwrap_or("(no description)")
+    }
+}
+
+/// Build `{issuer}/{path}`, tolerant of a trailing slash on the issuer.
+pub(crate) fn endpoint(issuer: &Url, path: &str) -> String {
+    format!(
+        "{}/{}",
+        issuer.as_str().trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
+}
+
+/// Encode name/value pairs as an `application/x-www-form-urlencoded` string (body or query).
+pub(crate) fn form_body(pairs: &[(&str, &str)]) -> String {
+    serde_urlencoded::to_string(pairs).unwrap_or_default()
+}
+
+/// POST an `application/x-www-form-urlencoded` body to the token endpoint and parse the
+/// response. Does not treat non-2xx as fatal — the OAuth error body is parsed regardless.
+pub(crate) async fn post_token(
+    http: &reqwest::Client,
+    token_url: &str,
+    form: &[(&str, &str)],
+) -> Result<TokenResponse, AuthError> {
+    let body = http
+        .post(token_url)
+        .header(
+            reqwest::header::CONTENT_TYPE,
+            "application/x-www-form-urlencoded",
+        )
+        .body(form_body(form))
+        .send()
+        .await?
+        .text()
+        .await?;
+    serde_json::from_str(&body)
+        .map_err(|e| AuthError::Protocol(format!("could not parse token response: {e}")))
+}
+
+/// Convert a successful token response into a [`TokenSet`].
+pub(crate) fn token_set(tr: TokenResponse) -> Result<TokenSet, AuthError> {
+    let access_token = tr
+        .access_token
+        .ok_or_else(|| AuthError::Protocol("token response missing access_token".into()))?;
+    Ok(TokenSet {
+        access_token,
+        id_token: tr.id_token.unwrap_or_default(),
+        refresh_token: tr.refresh_token,
+        expires_in: tr.expires_in.unwrap_or(0),
+    })
+}
+
+/// A reqwest client with the redisctl user agent.
+pub(crate) fn default_http_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .user_agent(concat!("redisctl/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .expect("building the reqwest client should not fail")
+}
+
+/// Truncate a string for inclusion in an error message (char-boundary safe).
+pub(crate) fn truncate(s: &str) -> String {
+    const MAX: usize = 200;
+    if s.chars().count() <= MAX {
+        s.to_string()
+    } else {
+        let head: String = s.chars().take(MAX).collect();
+        format!("{head}…")
+    }
+}

--- a/crates/redisctl-core/src/auth/mod.rs
+++ b/crates/redisctl-core/src/auth/mod.rs
@@ -9,160 +9,21 @@
 //! - [`auth_code_loopback::LoopbackFlowClient`] — auth-code + PKCE via a loopback redirect
 //!   (interactive human login).
 //!
-//! Both yield a [`TokenSet`] and share the token-endpoint plumbing below. No JWT/JWKS
-//! validation happens here — the SM API is the verifier of the token downstream.
+//! Both yield a [`TokenSet`] and share the common token-endpoint plumbing in `oidc`. No
+//! JWT/JWKS validation happens here — the SM API is the verifier of the token downstream.
 
 pub mod auth_code_loopback;
 pub mod authenticator;
 pub mod device_flow;
 pub mod sm_api;
 
+mod oidc;
+
 pub use auth_code_loopback::LoopbackFlowClient;
 pub use authenticator::{CloudAuthenticator, MintedCredentials};
 pub use device_flow::{DeviceAuthorization, DeviceFlowClient, PollOutcome};
+pub use oidc::{AuthError, TokenSet};
 pub use sm_api::{CapiKey, SmAccount, SmApiClient, SmUser};
 
-use serde::Deserialize;
-use thiserror::Error;
-use url::Url;
-
-/// OIDC tokens returned by any login flow (device flow or auth-code loopback).
-///
-/// `Debug` is hand-written so token material never lands in logs, panics, or `{:?}` output.
-#[derive(Clone)]
-pub struct TokenSet {
-    pub access_token: String,
-    pub id_token: String,
-    pub refresh_token: Option<String>,
-    /// Access-token lifetime in seconds (0 if the IdP omitted it).
-    pub expires_in: u64,
-}
-
-impl std::fmt::Debug for TokenSet {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("TokenSet")
-            .field("access_token", &"<redacted>")
-            .field("id_token", &"<redacted>")
-            .field(
-                "refresh_token",
-                &self.refresh_token.as_ref().map(|_| "<redacted>"),
-            )
-            .field("expires_in", &self.expires_in)
-            .finish()
-    }
-}
-
-/// Errors from the OIDC token-acquisition flows.
-///
-/// Exit-code mapping is applied at the CLI layer in the error-contract work unit;
-/// here we only classify the failure.
-#[derive(Debug, Error)]
-pub enum AuthError {
-    /// The device/authorization code expired before the user approved (`expired_token`).
-    #[error("the login code expired before it was approved; start login again")]
-    Expired,
-
-    /// The user denied the authorization request (`access_denied`).
-    #[error("the login request was denied")]
-    Denied,
-
-    /// Network/transport failure talking to the identity provider.
-    #[error("network error contacting the identity provider: {0}")]
-    Network(#[from] reqwest::Error),
-
-    /// The identity provider returned something unexpected or unparseable.
-    #[error("unexpected identity-provider response: {0}")]
-    Protocol(String),
-}
-
-// ---------------------------------------------------------------------------
-// Shared OIDC plumbing used by both flows.
-// ---------------------------------------------------------------------------
-
-/// Raw token-endpoint response — either the token fields or an OAuth `error` object.
-#[derive(Deserialize)]
-pub(crate) struct TokenResponse {
-    pub(crate) access_token: Option<String>,
-    pub(crate) id_token: Option<String>,
-    pub(crate) refresh_token: Option<String>,
-    pub(crate) expires_in: Option<u64>,
-    pub(crate) error: Option<String>,
-    pub(crate) error_description: Option<String>,
-}
-
-impl TokenResponse {
-    /// The `error_description`, or a placeholder — for building error messages.
-    pub(crate) fn description(&self) -> &str {
-        self.error_description
-            .as_deref()
-            .unwrap_or("(no description)")
-    }
-}
-
-/// Build `{issuer}/{path}`, tolerant of a trailing slash on the issuer.
-pub(crate) fn endpoint(issuer: &Url, path: &str) -> String {
-    format!(
-        "{}/{}",
-        issuer.as_str().trim_end_matches('/'),
-        path.trim_start_matches('/')
-    )
-}
-
-/// Encode name/value pairs as an `application/x-www-form-urlencoded` string (body or query).
-pub(crate) fn form_body(pairs: &[(&str, &str)]) -> String {
-    serde_urlencoded::to_string(pairs).unwrap_or_default()
-}
-
-/// POST an `application/x-www-form-urlencoded` body to the token endpoint and parse the
-/// response. Does not treat non-2xx as fatal — the OAuth error body is parsed regardless.
-pub(crate) async fn post_token(
-    http: &reqwest::Client,
-    token_url: &str,
-    form: &[(&str, &str)],
-) -> Result<TokenResponse, AuthError> {
-    let body = http
-        .post(token_url)
-        .header(
-            reqwest::header::CONTENT_TYPE,
-            "application/x-www-form-urlencoded",
-        )
-        .body(form_body(form))
-        .send()
-        .await?
-        .text()
-        .await?;
-    serde_json::from_str(&body)
-        .map_err(|e| AuthError::Protocol(format!("could not parse token response: {e}")))
-}
-
-/// Convert a successful token response into a [`TokenSet`].
-pub(crate) fn token_set(tr: TokenResponse) -> Result<TokenSet, AuthError> {
-    let access_token = tr
-        .access_token
-        .ok_or_else(|| AuthError::Protocol("token response missing access_token".into()))?;
-    Ok(TokenSet {
-        access_token,
-        id_token: tr.id_token.unwrap_or_default(),
-        refresh_token: tr.refresh_token,
-        expires_in: tr.expires_in.unwrap_or(0),
-    })
-}
-
-/// A reqwest client with the redisctl user agent.
-pub(crate) fn default_http_client() -> reqwest::Client {
-    reqwest::Client::builder()
-        .user_agent(concat!("redisctl/", env!("CARGO_PKG_VERSION")))
-        .build()
-        .expect("building the reqwest client should not fail")
-}
-
-/// Truncate a string for inclusion in an error message (char-boundary safe).
-pub(crate) fn truncate(s: &str) -> String {
-    const MAX: usize = 200;
-    if s.chars().count() <= MAX {
-        s.to_string()
-    } else {
-        let head: String = s.chars().take(MAX).collect();
-        format!("{head}…")
-    }
-}
+// Crate-private OIDC plumbing shared by the two flow clients (referenced as `super::*`).
+pub(crate) use oidc::{default_http_client, endpoint, form_body, post_token, token_set, truncate};

--- a/crates/redisctl-core/src/auth/oidc.rs
+++ b/crates/redisctl-core/src/auth/oidc.rs
@@ -1,0 +1,146 @@
+//! Shared OIDC vocabulary and token-endpoint plumbing used by both login flows.
+//!
+//! Holds the public [`TokenSet`] / [`AuthError`] types plus the crate-private helpers the
+//! device-flow and loopback clients build on. Kept out of `mod.rs` so that stays a thin
+//! facade, matching the other modules in this crate.
+
+use serde::Deserialize;
+use thiserror::Error;
+use url::Url;
+
+/// OIDC tokens returned by any login flow (device flow or auth-code loopback).
+///
+/// `Debug` is hand-written so token material never lands in logs, panics, or `{:?}` output.
+#[derive(Clone)]
+pub struct TokenSet {
+    pub access_token: String,
+    pub id_token: String,
+    pub refresh_token: Option<String>,
+    /// Access-token lifetime in seconds (0 if the IdP omitted it).
+    pub expires_in: u64,
+}
+
+impl std::fmt::Debug for TokenSet {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TokenSet")
+            .field("access_token", &"<redacted>")
+            .field("id_token", &"<redacted>")
+            .field(
+                "refresh_token",
+                &self.refresh_token.as_ref().map(|_| "<redacted>"),
+            )
+            .field("expires_in", &self.expires_in)
+            .finish()
+    }
+}
+
+/// Errors from the OIDC token-acquisition flows.
+///
+/// Exit-code mapping is applied at the CLI layer in the error-contract work unit;
+/// here we only classify the failure.
+#[derive(Debug, Error)]
+pub enum AuthError {
+    /// The device/authorization code expired before the user approved (`expired_token`).
+    #[error("the login code expired before it was approved; start login again")]
+    Expired,
+
+    /// The user denied the authorization request (`access_denied`).
+    #[error("the login request was denied")]
+    Denied,
+
+    /// Network/transport failure talking to the identity provider.
+    #[error("network error contacting the identity provider: {0}")]
+    Network(#[from] reqwest::Error),
+
+    /// The identity provider returned something unexpected or unparseable.
+    #[error("unexpected identity-provider response: {0}")]
+    Protocol(String),
+}
+
+/// Raw token-endpoint response — either the token fields or an OAuth `error` object.
+#[derive(Deserialize)]
+pub(crate) struct TokenResponse {
+    pub(crate) access_token: Option<String>,
+    pub(crate) id_token: Option<String>,
+    pub(crate) refresh_token: Option<String>,
+    pub(crate) expires_in: Option<u64>,
+    pub(crate) error: Option<String>,
+    pub(crate) error_description: Option<String>,
+}
+
+impl TokenResponse {
+    /// The `error_description`, or a placeholder — for building error messages.
+    pub(crate) fn description(&self) -> &str {
+        self.error_description
+            .as_deref()
+            .unwrap_or("(no description)")
+    }
+}
+
+/// Build `{issuer}/{path}`, tolerant of a trailing slash on the issuer.
+pub(crate) fn endpoint(issuer: &Url, path: &str) -> String {
+    format!(
+        "{}/{}",
+        issuer.as_str().trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
+}
+
+/// Encode name/value pairs as an `application/x-www-form-urlencoded` string (body or query).
+pub(crate) fn form_body(pairs: &[(&str, &str)]) -> String {
+    serde_urlencoded::to_string(pairs).unwrap_or_default()
+}
+
+/// POST an `application/x-www-form-urlencoded` body to the token endpoint and parse the
+/// response. Does not treat non-2xx as fatal — the OAuth error body is parsed regardless.
+pub(crate) async fn post_token(
+    http: &reqwest::Client,
+    token_url: &str,
+    form: &[(&str, &str)],
+) -> Result<TokenResponse, AuthError> {
+    let body = http
+        .post(token_url)
+        .header(
+            reqwest::header::CONTENT_TYPE,
+            "application/x-www-form-urlencoded",
+        )
+        .body(form_body(form))
+        .send()
+        .await?
+        .text()
+        .await?;
+    serde_json::from_str(&body)
+        .map_err(|e| AuthError::Protocol(format!("could not parse token response: {e}")))
+}
+
+/// Convert a successful token response into a [`TokenSet`].
+pub(crate) fn token_set(tr: TokenResponse) -> Result<TokenSet, AuthError> {
+    let access_token = tr
+        .access_token
+        .ok_or_else(|| AuthError::Protocol("token response missing access_token".into()))?;
+    Ok(TokenSet {
+        access_token,
+        id_token: tr.id_token.unwrap_or_default(),
+        refresh_token: tr.refresh_token,
+        expires_in: tr.expires_in.unwrap_or(0),
+    })
+}
+
+/// A reqwest client with the redisctl user agent.
+pub(crate) fn default_http_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .user_agent(concat!("redisctl/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .expect("building the reqwest client should not fail")
+}
+
+/// Truncate a string for inclusion in an error message (char-boundary safe).
+pub(crate) fn truncate(s: &str) -> String {
+    const MAX: usize = 200;
+    if s.chars().count() <= MAX {
+        s.to_string()
+    } else {
+        let head: String = s.chars().take(MAX).collect();
+        format!("{head}…")
+    }
+}

--- a/crates/redisctl-core/src/auth/oidc.rs
+++ b/crates/redisctl-core/src/auth/oidc.rs
@@ -126,6 +126,36 @@ pub(crate) fn token_set(tr: TokenResponse) -> Result<TokenSet, AuthError> {
     })
 }
 
+/// Exchange a refresh token for a fresh [`TokenSet`] via the refresh-token grant.
+///
+/// Okta rotates the refresh token, so the caller must persist the new one. The grant is
+/// flow-agnostic (a token from either login flow refreshes identically), so it lives here
+/// rather than on a specific flow client.
+pub(crate) async fn refresh(
+    http: &reqwest::Client,
+    issuer: &Url,
+    client_id: &str,
+    refresh_token: &str,
+) -> Result<TokenSet, AuthError> {
+    let tr = post_token(
+        http,
+        &endpoint(issuer, "v1/token"),
+        &[
+            ("client_id", client_id),
+            ("grant_type", "refresh_token"),
+            ("refresh_token", refresh_token),
+        ],
+    )
+    .await?;
+    if let Some(err) = tr.error.as_deref() {
+        return Err(AuthError::Protocol(format!(
+            "refresh failed ({err}): {}",
+            tr.description()
+        )));
+    }
+    token_set(tr)
+}
+
 /// A reqwest client with the redisctl user agent.
 pub(crate) fn default_http_client() -> reqwest::Client {
     reqwest::Client::builder()
@@ -142,5 +172,59 @@ pub(crate) fn truncate(s: &str) -> String {
     } else {
         let head: String = s.chars().take(MAX).collect();
         format!("{head}…")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    async fn mount_token(server: &MockServer, status: u16, body: serde_json::Value) {
+        Mock::given(method("POST"))
+            .and(path("/v1/token"))
+            .respond_with(ResponseTemplate::new(status).set_body_json(body))
+            .mount(server)
+            .await;
+    }
+
+    #[tokio::test]
+    async fn refresh_returns_rotated_token() {
+        let server = MockServer::start().await;
+        mount_token(
+            &server,
+            200,
+            serde_json::json!({
+                "access_token": "AT2",
+                "refresh_token": "RT2",
+                "expires_in": 3600
+            }),
+        )
+        .await;
+
+        let issuer = Url::parse(&server.uri()).unwrap();
+        let t = refresh(&default_http_client(), &issuer, "test-client", "RT1")
+            .await
+            .unwrap();
+        assert_eq!(t.access_token, "AT2");
+        // Okta rotates the refresh token — the caller must persist the new one.
+        assert_eq!(t.refresh_token.as_deref(), Some("RT2"));
+    }
+
+    #[tokio::test]
+    async fn refresh_error_is_protocol() {
+        let server = MockServer::start().await;
+        mount_token(
+            &server,
+            400,
+            serde_json::json!({"error": "invalid_grant", "error_description": "expired"}),
+        )
+        .await;
+        let issuer = Url::parse(&server.uri()).unwrap();
+        assert!(matches!(
+            refresh(&default_http_client(), &issuer, "test-client", "RT1").await,
+            Err(AuthError::Protocol(_))
+        ));
     }
 }

--- a/crates/redisctl-core/src/auth/sm_api.rs
+++ b/crates/redisctl-core/src/auth/sm_api.rs
@@ -170,14 +170,14 @@ impl SmApiClient {
     }
 
     /// `GET /users/me`.
-    pub async fn current_user(&self) -> Result<SmUser, AuthError> {
+    pub async fn fetch_current_user(&self) -> Result<SmUser, AuthError> {
         let body = self.authed_get("users/me").await?.text().await?;
         serde_json::from_str(&body)
             .map_err(|e| AuthError::Protocol(format!("could not parse /users/me: {e}")))
     }
 
     /// `GET /accounts`.
-    pub async fn accounts(&self) -> Result<Vec<SmAccount>, AuthError> {
+    pub async fn fetch_accounts(&self) -> Result<Vec<SmAccount>, AuthError> {
         let body = self.authed_get("accounts").await?.text().await?;
         let env: AccountsEnvelope = serde_json::from_str(&body)
             .map_err(|e| AuthError::Protocol(format!("could not parse /accounts: {e}")))?;
@@ -241,7 +241,7 @@ impl SmApiClient {
 
     /// `GET /accounts/cloud-api/cloudApiKeys` — list existing CAPI key names. Best-effort: used
     /// only to warn about `redisctl-*` key sprawl at login, so tolerant of response shape.
-    pub async fn list_capi_keys(&self) -> Result<Vec<String>, AuthError> {
+    pub async fn fetch_capi_keys(&self) -> Result<Vec<String>, AuthError> {
         let body = self
             .authed_get("accounts/cloud-api/cloudApiKeys")
             .await?
@@ -366,7 +366,7 @@ mod tests {
             .await;
 
         let c = logged_in(&server).await;
-        let user = c.current_user().await.unwrap();
+        let user = c.fetch_current_user().await.unwrap();
         assert_eq!(user.id, "114429");
         assert_eq!(user.user_account().unwrap(), 114429);
         assert_eq!(user.current_account_id.as_deref(), Some("112117"));
@@ -387,7 +387,7 @@ mod tests {
             .await;
 
         let c = logged_in(&server).await;
-        let accounts = c.accounts().await.unwrap();
+        let accounts = c.fetch_accounts().await.unwrap();
         assert_eq!(accounts.len(), 1);
         assert_eq!(accounts[0].id, 112117);
         assert_eq!(accounts[0].api_access_key.as_deref(), Some("ACCT-KEY"));

--- a/crates/redisctl-core/src/auth/sm_api.rs
+++ b/crates/redisctl-core/src/auth/sm_api.rs
@@ -1,0 +1,547 @@
+//! SM API exchange: turn Okta tokens into a Redis Cloud CAPI key.
+//!
+//! Sequence:
+//! 1. `POST /login` with `Authorization: Bearer <access_token>` → `Set-Cookie: JSESSIONID`.
+//!    **No `Sm-Id-Token` header for Google/GitHub logins** — sending it drives a SAML
+//!    account-mapping path that 400s; pass it only for SSO.
+//! 2. `GET /csrf` → token nested at `csrfToken.csrf_token`; echoed back as `X-CSRF-Token`.
+//! 3. `GET /users/me`, `GET /accounts` → resolve the user + account (+ account api key).
+//! 4. `POST /accounts/cloud-api/cloudApiAccessKey` to enable CAPI — a `400
+//!    account_api_key_already_exists` means it's already on (idempotent).
+//! 5. `POST /accounts/cloud-api/cloudApiKeys` → mints the user secret key (`secret_key`).
+//!
+//! This workspace's `reqwest` has no cookie-store feature, so the `JSESSIONID` cookie and
+//! CSRF token are carried manually on each request.
+
+use serde::Deserialize;
+use url::Url;
+
+use super::{AuthError, default_http_client, endpoint, truncate};
+
+/// SM API client. Stateless until [`SmApiClient::login`] establishes a session.
+pub struct SmApiClient {
+    base_url: Url,
+    http: reqwest::Client,
+    session: Option<Session>,
+}
+
+struct Session {
+    /// Full cookie header value, e.g. `JSESSIONID=abc123`.
+    cookie: String,
+    csrf: String,
+}
+
+/// The authenticated user (`GET /users/me`), trimmed to what the bootstrap needs.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SmUser {
+    /// User id (string in the API); parse via [`SmUser::user_account`] for the mint call.
+    pub id: String,
+    #[serde(default)]
+    pub current_account_id: Option<String>,
+    #[serde(default)]
+    pub email: Option<String>,
+    #[serde(default)]
+    pub product_type: Option<String>,
+}
+
+impl SmUser {
+    /// The numeric user account id used as `user_account` when minting a CAPI key.
+    pub fn user_account(&self) -> Result<u64, AuthError> {
+        self.id.parse().map_err(|_| {
+            AuthError::Protocol(format!("unexpected non-numeric user id {:?}", self.id))
+        })
+    }
+}
+
+/// An account (`GET /accounts`), trimmed to what the bootstrap needs.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SmAccount {
+    pub id: u64,
+    #[serde(default)]
+    pub name: Option<String>,
+    /// The account-level CAPI access key (`x-api-key`), present once CAPI is enabled.
+    #[serde(default)]
+    pub api_access_key: Option<String>,
+}
+
+/// A minted CAPI user key. `secret_key` is redacted from `Debug`.
+#[derive(Clone)]
+pub struct CapiKey {
+    pub name: String,
+    pub secret_key: String,
+}
+
+impl std::fmt::Debug for CapiKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CapiKey")
+            .field("name", &self.name)
+            .field("secret_key", &"<redacted>")
+            .finish()
+    }
+}
+
+#[derive(Deserialize)]
+struct CsrfEnvelope {
+    #[serde(rename = "csrfToken")]
+    token: CsrfToken,
+}
+
+#[derive(Deserialize)]
+struct CsrfToken {
+    csrf_token: String,
+}
+
+#[derive(Deserialize)]
+struct AccountsEnvelope {
+    #[serde(default)]
+    accounts: Vec<SmAccount>,
+}
+
+impl SmApiClient {
+    /// Build a client for the SM API base (e.g. `https://<sm-api-host>/api/v1`).
+    pub fn new(base_url: Url) -> Self {
+        Self {
+            base_url,
+            http: default_http_client(),
+            session: None,
+        }
+    }
+
+    /// Build with a caller-provided reqwest client (tests / shared client).
+    pub fn with_http_client(base_url: Url, http: reqwest::Client) -> Self {
+        Self {
+            base_url,
+            http,
+            session: None,
+        }
+    }
+
+    /// Establish a session: `POST /login` with the Okta access token, then fetch the CSRF
+    /// token. Pass `sm_id_token` only for SSO logins (omit for Google/GitHub).
+    pub async fn login(
+        &mut self,
+        access_token: &str,
+        sm_id_token: Option<&str>,
+    ) -> Result<(), AuthError> {
+        let mut req = self
+            .http
+            .post(endpoint(&self.base_url, "login"))
+            .header(
+                reqwest::header::AUTHORIZATION,
+                format!("Bearer {access_token}"),
+            )
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body("{}");
+        if let Some(id) = sm_id_token {
+            req = req.header("sm-id-token", id);
+        }
+        let resp = req.send().await?;
+        let status = resp.status();
+        let cookie = extract_jsessionid(&resp);
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(AuthError::Protocol(format!(
+                "SM /login failed ({status}): {}",
+                truncate(&body)
+            )));
+        }
+        let cookie = cookie
+            .ok_or_else(|| AuthError::Protocol("SM /login did not set a JSESSIONID".into()))?;
+        let csrf = self.fetch_csrf(&cookie).await?;
+        self.session = Some(Session {
+            cookie: format!("JSESSIONID={cookie}"),
+            csrf,
+        });
+        Ok(())
+    }
+
+    async fn fetch_csrf(&self, jsessionid: &str) -> Result<String, AuthError> {
+        let body = self
+            .http
+            .get(endpoint(&self.base_url, "csrf"))
+            .header(reqwest::header::COOKIE, format!("JSESSIONID={jsessionid}"))
+            .send()
+            .await?
+            .text()
+            .await?;
+        let env: CsrfEnvelope = serde_json::from_str(&body)
+            .map_err(|e| AuthError::Protocol(format!("could not parse /csrf response: {e}")))?;
+        Ok(env.token.csrf_token)
+    }
+
+    /// `GET /users/me`.
+    pub async fn current_user(&self) -> Result<SmUser, AuthError> {
+        let body = self.authed_get("users/me").await?.text().await?;
+        serde_json::from_str(&body)
+            .map_err(|e| AuthError::Protocol(format!("could not parse /users/me: {e}")))
+    }
+
+    /// `GET /accounts`.
+    pub async fn accounts(&self) -> Result<Vec<SmAccount>, AuthError> {
+        let body = self.authed_get("accounts").await?.text().await?;
+        let env: AccountsEnvelope = serde_json::from_str(&body)
+            .map_err(|e| AuthError::Protocol(format!("could not parse /accounts: {e}")))?;
+        Ok(env.accounts)
+    }
+
+    /// `POST /accounts/cloud-api/cloudApiAccessKey` — enable programmatic access. Idempotent:
+    /// a `400 account_api_key_already_exists` is treated as success.
+    pub async fn ensure_capi_enabled(&self) -> Result<(), AuthError> {
+        let resp = self
+            .authed_post_json(
+                "accounts/cloud-api/cloudApiAccessKey",
+                serde_json::json!({}),
+            )
+            .await?;
+        if resp.status().is_success() {
+            return Ok(());
+        }
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        if body.contains("account_api_key_already_exists") {
+            return Ok(());
+        }
+        Err(AuthError::Protocol(format!(
+            "enabling CAPI failed ({status}): {}",
+            truncate(&body)
+        )))
+    }
+
+    /// `POST /accounts/cloud-api/cloudApiKeys` — mint a named user secret key.
+    pub async fn mint_capi_key(&self, name: &str, user_account: u64) -> Result<CapiKey, AuthError> {
+        let body = self
+            .authed_post_json(
+                "accounts/cloud-api/cloudApiKeys",
+                serde_json::json!({
+                    "cloudApiKey": { "name": name, "user_account": user_account, "ip_whitelist": [] }
+                }),
+            )
+            .await?
+            .text()
+            .await?;
+        let value: serde_json::Value = serde_json::from_str(&body)
+            .map_err(|e| AuthError::Protocol(format!("could not parse mint response: {e}")))?;
+        // secret_key may be top-level or nested under `cloudApiKey`.
+        let obj = value.get("cloudApiKey").unwrap_or(&value);
+        let secret_key = obj
+            .get("secret_key")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| AuthError::Protocol("mint response missing secret_key".into()))?
+            .to_string();
+        let key_name = obj
+            .get("name")
+            .and_then(|v| v.as_str())
+            .unwrap_or(name)
+            .to_string();
+        Ok(CapiKey {
+            name: key_name,
+            secret_key,
+        })
+    }
+
+    /// `GET /accounts/cloud-api/cloudApiKeys` — list existing CAPI key names. Best-effort: used
+    /// only to warn about `redisctl-*` key sprawl at login, so tolerant of response shape.
+    pub async fn list_capi_keys(&self) -> Result<Vec<String>, AuthError> {
+        let body = self
+            .authed_get("accounts/cloud-api/cloudApiKeys")
+            .await?
+            .text()
+            .await?;
+        let value: serde_json::Value = serde_json::from_str(&body)
+            .map_err(|e| AuthError::Protocol(format!("could not parse cloudApiKeys list: {e}")))?;
+        // Tolerate a top-level array or a wrapper object ({"cloudApiKeys":[...]}).
+        let arr = value
+            .get("cloudApiKeys")
+            .and_then(|v| v.as_array())
+            .or_else(|| value.as_array())
+            .cloned()
+            .unwrap_or_default();
+        Ok(arr
+            .iter()
+            .filter_map(|k| {
+                let obj = k.get("cloudApiKey").unwrap_or(k);
+                obj.get("name").and_then(|v| v.as_str()).map(String::from)
+            })
+            .collect())
+    }
+
+    fn session(&self) -> Result<&Session, AuthError> {
+        self.session
+            .as_ref()
+            .ok_or_else(|| AuthError::Protocol("not logged in to the SM API".into()))
+    }
+
+    async fn authed_get(&self, path: &str) -> Result<reqwest::Response, AuthError> {
+        let s = self.session()?;
+        Ok(self
+            .http
+            .get(endpoint(&self.base_url, path))
+            .header(reqwest::header::COOKIE, &s.cookie)
+            .header("x-csrf-token", &s.csrf)
+            .send()
+            .await?)
+    }
+
+    async fn authed_post_json(
+        &self,
+        path: &str,
+        body: serde_json::Value,
+    ) -> Result<reqwest::Response, AuthError> {
+        let s = self.session()?;
+        Ok(self
+            .http
+            .post(endpoint(&self.base_url, path))
+            .header(reqwest::header::COOKIE, &s.cookie)
+            .header("x-csrf-token", &s.csrf)
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(body.to_string())
+            .send()
+            .await?)
+    }
+}
+
+/// Pull the `JSESSIONID` value out of the response's `Set-Cookie` headers.
+fn extract_jsessionid(resp: &reqwest::Response) -> Option<String> {
+    for value in resp.headers().get_all(reqwest::header::SET_COOKIE) {
+        let Ok(text) = value.to_str() else { continue };
+        for part in text.split(';') {
+            if let Some(v) = part.trim().strip_prefix("JSESSIONID=") {
+                return Some(v.to_string());
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    async fn mount_login_and_csrf(server: &MockServer) {
+        Mock::given(method("POST"))
+            .and(path("/login"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .append_header("Set-Cookie", "JSESSIONID=SID123; Path=/; HttpOnly"),
+            )
+            .mount(server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/csrf"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "csrfToken": { "csrf_token": "CSRF-XYZ", "csrf_enabled": true, "errors": [] }
+            })))
+            .mount(server)
+            .await;
+    }
+
+    fn client(server: &MockServer) -> SmApiClient {
+        SmApiClient::new(Url::parse(&server.uri()).unwrap())
+    }
+
+    async fn logged_in(server: &MockServer) -> SmApiClient {
+        mount_login_and_csrf(server).await;
+        let mut c = client(server);
+        c.login("ACCESS", None).await.unwrap();
+        c
+    }
+
+    #[tokio::test]
+    async fn login_then_users_me_sends_cookie_and_csrf() {
+        let server = MockServer::start().await;
+        // /users/me only matches when the session cookie + csrf header are present.
+        Mock::given(method("GET"))
+            .and(path("/users/me"))
+            .and(header("cookie", "JSESSIONID=SID123"))
+            .and(header("x-csrf-token", "CSRF-XYZ"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "114429",
+                "current_account_id": "112117",
+                "email": "user@example.com",
+                "product_type": "unifiedrc"
+            })))
+            .mount(&server)
+            .await;
+
+        let c = logged_in(&server).await;
+        let user = c.current_user().await.unwrap();
+        assert_eq!(user.id, "114429");
+        assert_eq!(user.user_account().unwrap(), 114429);
+        assert_eq!(user.current_account_id.as_deref(), Some("112117"));
+        assert_eq!(user.email.as_deref(), Some("user@example.com"));
+    }
+
+    #[tokio::test]
+    async fn accounts_extracts_api_access_key() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/accounts"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "accounts": [
+                    { "id": 112117, "name": "Krum", "api_access_key": "ACCT-KEY", "has_paid": false }
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let c = logged_in(&server).await;
+        let accounts = c.accounts().await.unwrap();
+        assert_eq!(accounts.len(), 1);
+        assert_eq!(accounts[0].id, 112117);
+        assert_eq!(accounts[0].api_access_key.as_deref(), Some("ACCT-KEY"));
+    }
+
+    #[tokio::test]
+    async fn ensure_capi_enabled_ok_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/accounts/cloud-api/cloudApiAccessKey"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "cloudApiAccessKey": { "accessKey": "ACCT-KEY" }
+            })))
+            .mount(&server)
+            .await;
+        let c = logged_in(&server).await;
+        assert!(c.ensure_capi_enabled().await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn ensure_capi_enabled_ok_when_already_exists() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/accounts/cloud-api/cloudApiAccessKey"))
+            .respond_with(ResponseTemplate::new(400).set_body_json(serde_json::json!({
+                "errors": { "status": 400, "code": "account_api_key_already_exists", "message": "" }
+            })))
+            .mount(&server)
+            .await;
+        let c = logged_in(&server).await;
+        assert!(c.ensure_capi_enabled().await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn ensure_capi_enabled_errors_on_other_failure() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/accounts/cloud-api/cloudApiAccessKey"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("boom"))
+            .mount(&server)
+            .await;
+        let c = logged_in(&server).await;
+        assert!(matches!(
+            c.ensure_capi_enabled().await,
+            Err(AuthError::Protocol(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn mint_capi_key_reads_secret_key() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/accounts/cloud-api/cloudApiKeys"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": 999, "name": "redisctl-x", "secret_key": "SECRET", "user_account": 114429,
+                "ip_whitelist": [], "errors": []
+            })))
+            .mount(&server)
+            .await;
+        let c = logged_in(&server).await;
+        let key = c.mint_capi_key("redisctl-x", 114429).await.unwrap();
+        assert_eq!(key.name, "redisctl-x");
+        assert_eq!(key.secret_key, "SECRET");
+        // Debug must not leak the secret.
+        assert!(!format!("{key:?}").contains("SECRET"));
+    }
+
+    #[tokio::test]
+    async fn mint_capi_key_reads_wrapped_secret_key() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/accounts/cloud-api/cloudApiKeys"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "cloudApiKey": { "name": "redisctl-y", "secret_key": "SEK" }
+            })))
+            .mount(&server)
+            .await;
+        let c = logged_in(&server).await;
+        let key = c.mint_capi_key("redisctl-y", 1).await.unwrap();
+        assert_eq!(key.secret_key, "SEK");
+    }
+
+    #[tokio::test]
+    async fn mint_capi_key_missing_secret_is_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/accounts/cloud-api/cloudApiKeys"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "name": "x", "errors": ["nope"]
+            })))
+            .mount(&server)
+            .await;
+        let c = logged_in(&server).await;
+        assert!(matches!(
+            c.mint_capi_key("x", 1).await,
+            Err(AuthError::Protocol(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn login_without_jsessionid_errors() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/login"))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+        let mut c = client(&server);
+        assert!(matches!(
+            c.login("ACCESS", None).await,
+            Err(AuthError::Protocol(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn login_failure_status_errors() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/login"))
+            .respond_with(
+                ResponseTemplate::new(401)
+                    .append_header("Set-Cookie", "JSESSIONID=SID; Path=/")
+                    .set_body_json(serde_json::json!({
+                        "errors": { "status": 401, "code": "user-invalid-access-token" }
+                    })),
+            )
+            .mount(&server)
+            .await;
+        let mut c = client(&server);
+        assert!(matches!(
+            c.login("ACCESS", None).await,
+            Err(AuthError::Protocol(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn login_sends_sm_id_token_only_when_provided() {
+        let server = MockServer::start().await;
+        // This mock matches ONLY when sm-id-token is present.
+        Mock::given(method("POST"))
+            .and(path("/login"))
+            .and(header("sm-id-token", "IDT"))
+            .respond_with(ResponseTemplate::new(200).append_header("Set-Cookie", "JSESSIONID=S"))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/csrf"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "csrfToken": { "csrf_token": "C" }
+            })))
+            .mount(&server)
+            .await;
+        let mut c = client(&server);
+        // With the id token, login matches the header-gated mock and succeeds.
+        assert!(c.login("ACCESS", Some("IDT")).await.is_ok());
+    }
+}

--- a/crates/redisctl-core/src/lib.rs
+++ b/crates/redisctl-core/src/lib.rs
@@ -66,6 +66,7 @@
 //! ).await?;
 //! ```
 
+pub mod auth;
 pub mod config;
 pub mod error;
 pub mod progress;
@@ -74,6 +75,10 @@ pub mod cloud;
 pub mod enterprise;
 
 // Re-export commonly used items
+pub use auth::{
+    AuthError, CapiKey, CloudAuthenticator, DeviceAuthorization, DeviceFlowClient,
+    LoopbackFlowClient, MintedCredentials, PollOutcome, SmAccount, SmApiClient, SmUser, TokenSet,
+};
 pub use error::{CoreError, Result};
 pub use progress::{ProgressCallback, ProgressEvent, poll_task};
 


### PR DESCRIPTION
## Summary

Adds `redisctl_core::auth`, the credential-bootstrapper backend that will power
`redisctl cloud auth login`: run a standard OIDC sign-in, exchange the resulting
tokens for a Redis Cloud API key, and hand it back to be persisted as a normal
cloud profile — so a first-time user no longer has to mint an API key by hand.

This is the **first PR in a chained series** for agent-native Cloud onboarding.
It is a pure, self-contained library with **no user-facing surface yet** — the
CLI commands, config persistence, and provisioning workflow land in follow-up
PRs. Splitting it out keeps each piece independently reviewable; this one is the
protocol/plumbing layer.

Fully **additive**: no existing command, flag, exit code, or behaviour changes.

### What's in the module

- `device_flow` — OAuth Device Authorization Grant (RFC 8628), for headless / agent contexts.
- `auth_code_loopback` — Authorization Code + PKCE (S256) over a loopback redirect, for interactive browser login.
- `sm_api` — exchanges the OIDC tokens for a Cloud API key (manual session cookie + CSRF handling; no cookie-store dependency).
- `authenticator` — orchestrates login → exchange → `MintedCredentials`.
- `oidc` — shared token-endpoint plumbing and a `TokenSet` whose `Debug` redacts token material.

## Scope

- **Affected areas:** `crates/redisctl-core/src/auth/*` (new module), `src/lib.rs` (re-exports), `Cargo.toml` + workspace `Cargo.toml` (new deps).
- **API surface changes:** new public types (`CloudAuthenticator`, `SmApiClient`, `DeviceFlowClient`, `LoopbackFlowClient`, `TokenSet`, `AuthError`, `MintedCredentials`, …). No existing APIs changed.
- **Dependencies added:** `reqwest`, `serde_urlencoded`, `url`, `base64`, `sha2`, `getrandom`.
- **Docs/tests:** module-level docs + 34 `wiremock`-based unit tests (success and error paths for each flow, plus the SM exchange).

## Testing

```cargo test -p redisctl-core          # 34 auth tests bind localhost ports```
```cargo clippy --workspace --all-targets --all-features -- -D warnings```

## Checklist

- [x] Scope and plan documented in this description
- [x] Tests added/updated; both success and error cases covered
- [x] Docs updated (module overviews, examples)
- [x] cargo fmt, clippy (-D warnings), tests pass locally
- [ ] CI status is green
- [x] Ready for review (remove Draft)
- [ ] Squash and merge when approved

