### PR TITLE
fix(cli): stop labeling anyhow-wrapped errors "Configuration error"

### DIFF
--- a/crates/redisctl/src/error.rs
+++ b/crates/redisctl/src/error.rs
@@ -73,9 +73,10 @@ impl CliDiagnostic {
 #[derive(Error, Debug)]
 pub enum RedisCtlError {
     #[error("Configuration error: {0}")]
-    Config(String),
-    #[error("Configuration error: {0}")]
     Configuration(String),
+
+    #[error("{0}")]
+    Other(String),
 
     #[error("Profile '{name}' not found")]
     ProfileNotFound { name: String },
@@ -235,6 +236,10 @@ impl RedisCtlError {
                 "Re-run with --force to skip the confirmation prompt".to_string(),
                 "Confirmation prompts require an interactive terminal".to_string(),
             ],
+            RedisCtlError::Configuration(_) => vec![
+                "Check the profile: redisctl profile show <name>".to_string(),
+                "Verify the config file syntax and required fields".to_string(),
+            ],
             _ => vec![],
         }
     }
@@ -329,7 +334,11 @@ impl From<std::io::Error> for RedisCtlError {
 
 impl From<anyhow::Error> for RedisCtlError {
     fn from(err: anyhow::Error) -> Self {
-        RedisCtlError::Config(err.to_string())
+        // {:#} renders the full anyhow context chain (message: cause: cause),
+        // and Other keeps the message as-is, instead of dropping the cause and
+        // mislabeling every anyhow-wrapped API, IO, or JSON error as a
+        // "Configuration error".
+        RedisCtlError::Other(format!("{:#}", err))
     }
 }
 

--- a/crates/redisctl/src/main.rs
+++ b/crates/redisctl/src/main.rs
@@ -652,7 +652,7 @@ async fn execute_enterprise_command(
         Alerts(alerts_cmd) => alerts_cmd
             .execute(&conn_mgr.config, profile, output, query)
             .await
-            .map_err(|e| RedisCtlError::Configuration(e.to_string())),
+            .map_err(RedisCtlError::from),
         BdbGroup(bdb_group_cmd) => {
             commands::enterprise::bdb_group::handle_bdb_group_command(
                 conn_mgr,
@@ -834,7 +834,7 @@ async fn execute_enterprise_command(
         License(license_cmd) => license_cmd
             .execute(&conn_mgr.config, profile, output, query)
             .await
-            .map_err(|e| RedisCtlError::Configuration(e.to_string())),
+            .map_err(RedisCtlError::from),
         Migration(migration_cmd) => {
             commands::enterprise::migration::handle_migration_command(
                 conn_mgr,
@@ -1089,7 +1089,7 @@ async fn handle_enterprise_workflow_command(
         License(license_workflow_cmd) => license_workflow_cmd
             .execute(&conn_mgr.config, output, None)
             .await
-            .map_err(|e| RedisCtlError::Configuration(e.to_string())),
+            .map_err(RedisCtlError::from),
         InitCluster {
             name,
             username,

--- a/crates/redisctl/tests/cli_integration_mocked_tests.rs
+++ b/crates/redisctl/tests/cli_integration_mocked_tests.rs
@@ -63,6 +63,22 @@ default_enterprise = "test"
     fs::write(config_path, config_content)
 }
 
+// anyhow-wrapped API failures must not be mislabeled "Configuration error"
+// and must keep the cause chain. Regression for CODE-01 / CODE-08.
+#[test]
+fn api_failure_is_not_labeled_configuration_error() {
+    let temp_dir = TempDir::new().unwrap();
+    // Unreachable host, so the request fails inside a .context() wrap.
+    create_cloud_profile(&temp_dir, "https://cloud.invalid/v1").unwrap();
+
+    test_cmd(&temp_dir)
+        .args(["cloud", "provider-account", "list"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Configuration error").not())
+        .stderr(predicate::str::contains("Failed to list cloud accounts"));
+}
+
 // A destructive command with no TTY and without --force must fail with a
 // non-zero exit rather than silently exit 0 having done nothing. Otherwise a
 // non-interactive `set -e` script would proceed believing the resource was


### PR DESCRIPTION
## Summary

Fixes findings CODE-01 and CODE-08. Part of #1045.

`From<anyhow::Error> for RedisCtlError` mapped every anyhow error to `RedisCtlError::Config(err.to_string())`. `err.to_string()` prints only the outermost context, so the cause chain was dropped, and the `Config` variant rendered as `Configuration error: ...`. About 354 command sites wrap API calls in `.context("Failed to ...")`, so connection, API, and JSON failures all surfaced as configuration errors with no cause and no tips. `Config` and `Configuration` were also duplicate variants with identical `#[error]` text, and `suggestions()` handled neither.

## Change

- `From<anyhow::Error>` routes to a new neutral `Other(String)` variant and formats with `{:#}` to keep the full context chain.
- Remove the duplicate `Config` variant (used only by that impl; `Configuration` stays for real config errors) and add a `suggestions()` arm for `Configuration`.
- Replace the three `main.rs` `map_err(|e| RedisCtlError::Configuration(e.to_string()))` sites (alerts, license, license-workflow) with `map_err(RedisCtlError::from)`.

## Before / after

```
# cloud provider-account list against an unreachable endpoint
- error: Configuration error: Failed to list cloud accounts
+ error: Failed to list cloud accounts: HTTP request failed: error sending request for url (...)

# invalid --data JSON
- error: Configuration error: Invalid JSON: ...
+ error: Invalid input: Invalid JSON: ...
```

## Validation

- New `api_failure_is_not_labeled_configuration_error` test asserts a failing API command's stderr does not contain "Configuration error" and keeps the operation message.
- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace --all-features`: all pass.

## Follow-up (tracked in #1045)

The deeper fix, stop wrapping `CloudError`/`RestError` in anyhow `.context()` so the classified `From<CloudError>`/`From<RestError>` conversions (which detect 401/404/connection and drive the `suggestions()` tips) are used, is a larger refactor across the command modules, plus an `AGENTS.md` guardrail note. This PR fixes the mislabeling for all paths at once; the classification/tips improvement is the follow-up.