### PR TITLE
feat(cli): emit a structured error envelope under -o json/yaml

### DIFF
--- a/crates/redisctl/src/error.rs
+++ b/crates/redisctl/src/error.rs
@@ -245,7 +245,62 @@ impl RedisCtlError {
     }
 
     /// Print a cargo-style diagnostic to stderr using colored formatting.
-    pub fn print_diagnostic(&self) {
+    /// A stable, machine-readable error code for the -o json/yaml envelope.
+    /// Exhaustive on purpose: a new variant must declare its code.
+    pub fn code(&self) -> &'static str {
+        match self {
+            RedisCtlError::Configuration(_) => "configuration",
+            RedisCtlError::Other(_) => "error",
+            RedisCtlError::ProfileNotFound { .. } => "profile_not_found",
+            RedisCtlError::ProfileTypeMismatch { .. } => "profile_type_mismatch",
+            RedisCtlError::NoProfileConfigured => "no_profile_configured",
+            RedisCtlError::MissingCredentials { .. } => "missing_credentials",
+            RedisCtlError::AuthenticationFailed { .. } => "authentication_failed",
+            RedisCtlError::ApiError { .. } => "api_error",
+            RedisCtlError::InvalidInput { .. } => "invalid_input",
+            RedisCtlError::Cancelled { .. } => "cancelled",
+            RedisCtlError::UnsupportedDeploymentType { .. } => "unsupported_deployment_type",
+            RedisCtlError::FileError { .. } => "file_error",
+            RedisCtlError::ConnectionError { .. } => "connection_error",
+            RedisCtlError::Timeout { .. } => "timeout",
+            RedisCtlError::OutputError { .. } => "output_error",
+        }
+    }
+
+    /// The structured error object emitted under -o json/-o yaml.
+    fn envelope(&self) -> serde_json::Value {
+        serde_json::json!({
+            "error": {
+                "code": self.code(),
+                "message": self.to_string(),
+                "tips": self.suggestions(),
+            }
+        })
+    }
+
+    /// Print an error to stderr. Under -o json/-o yaml this is a structured
+    /// envelope a script can parse; otherwise a cargo-style human diagnostic.
+    /// Always stderr, so the -o json success payload on stdout stays clean.
+    pub fn print_diagnostic(&self, format: crate::cli::OutputFormat) {
+        use crate::cli::OutputFormat;
+        match format {
+            OutputFormat::Json => {
+                let envelope = self.envelope();
+                eprintln!(
+                    "{}",
+                    serde_json::to_string_pretty(&envelope)
+                        .unwrap_or_else(|_| envelope.to_string())
+                );
+            }
+            OutputFormat::Yaml => match serde_yaml::to_string(&self.envelope()) {
+                Ok(s) => eprint!("{}", s),
+                Err(_) => self.print_human_diagnostic(),
+            },
+            OutputFormat::Auto | OutputFormat::Table => self.print_human_diagnostic(),
+        }
+    }
+
+    fn print_human_diagnostic(&self) {
         let mut diag = CliDiagnostic::error(&format!("{}", self));
 
         for suggestion in self.suggestions() {

--- a/crates/redisctl/src/main.rs
+++ b/crates/redisctl/src/main.rs
@@ -407,7 +407,7 @@ async fn main() -> Result<()> {
 
     // Execute command
     if let Err(e) = execute_command(&cli, &conn_mgr).await {
-        e.print_diagnostic();
+        e.print_diagnostic(cli.output);
         std::process::exit(1);
     }
 

--- a/crates/redisctl/tests/cli_integration_mocked_tests.rs
+++ b/crates/redisctl/tests/cli_integration_mocked_tests.rs
@@ -130,6 +130,39 @@ fn failing_command_keeps_stdout_clean_for_json() {
         .stderr(predicate::str::contains("error:"));
 }
 
+// Under -o json, a failure emits a parseable error envelope on stderr with a
+// stable code, and stdout stays empty. Regression for GAP-AUTOMATION-03.
+#[test]
+fn json_output_emits_structured_error_envelope() {
+    let temp_dir = TempDir::new().unwrap();
+    // An enterprise profile used with a cloud command fails with a type
+    // mismatch before any network call.
+    create_enterprise_profile(&temp_dir, "https://enterprise.invalid:9443").unwrap();
+
+    let output = test_cmd(&temp_dir)
+        .args([
+            "--profile",
+            "test",
+            "-o",
+            "json",
+            "cloud",
+            "database",
+            "list",
+        ])
+        .assert()
+        .failure()
+        .stdout(predicate::str::is_empty())
+        .get_output()
+        .clone();
+
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    let v: serde_json::Value =
+        serde_json::from_str(stderr.trim()).expect("stderr under -o json must be valid JSON");
+    assert_eq!(v["error"]["code"], "profile_type_mismatch");
+    assert!(v["error"]["message"].is_string());
+    assert!(v["error"]["tips"].is_array());
+}
+
 #[tokio::test]
 async fn test_api_cloud_get_with_auth_headers() {
     let temp_dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

Fixes finding GAP-AUTOMATION-03. Part of #1045.

`-o json`/`-o yaml` only affected the success payload. On failure, `print_diagnostic` always rendered the cargo-style human diagnostic regardless of output format, so a script wiring redisctl into CI had no stable error object to parse: no error code, no structured shape.

## Change

- `print_diagnostic(&self, format: OutputFormat)`: under `Json` it emits a JSON envelope, under `Yaml` a YAML envelope, both on **stderr** so the stdout success channel stays clean for `jq`. `Auto`/`Table` keep the existing human diagnostic.
- Each `RedisCtlError` variant has a stable `code()` string. The match is exhaustive, so a new variant will not compile until it declares a code.
- The envelope carries `code`, `message`, and `tips` (from `suggestions()`).

## Output

```
$ redisctl -o json --profile ent cloud database list 2>&1 1>/dev/null
{
  "error": {
    "code": "profile_type_mismatch",
    "message": "Profile 'ent' is type 'enterprise' but command requires 'cloud'",
    "tips": ["Available cloud profiles: ...", "..."]
  }
}

$ redisctl -o yaml ...   # same shape as YAML
$ redisctl ...           # default: unchanged human diagnostic
```

## Validation

- New `json_output_emits_structured_error_envelope` test parses stderr as JSON and asserts `error.code == "profile_type_mismatch"`, plus stdout empty.
- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace --all-features`: all pass.

## Scope

Exit codes are still `1` across the board; the taxonomy that would add an `exit_code` field to the envelope (GAP-AUTOMATION-02) is a separate change and a "now or never" interface decision. The `code` strings introduced here are the natural anchor for that mapping and should be documented alongside it.