### PR TITLE
fix(cli): unify confirmation prompts and fail non-interactive deletes

### DIFF
--- a/crates/redisctl/src/commands/cloud/connectivity/private_link.rs
+++ b/crates/redisctl/src/commands/cloud/connectivity/private_link.rs
@@ -408,21 +408,14 @@ async fn handle_delete(
     force: bool,
 ) -> CliResult<()> {
     // Confirmation prompt unless --force is used
-    if !force {
-        use dialoguer::Confirm;
-        let confirm = Confirm::new()
-            .with_prompt(format!(
-                "Are you sure you want to delete PrivateLink for subscription {}?",
-                params.subscription_id
-            ))
-            .default(false)
-            .interact()
-            .map_err(|e| anyhow::anyhow!("Failed to read confirmation: {}", e))?;
-
-        if !confirm {
-            println!("Delete operation cancelled");
-            return Ok(());
-        }
+    if !force
+        && !crate::commands::cloud::utils::confirm_action(&format!(
+            "Are you sure you want to delete PrivateLink for subscription {}?",
+            params.subscription_id
+        ))?
+    {
+        println!("Delete operation cancelled");
+        return Ok(());
     }
 
     let result = handler

--- a/crates/redisctl/src/commands/cloud/database_impl.rs
+++ b/crates/redisctl/src/commands/cloud/database_impl.rs
@@ -693,20 +693,14 @@ pub async fn delete_database(
     }
 
     // Confirmation prompt unless --force is used
-    if !force {
-        use dialoguer::Confirm;
-        let confirm = Confirm::new()
-            .with_prompt(format!("Are you sure you want to delete database {}?", id))
-            .default(false)
-            .interact()
-            .map_err(|e| RedisCtlError::InvalidInput {
-                message: format!("Failed to read confirmation: {}", e),
-            })?;
-
-        if !confirm {
-            println!("Database deletion cancelled");
-            return Ok(());
-        }
+    if !force
+        && !super::utils::confirm_action(&format!(
+            "Are you sure you want to delete database {}?",
+            id
+        ))?
+    {
+        println!("Database deletion cancelled");
+        return Ok(());
     }
 
     // Use Layer 2 workflow when --wait is specified
@@ -1732,23 +1726,14 @@ pub async fn flush_database(
     let (subscription_id, database_id) = parse_database_id(id)?;
 
     // Confirmation prompt unless --force is used
-    if !force {
-        use dialoguer::Confirm;
-        let confirm = Confirm::new()
-            .with_prompt(format!(
-                "Are you sure you want to flush database {}? This will delete all data!",
-                id
-            ))
-            .default(false)
-            .interact()
-            .map_err(|e| RedisCtlError::InvalidInput {
-                message: format!("Failed to read confirmation: {}", e),
-            })?;
-
-        if !confirm {
-            println!("Flush operation cancelled");
-            return Ok(());
-        }
+    if !force
+        && !super::utils::confirm_action(&format!(
+            "Are you sure you want to flush database {}? This will delete all data!",
+            id
+        ))?
+    {
+        println!("Flush operation cancelled");
+        return Ok(());
     }
 
     let client = conn_mgr.create_cloud_client(profile_name).await?;
@@ -1845,20 +1830,14 @@ pub async fn flush_crdb(
     let (subscription_id, database_id) = parse_database_id(id)?;
 
     // Confirmation prompt unless --force is used
-    if !force {
-        use dialoguer::Confirm;
-        let confirm = Confirm::new()
-            .with_prompt(format!("Are you sure you want to flush Active-Active database {}? This will delete all data!", id))
-            .default(false)
-            .interact()
-            .map_err(|e| RedisCtlError::InvalidInput {
-                message: format!("Failed to read confirmation: {}", e),
-            })?;
-
-        if !confirm {
-            println!("Flush operation cancelled");
-            return Ok(());
-        }
+    if !force
+        && !super::utils::confirm_action(&format!(
+            "Are you sure you want to flush Active-Active database {}? This will delete all data!",
+            id
+        ))?
+    {
+        println!("Flush operation cancelled");
+        return Ok(());
     }
 
     let client = conn_mgr.create_cloud_client(profile_name).await?;

--- a/crates/redisctl/src/commands/cloud/subscription_impl.rs
+++ b/crates/redisctl/src/commands/cloud/subscription_impl.rs
@@ -235,20 +235,14 @@ pub async fn delete_subscription(
     }
 
     // Confirmation prompt unless --force is used
-    if !force {
-        use dialoguer::Confirm;
-        let confirm = Confirm::new()
-            .with_prompt(format!("Are you sure you want to delete subscription {}? This will delete all databases in the subscription!", id))
-            .default(false)
-            .interact()
-            .map_err(|e| RedisCtlError::InvalidInput {
-                message: format!("Failed to read confirmation: {}", e),
-            })?;
-
-        if !confirm {
-            println!("Subscription deletion cancelled");
-            return Ok(());
-        }
+    if !force
+        && !super::utils::confirm_action(&format!(
+            "Are you sure you want to delete subscription {}? This will delete all databases in the subscription!",
+            id
+        ))?
+    {
+        println!("Subscription deletion cancelled");
+        return Ok(());
     }
 
     // Use Layer 2 workflow when --wait is specified
@@ -903,24 +897,15 @@ pub async fn delete_aa_regions(
 ) -> CliResult<()> {
     // Confirmation prompt unless --force is used
     if !force {
-        use dialoguer::Confirm;
         let region_list = if regions.is_empty() {
             "specified regions".to_string()
         } else {
             regions.join(", ")
         };
-        let confirm = Confirm::new()
-            .with_prompt(format!(
-                "Are you sure you want to delete regions ({}) from Active-Active subscription {}?",
-                region_list, id
-            ))
-            .default(false)
-            .interact()
-            .map_err(|e| RedisCtlError::InvalidInput {
-                message: format!("Failed to read confirmation: {}", e),
-            })?;
-
-        if !confirm {
+        if !super::utils::confirm_action(&format!(
+            "Are you sure you want to delete regions ({}) from Active-Active subscription {}?",
+            region_list, id
+        ))? {
             println!("Region deletion cancelled");
             return Ok(());
         }

--- a/crates/redisctl/src/commands/cloud/utils.rs
+++ b/crates/redisctl/src/commands/cloud/utils.rs
@@ -5,7 +5,7 @@ use chrono::{DateTime, Utc};
 use colored::Colorize;
 use serde_json::Value;
 use std::fs;
-use std::io::{self, Write};
+use std::io;
 use tabled::Tabled;
 use unicode_segmentation::UnicodeSegmentation;
 
@@ -188,15 +188,25 @@ pub fn provider_short_name(provider: &str) -> &str {
 
 pub use crate::output::{apply_jmespath, handle_output, print_formatted_output, resolve_auto};
 
-/// Prompts the user for confirmation
+/// Prompt to confirm a destructive action. Shared by all cloud and enterprise
+/// commands (enterprise re-exports this one).
+///
+/// Returns `Ok(true)` when confirmed and `Ok(false)` when the user
+/// interactively declines. When stdin is not a terminal there is no way to
+/// answer, so this returns `Err(RedisCtlError::Cancelled)` rather than a value:
+/// a non-interactive run without `--force` must never be mistaken for success
+/// and exit 0.
 pub fn confirm_action(message: &str) -> CliResult<bool> {
-    print!("Are you sure you want to {}? [y/N]: ", message);
-    io::stdout().flush()?;
-
-    let mut input = String::new();
-    io::stdin().read_line(&mut input)?;
-
-    Ok(input.trim().eq_ignore_ascii_case("y") || input.trim().eq_ignore_ascii_case("yes"))
+    if !io::stdin().is_terminal() {
+        return Err(RedisCtlError::Cancelled {
+            prompt: message.to_string(),
+        });
+    }
+    Ok(dialoguer::Confirm::new()
+        .with_prompt(message)
+        .default(false)
+        .interact()
+        .context("Failed to read confirmation")?)
 }
 
 /// Read file input, supporting @filename notation

--- a/crates/redisctl/src/commands/enterprise/utils.rs
+++ b/crates/redisctl/src/commands/enterprise/utils.rs
@@ -1,41 +1,12 @@
 //! Utility functions for Enterprise commands
 use crate::error::Result as CliResult;
-use anyhow::Context;
-use dialoguer::Confirm;
 use serde_json::Value;
 
 pub use crate::commands::cloud::utils::{
-    DetailRow, extract_field, format_memory_size, format_status, output_with_pager, truncate_string,
+    DetailRow, confirm_action, extract_field, format_memory_size, format_status, output_with_pager,
+    truncate_string,
 };
 pub use crate::output::{apply_jmespath, handle_output, print_formatted_output, resolve_auto};
-
-/// Confirm an action with the user
-pub fn confirm_action(message: &str) -> CliResult<bool> {
-    #[cfg(unix)]
-    {
-        use std::io::IsTerminal;
-        if std::io::stdin().is_terminal() {
-            Ok(Confirm::new()
-                .with_prompt(message)
-                .default(false)
-                .interact()
-                .context("Failed to get user confirmation")?)
-        } else {
-            // In non-interactive mode, print warning and return false
-            eprintln!("Warning: {} Use --force to skip confirmation.", message);
-            Ok(false)
-        }
-    }
-
-    #[cfg(not(unix))]
-    {
-        Ok(Confirm::new()
-            .with_prompt(message)
-            .default(false)
-            .interact()
-            .context("Failed to get user confirmation")?)
-    }
-}
 
 /// Read JSON data from string, file, or stdin
 pub fn read_json_data(data: &str) -> CliResult<Value> {

--- a/crates/redisctl/src/error.rs
+++ b/crates/redisctl/src/error.rs
@@ -109,6 +109,11 @@ pub enum RedisCtlError {
     #[error("Invalid input: {message}")]
     InvalidInput { message: String },
 
+    #[error(
+        "Confirmation required: {prompt} Re-run with --force to proceed in a non-interactive session."
+    )]
+    Cancelled { prompt: String },
+
     #[error("Command not supported for deployment type '{deployment_type}'")]
     UnsupportedDeploymentType { deployment_type: String },
     #[error("File error for '{path}': {message}")]
@@ -225,6 +230,10 @@ impl RedisCtlError {
                 format!("Check that file exists: {}", path),
                 "Verify file permissions are correct".to_string(),
                 "Ensure file path is correct (use absolute path if needed)".to_string(),
+            ],
+            RedisCtlError::Cancelled { .. } => vec![
+                "Re-run with --force to skip the confirmation prompt".to_string(),
+                "Confirmation prompts require an interactive terminal".to_string(),
             ],
             _ => vec![],
         }

--- a/crates/redisctl/tests/cli_integration_mocked_tests.rs
+++ b/crates/redisctl/tests/cli_integration_mocked_tests.rs
@@ -63,6 +63,41 @@ default_enterprise = "test"
     fs::write(config_path, config_content)
 }
 
+// A destructive command with no TTY and without --force must fail with a
+// non-zero exit rather than silently exit 0 having done nothing. Otherwise a
+// non-interactive `set -e` script would proceed believing the resource was
+// deleted. confirm_action runs before the client is built, so no mock server
+// is needed. Regression for the confirmation-prompt behavior (GAP-AUTOMATION-04).
+#[test]
+fn non_interactive_destructive_without_force_exits_nonzero() {
+    let temp_dir = TempDir::new().unwrap();
+    create_enterprise_profile(&temp_dir, "https://enterprise.invalid:9443").unwrap();
+
+    test_cmd(&temp_dir)
+        .args(["enterprise", "user", "delete", "5"])
+        .write_stdin("")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Confirmation required"))
+        .stderr(predicate::str::contains("--force"));
+}
+
+// With --force the confirmation is skipped: the command proceeds (and here
+// fails later on the unreachable host), so it must not report a confirmation
+// error.
+#[test]
+fn destructive_with_force_skips_confirmation() {
+    let temp_dir = TempDir::new().unwrap();
+    create_enterprise_profile(&temp_dir, "https://enterprise.invalid:9443").unwrap();
+
+    test_cmd(&temp_dir)
+        .args(["enterprise", "user", "delete", "5", "--force"])
+        .write_stdin("")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Confirmation required").not());
+}
+
 #[tokio::test]
 async fn test_api_cloud_get_with_auth_headers() {
     let temp_dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

Fixes the confirmation-behavior findings CODE-11 and GAP-AUTOMATION-04. Part of #1042.

The CLI had three confirmation mechanisms with divergent non-interactive behavior:

- `commands/enterprise/utils.rs` `confirm_action`: `dialoguer` with a TTY check; on non-TTY it printed a warning and returned `Ok(false)`.
- `commands/cloud/utils.rs` `confirm_action`: raw `stdin().read_line()` with no TTY check; hung on an open pipe with no data (the common CI case) and misread piped data as the answer.
- Six inline `dialoguer::Confirm` blocks in `cloud/database_impl.rs`, `cloud/subscription_impl.rs`, and `cloud/connectivity/private_link.rs`.

The enterprise path was the dangerous one (GAP-AUTOMATION-04): on non-TTY it returned `Ok(false)`, every caller then printed "Operation cancelled" and returned `Ok(())`, so a destructive command with `--force` omitted **exited 0 having done nothing**. Under `set -e`, a script proceeded believing the resource was deleted.

## Change

- One `confirm_action` in `cloud/utils.rs`; `enterprise/utils.rs` re-exports it. It TTY-checks and, when stdin is not a terminal, returns a new `RedisCtlError::Cancelled` instead of a value. That maps to a non-zero exit, so a non-interactive run without `--force` can never look like success.
- Interactive decline still returns `Ok(false)` and exits 0. `--force` still skips the prompt.
- The six inline blocks now call the shared helper.

## Behavior, measured

```
$ redisctl --profile ent enterprise user delete 5 </dev/null ; echo exit=$?
error: Confirmation required: Delete user 5? Re-run with --force to proceed in a non-interactive session.
exit=1                                          # was exit=0

$ bash -c 'set -e; redisctl ... enterprise user delete 5 </dev/null; echo CONTINUED'
# now aborts (exit 1); previously printed CONTINUED

$ redisctl --profile ent enterprise user delete 5 --force </dev/null
error: Connection error: ...                    # confirm skipped, proceeds to the call
```

## Validation

- New regression tests in `cli_integration_mocked_tests.rs`: non-interactive destructive without `--force` exits non-zero with the actionable message; `--force` skips the prompt.
- `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --workspace --all-features`: all pass.

## Note

Exit is currently 1 (the single non-zero code the CLI uses today). A distinct code for cancellation (12 in the proposed taxonomy) lands with the exit-code work in GAP-AUTOMATION-02. The flag standardization (CODE-03, UX-05) is deferred per maintainer decision; #1042 stays open for it.