### PR TITLE
feat(cli): add cloud auth login | status | logout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2299,6 +2299,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "oauth2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "getrandom 0.2.16",
+ "http",
+ "rand 0.8.6",
+ "reqwest 0.12.23",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2",
+ "thiserror 1.0.69",
+ "url",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2960,19 +2980,16 @@ dependencies = [
 name = "redisctl-core"
 version = "0.11.1"
 dependencies = [
- "base64 0.22.1",
  "clap",
  "directories",
- "getrandom 0.3.3",
  "keyring",
+ "oauth2",
  "redis-cloud",
  "redis-enterprise",
  "reqwest 0.13.1",
  "serde",
  "serde_json",
- "serde_urlencoded",
  "serial_test",
- "sha2",
  "shellexpand",
  "tempfile",
  "thiserror 2.0.17",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2970,6 +2970,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "unicode-segmentation",
+ "url",
  "urlencoding",
  "which 7.0.3",
  "wiremock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,8 @@ async-trait = "0.1"
 
 # HTTP and APIs
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls", "multipart"] }
+# Standards-compliant OAuth2/OIDC (device grant, auth-code+PKCE, refresh); rustls to match reqwest.
+oauth2 = { version = "5", default-features = false, features = ["reqwest", "rustls-tls"] }
 url = "2.5"
 base64 = "0.22"
 sha2 = "0.10"

--- a/crates/redisctl-core/Cargo.toml
+++ b/crates/redisctl-core/Cargo.toml
@@ -24,13 +24,11 @@ thiserror = { workspace = true }
 # Async runtime
 tokio = { workspace = true }
 
-# HTTP client + PKCE for the Okta OIDC flows (device authorization / auth-code loopback)
+# OAuth2/OIDC for the Okta login flows (device authorization / auth-code loopback), via the
+# maintained oauth2 crate. reqwest is the async HTTP backend it uses.
+oauth2 = { workspace = true }
 reqwest = { workspace = true }
-serde_urlencoded = { workspace = true }
 url = { workspace = true }
-base64 = { workspace = true }
-sha2 = { workspace = true }
-getrandom = { workspace = true }
 
 # Logging
 tracing = { workspace = true }

--- a/crates/redisctl-core/src/auth/auth_code_loopback.rs
+++ b/crates/redisctl-core/src/auth/auth_code_loopback.rs
@@ -1,30 +1,29 @@
 //! OIDC Authorization Code + PKCE via a loopback redirect (RFC 8252) — the interactive
 //! human login. The CLI opens the browser to the Okta sign-in page and self-hosts a
-//! one-shot `127.0.0.1` listener to catch the redirect; **no callback page is hosted
-//! anywhere** and the authorization code never leaves the machine.
+//! `127.0.0.1` listener to catch the redirect; **no callback page is hosted anywhere** and the
+//! authorization code never leaves the machine.
 //!
 //! Sequence:
 //! 1. Bind a loopback port on 127.0.0.1 (the redirect target; no page is hosted anywhere).
-//! 2. Build a PKCE S256 verifier/challenge + a random `state`.
+//! 2. Build a PKCE S256 verifier/challenge + a random `state` (both from the [`oauth2`] crate).
 //! 3. Hand the `/v1/authorize` URL to the caller's `open_browser`; the user signs in.
 //! 4. Catch the browser's redirect to `127.0.0.1/callback?code&state` on the listener.
-//! 5. Validate `state` (CSRF guard) and extract the code.
+//! 5. Validate `state` (CSRF guard) and extract the code — *before* rendering any success page.
 //! 6. Exchange the code (+ `code_verifier`) at `/v1/token` for a `TokenSet`.
 //!
-//! Converges on the same [`TokenSet`] and token-endpoint plumbing as the device flow.
+//! Converges on the same [`TokenSet`] and the shared `oidc` plumbing as the device flow.
 
 use std::net::Ipv4Addr;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
-use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
-use sha2::{Digest, Sha256};
+use oauth2::{AuthorizationCode, CsrfToken, PkceCodeChallenge, RedirectUrl, Scope};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use url::Url;
 
-use super::{AuthError, TokenSet, default_http_client, endpoint, form_body, post_token, token_set};
+use super::oidc::{map_basic_token_error, oauth_http_client, okta_client, to_token_set};
+use super::{AuthError, TokenSet};
 
-const AUTH_CODE_GRANT: &str = "authorization_code";
 /// Loopback ports tried in order. Each `http://127.0.0.1:PORT/callback` must be registered
 /// as a redirect URI on the Okta app (or the app configured to allow any loopback port).
 const DEFAULT_PORTS: &[u16] = &[8899, 8898, 8900];
@@ -38,7 +37,6 @@ const REQUEST_READ_TIMEOUT: Duration = Duration::from_secs(10);
 pub struct LoopbackFlowClient {
     issuer: Url,
     client_id: String,
-    http: reqwest::Client,
     ports: Vec<u16>,
     redirect_host: String,
     redirect_path: String,
@@ -52,18 +50,11 @@ impl LoopbackFlowClient {
         Self {
             issuer,
             client_id: client_id.into(),
-            http: default_http_client(),
             ports: DEFAULT_PORTS.to_vec(),
             redirect_host: "127.0.0.1".to_string(),
             redirect_path: "/callback".to_string(),
             timeout: DEFAULT_TIMEOUT,
         }
-    }
-
-    /// Use a caller-provided reqwest client.
-    pub fn with_http_client(mut self, http: reqwest::Client) -> Self {
-        self.http = http;
-        self
     }
 
     /// Override the candidate loopback ports (e.g. `[0]` for an ephemeral port in tests).
@@ -90,15 +81,33 @@ impl LoopbackFlowClient {
             self.redirect_host, port, self.redirect_path
         );
 
-        let pkce = Pkce::generate()?;
-        let state = random_urlsafe(16)?;
-        let url = self.authorize_url(&redirect_uri, scopes, &pkce.challenge, &state);
+        let client = okta_client(&self.issuer, &self.client_id)?.set_redirect_uri(
+            RedirectUrl::new(redirect_uri.clone())
+                .map_err(|e| AuthError::Protocol(format!("invalid redirect URL: {e}")))?,
+        );
 
-        open_browser(&url);
+        let (challenge, verifier) = PkceCodeChallenge::new_random_sha256();
+        let mut request = client
+            .authorize_url(CsrfToken::new_random)
+            .set_pkce_challenge(challenge)
+            .add_extra_param("prompt", "login");
+        for scope in scopes {
+            request = request.add_scope(Scope::new((*scope).to_string()));
+        }
+        let (url, csrf) = request.url();
 
-        let code = self.wait_for_callback(listener, &state).await?;
-        self.exchange_code(&code, &pkce.verifier, &redirect_uri)
+        open_browser(url.as_str());
+
+        let code = self.wait_for_callback(listener, csrf.secret()).await?;
+
+        let http = oauth_http_client()?;
+        let resp = client
+            .exchange_code(AuthorizationCode::new(code))
+            .set_pkce_verifier(verifier)
+            .request_async(&http)
             .await
+            .map_err(map_basic_token_error)?;
+        Ok(to_token_set(&resp))
     }
 
     async fn bind(&self) -> Result<(TcpListener, u16), AuthError> {
@@ -117,131 +126,151 @@ impl LoopbackFlowClient {
         )))
     }
 
-    fn authorize_url(
-        &self,
-        redirect_uri: &str,
-        scopes: &[&str],
-        challenge: &str,
-        state: &str,
-    ) -> String {
-        let scope = scopes.join(" ");
-        let query = form_body(&[
-            ("client_id", self.client_id.as_str()),
-            ("response_type", "code"),
-            ("scope", scope.as_str()),
-            ("redirect_uri", redirect_uri),
-            ("state", state),
-            ("code_challenge", challenge),
-            ("code_challenge_method", "S256"),
-            ("prompt", "login"),
-        ]);
-        format!("{}?{}", endpoint(&self.issuer, "v1/authorize"), query)
-    }
-
+    /// Wait for the browser's redirect, tolerating stray local connections. Two security
+    /// properties this upholds:
+    /// - The success page is written **only after** `state` (and any `error`) is validated, so a
+    ///   forged/mismatched callback never sees a "signed in" page.
+    /// - The listener keeps `accept()`ing (bounded by `self.timeout`) so an unrelated local
+    ///   request — which carries no `state` — is answered briefly and does not end the login; a
+    ///   real callback with a mismatched `state` is still a terminal CSRF rejection.
     async fn wait_for_callback(
         &self,
         listener: TcpListener,
         expected_state: &str,
     ) -> Result<String, AuthError> {
-        let accepted = tokio::time::timeout(self.timeout, listener.accept())
-            .await
-            .map_err(|_| {
-                AuthError::Protocol("timed out waiting for the browser redirect".into())
-            })?;
-        let (mut stream, _) =
-            accepted.map_err(|e| AuthError::Protocol(format!("accept failed: {e}")))?;
+        let deadline = Instant::now() + self.timeout;
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return Err(AuthError::Protocol(
+                    "timed out waiting for the browser redirect".into(),
+                ));
+            }
 
-        let target = tokio::time::timeout(REQUEST_READ_TIMEOUT, read_request_target(&mut stream))
-            .await
-            .map_err(|_| {
-                AuthError::Protocol("timed out reading the browser redirect request".into())
-            })??;
-        write_ok_page(&mut stream).await;
+            let (mut stream, _) = match tokio::time::timeout(remaining, listener.accept()).await {
+                Err(_) => {
+                    return Err(AuthError::Protocol(
+                        "timed out waiting for the browser redirect".into(),
+                    ));
+                }
+                Ok(Err(e)) => return Err(AuthError::Protocol(format!("accept failed: {e}"))),
+                Ok(Ok(pair)) => pair,
+            };
 
-        // The request target is a path+query; parse it against a dummy base to read the query.
-        let parsed = Url::parse(&format!("http://localhost{target}"))
-            .map_err(|e| AuthError::Protocol(format!("could not parse callback URL: {e}")))?;
-        let (mut code, mut state, mut error, mut error_desc) = (None, None, None, None);
-        for (k, v) in parsed.query_pairs() {
-            match k.as_ref() {
-                "code" => code = Some(v.into_owned()),
-                "state" => state = Some(v.into_owned()),
-                "error" => error = Some(v.into_owned()),
-                "error_description" => error_desc = Some(v.into_owned()),
-                _ => {}
+            // A connection that never completes its request must not hang the login: bound the
+            // read; on failure, answer briefly and keep waiting for the real callback.
+            let target =
+                match tokio::time::timeout(REQUEST_READ_TIMEOUT, read_request_target(&mut stream))
+                    .await
+                {
+                    Ok(Ok(t)) => t,
+                    _ => {
+                        write_page(
+                            &mut stream,
+                            400,
+                            "Bad Request",
+                            "Could not read the request.",
+                        )
+                        .await;
+                        continue;
+                    }
+                };
+
+            // The request target is a path+query; parse it against a dummy base to read the query.
+            let parsed = match Url::parse(&format!("http://localhost{target}")) {
+                Ok(u) => u,
+                Err(_) => {
+                    write_page(&mut stream, 400, "Bad Request", "Malformed callback URL.").await;
+                    continue;
+                }
+            };
+            let (mut code, mut state, mut error, mut error_desc) = (None, None, None, None);
+            for (k, v) in parsed.query_pairs() {
+                match k.as_ref() {
+                    "code" => code = Some(v.into_owned()),
+                    "state" => state = Some(v.into_owned()),
+                    "error" => error = Some(v.into_owned()),
+                    "error_description" => error_desc = Some(v.into_owned()),
+                    _ => {}
+                }
+            }
+
+            // Validate BEFORE writing any success page. An explicit IdP `error` is a terminal
+            // outcome for this login.
+            if let Some(err) = error {
+                write_page(
+                    &mut stream,
+                    400,
+                    "Bad Request",
+                    "Login failed. You can close this tab.",
+                )
+                .await;
+                return match err.as_str() {
+                    "access_denied" => Err(AuthError::Denied),
+                    other => Err(AuthError::Protocol(format!(
+                        "authorization error {other}: {}",
+                        error_desc.unwrap_or_default()
+                    ))),
+                };
+            }
+
+            match state.as_deref() {
+                // Our callback with a matching state: only now is a success page correct.
+                Some(s) if s == expected_state => {
+                    return match code {
+                        Some(c) => {
+                            write_page(
+                                &mut stream,
+                                200,
+                                "OK",
+                                "Signed in - you can close this tab.",
+                            )
+                            .await;
+                            Ok(c)
+                        }
+                        None => {
+                            write_page(
+                                &mut stream,
+                                400,
+                                "Bad Request",
+                                "Login failed. You can close this tab.",
+                            )
+                            .await;
+                            Err(AuthError::Protocol(
+                                "callback did not include an authorization code".into(),
+                            ))
+                        }
+                    };
+                }
+                // A callback carrying a mismatched state → CSRF / stale login. Reject with an
+                // error page, never a success page.
+                Some(_) => {
+                    write_page(
+                        &mut stream,
+                        400,
+                        "Bad Request",
+                        "Login failed (state mismatch). You can close this tab.",
+                    )
+                    .await;
+                    return Err(AuthError::Protocol(
+                        "state mismatch on callback (possible CSRF or stale login)".into(),
+                    ));
+                }
+                // No state at all → a stray/unrelated local request. Answer briefly and keep
+                // waiting for the real callback.
+                None => {
+                    write_page(
+                        &mut stream,
+                        404,
+                        "Not Found",
+                        "Waiting for the login callback.",
+                    )
+                    .await;
+                    continue;
+                }
             }
         }
-
-        if let Some(err) = error {
-            return match err.as_str() {
-                "access_denied" => Err(AuthError::Denied),
-                other => Err(AuthError::Protocol(format!(
-                    "authorization error {other}: {}",
-                    error_desc.unwrap_or_default()
-                ))),
-            };
-        }
-        if state.as_deref() != Some(expected_state) {
-            return Err(AuthError::Protocol(
-                "state mismatch on callback (possible CSRF or stale login)".into(),
-            ));
-        }
-        code.ok_or_else(|| {
-            AuthError::Protocol("callback did not include an authorization code".into())
-        })
     }
-
-    async fn exchange_code(
-        &self,
-        code: &str,
-        verifier: &str,
-        redirect_uri: &str,
-    ) -> Result<TokenSet, AuthError> {
-        let tr = post_token(
-            &self.http,
-            &endpoint(&self.issuer, "v1/token"),
-            &[
-                ("client_id", self.client_id.as_str()),
-                ("grant_type", AUTH_CODE_GRANT),
-                ("code", code),
-                ("redirect_uri", redirect_uri),
-                ("code_verifier", verifier),
-            ],
-        )
-        .await?;
-        if let Some(err) = tr.error.as_deref() {
-            return Err(AuthError::Protocol(format!(
-                "token exchange failed ({err}): {}",
-                tr.description()
-            )));
-        }
-        token_set(tr)
-    }
-}
-
-/// A PKCE verifier/challenge pair (S256).
-struct Pkce {
-    verifier: String,
-    challenge: String,
-}
-
-impl Pkce {
-    fn generate() -> Result<Self, AuthError> {
-        let verifier = random_urlsafe(32)?; // 32 bytes -> 43-char base64url (valid PKCE length)
-        let challenge = URL_SAFE_NO_PAD.encode(Sha256::digest(verifier.as_bytes()));
-        Ok(Self {
-            verifier,
-            challenge,
-        })
-    }
-}
-
-/// `n` random bytes, base64url-no-pad encoded — used for the PKCE verifier and `state`.
-fn random_urlsafe(n: usize) -> Result<String, AuthError> {
-    let mut buf = vec![0u8; n];
-    getrandom::fill(&mut buf)
-        .map_err(|e| AuthError::Protocol(format!("secure RNG unavailable: {e}")))?;
-    Ok(URL_SAFE_NO_PAD.encode(&buf))
 }
 
 /// Read the HTTP request line's target (the path+query) from the loopback connection.
@@ -271,15 +300,16 @@ async fn read_request_target(stream: &mut TcpStream) -> Result<String, AuthError
         .ok_or_else(|| AuthError::Protocol("malformed callback request line".into()))
 }
 
-/// Write a minimal "you can close this tab" page and close the connection.
-async fn write_ok_page(stream: &mut TcpStream) {
-    const BODY: &str = "<html><body style=\"font-family:sans-serif\">\
-        <h2>Signed in - you can close this tab.</h2></body></html>";
+/// Write a minimal HTML page and close the connection. Used for both the success page and the
+/// neutral error/"still waiting" pages, so the wording is decided by the caller after validation.
+async fn write_page(stream: &mut TcpStream, status: u16, reason: &str, message: &str) {
+    let body =
+        format!("<html><body style=\"font-family:sans-serif\"><h2>{message}</h2></body></html>");
     let response = format!(
-        "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\n\
+        "HTTP/1.1 {status} {reason}\r\nContent-Type: text/html; charset=utf-8\r\n\
          Content-Length: {}\r\nConnection: close\r\n\r\n{}",
-        BODY.len(),
-        BODY
+        body.len(),
+        body
     );
     let _ = stream.write_all(response.as_bytes()).await;
     let _ = stream.flush().await;
@@ -289,49 +319,21 @@ async fn write_ok_page(stream: &mut TcpStream) {
 mod tests {
     use super::*;
     use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
-    #[test]
-    fn pkce_challenge_matches_verifier() {
-        let p = Pkce::generate().unwrap();
-        assert!((43..=128).contains(&p.verifier.len()));
-        let expected = URL_SAFE_NO_PAD.encode(Sha256::digest(p.verifier.as_bytes()));
-        assert_eq!(p.challenge, expected);
-    }
-
-    #[test]
-    fn random_urlsafe_is_urlsafe_and_unique() {
-        let a = random_urlsafe(16).unwrap();
-        let b = random_urlsafe(16).unwrap();
-        assert_ne!(a, b);
-        assert!(!a.contains('+') && !a.contains('/') && !a.contains('='));
-    }
-
-    fn client_with_issuer(issuer: &str) -> LoopbackFlowClient {
-        LoopbackFlowClient::new(Url::parse(issuer).unwrap(), "cid")
-    }
-
-    #[test]
-    fn authorize_url_has_required_params() {
-        let c = client_with_issuer("https://issuer.example/oauth2/default");
-        let url = c.authorize_url(
-            "http://127.0.0.1:8899/callback",
-            &["openid", "email"],
-            "CHALLENGE",
-            "STATE",
-        );
-        assert!(url.starts_with("https://issuer.example/oauth2/default/v1/authorize?"));
-        let parsed = Url::parse(&url).unwrap();
-        let q: HashMap<_, _> = parsed.query_pairs().into_owned().collect();
-        assert_eq!(q["client_id"], "cid");
-        assert_eq!(q["response_type"], "code");
-        assert_eq!(q["code_challenge_method"], "S256");
-        assert_eq!(q["code_challenge"], "CHALLENGE");
-        assert_eq!(q["state"], "STATE");
-        assert_eq!(q["redirect_uri"], "http://127.0.0.1:8899/callback");
-        assert_eq!(q["scope"], "openid email");
-        assert_eq!(q["prompt"], "login");
+    async fn mount_token(server: &MockServer) {
+        Mock::given(method("POST"))
+            .and(path("/v1/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "AT",
+                "token_type": "Bearer",
+                "refresh_token": "RT",
+                "expires_in": 3600
+            })))
+            .mount(server)
+            .await;
     }
 
     async fn ephemeral(server: &MockServer) -> LoopbackFlowClient {
@@ -340,65 +342,98 @@ mod tests {
             .with_timeout(Duration::from_secs(5))
     }
 
-    /// Simulate the browser: read redirect_uri + state from the authorize URL and GET the
-    /// callback with the given extra query.
-    fn simulate_browser(url: &str, extra: &str) {
-        let parsed = Url::parse(url).unwrap();
-        let q: HashMap<_, _> = parsed.query_pairs().into_owned().collect();
-        let cb = format!("{}?{}&state={}", q["redirect_uri"], extra, q["state"]);
-        tokio::spawn(async move {
-            let _ = reqwest::get(&cb).await;
-        });
+    fn query_of(url: &str) -> HashMap<String, String> {
+        Url::parse(url)
+            .unwrap()
+            .query_pairs()
+            .into_owned()
+            .collect()
     }
 
     #[tokio::test]
-    async fn login_happy_path() {
+    async fn login_happy_path_and_authorize_url_params() {
         let server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .and(path("/v1/token"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "access_token": "AT",
-                "id_token": "IT",
-                "refresh_token": "RT",
-                "expires_in": 3600
-            })))
-            .mount(&server)
-            .await;
+        mount_token(&server).await;
 
+        let captured = Arc::new(Mutex::new(String::new()));
+        let cap = captured.clone();
         let token = ephemeral(&server)
             .await
-            .login(&["openid"], |url| simulate_browser(url, "code=THECODE"))
-            .await
-            .unwrap();
-        assert_eq!(token.access_token, "AT");
-        assert_eq!(token.refresh_token.as_deref(), Some("RT"));
-    }
-
-    #[tokio::test]
-    async fn login_state_mismatch_is_error() {
-        let server = MockServer::start().await;
-        let res = ephemeral(&server)
-            .await
-            .login(&["openid"], |url| {
-                // GET the callback with a wrong state (ignore the real one)
-                let parsed = Url::parse(url).unwrap();
-                let q: HashMap<_, _> = parsed.query_pairs().into_owned().collect();
-                let cb = format!("{}?code=X&state=WRONG", q["redirect_uri"]);
+            .login(&["openid", "email"], move |url| {
+                *cap.lock().unwrap() = url.to_string();
+                let q = query_of(url);
+                let cb = format!("{}?code=THECODE&state={}", q["redirect_uri"], q["state"]);
                 tokio::spawn(async move {
                     let _ = reqwest::get(&cb).await;
                 });
             })
+            .await
+            .unwrap();
+        assert_eq!(token.access_token, "AT");
+        assert_eq!(token.refresh_token.as_deref(), Some("RT"));
+
+        // The authorize URL the browser was handed carries the PKCE + CSRF params.
+        let url = captured.lock().unwrap().clone();
+        assert!(url.contains("/v1/authorize?"));
+        let q = query_of(&url);
+        assert_eq!(q["client_id"], "cid");
+        assert_eq!(q["response_type"], "code");
+        assert_eq!(q["code_challenge_method"], "S256");
+        assert!(q.contains_key("code_challenge"));
+        assert!(q.contains_key("state"));
+        assert_eq!(q["prompt"], "login");
+        assert_eq!(q["scope"], "openid email");
+        assert!(q["redirect_uri"].starts_with("http://127.0.0.1:"));
+        assert!(q["redirect_uri"].ends_with("/callback"));
+    }
+
+    /// Bug fix (a): a callback with a mismatched `state` is rejected AND never receives a
+    /// success page.
+    #[tokio::test]
+    async fn login_state_mismatch_is_rejected_without_success_page() {
+        let server = MockServer::start().await;
+        mount_token(&server).await;
+
+        // Capture the body the "browser" receives so we can assert it is not the success page.
+        let (tx, rx) = tokio::sync::oneshot::channel::<String>();
+        let res = ephemeral(&server)
+            .await
+            .login(&["openid"], move |url| {
+                let q = query_of(url);
+                let cb = format!("{}?code=X&state=WRONG-STATE", q["redirect_uri"]);
+                tokio::spawn(async move {
+                    let body = match reqwest::get(&cb).await {
+                        Ok(r) => r.text().await.unwrap_or_default(),
+                        Err(_) => String::new(),
+                    };
+                    let _ = tx.send(body);
+                });
+            })
             .await;
+
         assert!(matches!(res, Err(AuthError::Protocol(_))));
+        let body = rx.await.unwrap();
+        assert!(
+            !body.contains("Signed in"),
+            "mismatched state must not get a success page, got: {body}"
+        );
     }
 
     #[tokio::test]
     async fn login_access_denied_maps_to_denied() {
         let server = MockServer::start().await;
+        mount_token(&server).await;
         let res = ephemeral(&server)
             .await
             .login(&["openid"], |url| {
-                simulate_browser(url, "error=access_denied")
+                let q = query_of(url);
+                let cb = format!(
+                    "{}?error=access_denied&state={}",
+                    q["redirect_uri"], q["state"]
+                );
+                tokio::spawn(async move {
+                    let _ = reqwest::get(&cb).await;
+                });
             })
             .await;
         assert!(matches!(res, Err(AuthError::Denied)));
@@ -407,11 +442,41 @@ mod tests {
     #[tokio::test]
     async fn login_times_out_without_callback() {
         let server = MockServer::start().await;
+        mount_token(&server).await;
         let res = ephemeral(&server)
             .await
             .with_timeout(Duration::from_millis(150))
             .login(&["openid"], |_url| { /* browser never redirects */ })
             .await;
         assert!(matches!(res, Err(AuthError::Protocol(_))));
+    }
+
+    /// Bug fix (b): a stray request to the loopback port must not end the flow — the real
+    /// callback still succeeds.
+    #[tokio::test]
+    async fn login_ignores_stray_request() {
+        let server = MockServer::start().await;
+        mount_token(&server).await;
+        let token = ephemeral(&server)
+            .await
+            .login(&["openid"], |url| {
+                let q = query_of(url);
+                let redirect = q["redirect_uri"].clone();
+                let state = q["state"].clone();
+                // A stray, unrelated local request (no `state`) arrives first.
+                let stray = redirect.clone();
+                tokio::spawn(async move {
+                    let _ = reqwest::get(&stray).await;
+                });
+                // The legitimate callback follows shortly after.
+                let real = format!("{redirect}?code=THECODE&state={state}");
+                tokio::spawn(async move {
+                    tokio::time::sleep(Duration::from_millis(80)).await;
+                    let _ = reqwest::get(&real).await;
+                });
+            })
+            .await
+            .unwrap();
+        assert_eq!(token.access_token, "AT");
     }
 }

--- a/crates/redisctl-core/src/auth/authenticator.rs
+++ b/crates/redisctl-core/src/auth/authenticator.rs
@@ -86,22 +86,21 @@ impl CloudAuthenticator {
         self
     }
 
-    /// Device-authorization-grant client for headless / agent logins.
+    /// Device-authorization-grant client for headless / agent logins. The flow runs on the
+    /// `oauth2` crate's own HTTP stack, so it does not share this authenticator's SM client.
     pub fn device(&self) -> DeviceFlowClient {
         DeviceFlowClient::new(self.issuer.clone(), self.client_id.clone())
-            .with_http_client(self.http.clone())
     }
 
     /// Auth-code + PKCE loopback client for interactive human logins.
     pub fn loopback(&self) -> LoopbackFlowClient {
         LoopbackFlowClient::new(self.issuer.clone(), self.client_id.clone())
-            .with_http_client(self.http.clone())
     }
 
     /// Refresh an Okta refresh token for a fresh token set (Okta rotates it). The grant is
     /// flow-agnostic, so it goes straight through `oidc` rather than a specific flow client.
     pub async fn refresh(&self, refresh_token: &str) -> Result<TokenSet, AuthError> {
-        super::oidc::refresh(&self.http, &self.issuer, &self.client_id, refresh_token).await
+        super::oidc::refresh(&self.issuer, &self.client_id, refresh_token).await
     }
 
     /// Given tokens from a flow, run the SM exchange and mint a CAPI key named `key_name`.
@@ -280,7 +279,6 @@ mod tests {
         );
         let tokens = TokenSet {
             access_token: "AT".into(),
-            id_token: "IT".into(),
             refresh_token: Some("RT".into()),
             expires_in: 3600,
         };
@@ -314,7 +312,6 @@ mod tests {
         );
         let tokens = TokenSet {
             access_token: "AT".into(),
-            id_token: String::new(),
             refresh_token: None,
             expires_in: 3600,
         };

--- a/crates/redisctl-core/src/auth/device_flow.rs
+++ b/crates/redisctl-core/src/auth/device_flow.rs
@@ -1,70 +1,85 @@
 //! OIDC Device Authorization Grant (RFC 8628) client for the Redis Cloud Okta tenant.
 //!
-//! Two requests against the issuer:
-//! - `POST {issuer}/v1/device/authorize` — start; returns the user code + verification URI.
-//! - `POST {issuer}/v1/token` (device-code grant) — polled until approved/expired/denied.
+//! Two requests against the issuer, handled by the [`oauth2`] crate:
+//! - `POST {issuer}/v1/device/authorize` — [`start`](DeviceFlowClient::start); returns the user
+//!   code + verification URI plus the (secret) device code needed to resume.
+//! - `POST {issuer}/v1/token` (device-code grant) — [`poll`](DeviceFlowClient::poll); the crate
+//!   owns the polling loop (honoring the server's `interval`/`slow_down`) until the request is
+//!   approved, denied, or times out.
 //!
-//! The caller owns the polling loop (so the CLI can print progress and honor `--timeout`);
-//! [`DeviceFlowClient::poll_once`] performs a single attempt. Refreshing a token is
-//! flow-agnostic and lives in [`super::oidc::refresh`].
+//! `login --device` is deliberately split: the CLI calls [`start`](DeviceFlowClient::start),
+//! prints/persists the returned [`DeviceAuthorization`] (which is `serde`-serializable), and
+//! returns. A later `status --wait` — possibly a *different* process — rebuilds the client from
+//! the issuer + client id, deserializes the [`DeviceAuthorization`], and calls
+//! [`poll`](DeviceFlowClient::poll). Refreshing a token is flow-agnostic and lives in
+//! [`super::oidc::refresh`].
 
-use serde::Deserialize;
+use std::time::Duration;
+
+use oauth2::{Scope, StandardDeviceAuthorizationResponse};
+use serde::{Deserialize, Serialize};
 use url::Url;
 
-use super::{
-    AuthError, TokenSet, default_http_client, endpoint, form_body, post_token, token_set, truncate,
+use super::oidc::{
+    map_basic_token_error, map_device_token_error, oauth_http_client, okta_client, to_token_set,
 };
-
-const DEVICE_CODE_GRANT: &str = "urn:ietf:params:oauth:grant-type:device_code";
-/// RFC 8628 default poll interval when the server omits one.
-const DEFAULT_INTERVAL: u64 = 5;
+use super::{AuthError, TokenSet};
 
 /// Device-authorization-grant client bound to one Okta issuer + public client id.
+///
+/// Cheap to construct and holds no network state, so `status --wait` can rebuild it from the
+/// persisted issuer + client id to resume a login started by an earlier `login --device`.
 #[derive(Clone)]
 pub struct DeviceFlowClient {
     issuer: Url,
     client_id: String,
-    http: reqwest::Client,
 }
 
-/// The device-authorization response — what `auth login` surfaces to the developer.
+/// The device-authorization response — what `auth login --device` surfaces to the developer and
+/// persists so a later poll (in any process) can resume.
 ///
-/// `device_code` is retained to poll the token endpoint; it is a secret and is never printed.
-#[derive(Clone)]
+/// Wraps the RFC 8628 response from the [`oauth2`] crate. It is `serde`-serializable so the CLI
+/// can persist it between the non-blocking `login --device` and a later `status --wait`. The
+/// `device_code` it carries is a secret; `Debug` redacts it (as do the other code fields) via
+/// the underlying `oauth2` secret types.
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct DeviceAuthorization {
-    pub device_code: String,
-    pub user_code: String,
+    inner: StandardDeviceAuthorizationResponse,
+}
+
+impl DeviceAuthorization {
+    /// The end-user verification code (shown to the user to type at the verification URI).
+    pub fn user_code(&self) -> &str {
+        self.inner.user_code().secret().as_str()
+    }
+
     /// The page the user opens and then *types* the `user_code` into.
-    pub verification_uri: String,
-    /// The same page with the `user_code` pre-embedded (optional per RFC 8628), so the user
-    /// can just open it and confirm — no manual code entry. Prefer this when present.
-    pub verification_uri_complete: Option<String>,
-    pub expires_in: u64,
-    pub interval: u64,
-}
+    pub fn verification_uri(&self) -> &str {
+        self.inner.verification_uri().as_str()
+    }
 
-/// Outcome of a single token-endpoint poll. The caller decides when to poll again.
-#[derive(Debug)]
-pub enum PollOutcome {
-    /// Still waiting on the user; sleep `interval` and poll again.
-    Pending,
-    /// Server asked us to back off; increase the interval, then keep polling.
-    SlowDown,
-    /// Approved — tokens issued.
-    Ready(TokenSet),
-}
+    /// The same page with the `user_code` pre-embedded (optional per RFC 8628), so the user can
+    /// just open it and confirm — no manual code entry. Prefer this when present.
+    pub fn verification_uri_complete(&self) -> Option<&str> {
+        self.inner
+            .verification_uri_complete()
+            .map(|v| v.secret().as_str())
+    }
 
-/// Raw `/device/authorize` wire response. Kept separate from the public [`DeviceAuthorization`]
-/// so the wire shape (`interval` optional per RFC 8628) stays isolated from the resolved public
-/// type (`interval` defaulted); `start()` maps one to the other.
-#[derive(Deserialize)]
-struct DeviceAuthzResponse {
-    device_code: String,
-    user_code: String,
-    verification_uri: String,
-    verification_uri_complete: Option<String>,
-    expires_in: u64,
-    interval: Option<u64>,
+    /// Lifetime of the device/user code, in seconds.
+    pub fn expires_in(&self) -> u64 {
+        self.inner.expires_in().as_secs()
+    }
+
+    /// Minimum poll interval requested by the server, in seconds.
+    pub fn interval(&self) -> u64 {
+        self.inner.interval().as_secs()
+    }
+
+    /// Borrow the underlying RFC 8628 response (escape hatch for callers that need the raw type).
+    pub fn as_standard(&self) -> &StandardDeviceAuthorizationResponse {
+        &self.inner
+    }
 }
 
 impl DeviceFlowClient {
@@ -74,82 +89,47 @@ impl DeviceFlowClient {
         Self {
             issuer,
             client_id: client_id.into(),
-            http: default_http_client(),
         }
-    }
-
-    /// Use a caller-provided reqwest client (tests / shared client / custom user agent).
-    pub fn with_http_client(mut self, http: reqwest::Client) -> Self {
-        self.http = http;
-        self
     }
 
     /// Start device authorization: `POST /v1/device/authorize`.
+    ///
+    /// Returns the codes to display *and* the device code needed to resume polling — persist the
+    /// returned [`DeviceAuthorization`] and hand it to [`poll`](Self::poll) later.
     pub async fn start(&self, scopes: &[&str]) -> Result<DeviceAuthorization, AuthError> {
-        let scope = scopes.join(" ");
-        let resp = self
-            .http
-            .post(endpoint(&self.issuer, "v1/device/authorize"))
-            .header(
-                reqwest::header::CONTENT_TYPE,
-                "application/x-www-form-urlencoded",
-            )
-            .body(form_body(&[
-                ("client_id", self.client_id.as_str()),
-                ("scope", scope.as_str()),
-            ]))
-            .send()
-            .await?;
-        let status = resp.status();
-        let body = resp.text().await?;
-        if !status.is_success() {
-            return Err(AuthError::Protocol(format!(
-                "device authorize returned {status}: {}",
-                truncate(&body)
-            )));
+        let client = okta_client(&self.issuer, &self.client_id)?;
+        let http = oauth_http_client()?;
+        let mut request = client.exchange_device_code();
+        for scope in scopes {
+            request = request.add_scope(Scope::new((*scope).to_string()));
         }
-        let d: DeviceAuthzResponse = serde_json::from_str(&body).map_err(|e| {
-            AuthError::Protocol(format!("could not parse device-authorize response: {e}"))
-        })?;
-        Ok(DeviceAuthorization {
-            device_code: d.device_code,
-            user_code: d.user_code,
-            verification_uri: d.verification_uri,
-            verification_uri_complete: d.verification_uri_complete,
-            expires_in: d.expires_in,
-            interval: d.interval.unwrap_or(DEFAULT_INTERVAL),
-        })
+        let inner: StandardDeviceAuthorizationResponse = request
+            .request_async(&http)
+            .await
+            .map_err(map_basic_token_error)?;
+        Ok(DeviceAuthorization { inner })
     }
 
-    /// One poll of the token endpoint with the device-code grant. The caller owns the loop.
+    /// Poll the token endpoint until the user approves, the code is denied/expires, or `timeout`
+    /// elapses. The [`oauth2`] crate runs the loop internally (respecting the server's poll
+    /// interval and `slow_down`), so this is a single blocking call.
     ///
-    /// The OAuth device flow returns HTTP 400 with an `error` body for the pending/slow-down/
-    /// error cases, so we read and parse the body regardless of status.
-    pub async fn poll_once(&self, device_code: &str) -> Result<PollOutcome, AuthError> {
-        let tr = post_token(
-            &self.http,
-            &endpoint(&self.issuer, "v1/token"),
-            &[
-                ("client_id", self.client_id.as_str()),
-                ("grant_type", DEVICE_CODE_GRANT),
-                ("device_code", device_code),
-            ],
-        )
-        .await?;
-
-        if let Some(err) = tr.error.as_deref() {
-            return match err {
-                "authorization_pending" => Ok(PollOutcome::Pending),
-                "slow_down" => Ok(PollOutcome::SlowDown),
-                "expired_token" => Err(AuthError::Expired),
-                "access_denied" => Err(AuthError::Denied),
-                other => Err(AuthError::Protocol(format!(
-                    "token endpoint error {other}: {}",
-                    tr.description()
-                ))),
-            };
-        }
-        Ok(PollOutcome::Ready(token_set(tr)?))
+    /// `timeout` bounds the whole wait; `None` falls back to the device code's own lifetime. A
+    /// timeout surfaces as [`AuthError::Expired`]. Callable from a freshly built client after
+    /// deserializing `authz`.
+    pub async fn poll(
+        &self,
+        authz: &DeviceAuthorization,
+        timeout: Option<Duration>,
+    ) -> Result<TokenSet, AuthError> {
+        let client = okta_client(&self.issuer, &self.client_id)?;
+        let http = oauth_http_client()?;
+        let resp = client
+            .exchange_device_access_token(&authz.inner)
+            .request_async(&http, tokio::time::sleep, timeout)
+            .await
+            .map_err(map_device_token_error)?;
+        Ok(to_token_set(&resp))
     }
 }
 
@@ -163,6 +143,14 @@ mod tests {
         DeviceFlowClient::new(Url::parse(&server.uri()).unwrap(), "test-client")
     }
 
+    async fn mount_device_authorize(server: &MockServer, body: serde_json::Value) {
+        Mock::given(method("POST"))
+            .and(path("/v1/device/authorize"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(body))
+            .mount(server)
+            .await;
+    }
+
     async fn mount_token(server: &MockServer, status: u16, body: serde_json::Value) {
         Mock::given(method("POST"))
             .and(path("/v1/token"))
@@ -174,107 +162,102 @@ mod tests {
     #[tokio::test]
     async fn start_parses_device_authorization() {
         let server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .and(path("/v1/device/authorize"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+        mount_device_authorize(
+            &server,
+            serde_json::json!({
                 "device_code": "DC",
                 "user_code": "WDJB-MJHT",
                 "verification_uri": "https://x/activate",
                 "verification_uri_complete": "https://x/activate?user_code=WDJB-MJHT",
                 "expires_in": 600,
                 "interval": 5
-            })))
-            .mount(&server)
-            .await;
+            }),
+        )
+        .await;
 
         let d = client(&server)
             .start(&["openid", "offline_access"])
             .await
             .unwrap();
-        assert_eq!(d.device_code, "DC");
-        assert_eq!(d.user_code, "WDJB-MJHT");
-        assert_eq!(d.interval, 5);
+        assert_eq!(d.user_code(), "WDJB-MJHT");
+        assert_eq!(d.verification_uri(), "https://x/activate");
         assert_eq!(
-            d.verification_uri_complete.as_deref(),
+            d.verification_uri_complete(),
             Some("https://x/activate?user_code=WDJB-MJHT")
         );
+        assert_eq!(d.expires_in(), 600);
+        assert_eq!(d.interval(), 5);
+        // Debug must not leak the secret device code / user code.
+        assert!(!format!("{d:?}").contains("WDJB-MJHT"));
     }
 
     #[tokio::test]
     async fn start_defaults_interval_when_absent() {
         let server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .and(path("/v1/device/authorize"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+        mount_device_authorize(
+            &server,
+            serde_json::json!({
                 "device_code": "DC",
                 "user_code": "U",
                 "verification_uri": "https://x",
                 "expires_in": 600
-            })))
-            .mount(&server)
-            .await;
-
-        let d = client(&server).start(&["openid"]).await.unwrap();
-        assert_eq!(d.interval, DEFAULT_INTERVAL);
-    }
-
-    #[tokio::test]
-    async fn poll_pending() {
-        let server = MockServer::start().await;
-        mount_token(
-            &server,
-            400,
-            serde_json::json!({"error": "authorization_pending"}),
+            }),
         )
         .await;
-        assert!(matches!(
-            client(&server).poll_once("DC").await.unwrap(),
-            PollOutcome::Pending
-        ));
-    }
 
-    #[tokio::test]
-    async fn poll_slow_down() {
-        let server = MockServer::start().await;
-        mount_token(&server, 400, serde_json::json!({"error": "slow_down"})).await;
-        assert!(matches!(
-            client(&server).poll_once("DC").await.unwrap(),
-            PollOutcome::SlowDown
-        ));
+        // RFC 8628 default poll interval when the server omits one.
+        let d = client(&server).start(&["openid"]).await.unwrap();
+        assert_eq!(d.interval(), 5);
     }
 
     #[tokio::test]
     async fn poll_ready_returns_tokens() {
         let server = MockServer::start().await;
+        mount_device_authorize(
+            &server,
+            serde_json::json!({
+                "device_code": "DC", "user_code": "U",
+                "verification_uri": "https://x", "expires_in": 600, "interval": 5
+            }),
+        )
+        .await;
         mount_token(
             &server,
             200,
             serde_json::json!({
                 "access_token": "AT",
-                "id_token": "IT",
+                "token_type": "Bearer",
                 "refresh_token": "RT",
                 "expires_in": 3600
             }),
         )
         .await;
 
-        match client(&server).poll_once("DC").await.unwrap() {
-            PollOutcome::Ready(t) => {
-                assert_eq!(t.access_token, "AT");
-                assert_eq!(t.id_token, "IT");
-                assert_eq!(t.refresh_token.as_deref(), Some("RT"));
-                assert_eq!(t.expires_in, 3600);
-            }
-            other => panic!("expected Ready, got {other:?}"),
-        }
+        let c = client(&server);
+        let authz = c.start(&["openid"]).await.unwrap();
+        let t = c.poll(&authz, Some(Duration::from_secs(5))).await.unwrap();
+        assert_eq!(t.access_token, "AT");
+        assert_eq!(t.refresh_token.as_deref(), Some("RT"));
+        assert_eq!(t.expires_in, 3600);
     }
 
     #[tokio::test]
     async fn poll_expired_maps_to_error() {
         let server = MockServer::start().await;
+        mount_device_authorize(
+            &server,
+            serde_json::json!({
+                "device_code": "DC", "user_code": "U",
+                "verification_uri": "https://x", "expires_in": 600, "interval": 5
+            }),
+        )
+        .await;
         mount_token(&server, 400, serde_json::json!({"error": "expired_token"})).await;
+
+        let c = client(&server);
+        let authz = c.start(&["openid"]).await.unwrap();
         assert!(matches!(
-            client(&server).poll_once("DC").await,
+            c.poll(&authz, Some(Duration::from_secs(5))).await,
             Err(AuthError::Expired)
         ));
     }
@@ -282,39 +265,55 @@ mod tests {
     #[tokio::test]
     async fn poll_denied_maps_to_error() {
         let server = MockServer::start().await;
+        mount_device_authorize(
+            &server,
+            serde_json::json!({
+                "device_code": "DC", "user_code": "U",
+                "verification_uri": "https://x", "expires_in": 600, "interval": 5
+            }),
+        )
+        .await;
         mount_token(&server, 400, serde_json::json!({"error": "access_denied"})).await;
+
+        let c = client(&server);
+        let authz = c.start(&["openid"]).await.unwrap();
         assert!(matches!(
-            client(&server).poll_once("DC").await,
+            c.poll(&authz, Some(Duration::from_secs(5))).await,
             Err(AuthError::Denied)
         ));
     }
 
+    /// The device authorization must survive a serialize/deserialize round-trip and still be
+    /// usable to poll — this is the `login --device` (persist) then `status --wait` (resume,
+    /// possibly in another process) contract.
     #[tokio::test]
-    async fn poll_unknown_error_is_protocol() {
+    async fn device_authorization_round_trips_and_resumes() {
         let server = MockServer::start().await;
-        mount_token(
+        mount_device_authorize(
             &server,
-            400,
-            serde_json::json!({"error": "weird", "error_description": "nope"}),
+            serde_json::json!({
+                "device_code": "DC", "user_code": "U",
+                "verification_uri": "https://x", "expires_in": 600, "interval": 5
+            }),
         )
         .await;
-        assert!(matches!(
-            client(&server).poll_once("DC").await,
-            Err(AuthError::Protocol(_))
-        ));
-    }
+        mount_token(
+            &server,
+            200,
+            serde_json::json!({"access_token": "AT", "token_type": "Bearer", "expires_in": 3600}),
+        )
+        .await;
 
-    #[tokio::test]
-    async fn poll_malformed_body_is_protocol() {
-        let server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .and(path("/v1/token"))
-            .respond_with(ResponseTemplate::new(200).set_body_string("not json"))
-            .mount(&server)
-            .await;
-        assert!(matches!(
-            client(&server).poll_once("DC").await,
-            Err(AuthError::Protocol(_))
-        ));
+        let started = client(&server).start(&["openid"]).await.unwrap();
+        let json = serde_json::to_string(&started).unwrap();
+        let resumed: DeviceAuthorization = serde_json::from_str(&json).unwrap();
+
+        // A freshly built client (as a separate process would build) can complete the poll.
+        let fresh = DeviceFlowClient::new(Url::parse(&server.uri()).unwrap(), "test-client");
+        let t = fresh
+            .poll(&resumed, Some(Duration::from_secs(5)))
+            .await
+            .unwrap();
+        assert_eq!(t.access_token, "AT");
     }
 }

--- a/crates/redisctl-core/src/auth/mod.rs
+++ b/crates/redisctl-core/src/auth/mod.rs
@@ -21,9 +21,10 @@ mod oidc;
 
 pub use auth_code_loopback::LoopbackFlowClient;
 pub use authenticator::{CloudAuthenticator, MintedCredentials};
-pub use device_flow::{DeviceAuthorization, DeviceFlowClient, PollOutcome};
+pub use device_flow::{DeviceAuthorization, DeviceFlowClient};
 pub use oidc::{AuthError, TokenSet};
 pub use sm_api::{CapiKey, SmAccount, SmApiClient, SmUser};
 
-// Crate-private OIDC plumbing shared by the two flow clients (referenced as `super::*`).
-pub(crate) use oidc::{default_http_client, endpoint, form_body, post_token, token_set, truncate};
+// Crate-private OIDC plumbing shared by the SM exchange (referenced as `super::*`). The flow
+// clients pull their `oauth2` helpers directly from `super::oidc`.
+pub(crate) use oidc::{default_http_client, endpoint, truncate};

--- a/crates/redisctl-core/src/auth/oidc.rs
+++ b/crates/redisctl-core/src/auth/oidc.rs
@@ -1,10 +1,17 @@
 //! Shared OIDC vocabulary and token-endpoint plumbing used by both login flows.
 //!
 //! Holds the public [`TokenSet`] / [`AuthError`] types plus the crate-private helpers the
-//! device-flow and loopback clients build on. Kept out of `mod.rs` so that stays a thin
-//! facade, matching the other modules in this crate.
+//! device-flow and loopback clients build on. The OAuth2/OIDC protocol itself is handled by
+//! the maintained [`oauth2`] crate; this module owns the endpoint layout (Okta `v1/*` paths),
+//! the shared HTTP clients, and the mapping from `oauth2` errors to [`AuthError`]. Kept out of
+//! `mod.rs` so that stays a thin facade, matching the other modules in this crate.
 
-use serde::Deserialize;
+use oauth2::basic::{BasicClient, BasicRequestTokenError, BasicTokenResponse};
+use oauth2::{
+    AuthType, AuthUrl, ClientId, DeviceAuthorizationUrl, DeviceCodeErrorResponse,
+    DeviceCodeErrorResponseType, EndpointNotSet, EndpointSet, RefreshToken, RequestTokenError,
+    TokenResponse, TokenUrl,
+};
 use thiserror::Error;
 use url::Url;
 
@@ -14,7 +21,6 @@ use url::Url;
 #[derive(Clone)]
 pub struct TokenSet {
     pub access_token: String,
-    pub id_token: String,
     pub refresh_token: Option<String>,
     /// Access-token lifetime in seconds (0 if the IdP omitted it).
     pub expires_in: u64,
@@ -24,7 +30,6 @@ impl std::fmt::Debug for TokenSet {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("TokenSet")
             .field("access_token", &"<redacted>")
-            .field("id_token", &"<redacted>")
             .field(
                 "refresh_token",
                 &self.refresh_token.as_ref().map(|_| "<redacted>"),
@@ -48,7 +53,8 @@ pub enum AuthError {
     #[error("the login request was denied")]
     Denied,
 
-    /// Network/transport failure talking to the identity provider.
+    /// Network/transport failure talking to the SM API (the `oauth2` flows classify their own
+    /// transport failures as [`AuthError::Protocol`] because they run on a separate HTTP stack).
     #[error("network error contacting the identity provider: {0}")]
     Network(#[from] reqwest::Error),
 
@@ -57,25 +63,10 @@ pub enum AuthError {
     Protocol(String),
 }
 
-/// Raw token-endpoint response — either the token fields or an OAuth `error` object.
-#[derive(Deserialize)]
-pub(crate) struct TokenResponse {
-    pub(crate) access_token: Option<String>,
-    pub(crate) id_token: Option<String>,
-    pub(crate) refresh_token: Option<String>,
-    pub(crate) expires_in: Option<u64>,
-    pub(crate) error: Option<String>,
-    pub(crate) error_description: Option<String>,
-}
-
-impl TokenResponse {
-    /// The `error_description`, or a placeholder — for building error messages.
-    pub(crate) fn description(&self) -> &str {
-        self.error_description
-            .as_deref()
-            .unwrap_or("(no description)")
-    }
-}
+/// A `BasicClient` with the Okta authorize / token / device-authorization endpoints set. The
+/// remaining typestate slots (introspection, revocation) stay unset — we never call those.
+pub(crate) type OktaClient =
+    BasicClient<EndpointSet, EndpointSet, EndpointNotSet, EndpointNotSet, EndpointSet>;
 
 /// Build `{issuer}/{path}`, tolerant of a trailing slash on the issuer.
 pub(crate) fn endpoint(issuer: &Url, path: &str) -> String {
@@ -86,82 +77,89 @@ pub(crate) fn endpoint(issuer: &Url, path: &str) -> String {
     )
 }
 
-/// Encode name/value pairs as an `application/x-www-form-urlencoded` string (body or query).
-pub(crate) fn form_body(pairs: &[(&str, &str)]) -> String {
-    serde_urlencoded::to_string(pairs).unwrap_or_default()
-}
-
-/// POST an `application/x-www-form-urlencoded` body to the token endpoint and parse the
-/// response. Does not treat non-2xx as fatal — the OAuth error body is parsed regardless.
-pub(crate) async fn post_token(
-    http: &reqwest::Client,
-    token_url: &str,
-    form: &[(&str, &str)],
-) -> Result<TokenResponse, AuthError> {
-    let body = http
-        .post(token_url)
-        .header(
-            reqwest::header::CONTENT_TYPE,
-            "application/x-www-form-urlencoded",
-        )
-        .body(form_body(form))
-        .send()
-        .await?
-        .text()
-        .await?;
-    serde_json::from_str(&body)
-        .map_err(|e| AuthError::Protocol(format!("could not parse token response: {e}")))
-}
-
-/// Convert a successful token response into a [`TokenSet`].
-pub(crate) fn token_set(tr: TokenResponse) -> Result<TokenSet, AuthError> {
-    let access_token = tr
-        .access_token
-        .ok_or_else(|| AuthError::Protocol("token response missing access_token".into()))?;
-    Ok(TokenSet {
-        access_token,
-        id_token: tr.id_token.unwrap_or_default(),
-        refresh_token: tr.refresh_token,
-        expires_in: tr.expires_in.unwrap_or(0),
-    })
-}
-
-/// Exchange a refresh token for a fresh [`TokenSet`] via the refresh-token grant.
+/// Configure an [`oauth2`] client for the Okta tenant behind `issuer` as a public client
+/// (no secret; credentials go in the request body via [`AuthType::RequestBody`]).
 ///
-/// Okta rotates the refresh token, so the caller must persist the new one. The grant is
-/// flow-agnostic (a token from either login flow refreshes identically), so it lives here
-/// rather than on a specific flow client.
-pub(crate) async fn refresh(
-    http: &reqwest::Client,
-    issuer: &Url,
-    client_id: &str,
-    refresh_token: &str,
-) -> Result<TokenSet, AuthError> {
-    let tr = post_token(
-        http,
-        &endpoint(issuer, "v1/token"),
-        &[
-            ("client_id", client_id),
-            ("grant_type", "refresh_token"),
-            ("refresh_token", refresh_token),
-        ],
-    )
-    .await?;
-    if let Some(err) = tr.error.as_deref() {
-        return Err(AuthError::Protocol(format!(
-            "refresh failed ({err}): {}",
-            tr.description()
-        )));
-    }
-    token_set(tr)
+/// Okta's endpoints are derived from the issuer: `v1/authorize`, `v1/token`,
+/// `v1/device/authorize`. The loopback flow additionally calls `set_redirect_uri` on the
+/// returned client once it has bound a port.
+pub(crate) fn okta_client(issuer: &Url, client_id: &str) -> Result<OktaClient, AuthError> {
+    let auth = AuthUrl::new(endpoint(issuer, "v1/authorize"))
+        .map_err(|e| AuthError::Protocol(format!("invalid authorize URL: {e}")))?;
+    let token = TokenUrl::new(endpoint(issuer, "v1/token"))
+        .map_err(|e| AuthError::Protocol(format!("invalid token URL: {e}")))?;
+    let device = DeviceAuthorizationUrl::new(endpoint(issuer, "v1/device/authorize"))
+        .map_err(|e| AuthError::Protocol(format!("invalid device-authorization URL: {e}")))?;
+    Ok(BasicClient::new(ClientId::new(client_id.to_string()))
+        .set_auth_uri(auth)
+        .set_token_uri(token)
+        .set_device_authorization_url(device)
+        .set_auth_type(AuthType::RequestBody))
 }
 
-/// A reqwest client with the redisctl user agent.
+/// HTTP client for the [`oauth2`] flows. Redirects are disabled so the token/authorize
+/// requests can never be silently bounced to another host.
+pub(crate) fn oauth_http_client() -> Result<oauth2::reqwest::Client, AuthError> {
+    oauth2::reqwest::Client::builder()
+        .redirect(oauth2::reqwest::redirect::Policy::none())
+        .user_agent(concat!("redisctl/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .map_err(|e| AuthError::Protocol(format!("could not build the OAuth HTTP client: {e}")))
+}
+
+/// A reqwest client with the redisctl user agent (used by the SM API exchange).
 pub(crate) fn default_http_client() -> reqwest::Client {
     reqwest::Client::builder()
         .user_agent(concat!("redisctl/", env!("CARGO_PKG_VERSION")))
         .build()
         .expect("building the reqwest client should not fail")
+}
+
+/// Convert a successful [`oauth2`] token response into a [`TokenSet`].
+pub(crate) fn to_token_set(resp: &BasicTokenResponse) -> TokenSet {
+    TokenSet {
+        access_token: resp.access_token().secret().clone(),
+        refresh_token: resp.refresh_token().map(|r| r.secret().clone()),
+        expires_in: resp.expires_in().map(|d| d.as_secs()).unwrap_or(0),
+    }
+}
+
+/// Map an `oauth2` token/authorize error (with the *basic* error body) to an [`AuthError`].
+///
+/// Used by the auth-code, refresh, and device-authorize requests. Transport failures land in
+/// [`AuthError::Protocol`] because the `oauth2` flows run on `oauth2`'s bundled reqwest, whose
+/// error type differs from the one wrapped by [`AuthError::Network`].
+pub(crate) fn map_basic_token_error<RE>(err: BasicRequestTokenError<RE>) -> AuthError
+where
+    RE: std::error::Error,
+{
+    match err {
+        RequestTokenError::ServerResponse(resp) => match resp.error().as_ref() {
+            "access_denied" => AuthError::Denied,
+            "expired_token" => AuthError::Expired,
+            _ => AuthError::Protocol(format!("identity-provider error: {resp}")),
+        },
+        other => AuthError::Protocol(other.to_string()),
+    }
+}
+
+/// Map an `oauth2` device-access-token error to an [`AuthError`]. The device grant has its own
+/// error vocabulary (`authorization_pending` / `slow_down` are handled inside the crate's poll
+/// loop, so only the terminal outcomes reach here).
+pub(crate) fn map_device_token_error<RE>(
+    err: RequestTokenError<RE, DeviceCodeErrorResponse>,
+) -> AuthError
+where
+    RE: std::error::Error,
+{
+    match err {
+        RequestTokenError::ServerResponse(resp) => match resp.error() {
+            DeviceCodeErrorResponseType::ExpiredToken => AuthError::Expired,
+            DeviceCodeErrorResponseType::AccessDenied => AuthError::Denied,
+            _ => AuthError::Protocol(format!("identity-provider error: {resp}")),
+        },
+        other => AuthError::Protocol(other.to_string()),
+    }
 }
 
 /// Truncate a string for inclusion in an error message (char-boundary safe).
@@ -173,6 +171,26 @@ pub(crate) fn truncate(s: &str) -> String {
         let head: String = s.chars().take(MAX).collect();
         format!("{head}…")
     }
+}
+
+/// Exchange a refresh token for a fresh [`TokenSet`] via the refresh-token grant.
+///
+/// Okta rotates the refresh token, so the caller must persist the new one. The grant is
+/// flow-agnostic (a token from either login flow refreshes identically), so it lives here
+/// rather than on a specific flow client.
+pub(crate) async fn refresh(
+    issuer: &Url,
+    client_id: &str,
+    refresh_token: &str,
+) -> Result<TokenSet, AuthError> {
+    let client = okta_client(issuer, client_id)?;
+    let http = oauth_http_client()?;
+    let resp = client
+        .exchange_refresh_token(&RefreshToken::new(refresh_token.to_string()))
+        .request_async(&http)
+        .await
+        .map_err(map_basic_token_error)?;
+    Ok(to_token_set(&resp))
 }
 
 #[cfg(test)]
@@ -197,6 +215,7 @@ mod tests {
             200,
             serde_json::json!({
                 "access_token": "AT2",
+                "token_type": "Bearer",
                 "refresh_token": "RT2",
                 "expires_in": 3600
             }),
@@ -204,12 +223,11 @@ mod tests {
         .await;
 
         let issuer = Url::parse(&server.uri()).unwrap();
-        let t = refresh(&default_http_client(), &issuer, "test-client", "RT1")
-            .await
-            .unwrap();
+        let t = refresh(&issuer, "test-client", "RT1").await.unwrap();
         assert_eq!(t.access_token, "AT2");
         // Okta rotates the refresh token — the caller must persist the new one.
         assert_eq!(t.refresh_token.as_deref(), Some("RT2"));
+        assert_eq!(t.expires_in, 3600);
     }
 
     #[tokio::test]
@@ -223,8 +241,22 @@ mod tests {
         .await;
         let issuer = Url::parse(&server.uri()).unwrap();
         assert!(matches!(
-            refresh(&default_http_client(), &issuer, "test-client", "RT1").await,
+            refresh(&issuer, "test-client", "RT1").await,
             Err(AuthError::Protocol(_))
         ));
+    }
+
+    #[test]
+    fn token_set_debug_redacts_secrets() {
+        let t = TokenSet {
+            access_token: "AT-should-not-appear".into(),
+            refresh_token: Some("RT-should-not-appear".into()),
+            expires_in: 3600,
+        };
+        let dbg = format!("{t:?}");
+        assert!(dbg.contains("<redacted>"));
+        assert!(!dbg.contains("AT-should-not-appear"));
+        assert!(!dbg.contains("RT-should-not-appear"));
+        assert!(dbg.contains("3600"));
     }
 }

--- a/crates/redisctl-core/src/lib.rs
+++ b/crates/redisctl-core/src/lib.rs
@@ -77,7 +77,7 @@ pub mod enterprise;
 // Re-export commonly used items
 pub use auth::{
     AuthError, CapiKey, CloudAuthenticator, DeviceAuthorization, DeviceFlowClient,
-    LoopbackFlowClient, MintedCredentials, PollOutcome, SmAccount, SmApiClient, SmUser, TokenSet,
+    LoopbackFlowClient, MintedCredentials, SmAccount, SmApiClient, SmUser, TokenSet,
 };
 pub use error::{CoreError, Result};
 pub use progress::{ProgressCallback, ProgressEvent, poll_task};

--- a/crates/redisctl/Cargo.toml
+++ b/crates/redisctl/Cargo.toml
@@ -36,6 +36,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }
 rpassword = { workspace = true }
+url = { workspace = true }
 urlencoding = { workspace = true }
 dialoguer = "0.11"
 colored = "2.1"

--- a/crates/redisctl/src/cli/cloud.rs
+++ b/crates/redisctl/src/cli/cloud.rs
@@ -1590,6 +1590,11 @@ COMMAND GROUPS:
 
 Aliases shown in parentheses (e.g. 'cloud db list' instead of 'cloud database list').")]
 pub enum CloudCommands {
+    // -- Authentication --
+    /// Log in to Redis Cloud and manage the session (browser or device flow)
+    #[command(subcommand, display_order = 0)]
+    Auth(CloudAuthCommands),
+
     // -- Core --
     /// Database operations
     #[command(subcommand, display_order = 1, visible_alias = "db")]
@@ -1657,6 +1662,39 @@ pub enum CloudCommands {
     #[command(subcommand, display_order = 41)]
     Workflow(CloudWorkflowCommands),
 }
+/// Authentication subcommands for Redis Cloud.
+#[derive(Debug, Subcommand)]
+pub enum CloudAuthCommands {
+    /// Log in to Redis Cloud and store credentials (mints a CAPI key).
+    ///
+    /// Opens a browser by default; use --device for a headless URL + code flow.
+    Login {
+        /// Use the device-authorization flow (print a URL + code) instead of opening a browser.
+        #[arg(long)]
+        device: bool,
+        /// Store credentials as plaintext in the config file when no OS keyring is available.
+        #[arg(long)]
+        allow_plaintext: bool,
+        /// Block until the device flow is approved (one-shot). Without this, the device flow
+        /// returns the code immediately and `auth status --wait` completes the login — the
+        /// agent-friendly split. The browser (loopback) flow always blocks.
+        #[arg(long)]
+        wait: bool,
+    },
+    /// Report whether the profile is authenticated to Redis Cloud.
+    Status {
+        /// Block until a pending device-authorization login completes (or times out / is
+        /// denied), then run the exchange and persist credentials.
+        #[arg(long)]
+        wait: bool,
+        /// Max seconds to wait when --wait is set.
+        #[arg(long, default_value = "600")]
+        timeout: u64,
+    },
+    /// Remove the locally stored Redis Cloud credentials for the profile.
+    Logout,
+}
+
 #[derive(Debug, Subcommand)]
 pub enum CloudWorkflowCommands {
     /// List available workflows

--- a/crates/redisctl/src/commands/cloud/auth.rs
+++ b/crates/redisctl/src/commands/cloud/auth.rs
@@ -1,0 +1,498 @@
+//! `redisctl cloud auth login | status | logout`
+//!
+//! `login` is a credential bootstrapper: it runs an OIDC flow, exchanges the tokens with the
+//! SM API to mint a CAPI key, and writes a normal cloud profile. Afterward every existing
+//! `cloud` command works.
+//!
+//! Two shapes, matching the agent model:
+//! - **Browser (loopback)** — the default on an interactive terminal: a single blocking
+//!   `login` opens the browser and completes.
+//! - **Device flow** — headless / `--device`: `login` *initiates* and returns the code
+//!   immediately (non-blocking), so an agent can relay it; `status --wait` then blocks until
+//!   the user approves, runs the SM exchange, and persists. `login --device --wait` collapses
+//!   both into one blocking call for a human.
+
+#![allow(dead_code)] // Used by binary target
+
+use std::io::IsTerminal;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use redisctl_core::auth::{CloudAuthenticator, MintedCredentials};
+use redisctl_core::{CloudAuthConfig, Config, CredentialStore, DeviceAuthorization, TokenSet};
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+use crate::cli::CloudAuthCommands;
+use crate::connection::ConnectionManager;
+use crate::error::{RedisCtlError, Result as CliResult};
+use crate::output::{OutputFormat, print_formatted_output};
+use crate::structured_error::StructuredError;
+
+const SCOPES: [&str; 4] = ["openid", "profile", "email", "offline_access"];
+
+/// Above this many `redisctl-*` CAPI keys on an account, `login` nudges the user to revoke
+/// unused ones (a normal user has 1–3; more suggests login/logout cycles without cleanup).
+const STALE_KEY_WARN_THRESHOLD: usize = 3;
+
+/// Wrap an OIDC/SM `AuthError` into the structured exit contract (stable code + exit code).
+fn auth_err(e: redisctl_core::AuthError) -> RedisCtlError {
+    RedisCtlError::Structured(Box::new(StructuredError::from(e)))
+}
+
+pub async fn handle_auth_command(
+    conn_mgr: &ConnectionManager,
+    profile: Option<&str>,
+    cmd: &CloudAuthCommands,
+    output: OutputFormat,
+) -> CliResult<()> {
+    match cmd {
+        CloudAuthCommands::Login {
+            device,
+            allow_plaintext,
+            wait,
+        } => login(conn_mgr, profile, *device, *allow_plaintext, *wait, output).await,
+        CloudAuthCommands::Status { wait, timeout } => {
+            status(conn_mgr, profile, *wait, *timeout, output).await
+        }
+        CloudAuthCommands::Logout => logout(conn_mgr, profile, output),
+    }
+}
+
+/// The profile a login targets: `--profile`, else the configured default cloud profile, else
+/// a conventional `cloud`.
+fn target_profile(conn_mgr: &ConnectionManager, profile: Option<&str>) -> String {
+    profile
+        .map(str::to_string)
+        .or_else(|| conn_mgr.config.default_cloud.clone())
+        .unwrap_or_else(|| "cloud".to_string())
+}
+
+/// Resolve the login endpoints for `profile` and build an authenticator, or a structured
+/// `not_authenticated` error if the environment isn't provisioned for login.
+fn prepare(
+    conn_mgr: &ConnectionManager,
+    profile: Option<&str>,
+) -> CliResult<(String, CloudAuthenticator, CloudAuthConfig)> {
+    let profile_name = target_profile(conn_mgr, profile);
+    let auth_cfg = conn_mgr.config.resolve_cloud_auth(&profile_name);
+    if !auth_cfg.is_complete() {
+        return Err(RedisCtlError::Structured(Box::new(
+            StructuredError::not_authenticated(format!(
+                "cloud login endpoints are not configured for profile '{profile_name}'. Add a \
+                 [cloud_auth.{profile_name}] section (okta_issuer, okta_client_id, sm_api_url) to \
+                 the config, or use a profile whose environment is provisioned."
+            )),
+        )));
+    }
+    let issuer = parse_url(&auth_cfg.okta_issuer, "okta_issuer")?;
+    let sm_api_url = parse_url(&auth_cfg.sm_api_url, "sm_api_url")?;
+    let authenticator = CloudAuthenticator::new(
+        issuer,
+        &auth_cfg.okta_client_id,
+        sm_api_url,
+        &auth_cfg.capi_url,
+    );
+    Ok((profile_name, authenticator, auth_cfg))
+}
+
+async fn login(
+    conn_mgr: &ConnectionManager,
+    profile: Option<&str>,
+    device: bool,
+    allow_plaintext: bool,
+    wait: bool,
+    output: OutputFormat,
+) -> CliResult<()> {
+    let (profile_name, authenticator, auth_cfg) = prepare(conn_mgr, profile)?;
+
+    // Device flow is used with --device or when stderr isn't a TTY (headless / agent / piped);
+    // otherwise the interactive browser (loopback) flow.
+    let use_device = device || !std::io::stderr().is_terminal();
+
+    // Non-blocking device initiate (the agent path): return the code now, complete via
+    // `auth status --wait`. `--wait` (or the loopback flow) blocks through to completion.
+    if use_device && !wait {
+        return initiate_device_login(
+            conn_mgr,
+            &profile_name,
+            &authenticator,
+            allow_plaintext,
+            output,
+        )
+        .await;
+    }
+
+    let tokens = if use_device {
+        run_device_flow_blocking(&authenticator).await?
+    } else {
+        run_loopback_flow(&authenticator).await?
+    };
+    let creds = complete_and_persist(
+        conn_mgr,
+        &profile_name,
+        &authenticator,
+        &tokens,
+        allow_plaintext,
+        auth_cfg,
+    )
+    .await?;
+    emit_signed_in(&creds, &profile_name, output)
+}
+
+/// Start the device flow, save a pending record, and return the device code to the caller
+/// (agent) without blocking. Completion happens later via `auth status --wait`.
+async fn initiate_device_login(
+    conn_mgr: &ConnectionManager,
+    profile_name: &str,
+    authenticator: &CloudAuthenticator,
+    allow_plaintext: bool,
+    output: OutputFormat,
+) -> CliResult<()> {
+    let authz = authenticator
+        .device()
+        .start(&SCOPES)
+        .await
+        .map_err(auth_err)?;
+    let verify = authz
+        .verification_uri_complete()
+        .unwrap_or_else(|| authz.verification_uri());
+
+    save_pending(
+        conn_mgr,
+        &PendingAuth {
+            profile: profile_name.to_string(),
+            device_authorization: authz.clone(),
+            allow_plaintext,
+        },
+    )?;
+
+    eprintln!(
+        "\nTo sign in, open:\n  {verify}\nand confirm the code:  {}\nThen run: redisctl cloud \
+         auth status --wait   (or wait for the agent to poll)",
+        authz.user_code()
+    );
+    print_formatted_output(
+        serde_json::json!({
+            "status": "authorization_pending",
+            "profile": profile_name,
+            "verification_uri": authz.verification_uri(),
+            "verification_uri_complete": authz.verification_uri_complete(),
+            "user_code": authz.user_code(),
+            "expires_in": authz.expires_in(),
+            "interval": authz.interval(),
+        }),
+        output,
+    )
+}
+
+async fn run_device_flow_blocking(auth: &CloudAuthenticator) -> CliResult<TokenSet> {
+    let client = auth.device();
+    let authz = client.start(&SCOPES).await.map_err(auth_err)?;
+    let verify = authz
+        .verification_uri_complete()
+        .unwrap_or_else(|| authz.verification_uri());
+    eprintln!(
+        "\nTo sign in, open:\n  {verify}\nand confirm the code:  {}\n(waiting for approval…)",
+        authz.user_code()
+    );
+
+    // oauth2 owns the poll loop (honoring the server's interval / slow_down); `None` polls until
+    // the device code's own lifetime expires, which surfaces as `device_code_expired` via auth_err.
+    client.poll(&authz, None).await.map_err(auth_err)
+}
+
+async fn run_loopback_flow(auth: &CloudAuthenticator) -> CliResult<TokenSet> {
+    let tokens = auth
+        .loopback()
+        .login(&SCOPES, |url| {
+            eprintln!("Opening your browser to sign in…\n  {url}");
+            let _ = open_browser(url);
+        })
+        .await
+        .map_err(auth_err)?;
+    Ok(tokens)
+}
+
+/// Run the SM exchange, persist the profile + secrets, and return the minted credentials.
+async fn complete_and_persist(
+    conn_mgr: &ConnectionManager,
+    profile_name: &str,
+    authenticator: &CloudAuthenticator,
+    tokens: &TokenSet,
+    allow_plaintext: bool,
+    auth_cfg: CloudAuthConfig,
+) -> CliResult<MintedCredentials> {
+    let creds = authenticator
+        .complete_login(tokens, &default_key_name())
+        .await
+        .map_err(auth_err)?;
+
+    let store = if allow_plaintext {
+        CredentialStore::plaintext()
+    } else {
+        CredentialStore::new()
+    };
+    let mut config = conn_mgr.config.clone();
+    // On the keyring path, a store failure means the OS secret service is unavailable (D4):
+    // surface a distinct `keyring_unavailable` (exit 2) pointing at `--allow-plaintext`.
+    config
+        .apply_cloud_login(&store, profile_name, &creds, Some(auth_cfg))
+        .map_err(|e| {
+            if allow_plaintext {
+                RedisCtlError::from(e)
+            } else {
+                RedisCtlError::Structured(Box::new(StructuredError::keyring_unavailable(format!(
+                    "failed to store credentials in the OS keyring ({e}). Re-run \
+                     `redisctl cloud auth login --allow-plaintext` to store them in the config \
+                     file (0600) instead."
+                ))))
+            }
+        })?;
+    save_config(conn_mgr, &config)?;
+    Ok(creds)
+}
+
+fn emit_signed_in(
+    creds: &MintedCredentials,
+    profile_name: &str,
+    output: OutputFormat,
+) -> CliResult<()> {
+    eprintln!(
+        "\n\u{2713} Signed in as {}. Credentials saved to profile '{}'.",
+        creds.email.as_deref().unwrap_or("your account"),
+        profile_name
+    );
+    // D5: each login mints a new redisctl-* CAPI key. Warn (don't delete) when they pile up.
+    let key_count = creds.redisctl_key_count;
+    if key_count > STALE_KEY_WARN_THRESHOLD {
+        eprintln!(
+            "  note: this account now has {key_count} redisctl-* API keys. Revoke unused ones \
+             in the Redis Cloud console (Access Management > API Keys)."
+        );
+    }
+    print_formatted_output(
+        serde_json::json!({
+            "status": "ok",
+            "authenticated": true,
+            "profile": profile_name,
+            "account_id": creds.account_id,
+            "email": creds.email,
+            "redisctl_key_count": key_count,
+        }),
+        output,
+    )
+}
+
+async fn status(
+    conn_mgr: &ConnectionManager,
+    profile: Option<&str>,
+    wait: bool,
+    timeout: u64,
+    output: OutputFormat,
+) -> CliResult<()> {
+    let profile_name = target_profile(conn_mgr, profile);
+
+    // --wait completes a pending device-authorization login (the agent path): poll, exchange,
+    // persist. With no pending record it falls through to a plain status report.
+    if wait && let Some(pending) = load_pending(conn_mgr, &profile_name) {
+        let (_, authenticator, auth_cfg) = prepare(conn_mgr, Some(&profile_name))?;
+        match poll_pending(&authenticator, &pending, timeout).await? {
+            Some(tokens) => {
+                let creds = complete_and_persist(
+                    conn_mgr,
+                    &profile_name,
+                    &authenticator,
+                    &tokens,
+                    pending.allow_plaintext,
+                    auth_cfg,
+                )
+                .await?;
+                clear_pending(conn_mgr, &profile_name);
+                return emit_signed_in(&creds, &profile_name, output);
+            }
+            None => {
+                // Timed out but the code may still be valid — keep the pending record so a
+                // later `status --wait` can resume; report the pending state (exit 0).
+                return print_formatted_output(
+                    serde_json::json!({
+                        "status": "authorization_pending",
+                        "authenticated": false,
+                        "profile": profile_name,
+                    }),
+                    output,
+                );
+            }
+        }
+    }
+
+    let authenticated = conn_mgr
+        .resolve_cloud_connection(Some(&profile_name))
+        .is_ok();
+    print_formatted_output(
+        serde_json::json!({ "authenticated": authenticated, "profile": profile_name }),
+        output,
+    )
+}
+
+/// Poll a pending device authorization to completion. `Ok(Some)` = approved (tokens),
+/// `Ok(None)` = local `--timeout` elapsed while still pending. `expired`/`denied` from the
+/// server propagate as structured errors.
+async fn poll_pending(
+    auth: &CloudAuthenticator,
+    pending: &PendingAuth,
+    timeout_secs: u64,
+) -> CliResult<Option<TokenSet>> {
+    let client = auth.device();
+    // oauth2 owns the poll loop; bound it by the caller's `--timeout`. If our wait elapses first
+    // the login is still pending (`Ok(None)`); a real expiry/denial from the server surfaces as a
+    // structured error. This keeps "your wait elapsed" distinct from "the device code expired".
+    match tokio::time::timeout(
+        Duration::from_secs(timeout_secs),
+        client.poll(&pending.device_authorization, None),
+    )
+    .await
+    {
+        Err(_elapsed) => Ok(None),
+        Ok(result) => result.map(Some).map_err(auth_err),
+    }
+}
+
+fn logout(
+    conn_mgr: &ConnectionManager,
+    profile: Option<&str>,
+    output: OutputFormat,
+) -> CliResult<()> {
+    let profile_name = target_profile(conn_mgr, profile);
+    // Clear locally-stored secrets (best effort). Note: the minted CAPI key still exists in
+    // the Redis Cloud console until revoked there — server-side revocation is a follow-up.
+    let store = CredentialStore::new();
+    for suffix in ["cloud-api-key", "cloud-api-secret", "okta-refresh"] {
+        let _ = store.delete_credential(&format!("{profile_name}-{suffix}"));
+    }
+    clear_pending(conn_mgr, &profile_name);
+    let mut config = conn_mgr.config.clone();
+    // Logout forgets credentials, not the environment: preserve the [cloud_auth.<profile>]
+    // login endpoints across the profile removal so `auth login` still works afterward
+    // (remove_profile drops them otherwise, which would break re-login on QA/staging).
+    let saved_auth = config.cloud_auth.get(&profile_name).cloned();
+    config.remove_profile(&profile_name);
+    if let Some(auth) = saved_auth {
+        config.cloud_auth.insert(profile_name.clone(), auth);
+    }
+    save_config(conn_mgr, &config)?;
+    print_formatted_output(
+        serde_json::json!({ "status": "ok", "profile": profile_name, "logged_out": true }),
+        output,
+    )
+}
+
+// ---- pending device-authorization store (bridges the non-blocking login and status --wait) ----
+
+/// A device authorization awaiting approval, persisted between the `login` (initiate) and
+/// `status --wait` (complete) process runs.
+#[derive(Serialize, Deserialize)]
+struct PendingAuth {
+    profile: String,
+    /// The full device authorization (serde-serializable), so a later `status --wait` — possibly
+    /// a different process — can resume polling via `DeviceFlowClient::poll`.
+    device_authorization: DeviceAuthorization,
+    allow_plaintext: bool,
+}
+
+/// Directory for the pending file — next to the active config so it honors `--config-file`.
+fn pending_dir(conn_mgr: &ConnectionManager) -> PathBuf {
+    conn_mgr
+        .config_path
+        .as_ref()
+        .and_then(|p| p.parent().map(Path::to_path_buf))
+        .or_else(|| {
+            Config::config_path()
+                .ok()
+                .and_then(|p| p.parent().map(Path::to_path_buf))
+        })
+        .unwrap_or_else(std::env::temp_dir)
+}
+
+fn pending_path(conn_mgr: &ConnectionManager, profile: &str) -> PathBuf {
+    pending_dir(conn_mgr).join(format!("redisctl-pending-{profile}.json"))
+}
+
+fn save_pending(conn_mgr: &ConnectionManager, pending: &PendingAuth) -> CliResult<()> {
+    let path = pending_path(conn_mgr, &pending.profile);
+    let json = serde_json::to_vec_pretty(pending)?;
+    write_private(&path, &json)
+        .map_err(|e| RedisCtlError::Configuration(format!("could not save pending login: {e}")))
+}
+
+fn load_pending(conn_mgr: &ConnectionManager, profile: &str) -> Option<PendingAuth> {
+    let bytes = std::fs::read(pending_path(conn_mgr, profile)).ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+fn clear_pending(conn_mgr: &ConnectionManager, profile: &str) {
+    let _ = std::fs::remove_file(pending_path(conn_mgr, profile));
+}
+
+#[cfg(unix)]
+fn write_private(path: &std::path::Path, bytes: &[u8]) -> std::io::Result<()> {
+    use std::io::Write as _;
+    use std::os::unix::fs::OpenOptionsExt;
+    let mut f = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(path)?;
+    f.write_all(bytes)
+}
+
+#[cfg(not(unix))]
+fn write_private(path: &std::path::Path, bytes: &[u8]) -> std::io::Result<()> {
+    std::fs::write(path, bytes)
+}
+
+fn parse_url(value: &str, field: &str) -> CliResult<Url> {
+    Url::parse(value)
+        .map_err(|e| RedisCtlError::Configuration(format!("invalid {field} ({value:?}): {e}")))
+}
+
+fn save_config(conn_mgr: &ConnectionManager, config: &Config) -> CliResult<()> {
+    match &conn_mgr.config_path {
+        Some(path) => config.save_to_path(path)?,
+        None => config.save()?,
+    }
+    Ok(())
+}
+
+/// A recognizable, unique-per-login CAPI key name (visible/revocable in the console).
+fn default_key_name() -> String {
+    let ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    format!("redisctl-cli-{ts}")
+}
+
+/// Best-effort: open the given URL in the platform browser. Failure is non-fatal (the URL is
+/// also printed for manual opening).
+fn open_browser(url: &str) -> std::io::Result<()> {
+    use std::process::{Command, Stdio};
+    let mut cmd = if cfg!(target_os = "macos") {
+        let mut c = Command::new("open");
+        c.arg(url);
+        c
+    } else if cfg!(target_os = "windows") {
+        let mut c = Command::new("cmd");
+        c.args(["/C", "start", "", url]);
+        c
+    } else {
+        let mut c = Command::new("xdg-open");
+        c.arg(url);
+        c
+    };
+    cmd.stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .map(|_| ())
+}

--- a/crates/redisctl/src/commands/cloud/mod.rs
+++ b/crates/redisctl/src/commands/cloud/mod.rs
@@ -12,6 +12,7 @@ pub mod account;
 pub mod acl;
 pub mod acl_impl;
 pub mod async_utils;
+pub mod auth;
 pub mod cloud_account;
 pub mod cloud_account_impl;
 pub mod connectivity;

--- a/crates/redisctl/src/error.rs
+++ b/crates/redisctl/src/error.rs
@@ -132,6 +132,12 @@ pub enum RedisCtlError {
 
     #[error("Output formatting error: {message}")]
     OutputError { message: String },
+
+    /// Agent-native surface error carrying a stable code + exit code (see
+    /// [`crate::structured_error`]). Handled specially in `main` (JSON envelope to stdout,
+    /// mapped exit code) rather than the generic 0/1 path.
+    #[error("{0}")]
+    Structured(Box<crate::structured_error::StructuredError>),
 }
 
 /// Result type for redisctl operations
@@ -268,6 +274,8 @@ impl RedisCtlError {
             RedisCtlError::ConnectionError { .. } => "connection_error",
             RedisCtlError::Timeout { .. } => "timeout",
             RedisCtlError::OutputError { .. } => "output_error",
+            // Agent-native surface errors carry their own stable code.
+            RedisCtlError::Structured(se) => se.code,
         }
     }
 
@@ -398,6 +406,20 @@ impl From<anyhow::Error> for RedisCtlError {
         // mislabeling every anyhow-wrapped API, IO, or JSON error as a
         // "Configuration error".
         RedisCtlError::Other(format!("{:#}", err))
+    }
+}
+
+impl From<redisctl_core::AuthError> for RedisCtlError {
+    fn from(err: redisctl_core::AuthError) -> Self {
+        match err {
+            redisctl_core::AuthError::Network(e) => RedisCtlError::ConnectionError {
+                message: e.to_string(),
+            },
+            other => RedisCtlError::AuthenticationFailed {
+                message: other.to_string(),
+                profile_name: "<login>".to_string(),
+            },
+        }
     }
 }
 

--- a/crates/redisctl/src/main.rs
+++ b/crates/redisctl/src/main.rs
@@ -23,6 +23,7 @@ mod commands;
 mod connection;
 mod error;
 mod output;
+mod structured_error;
 mod workflows;
 
 use cli::{Cli, Commands};
@@ -413,11 +414,28 @@ async fn main() -> Result<()> {
 
     // Execute command
     if let Err(e) = execute_command(&cli, &conn_mgr).await {
+        // The agent-native surface carries a stable code + exit code: emit the JSON error
+        // envelope to stdout in machine mode (agents parse stdout), the styled diagnostic to
+        // stderr otherwise, and exit with the mapped code. All other errors keep the default
+        // envelope-to-stderr + exit-1 behaviour.
+        if let RedisCtlError::Structured(se) = &e {
+            emit_structured_error(se, cli.output);
+            std::process::exit(se.exit_code as i32);
+        }
         e.print_diagnostic(cli.output);
         std::process::exit(1);
     }
 
     Ok(())
+}
+
+fn emit_structured_error(se: &structured_error::StructuredError, output: cli::OutputFormat) {
+    match output {
+        cli::OutputFormat::Json | cli::OutputFormat::Yaml => {
+            let _ = crate::output::print_output(se.envelope(), output, None);
+        }
+        _ => error::CliDiagnostic::error(&se.message).print(),
+    }
 }
 
 fn init_tracing(verbose: u8) {
@@ -1240,6 +1258,16 @@ async fn execute_cloud_command(
     use cli::CloudCommands::*;
 
     match cloud_cmd {
+        Auth(auth_cmd) => {
+            commands::cloud::auth::handle_auth_command(
+                conn_mgr,
+                cli.profile.as_deref(),
+                auth_cmd,
+                cli.output,
+            )
+            .await
+        }
+
         Account(account_cmd) => {
             commands::cloud::handle_account_command(
                 conn_mgr,

--- a/crates/redisctl/src/structured_error.rs
+++ b/crates/redisctl/src/structured_error.rs
@@ -1,0 +1,193 @@
+//! Machine-branchable error contract for the agent-native surface (starting with `cloud auth *`).
+//!
+//! Existing commands keep today's 0/1 exit behavior; only the new surface produces
+//! [`StructuredError`]. On failure in JSON/YAML mode the CLI prints
+//! `{"status":"error","error":{code,message,retryable}}` to **stdout** (agents parse
+//! stdout) and exits with the mapped code; in human mode it prints the usual diagnostic to
+//! stderr. `message` is always safe to show — it never contains secrets.
+//!
+//! Exit codes: `1` unknown/backend, `2` usage/precondition the caller must fix, `3`
+//! transient/retryable, `4` quota/limit reached.
+
+// The binary target reads these fields/methods (main.rs); the library target can't see that,
+// and a few inventory entries (auth_pending, keyring_unavailable) are defined ahead of use.
+#![allow(dead_code)] // Used by binary target
+
+use redisctl_core::AuthError;
+
+/// A terminal error from the agent-native surface, carrying a stable code and exit status.
+#[derive(Debug, Clone)]
+pub struct StructuredError {
+    /// Stable, append-only identifier (see the inventory below). Agents branch on this.
+    pub code: &'static str,
+    /// Human, actionable, secret-free.
+    pub message: String,
+    /// Whether re-running the same command might succeed (transient failures).
+    pub retryable: bool,
+    /// Process exit code: 1 | 2 | 3 | 4.
+    pub exit_code: u8,
+}
+
+impl std::fmt::Display for StructuredError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for StructuredError {}
+
+impl StructuredError {
+    fn new(code: &'static str, exit_code: u8, retryable: bool, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            exit_code,
+            retryable,
+            message: message.into(),
+        }
+    }
+
+    // --- inventory (append-only) ---
+
+    pub fn device_code_expired() -> Self {
+        Self::new(
+            "device_code_expired",
+            3,
+            true,
+            "the login code expired before it was approved; run `redisctl cloud auth login` again",
+        )
+    }
+    pub fn auth_denied() -> Self {
+        Self::new("auth_denied", 2, false, "the login request was denied")
+    }
+    pub fn auth_pending() -> Self {
+        Self::new(
+            "auth_pending",
+            3,
+            true,
+            "login has not been approved yet; approve it and retry",
+        )
+    }
+    pub fn not_authenticated(message: impl Into<String>) -> Self {
+        Self::new("not_authenticated", 2, false, message)
+    }
+    pub fn sm_exchange_failed(message: impl Into<String>) -> Self {
+        Self::new("sm_exchange_failed", 1, false, message)
+    }
+    pub fn keyring_unavailable(message: impl Into<String>) -> Self {
+        Self::new("keyring_unavailable", 2, false, message)
+    }
+    pub fn invalid_name(message: impl Into<String>) -> Self {
+        Self::new("invalid_name", 2, false, message)
+    }
+    pub fn name_conflict(message: impl Into<String>) -> Self {
+        Self::new("name_conflict", 2, false, message)
+    }
+    pub fn free_db_exists(message: impl Into<String>) -> Self {
+        Self::new("free_db_exists", 4, false, message)
+    }
+    pub fn quota_exceeded(message: impl Into<String>) -> Self {
+        Self::new("quota_exceeded", 4, false, message)
+    }
+    pub fn transient_api_error(message: impl Into<String>) -> Self {
+        Self::new("transient_api_error", 3, true, message)
+    }
+    pub fn rate_limited(message: impl Into<String>) -> Self {
+        Self::new("rate_limited", 3, true, message)
+    }
+    pub fn unknown(message: impl Into<String>) -> Self {
+        Self::new("unknown", 1, false, message)
+    }
+
+    /// The PRD error envelope, printed to stdout in JSON/YAML mode.
+    pub fn envelope(&self) -> serde_json::Value {
+        serde_json::json!({
+            "status": "error",
+            "error": {
+                "code": self.code,
+                "message": self.message,
+                "retryable": self.retryable,
+            }
+        })
+    }
+}
+
+impl From<AuthError> for StructuredError {
+    fn from(err: AuthError) -> Self {
+        match err {
+            AuthError::Expired => Self::device_code_expired(),
+            AuthError::Denied => Self::auth_denied(),
+            // Transport failures to the IdP are worth retrying.
+            AuthError::Network(e) => Self::transient_api_error(format!(
+                "network error contacting the identity provider: {e}"
+            )),
+            // Unexpected IdP / SM response during the login exchange.
+            AuthError::Protocol(msg) => {
+                Self::sm_exchange_failed(format!("login exchange failed: {msg}"))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every constructor maps to a deliberate (exit_code, retryable) pair; exit codes stay in
+    /// the documented 1–4 range and retryable is only ever set for the 3-class.
+    #[test]
+    fn inventory_is_consistent() {
+        let all = [
+            StructuredError::device_code_expired(),
+            StructuredError::auth_denied(),
+            StructuredError::auth_pending(),
+            StructuredError::not_authenticated("x"),
+            StructuredError::sm_exchange_failed("x"),
+            StructuredError::keyring_unavailable("x"),
+            StructuredError::invalid_name("x"),
+            StructuredError::name_conflict("x"),
+            StructuredError::free_db_exists("x"),
+            StructuredError::quota_exceeded("x"),
+            StructuredError::transient_api_error("x"),
+            StructuredError::rate_limited("x"),
+            StructuredError::unknown("x"),
+        ];
+        for e in &all {
+            assert!(
+                (1..=4).contains(&e.exit_code),
+                "{}: exit_code {} out of range",
+                e.code,
+                e.exit_code
+            );
+            // retryable is reserved for the transient (exit 3) class.
+            assert_eq!(
+                e.retryable,
+                e.exit_code == 3,
+                "{}: retryable must align with exit 3",
+                e.code
+            );
+        }
+    }
+
+    #[test]
+    fn auth_error_mapping() {
+        assert_eq!(
+            StructuredError::from(AuthError::Expired).code,
+            "device_code_expired"
+        );
+        assert_eq!(StructuredError::from(AuthError::Denied).code, "auth_denied");
+        assert_eq!(
+            StructuredError::from(AuthError::Protocol("boom".into())).code,
+            "sm_exchange_failed"
+        );
+    }
+
+    #[test]
+    fn envelope_shape() {
+        let e = StructuredError::invalid_name("bad name");
+        let env = e.envelope();
+        assert_eq!(env["status"], "error");
+        assert_eq!(env["error"]["code"], "invalid_name");
+        assert_eq!(env["error"]["retryable"], false);
+        assert_eq!(env["error"]["message"], "bad name");
+    }
+}

--- a/crates/redisctl/tests/cloud_auth_tests.rs
+++ b/crates/redisctl/tests/cloud_auth_tests.rs
@@ -1,0 +1,160 @@
+//! CLI tests for the agent-native `cloud auth` command split (non-blocking device `login`
+//! that returns the code + a `status --wait` that completes). Uses a wiremock Okta issuer.
+
+use assert_cmd::Command;
+use serde_json::{Value, json};
+use tempfile::TempDir;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// Config with a `qa` cloud profile whose login endpoints point at the mock issuer.
+fn write_config(temp: &TempDir, issuer_base: &str) {
+    let config = format!(
+        r#"
+default_cloud = "qa"
+
+[cloud_auth.qa]
+okta_issuer = "{issuer_base}/oauth2/default"
+okta_client_id = "test-client"
+sm_api_url = "{issuer_base}/api/v1"
+capi_url = "{issuer_base}/v1"
+"#
+    );
+    std::fs::write(temp.path().join("config.toml"), config).unwrap();
+}
+
+fn cmd(temp: &TempDir) -> Command {
+    let mut c = Command::cargo_bin("redisctl").unwrap();
+    c.env_remove("REDIS_CLOUD_API_KEY");
+    c.env_remove("REDIS_CLOUD_SECRET_KEY");
+    c.env_remove("REDISCTL_PROFILE");
+    c.arg("--config-file").arg(temp.path().join("config.toml"));
+    c
+}
+
+/// `auth login --device` (no --wait) initiates the flow, prints the code, and returns without
+/// blocking — writing a pending record for `status --wait` to complete.
+#[tokio::test]
+async fn device_login_initiates_without_blocking() {
+    let temp = TempDir::new().unwrap();
+    let server = MockServer::start().await;
+    write_config(&temp, &server.uri());
+
+    Mock::given(method("POST"))
+        .and(path("/oauth2/default/v1/device/authorize"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "device_code": "DEV-CODE-123",
+            "user_code": "WDJB-MJHT",
+            "verification_uri": "https://example.test/activate",
+            "verification_uri_complete": "https://example.test/activate?user_code=WDJB-MJHT",
+            "expires_in": 600,
+            "interval": 5
+        })))
+        .mount(&server)
+        .await;
+
+    let output = cmd(&temp)
+        .args([
+            "cloud",
+            "auth",
+            "login",
+            "--profile",
+            "qa",
+            "--device",
+            "-o",
+            "json",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+
+    // Returned the device code immediately (non-blocking) — no secret, no tokens.
+    let report: Value = serde_json::from_slice(&output.stdout).expect("stdout is JSON");
+    assert_eq!(report["status"], "authorization_pending");
+    assert_eq!(report["user_code"], "WDJB-MJHT");
+    assert_eq!(
+        report["verification_uri_complete"],
+        "https://example.test/activate?user_code=WDJB-MJHT"
+    );
+
+    // A pending record was written next to the config so `status --wait` can resume it.
+    let pending = temp.path().join("redisctl-pending-qa.json");
+    assert!(pending.exists(), "pending record should be written");
+    let saved: Value = serde_json::from_slice(&std::fs::read(&pending).unwrap()).unwrap();
+    // The full device authorization (carrying the device code) is persisted so `status --wait`
+    // can resume polling; assert the code round-tripped without coupling to its exact nesting.
+    assert!(
+        saved.to_string().contains("DEV-CODE-123"),
+        "pending record should carry the device authorization"
+    );
+    assert_eq!(saved["profile"], "qa");
+}
+
+/// `status --wait` with a pending record still awaiting approval polls until the local timeout
+/// and reports `authorization_pending` (exit 0), keeping the record for a later resume.
+#[tokio::test]
+async fn status_wait_reports_pending_until_approved() {
+    let temp = TempDir::new().unwrap();
+    let server = MockServer::start().await;
+    write_config(&temp, &server.uri());
+
+    Mock::given(method("POST"))
+        .and(path("/oauth2/default/v1/device/authorize"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "device_code": "DEV-CODE-123",
+            "user_code": "WDJB-MJHT",
+            "verification_uri": "https://example.test/activate",
+            "expires_in": 600,
+            "interval": 1
+        })))
+        .mount(&server)
+        .await;
+    // The token endpoint keeps saying "pending" (user hasn't approved yet).
+    Mock::given(method("POST"))
+        .and(path("/oauth2/default/v1/token"))
+        .respond_with(ResponseTemplate::new(400).set_body_json(json!({
+            "error": "authorization_pending"
+        })))
+        .mount(&server)
+        .await;
+
+    // Initiate.
+    cmd(&temp)
+        .args([
+            "cloud",
+            "auth",
+            "login",
+            "--profile",
+            "qa",
+            "--device",
+            "-o",
+            "json",
+        ])
+        .assert()
+        .success();
+
+    // Wait with a short timeout — still pending, exits 0 with a pending report.
+    let output = cmd(&temp)
+        .args([
+            "cloud",
+            "auth",
+            "status",
+            "--profile",
+            "qa",
+            "--wait",
+            "--timeout",
+            "1",
+            "-o",
+            "json",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+    let report: Value = serde_json::from_slice(&output.stdout).expect("stdout is JSON");
+    assert_eq!(report["status"], "authorization_pending");
+    assert_eq!(report["authenticated"], false);
+    // Record kept so a later `status --wait` can resume.
+    assert!(temp.path().join("redisctl-pending-qa.json").exists());
+}


### PR DESCRIPTION
## Summary

Adds the `cloud auth login | status | logout` commands — the user-facing entry point of the
agent-native surface.

- `cloud auth login` runs an OIDC sign-in (interactive browser/loopback by default, or the
  device-authorization flow when headless / `--device`), exchanges the tokens with the SM API to
  mint a Redis Cloud API key, and writes it into a normal cloud profile — after which every
  existing `cloud` command works.
- `cloud auth status` reports auth state; `--wait [--timeout]` completes a pending device-flow
  login (the agent-friendly initiate/wait split).
- `cloud auth logout` clears the locally stored credentials while preserving the login endpoints.

Also adds the agent-native error contract this surface reports through, **layered on top of the
existing `-o json/yaml` error envelope** (existing commands are unchanged): a
`RedisCtlError::Structured` variant + `structured_error::StructuredError` — a stable `code` +
`retryable` + a mapped exit code (1/2/3/4), emitted as a JSON envelope to **stdout** in machine
mode so an agent can branch on `.error.code` and on the process exit status. `From<AuthError>`
maps the OIDC/SM failures onto it.

Fully **additive**: no existing command, flag, exit code, or behaviour changes.

## Scope

- **Affected areas:** `crates/redisctl` — `cli/cloud.rs`, `commands/cloud/auth.rs` (new), `structured_error.rs` (new), `error.rs` (`Structured` variant + `code()` arm + `From<AuthError>`), `main.rs` (agent-surface envelope→stdout + mapped exit, layered before the default handler), `Cargo.toml` (`url`).
- **API surface changes:** new `cloud auth login | status | logout`; the machine-branchable contract applies to the new surface only. No existing commands, flags, or exit codes change.
- **Docs/tests:** module docs, `structured_error` unit tests (code/exit-code invariant, envelope shape, `AuthError` mapping), and integration tests against a mock OIDC issuer.

## Testing

```cargo test -p redisctl --test cloud_auth_tests   # integration tests against a mock issuer```
```cargo test -p redisctl --bins structured_error   # error-contract unit tests```
```cargo clippy --workspace --all-targets --all-features -- -D warnings```

Live sign-in against QA needs environment-specific OIDC endpoints, which are intentionally kept
out of this repo. See [RED-210014](https://redislabs.atlassian.net/browse/RED-210014) for the `[cloud_auth.qa]` block, then:

```redisctl cloud auth login --profile qa```

## Auth flows

The Okta OIDC portions (device grant, auth-code + PKCE, token exchange, refresh) are handled by the
`oauth2` crate; the SM `/login` → CAPI-key exchange is redisctl's custom domain logic.

**Browser (loopback) — the interactive default:**

```mermaid
sequenceDiagram
    actor U as User
    participant CLI as redisctl
    participant OK as Okta (OIDC)
    participant SM as SM API
    participant CFG as profile + keyring
    U->>CLI: cloud auth login
    Note over CLI: bind loopback port, build PKCE and state
    CLI->>OK: open browser to /v1/authorize (PKCE challenge, state)
    U->>OK: sign in
    OK-->>CLI: redirect to loopback /callback (code, state)
    Note over CLI: validate state BEFORE responding, then success page
    CLI->>OK: POST /v1/token (code + PKCE verifier)
    OK-->>CLI: access + refresh tokens
    CLI->>SM: POST /login (Bearer access token)
    SM-->>CLI: session (JSESSIONID + CSRF)
    CLI->>SM: enable CAPI, mint a redisctl key
    SM-->>CLI: account API key + user secret
    CLI->>CFG: write cloud profile (secrets to keyring)
    CLI-->>U: signed in - profile ready
```

**Device flow — headless / agent (`--device`): non-blocking initiate, then `status --wait`:**

```mermaid
sequenceDiagram
    actor A as Agent
    actor H as Human
    participant CLI as redisctl
    participant OK as Okta (OIDC)
    participant SM as SM API
    participant CFG as profile + keyring
    A->>CLI: cloud auth login --device
    CLI->>OK: POST /v1/device/authorize
    OK-->>CLI: user_code, verification_uri, device_code
    CLI-->>A: authorization_pending + code (writes pending record)
    A->>H: relay verification URL + code
    H->>OK: open URL, sign in, confirm code
    A->>CLI: cloud auth status --wait
    CLI->>OK: poll /v1/token (device grant) until approved
    OK-->>CLI: access + refresh tokens
    CLI->>SM: login, enable CAPI, mint a redisctl key
    SM-->>CLI: account API key + user secret
    CLI->>CFG: write cloud profile
    CLI-->>A: authenticated + account_id
```

## Checklist

- [x] Scope and plan documented in this description
- [x] Tests added/updated; both success and error cases covered
- [x] Docs updated (module overviews, examples)
- [x] cargo fmt, clippy (-D warnings), tests pass locally
- [ ] CI status is green
- [x] Ready for review (remove Draft)
- [ ] Squash and merge when approved


[RED-210014]: https://redislabs.atlassian.net/browse/RED-210014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
