### PR TITLE
fix(cli): send tracing to stderr so -o json stays clean

### DIFF
--- a/crates/redisctl/src/main.rs
+++ b/crates/redisctl/src/main.rs
@@ -2,7 +2,8 @@ use anyhow::{Context, Result};
 use clap::{CommandFactory, Parser};
 use clap_complete::{generate, shells};
 use redisctl_core::{Config, ConfigError, DeploymentType};
-use tracing::{debug, error, info, trace};
+use std::io::IsTerminal;
+use tracing::{debug, info, trace};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 mod cli;
@@ -430,7 +431,11 @@ fn init_tracing(verbose: u8) {
     tracing_subscriber::registry()
         .with(filter)
         .with(
+            // Log to stderr so structured output (-o json/yaml) on stdout is
+            // never corrupted, and only colorize when stderr is a terminal.
             tracing_subscriber::fmt::layer()
+                .with_writer(std::io::stderr)
+                .with_ansi(std::io::stderr().is_terminal())
                 .with_target(true)
                 .with_thread_ids(false)
                 .with_thread_names(false)
@@ -535,7 +540,9 @@ async fn execute_command(cli: &Cli, conn_mgr: &ConnectionManager) -> Result<(), 
     let duration = start.elapsed();
     match &result {
         Ok(_) => info!("Command completed successfully in {:?}", duration),
-        Err(e) => error!("Command failed after {:?}: {}", duration, e),
+        // debug, not error: the stderr diagnostic (print_diagnostic) is the one
+        // user-facing failure message. Logging at error here duplicated it.
+        Err(e) => debug!("Command failed after {:?}: {}", duration, e),
     }
 
     result

--- a/crates/redisctl/tests/cli_integration_mocked_tests.rs
+++ b/crates/redisctl/tests/cli_integration_mocked_tests.rs
@@ -98,6 +98,22 @@ fn destructive_with_force_skips_confirmation() {
         .stderr(predicate::str::contains("Confirmation required").not());
 }
 
+// A failing command must not write tracing output (ANSI escapes or the
+// duplicate "Command failed" line) to stdout, or it corrupts -o json for a
+// consumer piping the output. Regression for GAP-AUTOMATION-01 / UX-02.
+#[test]
+fn failing_command_keeps_stdout_clean_for_json() {
+    let temp_dir = TempDir::new().unwrap();
+    create_enterprise_profile(&temp_dir, "https://enterprise.invalid:9443").unwrap();
+
+    test_cmd(&temp_dir)
+        .args(["-o", "json", "enterprise", "database", "list"])
+        .assert()
+        .failure()
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::contains("error:"));
+}
+
 #[tokio::test]
 async fn test_api_cloud_get_with_auth_headers() {
     let temp_dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

Fixes findings GAP-AUTOMATION-01 and UX-02. Part of #1045.

`init_tracing` built the `fmt::layer()` with no writer, so all log output, including ANSI escape sequences, went to **stdout**. On failure this landed in the `-o json`/`-o yaml` payload and broke any consumer piping the output:

```
$ redisctl -o json <failing command> | jq .
jq: parse error: Invalid numeric literal at line 1, column 2
```

Separately, the `error!` log at the end of `execute_command` duplicated the stderr diagnostic from `print_diagnostic`, so every failure printed twice.

## Change (matches `redisctl-mcp`, which already does this)

- fmt layer gets `.with_writer(std::io::stderr)` and `.with_ansi(std::io::stderr().is_terminal())` (color only when stderr is a terminal).
- The failure log at `main.rs` drops from `error!` to `debug!`, so the stderr diagnostic is the single user-facing failure message. `error` is removed from the `tracing` import (it had no other use).

## Verified

```
# failing command, -o json
stdout: 0 bytes (was an ANSI-colored ERROR line)   ANSI on stdout: no   ERROR on stdout: no
stderr: error: Connection error: ...

# success path
redisctl -o json version  -> valid JSON on stdout, empty stderr
# verbose
redisctl -v -o json version -> logs on stderr, stdout still clean JSON
```

Adds `failing_command_keeps_stdout_clean_for_json` asserting a failing `-o json` command has empty stdout and the error on stderr.

`cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --workspace --all-features` all pass.

## Not in this PR (tracked in #1045)

The machine-readable error envelope (GAP-AUTOMATION-03, CODE-01) and the exit-code taxonomy (GAP-AUTOMATION-02) are larger follow-ups.