### PR TITLE
ci(docker): build arch images on native runners instead of QEMU

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,9 +12,75 @@ env:
   IMAGE_NAME: redis/redisctl
 
 jobs:
-  docker:
-    name: Build and Push Docker Images
+  # Build each architecture on a native runner and push it by digest.
+  # This replaces the previous single-job QEMU build, whose emulated
+  # linux/arm64 compile of the whole workspace (lto = true) exceeded the
+  # runner time limit and left the 0.11.1 image unpublished.
+  build:
+    name: Build ${{ matrix.platform }}
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Prepare platform tag
+        id: prep
+        run: |
+          platform="${{ matrix.platform }}"
+          echo "pair=${platform//\//-}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          platforms: ${{ matrix.platform }}
+          cache-from: type=gha,scope=${{ steps.prep.outputs.pair }}
+          cache-to: type=gha,mode=max,scope=${{ steps.prep.outputs.pair }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ steps.prep.outputs.pair }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Assemble the per-arch digests into one multi-arch manifest and apply
+  # the release tags. Only this job needs the repository (for the version).
+  merge:
+    name: Merge and push manifest
     runs-on: ubuntu-latest
+    needs: build
     permissions:
       contents: read
       packages: write
@@ -57,12 +123,16 @@ jobs:
           fi
 
           echo "Final version: $VERSION"
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "major=$(echo $VERSION | cut -d. -f1)" >> $GITHUB_OUTPUT
-          echo "minor=$(echo $VERSION | cut -d. -f1-2)" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "major=$(echo "$VERSION" | cut -d. -f1)" >> "$GITHUB_OUTPUT"
+          echo "minor=$(echo "$VERSION" | cut -d. -f1-2)" >> "$GITHUB_OUTPUT"
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -70,21 +140,23 @@ jobs:
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./docker/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ghcr.io/${{ env.IMAGE_NAME }}:latest
-            ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
-            ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.minor }}
-            ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.major }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          # word splitting on the digest glob is intentional: one arg per digest
+          # shellcheck disable=SC2046
+          docker buildx imagetools create \
+            -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
+            -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }} \
+            -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.minor }} \
+            -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.major }} \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect manifest
+        run: |
+          docker buildx imagetools inspect \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}


### PR DESCRIPTION
## Summary

Fixes the Docker publish that has been silently broken since 0.11.1. Closes #1040 (finding HYG-04).

The old `docker.yml` built `linux/amd64,linux/arm64` in one job via QEMU, and the Dockerfile compiles the whole workspace from source (`lto = true`, `codegen-units = 1`). The emulated arm64 compile exceeded the runner time limit for the `redisctl-v0.11.1` tag and left the image unpublished; `ghcr.io/redis/redisctl` still serves 0.11.0.

## Change

- `build` job: matrix over `ubuntu-latest` (linux/amd64) and `ubuntu-24.04-arm` (linux/arm64), each building natively and pushing by digest (`push-by-digest=true`), with per-arch GHA cache scopes.
- `merge` job: downloads the digests, assembles a multi-arch manifest with `docker buildx imagetools create`, and applies the same four tags as before (`latest`, `version`, `minor`, `major`). The version-extraction logic is preserved verbatim.

No emulation, so no timeout. The Dockerfile is unchanged.

## Validation

`docker.yml` triggers only on tags and `workflow_dispatch`, so this PR's own CI does not run it. `actionlint` is clean apart from two pre-existing shellcheck false-positives in the preserved version-extraction block (`SC2193` on GitHub's `${{ }}` templating).

This needs a maintainer to validate the publish, since it pushes to the production registry:

1. Run the **Docker Build** workflow via `workflow_dispatch` (from this branch to validate before merge, or after merge from `main`).
2. Confirm both `Build linux/amd64` and `Build linux/arm64` succeed and `Merge and push manifest` pushes.
3. `docker buildx imagetools inspect ghcr.io/redis/redisctl:latest` shows both platforms, and `docker run --rm ghcr.io/redis/redisctl:latest --version` works on each.

Kept as a draft until that dispatch confirms green. Once confirmed, a dispatch also publishes the missing current image.

## Note

`ubuntu-24.04-arm` runners are free for public repositories. If the native arm build is still slow enough to be a problem, the fallback is to have the Dockerfile COPY dist-built `aarch64-unknown-linux-musl` binaries instead of compiling, which is a larger change across `Cargo.toml`, the Dockerfile, and this workflow.