### PR TITLE
ci: run bin-target tests in the gated test-unit job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,11 @@ jobs:
           shared-key: "test-${{ matrix.package }}"
 
       - name: Run unit tests
-        run: cargo test --package ${{ matrix.package }} --lib --all-features
+        # --bins includes tests compiled into the binary targets (redisctl and
+        # redisctl-mcp main.rs), which hold the MCP safety-tier registration
+        # tests. Without it those only run in build-platforms, which ci-status
+        # does not check, so a green CI Status could hide a tier regression.
+        run: cargo test --package ${{ matrix.package }} --lib --bins --all-features
 
   # Integration tests
   test-integration:


### PR DESCRIPTION
## Summary

Makes the MCP safety-tier tests unskippable. Addresses the TEST-02 part of #1038.

`test-unit` ran `cargo test --package <X> --lib`, which excludes tests compiled into the bin targets: 42 in `crates/redisctl-mcp/src/main.rs` and 35 in `crates/redisctl/src/main.rs`. Those 77 include every MCP safety-tier registration test (`cloud_read_tools_are_read_only`, `enterprise_write_tools_are_non_destructive`, `redis_command_is_destructive`, `essentials_preset_filters_tools`, `policy_disabled_toolset_removes_from_enabled`). They ran only in `build-platforms`, which the `ci-status` aggregate gate never inspects, so a tier-classification regression could produce a green `CI Status`.

Adding `--bins` runs those tests inside `test-unit`, which `ci-status` already checks. This closes the gap without relying on the matrix-result semantics of `build-platforms`.

## Change

One line in `.github/workflows/ci.yml`:

```
- run: cargo test --package ${{ matrix.package }} --lib --all-features
+ run: cargo test --package ${{ matrix.package }} --lib --bins --all-features
```

## Validation

`cargo test --package <pkg> --lib --bins --all-features --no-run` for all three matrix packages:

- `redisctl-core`: no bin target, so `--bins` is a no-op (lib unittests only).
- `redisctl`: compiles `src/lib.rs` and `src/main.rs` test executables (the 35 bin tests).
- `redisctl-mcp`: compiles `src/lib.rs` and `src/main.rs` test executables (the 42 bin tests).

`cargo test --workspace --all-features` passes locally including all bin-target tests.

## Not in this PR (tracked in #1038)

- **CONTRIB-06:** extend ruleset 8009354 to require the `CI Status` check and one approval. Repo setting, maintainer action.
- **GAP-DOCDRIFT-02:** `ci.yml` `paths-ignore` and `docs.yml` `paths` are complementary, so a docs-only PR emits no `CI Status`. Making `CI Status` a required check needs a no-path-filter job first; best landed with the doc-command checker (GAP-DOCDRIFT-01).