### PR TITLE
refactor: delete dead code revealed by removing dead_code allows

### DIFF
--- a/crates/redisctl/src/commands/api.rs
+++ b/crates/redisctl/src/commands/api.rs
@@ -9,7 +9,6 @@ use redisctl_core::{Config, DeploymentType};
 use serde_json::Value;
 
 /// Parameters for API command execution
-#[allow(dead_code)] // Used by binary target
 pub struct ApiCommandParams {
     pub config: Config,
     pub config_path: Option<std::path::PathBuf>,
@@ -24,7 +23,6 @@ pub struct ApiCommandParams {
 }
 
 /// Handle raw API commands
-#[allow(dead_code)] // Used by binary target
 pub async fn handle_api_command(params: ApiCommandParams) -> CliResult<()> {
     let connection_manager = ConnectionManager::with_config_path(params.config, params.config_path);
 

--- a/crates/redisctl/src/commands/cloud/account.rs
+++ b/crates/redisctl/src/commands/cloud/account.rs
@@ -1,7 +1,5 @@
 //! Cloud account command implementations
 
-#![allow(dead_code)] // Used by binary target
-
 use anyhow::Context;
 use redis_cloud::AccountHandler;
 use serde_json::Value;

--- a/crates/redisctl/src/commands/cloud/acl.rs
+++ b/crates/redisctl/src/commands/cloud/acl.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use crate::cli::{CloudAclCommands, OutputFormat};
 use crate::connection::ConnectionManager;
 use crate::error::Result as CliResult;

--- a/crates/redisctl/src/commands/cloud/acl_impl.rs
+++ b/crates/redisctl/src/commands/cloud/acl_impl.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use crate::cli::OutputFormat;
 use crate::commands::cloud::async_utils::{AsyncOperationArgs, handle_async_response};
 use crate::connection::ConnectionManager;
@@ -99,44 +97,6 @@ fn print_redis_rules_table(data: &Value) -> CliResult<()> {
     Ok(())
 }
 
-fn print_redis_rule_detail(data: &Value) -> CliResult<()> {
-    let mut rows = Vec::new();
-
-    let fields = [
-        ("ID", "id"),
-        ("Name", "name"),
-        ("ACL", "acl"),
-        ("Default", "isDefault"),
-        ("Status", "status"),
-    ];
-
-    for (label, key) in &fields {
-        if let Some(val) = data.get(*key) {
-            let display = match val {
-                Value::Null => continue,
-                Value::String(s) => s.clone(),
-                Value::Bool(b) => b.to_string(),
-                Value::Number(n) => n.to_string(),
-                _ => val.to_string(),
-            };
-            rows.push(DetailRow {
-                field: label.to_string(),
-                value: display,
-            });
-        }
-    }
-
-    if rows.is_empty() {
-        println!("No Redis rule information available");
-        return Ok(());
-    }
-
-    let mut table = Table::new(&rows);
-    table.with(Style::blank());
-    output_with_pager(&table.to_string());
-    Ok(())
-}
-
 fn print_acl_roles_table(data: &Value) -> CliResult<()> {
     let items = match extract_items(data, "roles") {
         Some(arr) if !arr.is_empty() => arr,
@@ -168,64 +128,6 @@ fn print_acl_roles_table(data: &Value) -> CliResult<()> {
             }
         })
         .collect();
-
-    let mut table = Table::new(&rows);
-    table.with(Style::blank());
-    output_with_pager(&table.to_string());
-    Ok(())
-}
-
-fn print_acl_role_detail(data: &Value) -> CliResult<()> {
-    let mut rows = Vec::new();
-
-    let fields = [("ID", "id"), ("Name", "name"), ("Status", "status")];
-
-    for (label, key) in &fields {
-        if let Some(val) = data.get(*key) {
-            let display = match val {
-                Value::Null => continue,
-                Value::String(s) => s.clone(),
-                Value::Bool(b) => b.to_string(),
-                Value::Number(n) => n.to_string(),
-                _ => val.to_string(),
-            };
-            rows.push(DetailRow {
-                field: label.to_string(),
-                value: display,
-            });
-        }
-    }
-
-    if let Some(rules) = data.get("redisRules").and_then(|v| v.as_array()) {
-        let names: Vec<String> = rules
-            .iter()
-            .filter_map(|r| r.get("ruleName").and_then(|n| n.as_str()).map(String::from))
-            .collect();
-        if !names.is_empty() {
-            rows.push(DetailRow {
-                field: "Redis Rules".to_string(),
-                value: names.join(", "),
-            });
-        }
-    }
-
-    if let Some(users) = data.get("users").and_then(|v| v.as_array()) {
-        let names: Vec<String> = users
-            .iter()
-            .filter_map(|u| u.get("name").and_then(|n| n.as_str()).map(String::from))
-            .collect();
-        if !names.is_empty() {
-            rows.push(DetailRow {
-                field: "Users".to_string(),
-                value: names.join(", "),
-            });
-        }
-    }
-
-    if rows.is_empty() {
-        println!("No ACL role information available");
-        return Ok(());
-    }
 
     let mut table = Table::new(&rows);
     table.with(Style::blank());

--- a/crates/redisctl/src/commands/cloud/cloud_account.rs
+++ b/crates/redisctl/src/commands/cloud/cloud_account.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use crate::cli::{CloudProviderAccountCommands, OutputFormat};
 use crate::commands::cloud::cloud_account_impl::{
     self, CloudAccountOperationParams, CreateParams, UpdateParams,

--- a/crates/redisctl/src/commands/cloud/cloud_account_impl.rs
+++ b/crates/redisctl/src/commands/cloud/cloud_account_impl.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use crate::cli::OutputFormat;
 use crate::commands::cloud::async_utils::{AsyncOperationArgs, handle_async_response};
 use crate::commands::cloud::utils::{confirm_action, handle_output, print_formatted_output};

--- a/crates/redisctl/src/commands/cloud/connectivity/mod.rs
+++ b/crates/redisctl/src/commands/cloud/connectivity/mod.rs
@@ -1,7 +1,5 @@
 //! Cloud connectivity command implementations
 
-#![allow(dead_code)]
-
 pub mod private_link;
 pub mod psc;
 pub mod tgw;

--- a/crates/redisctl/src/commands/cloud/connectivity/private_link.rs
+++ b/crates/redisctl/src/commands/cloud/connectivity/private_link.rs
@@ -1,7 +1,5 @@
 //! AWS PrivateLink command implementations
 
-#![allow(dead_code)]
-
 use super::ConnectivityOperationParams;
 use crate::cli::{OutputFormat, PrivateLinkCommands};
 use crate::commands::cloud::async_utils::handle_async_response;

--- a/crates/redisctl/src/commands/cloud/connectivity/psc.rs
+++ b/crates/redisctl/src/commands/cloud/connectivity/psc.rs
@@ -1,7 +1,5 @@
 //! Private Service Connect (PSC) command implementations
 
-#![allow(dead_code)]
-
 use super::ConnectivityOperationParams;
 use crate::cli::{OutputFormat, PscCommands};
 use crate::commands::cloud::async_utils::handle_async_response;

--- a/crates/redisctl/src/commands/cloud/connectivity/tgw.rs
+++ b/crates/redisctl/src/commands/cloud/connectivity/tgw.rs
@@ -1,7 +1,5 @@
 //! Transit Gateway (TGW) command implementations
 
-#![allow(dead_code)]
-
 use super::ConnectivityOperationParams;
 use crate::cli::{OutputFormat, TgwCommands};
 use crate::commands::cloud::async_utils::handle_async_response;

--- a/crates/redisctl/src/commands/cloud/connectivity/vpc_peering.rs
+++ b/crates/redisctl/src/commands/cloud/connectivity/vpc_peering.rs
@@ -1,7 +1,5 @@
 //! VPC Peering command implementations
 
-#![allow(dead_code)]
-
 use super::ConnectivityOperationParams;
 use crate::cli::{OutputFormat, VpcPeeringCommands};
 use crate::commands::cloud::async_utils::handle_async_response;

--- a/crates/redisctl/src/commands/cloud/cost_report.rs
+++ b/crates/redisctl/src/commands/cloud/cost_report.rs
@@ -2,8 +2,6 @@
 //!
 //! Handles generating and downloading cost reports in FOCUS format.
 
-#![allow(dead_code)] // Functions used from main.rs binary
-
 use crate::cli::{CloudCostReportCommands, OutputFormat};
 use crate::commands::cloud::async_utils::{AsyncOperationArgs, handle_async_response};
 use crate::connection::ConnectionManager;

--- a/crates/redisctl/src/commands/cloud/database.rs
+++ b/crates/redisctl/src/commands/cloud/database.rs
@@ -1,7 +1,5 @@
 //! Cloud database command implementations
 
-#![allow(dead_code)] // Used by binary target
-
 use super::utils::DetailRow;
 use super::utils::*;
 use crate::cli::{CloudDatabaseCommands, OutputFormat};
@@ -530,33 +528,6 @@ fn print_databases_table(data: &Value) -> CliResult<()> {
 
     output_with_pager(&table.to_string());
     Ok(())
-}
-
-/// Parse database ID into subscription and database IDs
-fn parse_database_id(id: &str) -> CliResult<(u32, u32)> {
-    let parts: Vec<&str> = id.split(':').collect();
-    if parts.len() != 2 {
-        return Err(RedisCtlError::InvalidInput {
-            message: format!(
-                "Invalid database ID format: {}. Expected format: subscription_id:database_id",
-                id
-            ),
-        });
-    }
-
-    let subscription_id = parts[0]
-        .parse::<u32>()
-        .map_err(|_| RedisCtlError::InvalidInput {
-            message: format!("Invalid subscription ID: {}", parts[0]),
-        })?;
-
-    let database_id = parts[1]
-        .parse::<u32>()
-        .map_err(|_| RedisCtlError::InvalidInput {
-            message: format!("Invalid database ID: {}", parts[1]),
-        })?;
-
-    Ok((subscription_id, database_id))
 }
 
 /// Format database memory

--- a/crates/redisctl/src/commands/cloud/fixed_database.rs
+++ b/crates/redisctl/src/commands/cloud/fixed_database.rs
@@ -1,7 +1,5 @@
 //! Fixed database command implementations
 
-#![allow(dead_code)]
-
 use crate::cli::{CloudFixedDatabaseCommands, OutputFormat};
 use crate::commands::cloud::async_utils::handle_async_response;
 use crate::commands::cloud::utils::{confirm_action, handle_output, print_formatted_output};

--- a/crates/redisctl/src/commands/cloud/fixed_subscription.rs
+++ b/crates/redisctl/src/commands/cloud/fixed_subscription.rs
@@ -1,7 +1,5 @@
 //! Fixed subscription command implementations
 
-#![allow(dead_code)]
-
 use crate::cli::{CloudFixedSubscriptionCommands, OutputFormat};
 use crate::commands::cloud::async_utils::handle_async_response;
 use crate::commands::cloud::utils::{confirm_action, handle_output, print_formatted_output};

--- a/crates/redisctl/src/commands/cloud/payment_method.rs
+++ b/crates/redisctl/src/commands/cloud/payment_method.rs
@@ -1,7 +1,5 @@
 //! Cloud payment method command implementations
 
-#![allow(dead_code)] // Used by binary target
-
 use anyhow::Context;
 use redis_cloud::AccountHandler;
 use serde_json::Value;

--- a/crates/redisctl/src/commands/cloud/subscription.rs
+++ b/crates/redisctl/src/commands/cloud/subscription.rs
@@ -1,7 +1,5 @@
 //! Cloud subscription command implementations
 
-#![allow(dead_code)] // Used by binary target
-
 use anyhow::Context;
 use serde_json::Value;
 use tabled::{Table, Tabled, settings::Style};

--- a/crates/redisctl/src/commands/cloud/task.rs
+++ b/crates/redisctl/src/commands/cloud/task.rs
@@ -1,7 +1,5 @@
 //! Cloud task command implementations
 
-#![allow(dead_code)]
-
 use crate::cli::{CloudTaskCommands, OutputFormat};
 use crate::connection::ConnectionManager;
 use crate::error::{RedisCtlError, Result as CliResult};

--- a/crates/redisctl/src/commands/cloud/user.rs
+++ b/crates/redisctl/src/commands/cloud/user.rs
@@ -1,7 +1,5 @@
 //! Cloud user command implementations
 
-#![allow(dead_code)] // Used by binary target
-
 use super::async_utils::{AsyncOperationArgs, handle_async_response};
 use super::utils::DetailRow;
 use super::utils::*;

--- a/crates/redisctl/src/commands/curl.rs
+++ b/crates/redisctl/src/commands/curl.rs
@@ -7,7 +7,6 @@ use serde_json::Value;
 /// Format a curl command for a Cloud API request.
 ///
 /// Auth headers are redacted by default.
-#[allow(dead_code)] // Used by binary target
 pub fn format_cloud_curl(
     info: &CloudConnectionInfo,
     method: &HttpMethod,
@@ -36,7 +35,6 @@ pub fn format_cloud_curl(
 /// Format a curl command for an Enterprise API request.
 ///
 /// Auth credentials are redacted by default.
-#[allow(dead_code)] // Used by binary target
 pub fn format_enterprise_curl(
     info: &EnterpriseConnectionInfo,
     method: &HttpMethod,

--- a/crates/redisctl/src/commands/db.rs
+++ b/crates/redisctl/src/commands/db.rs
@@ -1,7 +1,5 @@
 //! Database command implementations
 
-#![allow(dead_code)] // Functions called from bin target
-
 use crate::cli::{DbCommands, OutputFormat};
 use crate::connection::ConnectionManager;
 use crate::error::RedisCtlError;

--- a/crates/redisctl/src/commands/enterprise/actions.rs
+++ b/crates/redisctl/src/commands/enterprise/actions.rs
@@ -59,7 +59,6 @@ pub enum ActionCommands {
 }
 
 impl ActionCommands {
-    #[allow(dead_code)]
     pub async fn execute(
         &self,
         conn_mgr: &ConnectionManager,
@@ -239,7 +238,6 @@ impl ActionCommands {
     }
 }
 
-#[allow(dead_code)]
 pub async fn handle_action_command(
     conn_mgr: &ConnectionManager,
     profile_name: Option<&str>,

--- a/crates/redisctl/src/commands/enterprise/alerts.rs
+++ b/crates/redisctl/src/commands/enterprise/alerts.rs
@@ -83,7 +83,6 @@ pub enum AlertsCommands {
 }
 
 impl AlertsCommands {
-    #[allow(dead_code)]
     pub async fn execute(
         &self,
         config: &Config,

--- a/crates/redisctl/src/commands/enterprise/bdb_group.rs
+++ b/crates/redisctl/src/commands/enterprise/bdb_group.rs
@@ -103,7 +103,6 @@ pub enum BdbGroupCommands {
 }
 
 impl BdbGroupCommands {
-    #[allow(dead_code)]
     pub async fn execute(
         &self,
         conn_mgr: &ConnectionManager,
@@ -357,7 +356,6 @@ impl BdbGroupCommands {
     }
 }
 
-#[allow(dead_code)]
 pub async fn handle_bdb_group_command(
     conn_mgr: &ConnectionManager,
     profile_name: Option<&str>,

--- a/crates/redisctl/src/commands/enterprise/bootstrap.rs
+++ b/crates/redisctl/src/commands/enterprise/bootstrap.rs
@@ -86,7 +86,6 @@ pub enum BootstrapCommands {
     },
 }
 
-#[allow(dead_code)]
 pub async fn handle_bootstrap_command(
     conn_mgr: &ConnectionManager,
     profile_name: Option<&str>,
@@ -157,7 +156,6 @@ pub async fn handle_bootstrap_command(
     }
 }
 
-#[allow(dead_code)]
 async fn handle_bootstrap_status(
     conn_mgr: &ConnectionManager,
     profile_name: Option<&str>,
@@ -180,7 +178,6 @@ async fn handle_bootstrap_status(
     utils::print_formatted_output(result, output_format)
 }
 
-#[allow(dead_code)]
 #[allow(clippy::too_many_arguments)]
 async fn handle_create_cluster(
     conn_mgr: &ConnectionManager,
@@ -242,7 +239,6 @@ async fn handle_create_cluster(
     utils::print_formatted_output(result, output_format)
 }
 
-#[allow(dead_code)]
 #[allow(clippy::too_many_arguments)]
 async fn handle_join_cluster(
     conn_mgr: &ConnectionManager,
@@ -300,7 +296,6 @@ async fn handle_join_cluster(
     utils::print_formatted_output(result, output_format)
 }
 
-#[allow(dead_code)]
 #[allow(clippy::too_many_arguments)]
 async fn handle_validate_bootstrap(
     conn_mgr: &ConnectionManager,

--- a/crates/redisctl/src/commands/enterprise/cluster.rs
+++ b/crates/redisctl/src/commands/enterprise/cluster.rs
@@ -1,7 +1,5 @@
 //! Cluster command router for Enterprise
 
-#![allow(dead_code)]
-
 use crate::cli::{EnterpriseClusterCommands, OutputFormat};
 use crate::connection::ConnectionManager;
 use crate::error::Result as CliResult;

--- a/crates/redisctl/src/commands/enterprise/cluster_impl.rs
+++ b/crates/redisctl/src/commands/enterprise/cluster_impl.rs
@@ -1,7 +1,5 @@
 //! Cluster command implementations for Redis Enterprise
 
-#![allow(dead_code)]
-
 use crate::cli::OutputFormat;
 use crate::connection::ConnectionManager;
 use crate::error::RedisCtlError;

--- a/crates/redisctl/src/commands/enterprise/cm_settings.rs
+++ b/crates/redisctl/src/commands/enterprise/cm_settings.rs
@@ -101,7 +101,6 @@ pub enum CmSettingsCommands {
 }
 
 impl CmSettingsCommands {
-    #[allow(dead_code)]
     pub async fn execute(
         &self,
         conn_mgr: &ConnectionManager,
@@ -358,7 +357,6 @@ impl CmSettingsCommands {
     }
 }
 
-#[allow(dead_code)]
 pub async fn handle_cm_settings_command(
     conn_mgr: &ConnectionManager,
     profile_name: Option<&str>,

--- a/crates/redisctl/src/commands/enterprise/crdb.rs
+++ b/crates/redisctl/src/commands/enterprise/crdb.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use crate::cli::{EnterpriseCrdbCommands, OutputFormat};
 use crate::connection::ConnectionManager;
 use crate::error::Result as CliResult;

--- a/crates/redisctl/src/commands/enterprise/crdb_impl.rs
+++ b/crates/redisctl/src/commands/enterprise/crdb_impl.rs
@@ -1,7 +1,5 @@
 //! Enterprise CRDB (Active-Active) command implementations
 
-#![allow(dead_code)]
-
 use crate::error::RedisCtlError;
 
 use crate::cli::OutputFormat;

--- a/crates/redisctl/src/commands/enterprise/crdb_task.rs
+++ b/crates/redisctl/src/commands/enterprise/crdb_task.rs
@@ -91,7 +91,6 @@ pub enum CrdbTaskCommands {
 }
 
 impl CrdbTaskCommands {
-    #[allow(dead_code)]
     pub async fn execute(
         &self,
         conn_mgr: &ConnectionManager,
@@ -346,7 +345,6 @@ impl CrdbTaskCommands {
     }
 }
 
-#[allow(dead_code)]
 pub async fn handle_crdb_task_command(
     conn_mgr: &ConnectionManager,
     profile_name: Option<&str>,

--- a/crates/redisctl/src/commands/enterprise/database.rs
+++ b/crates/redisctl/src/commands/enterprise/database.rs
@@ -1,7 +1,5 @@
 //! Enterprise database command handler
 
-#![allow(dead_code)]
-
 use crate::cli::{EnterpriseDatabaseCommands, OutputFormat};
 use crate::connection::ConnectionManager;
 use crate::error::Result as CliResult;

--- a/crates/redisctl/src/commands/enterprise/database_impl.rs
+++ b/crates/redisctl/src/commands/enterprise/database_impl.rs
@@ -1,7 +1,5 @@
 //! Enterprise database command implementations
 
-#![allow(dead_code)]
-
 use std::time::Duration;
 
 use indicatif::{ProgressBar, ProgressStyle};

--- a/crates/redisctl/src/commands/enterprise/debuginfo.rs
+++ b/crates/redisctl/src/commands/enterprise/debuginfo.rs
@@ -1,10 +1,8 @@
 use crate::cli::OutputFormat;
-use crate::commands::enterprise::utils;
 use crate::connection::ConnectionManager;
 use crate::error::RedisCtlError;
 use anyhow::Context;
 use clap::Subcommand;
-use serde_json::Value;
 use std::path::PathBuf;
 
 #[derive(Debug, Clone, Subcommand)]
@@ -50,7 +48,6 @@ pub enum DebugInfoCommands {
     },
 }
 
-#[allow(dead_code)]
 pub async fn handle_debuginfo_command(
     conn_mgr: &ConnectionManager,
     profile_name: Option<&str>,
@@ -108,77 +105,6 @@ pub async fn handle_debuginfo_command(
             .await
         }
     }
-}
-
-#[allow(dead_code)]
-async fn handle_debuginfo_all(
-    conn_mgr: &ConnectionManager,
-    profile_name: Option<&str>,
-    output_format: OutputFormat,
-    query: Option<&str>,
-) -> Result<(), RedisCtlError> {
-    let client = conn_mgr.create_enterprise_client(profile_name).await?;
-
-    let response = client
-        .get::<Value>("/v1/debuginfo/all")
-        .await
-        .map_err(RedisCtlError::from)?;
-
-    let result = if let Some(q) = query {
-        utils::apply_jmespath(&response, q)?
-    } else {
-        response
-    };
-
-    utils::print_formatted_output(result, output_format)
-}
-
-#[allow(dead_code)]
-async fn handle_debuginfo_node(
-    conn_mgr: &ConnectionManager,
-    profile_name: Option<&str>,
-    output_format: OutputFormat,
-    query: Option<&str>,
-) -> Result<(), RedisCtlError> {
-    let client = conn_mgr.create_enterprise_client(profile_name).await?;
-
-    let response = client
-        .get::<Value>("/v1/debuginfo/node")
-        .await
-        .map_err(RedisCtlError::from)?;
-
-    let result = if let Some(q) = query {
-        utils::apply_jmespath(&response, q)?
-    } else {
-        response
-    };
-
-    utils::print_formatted_output(result, output_format)
-}
-
-#[allow(dead_code)]
-async fn handle_debuginfo_database(
-    conn_mgr: &ConnectionManager,
-    profile_name: Option<&str>,
-    bdb_uid: u32,
-    output_format: OutputFormat,
-    query: Option<&str>,
-) -> Result<(), RedisCtlError> {
-    let client = conn_mgr.create_enterprise_client(profile_name).await?;
-
-    let endpoint = format!("/v1/debuginfo/node/bdb/{}", bdb_uid);
-    let response = client.get::<Value>(&endpoint).await.context(format!(
-        "Failed to collect debug info for database {}",
-        bdb_uid
-    ))?;
-
-    let result = if let Some(q) = query {
-        utils::apply_jmespath(&response, q)?
-    } else {
-        response
-    };
-
-    utils::print_formatted_output(result, output_format)
 }
 
 // Binary download handlers

--- a/crates/redisctl/src/commands/enterprise/diagnostics.rs
+++ b/crates/redisctl/src/commands/enterprise/diagnostics.rs
@@ -69,7 +69,6 @@ pub enum DiagnosticsCommands {
 }
 
 impl DiagnosticsCommands {
-    #[allow(dead_code)]
     pub async fn execute(
         &self,
         conn_mgr: &ConnectionManager,
@@ -234,7 +233,6 @@ impl DiagnosticsCommands {
     }
 }
 
-#[allow(dead_code)]
 pub async fn handle_diagnostics_command(
     conn_mgr: &ConnectionManager,
     profile_name: Option<&str>,
@@ -266,7 +264,6 @@ fn map_endpoint_error(err: RestError, command: &str, endpoint: &str) -> RedisCtl
 }
 
 // Helper functions
-#[allow(dead_code)]
 fn parse_comma_separated(input: &Option<String>) -> Option<Vec<String>> {
     input.as_ref().map(|s| {
         s.split(',')
@@ -276,7 +273,6 @@ fn parse_comma_separated(input: &Option<String>) -> Option<Vec<String>> {
     })
 }
 
-#[allow(dead_code)]
 fn parse_comma_separated_u32(input: &Option<String>) -> Option<Vec<u32>> {
     input.as_ref().and_then(|s| {
         let values: Result<Vec<u32>, _> = s

--- a/crates/redisctl/src/commands/enterprise/endpoint.rs
+++ b/crates/redisctl/src/commands/enterprise/endpoint.rs
@@ -4,7 +4,6 @@ use clap::Subcommand;
 
 use crate::{cli::OutputFormat, connection::ConnectionManager, error::Result as CliResult};
 
-#[allow(dead_code)]
 pub async fn handle_endpoint_command(
     conn_mgr: &ConnectionManager,
     profile_name: Option<&str>,
@@ -30,7 +29,6 @@ pub enum EndpointCommands {
 }
 
 impl EndpointCommands {
-    #[allow(dead_code)]
     pub async fn execute(
         &self,
         conn_mgr: &ConnectionManager,
@@ -42,7 +40,6 @@ impl EndpointCommands {
     }
 }
 
-#[allow(dead_code)]
 async fn handle_endpoint_command_impl(
     conn_mgr: &ConnectionManager,
     profile_name: Option<&str>,

--- a/crates/redisctl/src/commands/enterprise/job_scheduler.rs
+++ b/crates/redisctl/src/commands/enterprise/job_scheduler.rs
@@ -126,7 +126,6 @@ pub enum JobSchedulerCommands {
 }
 
 impl JobSchedulerCommands {
-    #[allow(dead_code)]
     pub async fn execute(
         &self,
         conn_mgr: &ConnectionManager,
@@ -350,7 +349,6 @@ impl JobSchedulerCommands {
     }
 }
 
-#[allow(dead_code)]
 pub async fn handle_job_scheduler_command(
     conn_mgr: &ConnectionManager,
     profile_name: Option<&str>,

--- a/crates/redisctl/src/commands/enterprise/jsonschema.rs
+++ b/crates/redisctl/src/commands/enterprise/jsonschema.rs
@@ -3,7 +3,6 @@ use clap::Subcommand;
 
 use crate::{cli::OutputFormat, connection::ConnectionManager, error::Result as CliResult};
 
-#[allow(dead_code)]
 pub async fn handle_jsonschema_command(
     conn_mgr: &ConnectionManager,
     profile_name: Option<&str>,
@@ -23,7 +22,6 @@ pub enum JsonSchemaCommands {
 }
 
 impl JsonSchemaCommands {
-    #[allow(dead_code)]
     pub async fn execute(
         &self,
         conn_mgr: &ConnectionManager,
@@ -35,7 +33,6 @@ impl JsonSchemaCommands {
     }
 }
 
-#[allow(dead_code)]
 async fn handle_jsonschema_command_impl(
     conn_mgr: &ConnectionManager,
     profile_name: Option<&str>,

--- a/crates/redisctl/src/commands/enterprise/ldap.rs
+++ b/crates/redisctl/src/commands/enterprise/ldap.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use crate::cli::OutputFormat;
 use crate::commands::enterprise::utils;
 use crate::connection::ConnectionManager;

--- a/crates/redisctl/src/commands/enterprise/license.rs
+++ b/crates/redisctl/src/commands/enterprise/license.rs
@@ -56,7 +56,6 @@ pub enum LicenseCommands {
 }
 
 impl LicenseCommands {
-    #[allow(dead_code)]
     pub async fn execute(
         &self,
         config: &Config,

--- a/crates/redisctl/src/commands/enterprise/license_workflow.rs
+++ b/crates/redisctl/src/commands/enterprise/license_workflow.rs
@@ -47,7 +47,6 @@ pub enum LicenseWorkflowCommands {
 }
 
 impl LicenseWorkflowCommands {
-    #[allow(dead_code)]
     pub async fn execute(
         &self,
         config: &Config,

--- a/crates/redisctl/src/commands/enterprise/local.rs
+++ b/crates/redisctl/src/commands/enterprise/local.rs
@@ -36,7 +36,6 @@ pub enum LocalCommands {
 }
 
 impl LocalCommands {
-    #[allow(dead_code)]
     pub async fn execute(
         &self,
         conn_mgr: &ConnectionManager,
@@ -115,7 +114,6 @@ impl LocalCommands {
     }
 }
 
-#[allow(dead_code)]
 pub async fn handle_local_command(
     conn_mgr: &ConnectionManager,
     profile_name: Option<&str>,

--- a/crates/redisctl/src/commands/enterprise/logs_impl.rs
+++ b/crates/redisctl/src/commands/enterprise/logs_impl.rs
@@ -1,5 +1,4 @@
 //! Implementation of enterprise logs commands
-#![allow(dead_code)]
 
 use crate::error::RedisCtlError;
 

--- a/crates/redisctl/src/commands/enterprise/migration.rs
+++ b/crates/redisctl/src/commands/enterprise/migration.rs
@@ -4,7 +4,6 @@ use clap::Subcommand;
 use crate::error::RedisCtlError;
 use crate::{cli::OutputFormat, connection::ConnectionManager, error::Result as CliResult};
 
-#[allow(dead_code)]
 pub async fn handle_migration_command(
     conn_mgr: &ConnectionManager,
     profile_name: Option<&str>,
@@ -184,7 +183,6 @@ pub enum MigrationCommands {
 }
 
 impl MigrationCommands {
-    #[allow(dead_code)]
     pub async fn execute(
         &self,
         conn_mgr: &ConnectionManager,
@@ -196,7 +194,6 @@ impl MigrationCommands {
     }
 }
 
-#[allow(dead_code)]
 async fn handle_migration_command_impl(
     conn_mgr: &ConnectionManager,
     profile_name: Option<&str>,

--- a/crates/redisctl/src/commands/enterprise/module_impl.rs
+++ b/crates/redisctl/src/commands/enterprise/module_impl.rs
@@ -1,5 +1,4 @@
 //! Implementation of enterprise module commands
-#![allow(dead_code)]
 
 use crate::error::RedisCtlError;
 

--- a/crates/redisctl/src/commands/enterprise/node.rs
+++ b/crates/redisctl/src/commands/enterprise/node.rs
@@ -1,7 +1,5 @@
 //! Node command router for Enterprise
 
-#![allow(dead_code)]
-
 use crate::cli::{EnterpriseNodeCommands, OutputFormat};
 use crate::connection::ConnectionManager;
 use crate::error::Result as CliResult;

--- a/crates/redisctl/src/commands/enterprise/node_impl.rs
+++ b/crates/redisctl/src/commands/enterprise/node_impl.rs
@@ -1,7 +1,5 @@
 //! Node command implementations for Redis Enterprise
 
-#![allow(dead_code)]
-
 use crate::cli::OutputFormat;
 use crate::connection::ConnectionManager;
 use crate::error::Result as CliResult;

--- a/crates/redisctl/src/commands/enterprise/ocsp.rs
+++ b/crates/redisctl/src/commands/enterprise/ocsp.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use crate::cli::OutputFormat;
 use crate::commands::enterprise::utils;
 use crate::connection::ConnectionManager;

--- a/crates/redisctl/src/commands/enterprise/proxy.rs
+++ b/crates/redisctl/src/commands/enterprise/proxy.rs
@@ -23,7 +23,6 @@ struct ProxyRow {
     max_connections: String,
 }
 
-#[allow(dead_code)]
 pub async fn handle_proxy_command(
     conn_mgr: &ConnectionManager,
     profile_name: Option<&str>,
@@ -98,7 +97,6 @@ pub enum ProxyCommands {
 }
 
 impl ProxyCommands {
-    #[allow(dead_code)]
     pub async fn execute(
         &self,
         conn_mgr: &ConnectionManager,
@@ -110,7 +108,6 @@ impl ProxyCommands {
     }
 }
 
-#[allow(dead_code)]
 async fn handle_proxy_command_impl(
     conn_mgr: &ConnectionManager,
     profile_name: Option<&str>,

--- a/crates/redisctl/src/commands/enterprise/rbac.rs
+++ b/crates/redisctl/src/commands/enterprise/rbac.rs
@@ -1,10 +1,8 @@
 //! RBAC command router for Enterprise
 
-#![allow(dead_code)]
-
 use crate::cli::{
-    EnterpriseAclCommands, EnterpriseAuthCommands, EnterpriseLdapCommands, EnterpriseRoleCommands,
-    EnterpriseUserCommands, OutputFormat,
+    EnterpriseAclCommands, EnterpriseAuthCommands, EnterpriseRoleCommands, EnterpriseUserCommands,
+    OutputFormat,
 };
 use crate::connection::ConnectionManager;
 use crate::error::Result as CliResult;
@@ -236,53 +234,6 @@ pub async fn handle_acl_command(
         }
         EnterpriseAclCommands::Test { user, command } => {
             rbac_impl::test_acl(conn_mgr, profile_name, *user, command, output_format, query).await
-        }
-    }
-}
-
-pub async fn handle_ldap_command(
-    conn_mgr: &ConnectionManager,
-    profile_name: Option<&str>,
-    command: &EnterpriseLdapCommands,
-    output_format: OutputFormat,
-    query: Option<&str>,
-) -> CliResult<()> {
-    match command {
-        EnterpriseLdapCommands::GetConfig => {
-            rbac_impl::get_ldap_config(conn_mgr, profile_name, output_format, query).await
-        }
-        EnterpriseLdapCommands::UpdateConfig {
-            enabled,
-            server_url,
-            bind_dn,
-            bind_password,
-            base_dn,
-            user_filter,
-            data,
-        } => {
-            rbac_impl::update_ldap_config(
-                conn_mgr,
-                profile_name,
-                *enabled,
-                server_url.as_deref(),
-                bind_dn.as_deref(),
-                bind_password.as_deref(),
-                base_dn.as_deref(),
-                user_filter.as_deref(),
-                data.as_deref(),
-                output_format,
-                query,
-            )
-            .await
-        }
-        EnterpriseLdapCommands::TestConnection => {
-            rbac_impl::test_ldap_connection(conn_mgr, profile_name, output_format, query).await
-        }
-        EnterpriseLdapCommands::Sync => {
-            rbac_impl::sync_ldap(conn_mgr, profile_name, output_format, query).await
-        }
-        EnterpriseLdapCommands::GetMappings => {
-            rbac_impl::get_ldap_mappings(conn_mgr, profile_name, output_format, query).await
         }
     }
 }

--- a/crates/redisctl/src/commands/enterprise/rbac_impl.rs
+++ b/crates/redisctl/src/commands/enterprise/rbac_impl.rs
@@ -1,12 +1,9 @@
 //! RBAC command implementations for Redis Enterprise
 
-#![allow(dead_code)]
-
 use crate::cli::OutputFormat;
 use crate::connection::ConnectionManager;
 use crate::error::{RedisCtlError, Result as CliResult};
 use anyhow::Context;
-use redis_enterprise::ldap_mappings::LdapMappingHandler;
 use redis_enterprise::redis_acls::{CreateRedisAclRequest, RedisAclHandler};
 use redis_enterprise::roles::RolesHandler;
 use redis_enterprise::users::{AuthRequest, PasswordSet, UserHandler};
@@ -827,129 +824,6 @@ pub async fn test_acl(
         });
 
     let data = handle_output(result, output_format, query)?;
-    print_formatted_output(data, output_format)?;
-    Ok(())
-}
-
-// ============================================================================
-// LDAP Integration Commands
-// ============================================================================
-
-pub async fn get_ldap_config(
-    conn_mgr: &ConnectionManager,
-    profile_name: Option<&str>,
-    output_format: OutputFormat,
-    query: Option<&str>,
-) -> CliResult<()> {
-    let client = conn_mgr.create_enterprise_client(profile_name).await?;
-
-    let config = client.get_raw("/v1/cluster/ldap").await?;
-    let data = handle_output(config, output_format, query)?;
-    print_formatted_output(data, output_format)?;
-    Ok(())
-}
-
-#[allow(clippy::too_many_arguments)]
-pub async fn update_ldap_config(
-    conn_mgr: &ConnectionManager,
-    profile_name: Option<&str>,
-    enabled: Option<bool>,
-    server_url: Option<&str>,
-    bind_dn: Option<&str>,
-    bind_password: Option<&str>,
-    base_dn: Option<&str>,
-    user_filter: Option<&str>,
-    data: Option<&str>,
-    output_format: OutputFormat,
-    query: Option<&str>,
-) -> CliResult<()> {
-    let client = conn_mgr.create_enterprise_client(profile_name).await?;
-
-    // Start with JSON from --data if provided, otherwise empty object
-    let mut ldap_data = if let Some(data_str) = data {
-        read_json_data(data_str).context("Failed to parse LDAP data")?
-    } else {
-        serde_json::json!({})
-    };
-
-    let ldap_obj = ldap_data.as_object_mut().unwrap();
-
-    // CLI parameters override JSON values
-    if let Some(en) = enabled {
-        ldap_obj.insert("enabled".to_string(), serde_json::json!(en));
-    }
-    if let Some(url) = server_url {
-        ldap_obj.insert("server_url".to_string(), serde_json::json!(url));
-    }
-    if let Some(dn) = bind_dn {
-        ldap_obj.insert("bind_dn".to_string(), serde_json::json!(dn));
-    }
-    if let Some(pass) = bind_password {
-        ldap_obj.insert("bind_password".to_string(), serde_json::json!(pass));
-    }
-    if let Some(dn) = base_dn {
-        ldap_obj.insert("base_dn".to_string(), serde_json::json!(dn));
-    }
-    if let Some(filter) = user_filter {
-        ldap_obj.insert("user_filter".to_string(), serde_json::json!(filter));
-    }
-
-    let result = client.put_raw("/v1/cluster/ldap", ldap_data).await?;
-    let output_data = handle_output(result, output_format, query)?;
-    print_formatted_output(output_data, output_format)?;
-    Ok(())
-}
-
-pub async fn test_ldap_connection(
-    conn_mgr: &ConnectionManager,
-    profile_name: Option<&str>,
-    output_format: OutputFormat,
-    query: Option<&str>,
-) -> CliResult<()> {
-    let client = conn_mgr.create_enterprise_client(profile_name).await?;
-
-    let result = client
-        .post_raw("/v1/cluster/ldap/test", serde_json::json!({}))
-        .await
-        .unwrap_or_else(|e| {
-            serde_json::json!({
-                "status": "error",
-                "message": e.to_string()
-            })
-        });
-
-    let data = handle_output(result, output_format, query)?;
-    print_formatted_output(data, output_format)?;
-    Ok(())
-}
-
-pub async fn sync_ldap(
-    conn_mgr: &ConnectionManager,
-    profile_name: Option<&str>,
-    output_format: OutputFormat,
-    query: Option<&str>,
-) -> CliResult<()> {
-    let client = conn_mgr.create_enterprise_client(profile_name).await?;
-
-    let result = client
-        .post_raw("/v1/cluster/ldap/sync", serde_json::json!({}))
-        .await?;
-    let data = handle_output(result, output_format, query)?;
-    print_formatted_output(data, output_format)?;
-    Ok(())
-}
-
-pub async fn get_ldap_mappings(
-    conn_mgr: &ConnectionManager,
-    profile_name: Option<&str>,
-    output_format: OutputFormat,
-    query: Option<&str>,
-) -> CliResult<()> {
-    let client = conn_mgr.create_enterprise_client(profile_name).await?;
-    let handler = LdapMappingHandler::new(client);
-    let mappings = handler.list().await?;
-    let mappings_json = serde_json::to_value(mappings).context("Failed to serialize mappings")?;
-    let data = handle_output(mappings_json, output_format, query)?;
     print_formatted_output(data, output_format)?;
     Ok(())
 }

--- a/crates/redisctl/src/commands/enterprise/services.rs
+++ b/crates/redisctl/src/commands/enterprise/services.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use crate::cli::OutputFormat;
 use crate::commands::enterprise::utils;
 use crate::connection::ConnectionManager;

--- a/crates/redisctl/src/commands/enterprise/shard.rs
+++ b/crates/redisctl/src/commands/enterprise/shard.rs
@@ -168,7 +168,6 @@ pub enum ShardCommands {
 }
 
 impl ShardCommands {
-    #[allow(dead_code)]
     pub async fn execute(
         &self,
         conn_mgr: &ConnectionManager,
@@ -485,7 +484,6 @@ impl ShardCommands {
     }
 }
 
-#[allow(dead_code)]
 pub async fn handle_shard_command(
     conn_mgr: &ConnectionManager,
     profile_name: Option<&str>,

--- a/crates/redisctl/src/commands/enterprise/stats.rs
+++ b/crates/redisctl/src/commands/enterprise/stats.rs
@@ -1,5 +1,4 @@
 //! Enterprise statistics and metrics commands
-#![allow(dead_code)]
 
 use crate::cli::{EnterpriseStatsCommands, OutputFormat};
 use crate::connection::ConnectionManager;

--- a/crates/redisctl/src/commands/enterprise/status.rs
+++ b/crates/redisctl/src/commands/enterprise/status.rs
@@ -3,8 +3,6 @@
 //! Provides a single command to view cluster, nodes, databases, and shards status,
 //! similar to `rladmin status extra all`.
 
-#![allow(dead_code)]
-
 use crate::cli::OutputFormat;
 use crate::connection::ConnectionManager;
 use crate::error::Result as CliResult;

--- a/crates/redisctl/src/commands/enterprise/suffix.rs
+++ b/crates/redisctl/src/commands/enterprise/suffix.rs
@@ -4,7 +4,6 @@ use clap::Subcommand;
 
 use crate::{cli::OutputFormat, connection::ConnectionManager, error::Result as CliResult};
 
-#[allow(dead_code)]
 pub async fn handle_suffix_command(
     conn_mgr: &ConnectionManager,
     profile_name: Option<&str>,
@@ -109,7 +108,6 @@ pub enum SuffixCommands {
 }
 
 impl SuffixCommands {
-    #[allow(dead_code)]
     pub async fn execute(
         &self,
         conn_mgr: &ConnectionManager,
@@ -121,7 +119,6 @@ impl SuffixCommands {
     }
 }
 
-#[allow(dead_code)]
 async fn handle_suffix_command_impl(
     conn_mgr: &ConnectionManager,
     profile_name: Option<&str>,

--- a/crates/redisctl/src/commands/enterprise/support_package.rs
+++ b/crates/redisctl/src/commands/enterprise/support_package.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 mod optimizer;
 #[cfg(feature = "upload")]
 mod upload;

--- a/crates/redisctl/src/commands/enterprise/support_package/optimizer.rs
+++ b/crates/redisctl/src/commands/enterprise/support_package/optimizer.rs
@@ -37,25 +37,6 @@ impl Default for OptimizationOptions {
     }
 }
 
-/// Result of optimization operation
-#[derive(Debug)]
-pub struct OptimizationResult {
-    pub original_size: usize,
-    pub optimized_size: usize,
-    pub files_processed: usize,
-    pub files_truncated: usize,
-    pub files_removed: usize,
-}
-
-impl OptimizationResult {
-    pub fn reduction_percentage(&self) -> f64 {
-        if self.original_size == 0 {
-            return 0.0;
-        }
-        ((self.original_size - self.optimized_size) as f64 / self.original_size as f64) * 100.0
-    }
-}
-
 /// Optimize a support package (tar.gz format)
 pub fn optimize_support_package(data: &[u8], options: &OptimizationOptions) -> Result<Vec<u8>> {
     if options.verbose {

--- a/crates/redisctl/src/commands/enterprise/support_package/upload.rs
+++ b/crates/redisctl/src/commands/enterprise/support_package/upload.rs
@@ -133,24 +133,6 @@ fn resolve_config_key(key: &str) -> Result<String> {
     }
 }
 
-/// Store Files.com API key in system keyring
-///
-/// This securely stores the API key using the platform's native keyring:
-/// - macOS: Keychain
-/// - Windows: Credential Manager
-/// - Linux: Secret Service (GNOME Keyring, KWallet, etc.)
-#[cfg(all(feature = "upload", feature = "secure-storage"))]
-pub fn set_in_keyring(api_key: &str) -> Result<()> {
-    let entry = keyring::Entry::new("redisctl", "files-api-key")
-        .context("Failed to access system keyring")?;
-
-    entry
-        .set_password(api_key)
-        .context("Failed to store API key in keyring")?;
-
-    Ok(())
-}
-
 /// Retrieve Files.com API key from system keyring
 #[cfg(all(feature = "upload", feature = "secure-storage"))]
 pub fn get_from_keyring() -> Result<String> {
@@ -158,17 +140,4 @@ pub fn get_from_keyring() -> Result<String> {
         .context("Failed to access system keyring")?;
 
     entry.get_password().context("API key not found in keyring")
-}
-
-/// Remove Files.com API key from system keyring
-#[cfg(all(feature = "upload", feature = "secure-storage"))]
-pub fn delete_from_keyring() -> Result<()> {
-    let entry = keyring::Entry::new("redisctl", "files-api-key")
-        .context("Failed to access system keyring")?;
-
-    entry
-        .delete_credential()
-        .context("Failed to delete API key from keyring")?;
-
-    Ok(())
 }

--- a/crates/redisctl/src/commands/enterprise/usage_report.rs
+++ b/crates/redisctl/src/commands/enterprise/usage_report.rs
@@ -4,7 +4,6 @@ use clap::Subcommand;
 
 use crate::{cli::OutputFormat, connection::ConnectionManager, error::Result as CliResult};
 
-#[allow(dead_code)]
 pub async fn handle_usage_report_command(
     conn_mgr: &ConnectionManager,
     profile_name: Option<&str>,
@@ -35,7 +34,6 @@ pub enum UsageReportCommands {
 }
 
 impl UsageReportCommands {
-    #[allow(dead_code)]
     pub async fn execute(
         &self,
         conn_mgr: &ConnectionManager,
@@ -47,7 +45,6 @@ impl UsageReportCommands {
     }
 }
 
-#[allow(dead_code)]
 async fn handle_usage_report_command_impl(
     conn_mgr: &ConnectionManager,
     profile_name: Option<&str>,

--- a/crates/redisctl/src/commands/files_key.rs
+++ b/crates/redisctl/src/commands/files_key.rs
@@ -4,8 +4,6 @@
 //! support package uploads. Keys can be stored in the system keyring (secure)
 //! or in the config file (plaintext).
 
-#![allow(dead_code)] // Functions are called from main.rs router
-
 use anyhow::{Context, Result};
 use redisctl_core::Config;
 

--- a/crates/redisctl/src/commands/profile.rs
+++ b/crates/redisctl/src/commands/profile.rs
@@ -1,7 +1,5 @@
 //! Profile management command implementations
 
-#![allow(dead_code)] // Functions called from bin target
-
 use crate::cli::{OutputFormat, ProfileCommands};
 use crate::connection::ConnectionManager;
 use crate::error::RedisCtlError;

--- a/crates/redisctl/src/connection.rs
+++ b/crates/redisctl/src/connection.rs
@@ -9,7 +9,10 @@ use tracing::{debug, info, trace};
 const REDISCTL_USER_AGENT: &str = concat!("redisctl/", env!("CARGO_PKG_VERSION"));
 
 /// Resolved Cloud connection details (without creating an HTTP client)
-#[allow(dead_code)] // Used by binary target
+// The credential fields are populated but not yet read by the curl builder in
+// commands/curl.rs, so `api ... --curl` output omits its auth headers. Kept
+// pending that fix (see #1049); do not delete the fields without fixing curl.
+#[allow(dead_code)]
 pub struct CloudConnectionInfo {
     pub base_url: String,
     pub api_key: String,
@@ -18,7 +21,9 @@ pub struct CloudConnectionInfo {
 }
 
 /// Resolved Enterprise connection details (without creating an HTTP client)
-#[allow(dead_code)] // Used by binary target
+// See CloudConnectionInfo: credential fields populated but not read by the curl
+// builder, so `api ... --curl` output omits auth. Kept pending fix (see #1049).
+#[allow(dead_code)]
 pub struct EnterpriseConnectionInfo {
     pub base_url: String,
     pub username: String,
@@ -29,7 +34,6 @@ pub struct EnterpriseConnectionInfo {
 }
 
 /// Connection manager for creating authenticated clients
-#[allow(dead_code)] // Used by binary target
 #[derive(Clone)]
 pub struct ConnectionManager {
     pub config: Config,
@@ -38,7 +42,6 @@ pub struct ConnectionManager {
 
 impl ConnectionManager {
     /// Create a new connection manager with the given configuration
-    #[allow(dead_code)] // Used by binary target
     pub fn new(config: Config) -> Self {
         Self {
             config,
@@ -47,7 +50,6 @@ impl ConnectionManager {
     }
 
     /// Create a new connection manager with a custom config path
-    #[allow(dead_code)] // Used by binary target
     pub fn with_config_path(config: Config, config_path: Option<std::path::PathBuf>) -> Self {
         Self {
             config,
@@ -55,24 +57,10 @@ impl ConnectionManager {
         }
     }
 
-    /// Save the configuration to the appropriate location
-    #[allow(dead_code)] // Used by binary target
-    pub fn save_config(&self) -> CliResult<()> {
-        if let Some(ref path) = self.config_path {
-            self.config
-                .save_to_path(path)
-                .context("Failed to save configuration")?;
-        } else {
-            self.config.save().context("Failed to save configuration")?;
-        }
-        Ok(())
-    }
-
     /// Resolve Cloud connection info without creating an HTTP client.
     ///
     /// Follows the same credential resolution logic as `create_cloud_client`:
     /// environment variables override profile config, and --config-file disables env vars.
-    #[allow(dead_code)] // Used by binary target
     pub fn resolve_cloud_connection(
         &self,
         profile_name: Option<&str>,
@@ -91,7 +79,6 @@ impl ConnectionManager {
     /// When --config-file is explicitly specified, environment variables are ignored to provide
     /// true configuration isolation. This allows testing with isolated configs and follows the
     /// principle of "explicit wins" (CLI args > env vars > defaults).
-    #[allow(dead_code)] // Used by binary target
     pub async fn create_cloud_client(
         &self,
         profile_name: Option<&str>,
@@ -235,7 +222,6 @@ impl ConnectionManager {
     ///
     /// Follows the same credential resolution logic as `create_enterprise_client`:
     /// environment variables override profile config, and --config-file disables env vars.
-    #[allow(dead_code)] // Used by binary target
     pub fn resolve_enterprise_connection(
         &self,
         profile_name: Option<&str>,
@@ -257,7 +243,6 @@ impl ConnectionManager {
     /// When --config-file is explicitly specified, environment variables are ignored to provide
     /// true configuration isolation. This allows testing with isolated configs and follows the
     /// principle of "explicit wins" (CLI args > env vars > defaults).
-    #[allow(dead_code)] // Used by binary target
     pub async fn create_enterprise_client(
         &self,
         profile_name: Option<&str>,

--- a/crates/redisctl/src/error.rs
+++ b/crates/redisctl/src/error.rs
@@ -2,8 +2,6 @@
 //!
 //! Defines structured error types using thiserror for better error handling and user experience.
 
-#![allow(dead_code)] // Foundation code - will be used in future PRs
-
 use colored::Colorize;
 use thiserror::Error;
 
@@ -89,9 +87,14 @@ pub enum RedisCtlError {
         available_profiles: Vec<String>,
     },
 
+    // Intended error types that no code path constructs yet: the CLI currently
+    // reports these conditions with generic errors instead. Kept (with their
+    // messages and suggestions) to be wired up rather than cut; see #1049.
+    #[allow(dead_code)]
     #[error("No profile configured. Use 'redisctl profile set' to configure a profile.")]
     NoProfileConfigured,
 
+    #[allow(dead_code)]
     #[error("Missing credentials for profile '{name}': {missing_fields}")]
     MissingCredentials {
         name: String,
@@ -115,6 +118,7 @@ pub enum RedisCtlError {
     )]
     Cancelled { prompt: String },
 
+    #[allow(dead_code)] // intended but not yet produced by any code path; see #1049
     #[error("Command not supported for deployment type '{deployment_type}'")]
     UnsupportedDeploymentType { deployment_type: String },
     #[error("File error for '{path}': {message}")]

--- a/crates/redisctl/src/main.rs
+++ b/crates/redisctl/src/main.rs
@@ -1017,7 +1017,6 @@ async fn handle_cloud_workflow_command(
                 conn_mgr: conn_mgr.clone(),
                 profile_name: profile.map(String::from),
                 output_format: output,
-                wait_timeout: args.wait_timeout as u64,
             };
 
             let registry = WorkflowRegistry::new();
@@ -1110,7 +1109,9 @@ async fn handle_enterprise_workflow_command(
             skip_database,
             database_name,
             database_memory_gb,
-            async_ops,
+            // init-cluster does not consume the async flags; the value used to
+            // flow into WorkflowContext.wait_timeout, which was never read.
+            async_ops: _,
         } => {
             let mut args = WorkflowArgs::new();
             args.insert("name", name);
@@ -1124,11 +1125,6 @@ async fn handle_enterprise_workflow_command(
                 conn_mgr: conn_mgr.clone(),
                 profile_name: profile.map(String::from),
                 output_format: output,
-                wait_timeout: if async_ops.wait {
-                    async_ops.wait_timeout
-                } else {
-                    0
-                },
             };
 
             let registry = WorkflowRegistry::new();

--- a/crates/redisctl/src/output.rs
+++ b/crates/redisctl/src/output.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use anyhow::{Context, Result};
 use jpx_core::Runtime;
 use regex::Regex;

--- a/crates/redisctl/src/workflows/cloud/subscription_setup.rs
+++ b/crates/redisctl/src/workflows/cloud/subscription_setup.rs
@@ -408,30 +408,6 @@ fn build_subscription_payload(args: &SubscriptionSetupArgs, payment_method_id: u
     })
 }
 
-fn build_database_payload(args: &SubscriptionSetupArgs) -> Value {
-    let mut payload = json!({
-        "name": args.database_name,
-        "memoryLimitInGb": args.database_memory_gb,
-        "throughputMeasurement": {
-            "by": "operations-per-second",
-            "value": args.database_throughput
-        },
-        "dataPersistence": if args.data_persistence { "aof-every-1-second" } else { "none" },
-        "replication": args.high_availability,
-    });
-
-    // Add modules if specified
-    if let Some(modules_str) = &args.modules {
-        let modules: Vec<Value> = modules_str
-            .split(',')
-            .map(|m| json!({"name": m.trim()}))
-            .collect();
-        payload["modules"] = json!(modules);
-    }
-
-    payload
-}
-
 async fn wait_for_task_completion(
     client: &redis_cloud::CloudClient,
     task_id: &str,

--- a/crates/redisctl/src/workflows/mod.rs
+++ b/crates/redisctl/src/workflows/mod.rs
@@ -3,8 +3,6 @@
 //! Workflows orchestrate complex operations that require multiple API calls,
 //! waiting for async operations, and conditional logic.
 
-#![allow(dead_code)]
-
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -36,8 +34,6 @@ pub struct WorkflowContext {
     pub conn_mgr: crate::connection::ConnectionManager,
     pub profile_name: Option<String>,
     pub output_format: crate::output::OutputFormat,
-    #[allow(dead_code)] // Will be used by future workflows
-    pub wait_timeout: u64,
 }
 
 /// Arguments passed to a workflow
@@ -89,15 +85,6 @@ impl WorkflowResult {
     pub fn success(message: impl Into<String>) -> Self {
         Self {
             success: true,
-            message: message.into(),
-            outputs: HashMap::new(),
-        }
-    }
-
-    #[allow(dead_code)] // Will be used by future workflows
-    pub fn failure(message: impl Into<String>) -> Self {
-        Self {
-            success: false,
             message: message.into(),
             outputs: HashMap::new(),
         }


### PR DESCRIPTION
## Summary

Phase 2b of the de-complexification (#1049), finding CODE-12. **Stacked on #1051** (base is `chore/code-12-drop-lib`); review/merge that first.

With the lib target gone (#1051), the 106 `#[allow(dead_code)]` annotations in `crates/redisctl/src` (42 blanket module-level, 64 item-level) were pointless: they existed because the lib compiled every module and used none. Removing them all turns the dead-code lint back on for the binary. It flagged **24** genuinely dead items.

## Deleted (20)

- **Superseded LDAP path:** `rbac.rs::handle_ldap_command` and five `rbac_impl.rs` LDAP functions. `enterprise ldap` runs through `ldap.rs`; these were the old implementation.
- **Superseded debuginfo:** `handle_debuginfo_all/node/database`. The live command uses the `_binary` variants.
- **Unused helpers:** two ACL detail printers, `parse_database_id`, the `OptimizationResult` struct + method, two support-package keyring helpers, `build_database_payload`, `WorkflowResult::failure`, `ConnectionManager::save_config`, and `WorkflowContext.wait_timeout` (set but never read, so `init-cluster` already ignored `--wait-timeout`).

## Kept, with a targeted `#[allow(dead_code)]` + comment (5, see #1049)

These are not cruft, so they were not cut:

- **`error.rs` `NoProfileConfigured` / `MissingCredentials` / `UnsupportedDeploymentType`:** intended error types with good messages and `suggestions()`, but no code path constructs them (the CLI reports these conditions with generic errors instead). A latent UX improvement to wire up.
- **`connection.rs` `CloudConnectionInfo` / `EnterpriseConnectionInfo` credential fields:** populated but never read by the curl builder, so **`api ... --curl` output omits its auth headers**. That looks like a real bug; kept pending a fix rather than deleted.

## Result

Net ~670 lines removed. **5 documented allows remain instead of 106 blanket ones**, and the dead-code lint now covers the whole crate, so new dead code will be caught going forward.

## Validation

- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace --all-features`: all pass, zero failures.

## Follow-ups (flagged, not done here)

1. Wire up the three error variants (small behavior PR).
2. Fix `api ... --curl` to emit auth headers, then the connection-info credential fields become live.