### PR TITLE
fix(cli): stop cm-settings import panicking on duplicate -f short

### DIFF
--- a/crates/redisctl/src/commands/enterprise/cm_settings.rs
+++ b/crates/redisctl/src/commands/enterprise/cm_settings.rs
@@ -77,7 +77,7 @@ pub enum CmSettingsCommands {
         file: String,
 
         /// Force import without confirmation
-        #[arg(short, long)]
+        #[arg(long)]
         force: bool,
     },
 

--- a/crates/redisctl/tests/cli_basic_tests.rs
+++ b/crates/redisctl/tests/cli_basic_tests.rs
@@ -498,6 +498,17 @@ fn test_completions_help() {
         .stdout(predicate::str::contains("zsh"));
 }
 
+// Generating completions walks the entire command tree, which is what trips
+// clap's duplicate-short debug assert. `completions --help` does not build the
+// subtree, so it cannot catch a duplicate short flag. Generate for every shell
+// so a future collision fails here instead of only in a debug build.
+#[test]
+fn test_completions_generate_all_shells() {
+    for shell in ["bash", "zsh", "fish", "powershell", "elvish"] {
+        redisctl().arg("completions").arg(shell).assert().success();
+    }
+}
+
 // === CLOUD SUBCOMMAND HELP TESTS ===
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes the debug-build panic from finding UX-01. Part of #1042.

`crates/redisctl/src/commands/enterprise/cm_settings.rs` `Import` declared both `file` and `force` with `#[arg(short, long)]`, so both wanted `-f`. clap's debug-assert then panics when the command tree is built:

- `cargo run -- completions <shell>` (any shell) walks the whole tree and exits 101.
- `enterprise cm-settings import --help` exits 101.

Release builds skip the assert, and `-f` there already resolved to `--file`, so `force`'s short was dead. This is exactly the reason the now-or-never review recommends `--force` stay long-only with no `-f`.

## Change

- Drop `short` from `force` on the `Import` command. `-f` still maps to `--file`; `--force` is unchanged as a long flag. Non-breaking.
- Add `test_completions_generate_all_shells`, which generates completions for bash/zsh/fish/powershell/elvish. That walks the full command tree, so a future duplicate short fails in CI. The existing `test_completions_help` only ran `completions --help`, which does not build the subtree, which is why `cargo test` did not catch this.

## Validation

- `completions {bash,zsh,fish,powershell,elvish}`: all exit 0 (were 101).
- `enterprise cm-settings import --help`: exits 0, shows `-f, --file <FILE>` and `--force`.
- `cargo fmt --all -- --check`, `cargo clippy -p redisctl --all-targets --all-features -- -D warnings`, and the new test all pass.

## Not in this PR (tracked in #1042)

The broader `--force` / `-y` standardization (CODE-03, UX-05) is a breaking change and lands separately after sign-off. Confirmation behavior (CODE-11, GAP-AUTOMATION-04) is a third PR.