### PR TITLE
refactor(cli): use the canonical dispatch pattern for alerts and license

### DIFF
--- a/crates/redisctl/src/cli/enterprise.rs
+++ b/crates/redisctl/src/cli/enterprise.rs
@@ -93,7 +93,7 @@ pub enum EnterpriseCommands {
 
     /// Alert management operations
     #[command(subcommand, display_order = 22, visible_alias = "alert")]
-    Alerts(crate::commands::enterprise::alerts::AlertsCommands),
+    Alerts(EnterpriseAlertsCommands),
 
     /// Log operations
     #[command(subcommand, display_order = 23, visible_alias = "log")]
@@ -110,7 +110,7 @@ pub enum EnterpriseCommands {
     // -- Administration --
     /// License management
     #[command(subcommand, display_order = 30, visible_alias = "lic")]
-    License(crate::commands::enterprise::license::LicenseCommands),
+    License(EnterpriseLicenseCommands),
 
     /// Module management operations
     #[command(subcommand, display_order = 31)]
@@ -195,7 +195,7 @@ pub enum EnterpriseWorkflowCommands {
     List,
     /// License management workflows
     #[command(subcommand)]
-    License(crate::commands::enterprise::license_workflow::LicenseWorkflowCommands),
+    License(EnterpriseLicenseWorkflowCommands),
 
     /// Initialize a Redis Enterprise cluster
     #[command(name = "init-cluster")]
@@ -227,6 +227,174 @@ pub enum EnterpriseWorkflowCommands {
         /// Async operation options
         #[command(flatten)]
         async_ops: crate::commands::cloud::async_utils::AsyncOperationArgs,
+    },
+}
+
+/// Alert management commands
+#[derive(Debug, Subcommand)]
+pub enum EnterpriseAlertsCommands {
+    /// List all alerts
+    List {
+        /// Filter by alert type (cluster, node, bdb)
+        #[arg(long)]
+        filter_type: Option<String>,
+        /// Filter by severity (info, warning, error, critical)
+        #[arg(long)]
+        severity: Option<String>,
+    },
+    /// Get specific alert
+    Get {
+        /// Alert UID
+        uid: u64,
+    },
+    /// Get cluster alerts
+    Cluster {
+        /// Specific alert name
+        #[arg(long)]
+        alert: Option<String>,
+    },
+    /// Get node alerts
+    Node {
+        /// Node UID (optional, defaults to all nodes)
+        node_uid: Option<u64>,
+        /// Specific alert name
+        #[arg(long)]
+        alert: Option<String>,
+    },
+    /// Get database alerts
+    Database {
+        /// Database UID (optional, defaults to all databases)
+        bdb_uid: Option<u64>,
+        /// Specific alert name
+        #[arg(long)]
+        alert: Option<String>,
+    },
+    /// Get alert settings
+    #[command(name = "settings-get")]
+    SettingsGet,
+    /// Update alert settings
+    #[command(
+        name = "settings-update",
+        after_help = "EXAMPLES:
+    # Enable cluster alerts
+    redisctl enterprise alerts settings-update --cluster-alerts true
+
+    # Set alert thresholds
+    redisctl enterprise alerts settings-update --memory-threshold 80 --cpu-threshold 90
+
+    # Using JSON for full configuration
+    redisctl enterprise alerts settings-update --data @settings.json"
+    )]
+    SettingsUpdate {
+        /// Enable/disable cluster alerts
+        #[arg(long)]
+        cluster_alerts: Option<bool>,
+        /// Enable/disable node alerts
+        #[arg(long)]
+        node_alerts: Option<bool>,
+        /// Enable/disable database alerts
+        #[arg(long)]
+        bdb_alerts: Option<bool>,
+        /// Memory usage threshold percentage for alerts
+        #[arg(long)]
+        memory_threshold: Option<u32>,
+        /// CPU usage threshold percentage for alerts
+        #[arg(long)]
+        cpu_threshold: Option<u32>,
+        /// JSON data for alert settings (optional, use '-' for stdin)
+        #[arg(long, value_name = "FILE|JSON")]
+        data: Option<String>,
+    },
+}
+
+/// License management commands
+#[derive(Debug, Subcommand)]
+pub enum EnterpriseLicenseCommands {
+    /// Get current license information
+    Get,
+    /// Update license with JSON data
+    #[command(after_help = "EXAMPLES:
+    # Update license with key
+    redisctl enterprise license update --license-key ABC123...
+
+    # Using JSON file
+    redisctl enterprise license update --data @license.json")]
+    Update {
+        /// License key string
+        #[arg(long)]
+        license_key: Option<String>,
+        /// License data as JSON string or @file.json (optional)
+        #[arg(long, value_name = "FILE|JSON")]
+        data: Option<String>,
+    },
+    /// Upload license file
+    Upload {
+        /// Path to license file
+        #[arg(long)]
+        file: String,
+    },
+    /// Validate license
+    #[command(after_help = "EXAMPLES:
+    # Validate license key
+    redisctl enterprise license validate --license-key ABC123...
+
+    # Validate from JSON
+    redisctl enterprise license validate --data @license.json")]
+    Validate {
+        /// License key string to validate
+        #[arg(long)]
+        license_key: Option<String>,
+        /// License data as JSON string or @file.json (optional)
+        #[arg(long, value_name = "FILE|JSON")]
+        data: Option<String>,
+    },
+    /// Check license expiration
+    Expiry,
+    /// List licensed features
+    Features,
+    /// Show license usage and limits
+    Usage,
+}
+
+/// License workflow commands
+#[derive(Debug, Subcommand)]
+pub enum EnterpriseLicenseWorkflowCommands {
+    /// Audit licenses across all configured profiles
+    Audit {
+        /// Only show profiles with expiring licenses (within 30 days)
+        #[arg(long)]
+        expiring: bool,
+        /// Only show profiles with expired licenses
+        #[arg(long)]
+        expired: bool,
+    },
+    /// Update license across multiple profiles
+    #[command(name = "bulk-update")]
+    BulkUpdate {
+        /// Profiles to update (comma-separated, or 'all' for all enterprise profiles)
+        #[arg(long)]
+        profiles: String,
+        /// License data as JSON string or @file.json
+        #[arg(long)]
+        data: String,
+        /// Dry run - show what would be updated without making changes
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Generate license compliance report
+    Report {
+        /// Output format for report (csv for spreadsheet export)
+        #[arg(long, default_value = "table")]
+        format: String,
+    },
+    /// Monitor license expiration and send alerts
+    Monitor {
+        /// Days before expiration to trigger warning
+        #[arg(long, default_value = "30")]
+        warning_days: i64,
+        /// Exit with error code if any licenses are expiring
+        #[arg(long)]
+        fail_on_warning: bool,
     },
 }
 

--- a/crates/redisctl/src/commands/enterprise/alerts.rs
+++ b/crates/redisctl/src/commands/enterprise/alerts.rs
@@ -1,487 +1,97 @@
-use crate::error::RedisCtlError;
-use anyhow::Result as AnyhowResult;
-use clap::Subcommand;
-use redisctl_core::Config;
-use serde_json::Value;
+//! Enterprise alerts command handler
 
-use crate::cli::OutputFormat;
+use crate::cli::{EnterpriseAlertsCommands, OutputFormat};
+use crate::connection::ConnectionManager;
+use crate::error::{RedisCtlError, Result as CliResult};
 
-#[derive(Debug, Subcommand)]
-pub enum AlertsCommands {
-    /// List all alerts
-    List {
-        /// Filter by alert type (cluster, node, bdb)
-        #[arg(long)]
-        filter_type: Option<String>,
-        /// Filter by severity (info, warning, error, critical)
-        #[arg(long)]
-        severity: Option<String>,
-    },
-    /// Get specific alert
-    Get {
-        /// Alert UID
-        uid: u64,
-    },
-    /// Get cluster alerts
-    Cluster {
-        /// Specific alert name
-        #[arg(long)]
-        alert: Option<String>,
-    },
-    /// Get node alerts
-    Node {
-        /// Node UID (optional, defaults to all nodes)
-        node_uid: Option<u64>,
-        /// Specific alert name
-        #[arg(long)]
-        alert: Option<String>,
-    },
-    /// Get database alerts
-    Database {
-        /// Database UID (optional, defaults to all databases)
-        bdb_uid: Option<u64>,
-        /// Specific alert name
-        #[arg(long)]
-        alert: Option<String>,
-    },
-    /// Get alert settings
-    #[command(name = "settings-get")]
-    SettingsGet,
-    /// Update alert settings
-    #[command(
-        name = "settings-update",
-        after_help = "EXAMPLES:
-    # Enable cluster alerts
-    redisctl enterprise alerts settings-update --cluster-alerts true
+use super::alerts_impl;
 
-    # Set alert thresholds
-    redisctl enterprise alerts settings-update --memory-threshold 80 --cpu-threshold 90
-
-    # Using JSON for full configuration
-    redisctl enterprise alerts settings-update --data @settings.json"
-    )]
-    SettingsUpdate {
-        /// Enable/disable cluster alerts
-        #[arg(long)]
-        cluster_alerts: Option<bool>,
-        /// Enable/disable node alerts
-        #[arg(long)]
-        node_alerts: Option<bool>,
-        /// Enable/disable database alerts
-        #[arg(long)]
-        bdb_alerts: Option<bool>,
-        /// Memory usage threshold percentage for alerts
-        #[arg(long)]
-        memory_threshold: Option<u32>,
-        /// CPU usage threshold percentage for alerts
-        #[arg(long)]
-        cpu_threshold: Option<u32>,
-        /// JSON data for alert settings (optional, use '-' for stdin)
-        #[arg(long, value_name = "FILE|JSON")]
-        data: Option<String>,
-    },
-}
-
-impl AlertsCommands {
-    pub async fn execute(
-        &self,
-        config: &Config,
-        profile_name: Option<&str>,
-        output_format: OutputFormat,
-        query: Option<&str>,
-    ) -> AnyhowResult<()> {
-        let conn_manager = crate::connection::ConnectionManager::new(config.clone());
-
-        match self {
-            Self::List {
-                filter_type,
-                severity,
-            } => {
-                handle_list_alerts(
-                    &conn_manager,
-                    profile_name,
-                    filter_type.as_deref(),
-                    severity.as_deref(),
-                    output_format,
-                    query,
-                )
-                .await
-            }
-            Self::Get { uid } => {
-                handle_get_alert(&conn_manager, profile_name, *uid, output_format, query).await
-            }
-            Self::Cluster { alert } => {
-                handle_cluster_alerts(
-                    &conn_manager,
-                    profile_name,
-                    alert.as_deref(),
-                    output_format,
-                    query,
-                )
-                .await
-            }
-            Self::Node { node_uid, alert } => {
-                handle_node_alerts(
-                    &conn_manager,
-                    profile_name,
-                    *node_uid,
-                    alert.as_deref(),
-                    output_format,
-                    query,
-                )
-                .await
-            }
-            Self::Database { bdb_uid, alert } => {
-                handle_database_alerts(
-                    &conn_manager,
-                    profile_name,
-                    *bdb_uid,
-                    alert.as_deref(),
-                    output_format,
-                    query,
-                )
-                .await
-            }
-            Self::SettingsGet => {
-                handle_get_alert_settings(&conn_manager, profile_name, output_format, query).await
-            }
-            Self::SettingsUpdate {
-                cluster_alerts,
-                node_alerts,
-                bdb_alerts,
-                memory_threshold,
-                cpu_threshold,
-                data,
-            } => {
-                handle_update_alert_settings(
-                    &conn_manager,
-                    profile_name,
-                    *cluster_alerts,
-                    *node_alerts,
-                    *bdb_alerts,
-                    *memory_threshold,
-                    *cpu_threshold,
-                    data.as_deref(),
-                    output_format,
-                    query,
-                )
-                .await
-            }
+/// Handle enterprise alerts commands
+pub async fn handle_alerts_command(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    command: &EnterpriseAlertsCommands,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    let result = match command {
+        EnterpriseAlertsCommands::List {
+            filter_type,
+            severity,
+        } => {
+            alerts_impl::list_alerts(
+                conn_mgr,
+                profile_name,
+                filter_type.as_deref(),
+                severity.as_deref(),
+                output_format,
+                query,
+            )
+            .await
         }
-    }
-}
-
-async fn handle_list_alerts(
-    conn_mgr: &crate::connection::ConnectionManager,
-    profile_name: Option<&str>,
-    filter_type: Option<&str>,
-    severity: Option<&str>,
-    output_format: OutputFormat,
-    query: Option<&str>,
-) -> AnyhowResult<()> {
-    let client = conn_mgr.create_enterprise_client(profile_name).await?;
-
-    // Get alerts from all sources and combine
-    let mut all_alerts = Vec::new();
-
-    // Get cluster alerts
-    if (filter_type.is_none() || filter_type == Some("cluster"))
-        && let Ok(cluster_alerts) = client.get::<Value>("/v1/cluster/alerts").await
-        && let Some(alerts) = cluster_alerts.as_array()
-    {
-        for alert in alerts {
-            let mut alert = alert.clone();
-            if let Some(obj) = alert.as_object_mut() {
-                obj.insert("type".to_string(), Value::String("cluster".to_string()));
-            }
-            all_alerts.push(alert);
+        EnterpriseAlertsCommands::Get { uid } => {
+            alerts_impl::get_alert(conn_mgr, profile_name, *uid, output_format, query).await
         }
-    }
-
-    // Get node alerts
-    if (filter_type.is_none() || filter_type == Some("node"))
-        && let Ok(node_alerts) = client.get::<Value>("/v1/nodes/alerts").await
-        && let Some(alerts) = node_alerts.as_array()
-    {
-        for alert in alerts {
-            let mut alert = alert.clone();
-            if let Some(obj) = alert.as_object_mut() {
-                obj.insert("type".to_string(), Value::String("node".to_string()));
-            }
-            all_alerts.push(alert);
+        EnterpriseAlertsCommands::Cluster { alert } => {
+            alerts_impl::cluster_alerts(
+                conn_mgr,
+                profile_name,
+                alert.as_deref(),
+                output_format,
+                query,
+            )
+            .await
         }
-    }
-
-    // Get database alerts
-    if (filter_type.is_none() || filter_type == Some("bdb"))
-        && let Ok(bdb_alerts) = client.get::<Value>("/v1/bdbs/alerts").await
-        && let Some(alerts) = bdb_alerts.as_array()
-    {
-        for alert in alerts {
-            let mut alert = alert.clone();
-            if let Some(obj) = alert.as_object_mut() {
-                obj.insert("type".to_string(), Value::String("database".to_string()));
-            }
-            all_alerts.push(alert);
+        EnterpriseAlertsCommands::Node { node_uid, alert } => {
+            alerts_impl::node_alerts(
+                conn_mgr,
+                profile_name,
+                *node_uid,
+                alert.as_deref(),
+                output_format,
+                query,
+            )
+            .await
         }
-    }
-
-    // Filter by severity if specified
-    if let Some(severity) = severity {
-        all_alerts.retain(|alert| {
-            alert
-                .get("severity")
-                .and_then(|s| s.as_str())
-                .map(|s| s.eq_ignore_ascii_case(severity))
-                .unwrap_or(false)
-        });
-    }
-
-    let response = Value::Array(all_alerts);
-
-    // Apply JMESPath query if provided
-    let response = if let Some(q) = query {
-        super::utils::apply_jmespath(&response, q)?
-    } else {
-        response
+        EnterpriseAlertsCommands::Database { bdb_uid, alert } => {
+            alerts_impl::database_alerts(
+                conn_mgr,
+                profile_name,
+                *bdb_uid,
+                alert.as_deref(),
+                output_format,
+                query,
+            )
+            .await
+        }
+        EnterpriseAlertsCommands::SettingsGet => {
+            alerts_impl::get_alert_settings(conn_mgr, profile_name, output_format, query).await
+        }
+        EnterpriseAlertsCommands::SettingsUpdate {
+            cluster_alerts,
+            node_alerts,
+            bdb_alerts,
+            memory_threshold,
+            cpu_threshold,
+            data,
+        } => {
+            alerts_impl::update_alert_settings(
+                conn_mgr,
+                profile_name,
+                *cluster_alerts,
+                *node_alerts,
+                *bdb_alerts,
+                *memory_threshold,
+                *cpu_threshold,
+                data.as_deref(),
+                output_format,
+                query,
+            )
+            .await
+        }
     };
 
-    super::utils::print_formatted_output(response, output_format).map_err(|e| anyhow::anyhow!(e))
-}
-
-async fn handle_get_alert(
-    conn_mgr: &crate::connection::ConnectionManager,
-    profile_name: Option<&str>,
-    uid: u64,
-    output_format: OutputFormat,
-    query: Option<&str>,
-) -> AnyhowResult<()> {
-    let client = conn_mgr.create_enterprise_client(profile_name).await?;
-
-    // Try to find the alert in different endpoints
-    // First try cluster alerts
-    if let Ok(alerts) = client
-        .get::<Value>(&format!("/v1/cluster/alerts/{}", uid))
-        .await
-    {
-        let response = if let Some(q) = query {
-            super::utils::apply_jmespath(&alerts, q)?
-        } else {
-            alerts
-        };
-        return super::utils::print_formatted_output(response, output_format)
-            .map_err(|e| anyhow::anyhow!(e));
-    }
-
-    // Try node alerts
-    if let Ok(alerts) = client
-        .get::<Value>(&format!("/v1/nodes/alerts/{}", uid))
-        .await
-    {
-        let response = if let Some(q) = query {
-            super::utils::apply_jmespath(&alerts, q)?
-        } else {
-            alerts
-        };
-        return super::utils::print_formatted_output(response, output_format)
-            .map_err(|e| anyhow::anyhow!(e));
-    }
-
-    // Try database alerts
-    if let Ok(alerts) = client
-        .get::<Value>(&format!("/v1/bdbs/alerts/{}", uid))
-        .await
-    {
-        let response = if let Some(q) = query {
-            super::utils::apply_jmespath(&alerts, q)?
-        } else {
-            alerts
-        };
-        return super::utils::print_formatted_output(response, output_format)
-            .map_err(|e| anyhow::anyhow!(e));
-    }
-
-    anyhow::bail!("Alert with UID {} not found", uid)
-}
-
-async fn handle_cluster_alerts(
-    conn_mgr: &crate::connection::ConnectionManager,
-    profile_name: Option<&str>,
-    alert: Option<&str>,
-    output_format: OutputFormat,
-    query: Option<&str>,
-) -> AnyhowResult<()> {
-    let client = conn_mgr.create_enterprise_client(profile_name).await?;
-
-    let endpoint = if let Some(alert_name) = alert {
-        format!("/v1/cluster/alerts/{}", alert_name)
-    } else {
-        "/v1/cluster/alerts".to_string()
-    };
-
-    let response = client
-        .get::<Value>(&endpoint)
-        .await
-        .map_err(RedisCtlError::from)?;
-
-    let response = if let Some(q) = query {
-        super::utils::apply_jmespath(&response, q)?
-    } else {
-        response
-    };
-
-    super::utils::print_formatted_output(response, output_format).map_err(|e| anyhow::anyhow!(e))
-}
-
-async fn handle_node_alerts(
-    conn_mgr: &crate::connection::ConnectionManager,
-    profile_name: Option<&str>,
-    node_uid: Option<u64>,
-    alert: Option<&str>,
-    output_format: OutputFormat,
-    query: Option<&str>,
-) -> AnyhowResult<()> {
-    let client = conn_mgr.create_enterprise_client(profile_name).await?;
-
-    let endpoint = match (node_uid, alert) {
-        (Some(uid), Some(alert_name)) => format!("/v1/nodes/alerts/{}/{}", uid, alert_name),
-        (Some(uid), None) => format!("/v1/nodes/alerts/{}", uid),
-        (None, None) => "/v1/nodes/alerts".to_string(),
-        (None, Some(_)) => anyhow::bail!("Cannot specify alert without node_uid"),
-    };
-
-    let response = client
-        .get::<Value>(&endpoint)
-        .await
-        .map_err(RedisCtlError::from)?;
-
-    let response = if let Some(q) = query {
-        super::utils::apply_jmespath(&response, q)?
-    } else {
-        response
-    };
-
-    super::utils::print_formatted_output(response, output_format).map_err(|e| anyhow::anyhow!(e))
-}
-
-async fn handle_database_alerts(
-    conn_mgr: &crate::connection::ConnectionManager,
-    profile_name: Option<&str>,
-    bdb_uid: Option<u64>,
-    alert: Option<&str>,
-    output_format: OutputFormat,
-    query: Option<&str>,
-) -> AnyhowResult<()> {
-    let client = conn_mgr.create_enterprise_client(profile_name).await?;
-
-    let endpoint = match (bdb_uid, alert) {
-        (Some(uid), Some(alert_name)) => format!("/v1/bdbs/alerts/{}/{}", uid, alert_name),
-        (Some(uid), None) => format!("/v1/bdbs/alerts/{}", uid),
-        (None, None) => "/v1/bdbs/alerts".to_string(),
-        (None, Some(_)) => anyhow::bail!("Cannot specify alert without bdb_uid"),
-    };
-
-    let response = client
-        .get::<Value>(&endpoint)
-        .await
-        .map_err(RedisCtlError::from)?;
-
-    let response = if let Some(q) = query {
-        super::utils::apply_jmespath(&response, q)?
-    } else {
-        response
-    };
-
-    super::utils::print_formatted_output(response, output_format).map_err(|e| anyhow::anyhow!(e))
-}
-
-async fn handle_get_alert_settings(
-    conn_mgr: &crate::connection::ConnectionManager,
-    profile_name: Option<&str>,
-    output_format: OutputFormat,
-    query: Option<&str>,
-) -> AnyhowResult<()> {
-    let client = conn_mgr.create_enterprise_client(profile_name).await?;
-
-    // Alert settings are part of cluster configuration
-    let response = client
-        .get::<Value>("/v1/cluster")
-        .await
-        .map_err(RedisCtlError::from)?;
-
-    // Extract alert_settings from the cluster config
-    let alert_settings = response
-        .get("alert_settings")
-        .cloned()
-        .unwrap_or_else(|| Value::Object(serde_json::Map::new()));
-
-    let response = if let Some(q) = query {
-        super::utils::apply_jmespath(&alert_settings, q)?
-    } else {
-        alert_settings
-    };
-
-    super::utils::print_formatted_output(response, output_format).map_err(|e| anyhow::anyhow!(e))
-}
-
-#[allow(clippy::too_many_arguments)]
-async fn handle_update_alert_settings(
-    conn_mgr: &crate::connection::ConnectionManager,
-    profile_name: Option<&str>,
-    cluster_alerts: Option<bool>,
-    node_alerts: Option<bool>,
-    bdb_alerts: Option<bool>,
-    memory_threshold: Option<u32>,
-    cpu_threshold: Option<u32>,
-    data: Option<&str>,
-    output_format: OutputFormat,
-    query: Option<&str>,
-) -> AnyhowResult<()> {
-    let client = conn_mgr.create_enterprise_client(profile_name).await?;
-
-    // Start with JSON from --data if provided, otherwise empty object
-    let mut json_data = if let Some(data_str) = data {
-        super::utils::read_json_data(data_str)?
-    } else {
-        serde_json::json!({})
-    };
-
-    let data_obj = json_data.as_object_mut().unwrap();
-
-    // CLI parameters override JSON values
-    if let Some(ca) = cluster_alerts {
-        data_obj.insert("cluster_alerts_enabled".to_string(), serde_json::json!(ca));
-    }
-    if let Some(na) = node_alerts {
-        data_obj.insert("node_alerts_enabled".to_string(), serde_json::json!(na));
-    }
-    if let Some(ba) = bdb_alerts {
-        data_obj.insert("bdb_alerts_enabled".to_string(), serde_json::json!(ba));
-    }
-    if let Some(mt) = memory_threshold {
-        data_obj.insert("memory_threshold".to_string(), serde_json::json!(mt));
-    }
-    if let Some(ct) = cpu_threshold {
-        data_obj.insert("cpu_threshold".to_string(), serde_json::json!(ct));
-    }
-
-    // Alert settings are updated through cluster configuration
-    let update_payload = serde_json::json!({
-        "alert_settings": json_data
-    });
-
-    let response = client
-        .put::<_, Value>("/v1/cluster", &update_payload)
-        .await
-        .map_err(RedisCtlError::from)?;
-
-    let response = if let Some(q) = query {
-        super::utils::apply_jmespath(&response, q)?
-    } else {
-        response
-    };
-
-    super::utils::print_formatted_output(response, output_format).map_err(|e| anyhow::anyhow!(e))
+    result.map_err(RedisCtlError::from)
 }
 
 #[cfg(test)]
@@ -493,48 +103,48 @@ mod tests {
         // Test that all alerts commands can be constructed
 
         // List command
-        let _cmd = AlertsCommands::List {
+        let _cmd = EnterpriseAlertsCommands::List {
             filter_type: None,
             severity: None,
         };
 
-        let _cmd = AlertsCommands::List {
+        let _cmd = EnterpriseAlertsCommands::List {
             filter_type: Some("cluster".to_string()),
             severity: Some("error".to_string()),
         };
 
         // Get command
-        let _cmd = AlertsCommands::Get { uid: 1 };
+        let _cmd = EnterpriseAlertsCommands::Get { uid: 1 };
 
         // Cluster alerts
-        let _cmd = AlertsCommands::Cluster { alert: None };
-        let _cmd = AlertsCommands::Cluster {
+        let _cmd = EnterpriseAlertsCommands::Cluster { alert: None };
+        let _cmd = EnterpriseAlertsCommands::Cluster {
             alert: Some("test_alert".to_string()),
         };
 
         // Node alerts
-        let _cmd = AlertsCommands::Node {
+        let _cmd = EnterpriseAlertsCommands::Node {
             node_uid: None,
             alert: None,
         };
-        let _cmd = AlertsCommands::Node {
+        let _cmd = EnterpriseAlertsCommands::Node {
             node_uid: Some(1),
             alert: Some("test".to_string()),
         };
 
         // Database alerts
-        let _cmd = AlertsCommands::Database {
+        let _cmd = EnterpriseAlertsCommands::Database {
             bdb_uid: None,
             alert: None,
         };
-        let _cmd = AlertsCommands::Database {
+        let _cmd = EnterpriseAlertsCommands::Database {
             bdb_uid: Some(1),
             alert: Some("test".to_string()),
         };
 
         // Settings commands
-        let _cmd = AlertsCommands::SettingsGet;
-        let _cmd = AlertsCommands::SettingsUpdate {
+        let _cmd = EnterpriseAlertsCommands::SettingsGet;
+        let _cmd = EnterpriseAlertsCommands::SettingsUpdate {
             cluster_alerts: Some(true),
             node_alerts: None,
             bdb_alerts: None,

--- a/crates/redisctl/src/commands/enterprise/alerts_impl.rs
+++ b/crates/redisctl/src/commands/enterprise/alerts_impl.rs
@@ -1,0 +1,321 @@
+//! Implementation of enterprise alerts commands
+
+use anyhow::Result as AnyhowResult;
+use serde_json::Value;
+
+use crate::cli::OutputFormat;
+use crate::connection::ConnectionManager;
+use crate::error::RedisCtlError;
+
+pub async fn list_alerts(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    filter_type: Option<&str>,
+    severity: Option<&str>,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> AnyhowResult<()> {
+    let client = conn_mgr.create_enterprise_client(profile_name).await?;
+
+    // Get alerts from all sources and combine
+    let mut all_alerts = Vec::new();
+
+    // Get cluster alerts
+    if (filter_type.is_none() || filter_type == Some("cluster"))
+        && let Ok(cluster_alerts) = client.get::<Value>("/v1/cluster/alerts").await
+        && let Some(alerts) = cluster_alerts.as_array()
+    {
+        for alert in alerts {
+            let mut alert = alert.clone();
+            if let Some(obj) = alert.as_object_mut() {
+                obj.insert("type".to_string(), Value::String("cluster".to_string()));
+            }
+            all_alerts.push(alert);
+        }
+    }
+
+    // Get node alerts
+    if (filter_type.is_none() || filter_type == Some("node"))
+        && let Ok(node_alerts) = client.get::<Value>("/v1/nodes/alerts").await
+        && let Some(alerts) = node_alerts.as_array()
+    {
+        for alert in alerts {
+            let mut alert = alert.clone();
+            if let Some(obj) = alert.as_object_mut() {
+                obj.insert("type".to_string(), Value::String("node".to_string()));
+            }
+            all_alerts.push(alert);
+        }
+    }
+
+    // Get database alerts
+    if (filter_type.is_none() || filter_type == Some("bdb"))
+        && let Ok(bdb_alerts) = client.get::<Value>("/v1/bdbs/alerts").await
+        && let Some(alerts) = bdb_alerts.as_array()
+    {
+        for alert in alerts {
+            let mut alert = alert.clone();
+            if let Some(obj) = alert.as_object_mut() {
+                obj.insert("type".to_string(), Value::String("database".to_string()));
+            }
+            all_alerts.push(alert);
+        }
+    }
+
+    // Filter by severity if specified
+    if let Some(severity) = severity {
+        all_alerts.retain(|alert| {
+            alert
+                .get("severity")
+                .and_then(|s| s.as_str())
+                .map(|s| s.eq_ignore_ascii_case(severity))
+                .unwrap_or(false)
+        });
+    }
+
+    let response = Value::Array(all_alerts);
+
+    // Apply JMESPath query if provided
+    let response = if let Some(q) = query {
+        super::utils::apply_jmespath(&response, q)?
+    } else {
+        response
+    };
+
+    super::utils::print_formatted_output(response, output_format).map_err(|e| anyhow::anyhow!(e))
+}
+
+pub async fn get_alert(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    uid: u64,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> AnyhowResult<()> {
+    let client = conn_mgr.create_enterprise_client(profile_name).await?;
+
+    // Try to find the alert in different endpoints
+    // First try cluster alerts
+    if let Ok(alerts) = client
+        .get::<Value>(&format!("/v1/cluster/alerts/{}", uid))
+        .await
+    {
+        let response = if let Some(q) = query {
+            super::utils::apply_jmespath(&alerts, q)?
+        } else {
+            alerts
+        };
+        return super::utils::print_formatted_output(response, output_format)
+            .map_err(|e| anyhow::anyhow!(e));
+    }
+
+    // Try node alerts
+    if let Ok(alerts) = client
+        .get::<Value>(&format!("/v1/nodes/alerts/{}", uid))
+        .await
+    {
+        let response = if let Some(q) = query {
+            super::utils::apply_jmespath(&alerts, q)?
+        } else {
+            alerts
+        };
+        return super::utils::print_formatted_output(response, output_format)
+            .map_err(|e| anyhow::anyhow!(e));
+    }
+
+    // Try database alerts
+    if let Ok(alerts) = client
+        .get::<Value>(&format!("/v1/bdbs/alerts/{}", uid))
+        .await
+    {
+        let response = if let Some(q) = query {
+            super::utils::apply_jmespath(&alerts, q)?
+        } else {
+            alerts
+        };
+        return super::utils::print_formatted_output(response, output_format)
+            .map_err(|e| anyhow::anyhow!(e));
+    }
+
+    anyhow::bail!("Alert with UID {} not found", uid)
+}
+
+pub async fn cluster_alerts(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    alert: Option<&str>,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> AnyhowResult<()> {
+    let client = conn_mgr.create_enterprise_client(profile_name).await?;
+
+    let endpoint = if let Some(alert_name) = alert {
+        format!("/v1/cluster/alerts/{}", alert_name)
+    } else {
+        "/v1/cluster/alerts".to_string()
+    };
+
+    let response = client
+        .get::<Value>(&endpoint)
+        .await
+        .map_err(RedisCtlError::from)?;
+
+    let response = if let Some(q) = query {
+        super::utils::apply_jmespath(&response, q)?
+    } else {
+        response
+    };
+
+    super::utils::print_formatted_output(response, output_format).map_err(|e| anyhow::anyhow!(e))
+}
+
+pub async fn node_alerts(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    node_uid: Option<u64>,
+    alert: Option<&str>,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> AnyhowResult<()> {
+    let client = conn_mgr.create_enterprise_client(profile_name).await?;
+
+    let endpoint = match (node_uid, alert) {
+        (Some(uid), Some(alert_name)) => format!("/v1/nodes/alerts/{}/{}", uid, alert_name),
+        (Some(uid), None) => format!("/v1/nodes/alerts/{}", uid),
+        (None, None) => "/v1/nodes/alerts".to_string(),
+        (None, Some(_)) => anyhow::bail!("Cannot specify alert without node_uid"),
+    };
+
+    let response = client
+        .get::<Value>(&endpoint)
+        .await
+        .map_err(RedisCtlError::from)?;
+
+    let response = if let Some(q) = query {
+        super::utils::apply_jmespath(&response, q)?
+    } else {
+        response
+    };
+
+    super::utils::print_formatted_output(response, output_format).map_err(|e| anyhow::anyhow!(e))
+}
+
+pub async fn database_alerts(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    bdb_uid: Option<u64>,
+    alert: Option<&str>,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> AnyhowResult<()> {
+    let client = conn_mgr.create_enterprise_client(profile_name).await?;
+
+    let endpoint = match (bdb_uid, alert) {
+        (Some(uid), Some(alert_name)) => format!("/v1/bdbs/alerts/{}/{}", uid, alert_name),
+        (Some(uid), None) => format!("/v1/bdbs/alerts/{}", uid),
+        (None, None) => "/v1/bdbs/alerts".to_string(),
+        (None, Some(_)) => anyhow::bail!("Cannot specify alert without bdb_uid"),
+    };
+
+    let response = client
+        .get::<Value>(&endpoint)
+        .await
+        .map_err(RedisCtlError::from)?;
+
+    let response = if let Some(q) = query {
+        super::utils::apply_jmespath(&response, q)?
+    } else {
+        response
+    };
+
+    super::utils::print_formatted_output(response, output_format).map_err(|e| anyhow::anyhow!(e))
+}
+
+pub async fn get_alert_settings(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> AnyhowResult<()> {
+    let client = conn_mgr.create_enterprise_client(profile_name).await?;
+
+    // Alert settings are part of cluster configuration
+    let response = client
+        .get::<Value>("/v1/cluster")
+        .await
+        .map_err(RedisCtlError::from)?;
+
+    // Extract alert_settings from the cluster config
+    let alert_settings = response
+        .get("alert_settings")
+        .cloned()
+        .unwrap_or_else(|| Value::Object(serde_json::Map::new()));
+
+    let response = if let Some(q) = query {
+        super::utils::apply_jmespath(&alert_settings, q)?
+    } else {
+        alert_settings
+    };
+
+    super::utils::print_formatted_output(response, output_format).map_err(|e| anyhow::anyhow!(e))
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn update_alert_settings(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    cluster_alerts: Option<bool>,
+    node_alerts: Option<bool>,
+    bdb_alerts: Option<bool>,
+    memory_threshold: Option<u32>,
+    cpu_threshold: Option<u32>,
+    data: Option<&str>,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> AnyhowResult<()> {
+    let client = conn_mgr.create_enterprise_client(profile_name).await?;
+
+    // Start with JSON from --data if provided, otherwise empty object
+    let mut json_data = if let Some(data_str) = data {
+        super::utils::read_json_data(data_str)?
+    } else {
+        serde_json::json!({})
+    };
+
+    let data_obj = json_data.as_object_mut().unwrap();
+
+    // CLI parameters override JSON values
+    if let Some(ca) = cluster_alerts {
+        data_obj.insert("cluster_alerts_enabled".to_string(), serde_json::json!(ca));
+    }
+    if let Some(na) = node_alerts {
+        data_obj.insert("node_alerts_enabled".to_string(), serde_json::json!(na));
+    }
+    if let Some(ba) = bdb_alerts {
+        data_obj.insert("bdb_alerts_enabled".to_string(), serde_json::json!(ba));
+    }
+    if let Some(mt) = memory_threshold {
+        data_obj.insert("memory_threshold".to_string(), serde_json::json!(mt));
+    }
+    if let Some(ct) = cpu_threshold {
+        data_obj.insert("cpu_threshold".to_string(), serde_json::json!(ct));
+    }
+
+    // Alert settings are updated through cluster configuration
+    let update_payload = serde_json::json!({
+        "alert_settings": json_data
+    });
+
+    let response = client
+        .put::<_, Value>("/v1/cluster", &update_payload)
+        .await
+        .map_err(RedisCtlError::from)?;
+
+    let response = if let Some(q) = query {
+        super::utils::apply_jmespath(&response, q)?
+    } else {
+        response
+    };
+
+    super::utils::print_formatted_output(response, output_format).map_err(|e| anyhow::anyhow!(e))
+}

--- a/crates/redisctl/src/commands/enterprise/license.rs
+++ b/crates/redisctl/src/commands/enterprise/license.rs
@@ -1,427 +1,60 @@
-use crate::error::RedisCtlError;
-use anyhow::{Context, Result as AnyhowResult};
-use clap::Subcommand;
-use redisctl_core::Config;
-use serde_json::Value;
-use std::path::Path;
+//! Enterprise license command handler
 
-use crate::cli::OutputFormat;
+use crate::cli::{EnterpriseLicenseCommands, OutputFormat};
+use crate::connection::ConnectionManager;
+use crate::error::{RedisCtlError, Result as CliResult};
 
-#[derive(Debug, Subcommand)]
-pub enum LicenseCommands {
-    /// Get current license information
-    Get,
-    /// Update license with JSON data
-    #[command(after_help = "EXAMPLES:
-    # Update license with key
-    redisctl enterprise license update --license-key ABC123...
+use super::license_impl;
 
-    # Using JSON file
-    redisctl enterprise license update --data @license.json")]
-    Update {
-        /// License key string
-        #[arg(long)]
-        license_key: Option<String>,
-        /// License data as JSON string or @file.json (optional)
-        #[arg(long, value_name = "FILE|JSON")]
-        data: Option<String>,
-    },
-    /// Upload license file
-    Upload {
-        /// Path to license file
-        #[arg(long)]
-        file: String,
-    },
-    /// Validate license
-    #[command(after_help = "EXAMPLES:
-    # Validate license key
-    redisctl enterprise license validate --license-key ABC123...
-
-    # Validate from JSON
-    redisctl enterprise license validate --data @license.json")]
-    Validate {
-        /// License key string to validate
-        #[arg(long)]
-        license_key: Option<String>,
-        /// License data as JSON string or @file.json (optional)
-        #[arg(long, value_name = "FILE|JSON")]
-        data: Option<String>,
-    },
-    /// Check license expiration
-    Expiry,
-    /// List licensed features
-    Features,
-    /// Show license usage and limits
-    Usage,
-}
-
-impl LicenseCommands {
-    pub async fn execute(
-        &self,
-        config: &Config,
-        profile_name: Option<&str>,
-        output_format: OutputFormat,
-        query: Option<&str>,
-    ) -> AnyhowResult<()> {
-        let conn_manager = crate::connection::ConnectionManager::new(config.clone());
-
-        match self {
-            Self::Get => {
-                handle_get_license(&conn_manager, profile_name, output_format, query).await
-            }
-            Self::Update { license_key, data } => {
-                handle_update_license(
-                    &conn_manager,
-                    profile_name,
-                    license_key.as_deref(),
-                    data.as_deref(),
-                    output_format,
-                    query,
-                )
-                .await
-            }
-            Self::Upload { file } => {
-                handle_upload_license(&conn_manager, profile_name, file, output_format, query).await
-            }
-            Self::Validate { license_key, data } => {
-                handle_validate_license(
-                    &conn_manager,
-                    profile_name,
-                    license_key.as_deref(),
-                    data.as_deref(),
-                    output_format,
-                    query,
-                )
-                .await
-            }
-            Self::Expiry => {
-                handle_license_expiry(&conn_manager, profile_name, output_format, query).await
-            }
-            Self::Features => {
-                handle_license_features(&conn_manager, profile_name, output_format, query).await
-            }
-            Self::Usage => {
-                handle_license_usage(&conn_manager, profile_name, output_format, query).await
-            }
+/// Handle enterprise license commands
+pub async fn handle_license_command(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    command: &EnterpriseLicenseCommands,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    let result = match command {
+        EnterpriseLicenseCommands::Get => {
+            license_impl::get_license(conn_mgr, profile_name, output_format, query).await
         }
-    }
-}
-
-async fn handle_get_license(
-    conn_mgr: &crate::connection::ConnectionManager,
-    profile_name: Option<&str>,
-    output_format: OutputFormat,
-    query: Option<&str>,
-) -> AnyhowResult<()> {
-    let client = conn_mgr.create_enterprise_client(profile_name).await?;
-
-    let response = client
-        .get::<Value>("/v1/license")
-        .await
-        .map_err(RedisCtlError::from)?;
-
-    let response = if let Some(q) = query {
-        super::utils::apply_jmespath(&response, q)?
-    } else {
-        response
-    };
-
-    super::utils::print_formatted_output(response, output_format).map_err(|e| anyhow::anyhow!(e))
-}
-
-async fn handle_update_license(
-    conn_mgr: &crate::connection::ConnectionManager,
-    profile_name: Option<&str>,
-    license_key: Option<&str>,
-    data: Option<&str>,
-    output_format: OutputFormat,
-    query: Option<&str>,
-) -> AnyhowResult<()> {
-    let client = conn_mgr.create_enterprise_client(profile_name).await?;
-
-    // Start with JSON from --data if provided, otherwise empty object
-    let mut json_data = if let Some(data_str) = data {
-        super::utils::read_json_data(data_str)?
-    } else {
-        serde_json::json!({})
-    };
-
-    let data_obj = json_data.as_object_mut().unwrap();
-
-    // CLI parameters override JSON values
-    if let Some(key) = license_key {
-        data_obj.insert("license".to_string(), serde_json::json!(key));
-    }
-
-    let response = client
-        .put::<_, Value>("/v1/license", &json_data)
-        .await
-        .map_err(RedisCtlError::from)?;
-
-    let response = if let Some(q) = query {
-        super::utils::apply_jmespath(&response, q)?
-    } else {
-        response
-    };
-
-    super::utils::print_formatted_output(response, output_format).map_err(|e| anyhow::anyhow!(e))
-}
-
-async fn handle_upload_license(
-    conn_mgr: &crate::connection::ConnectionManager,
-    profile_name: Option<&str>,
-    file: &str,
-    output_format: OutputFormat,
-    query: Option<&str>,
-) -> AnyhowResult<()> {
-    let client = conn_mgr.create_enterprise_client(profile_name).await?;
-
-    // Read the license file
-    let path = Path::new(file);
-    if !path.exists() {
-        anyhow::bail!("License file not found: {}", file);
-    }
-
-    let license_content = std::fs::read_to_string(path)
-        .with_context(|| format!("Failed to read license file: {}", file))?;
-
-    // Try to parse as JSON first
-    let license_data = if let Ok(json) = serde_json::from_str::<Value>(&license_content) {
-        json
-    } else {
-        // If not JSON, wrap the content as a license string
-        serde_json::json!({
-            "license": license_content.trim()
-        })
-    };
-
-    let response = client
-        .put::<_, Value>("/v1/license", &license_data)
-        .await
-        .map_err(RedisCtlError::from)?;
-
-    let response = if let Some(q) = query {
-        super::utils::apply_jmespath(&response, q)?
-    } else {
-        response
-    };
-
-    super::utils::print_formatted_output(response, output_format).map_err(|e| anyhow::anyhow!(e))
-}
-
-async fn handle_validate_license(
-    conn_mgr: &crate::connection::ConnectionManager,
-    profile_name: Option<&str>,
-    license_key: Option<&str>,
-    data: Option<&str>,
-    output_format: OutputFormat,
-    query: Option<&str>,
-) -> AnyhowResult<()> {
-    let client = conn_mgr.create_enterprise_client(profile_name).await?;
-
-    // Start with JSON from --data if provided, otherwise empty object
-    let mut json_data = if let Some(data_str) = data {
-        super::utils::read_json_data(data_str)?
-    } else {
-        serde_json::json!({})
-    };
-
-    let data_obj = json_data.as_object_mut().unwrap();
-
-    // CLI parameters override JSON values
-    if let Some(key) = license_key {
-        data_obj.insert("license".to_string(), serde_json::json!(key));
-    }
-
-    // The validation endpoint might not exist, so we'll use the regular PUT with dry_run if available
-    // Otherwise, we'll just try to parse and validate the license locally
-    let response = client
-        .put::<_, Value>("/v1/license?dry_run=true", &json_data)
-        .await
-        .or_else(|_| -> Result<Value, anyhow::Error> {
-            // If dry_run is not supported, just get current license and check format
-            Ok(serde_json::json!({
-                "valid": json_data.get("license").is_some() || json_data.get("key").is_some(),
-                "message": "License format appears valid (server validation not available)"
-            }))
-        })
-        .context("Failed to validate license")?;
-
-    let response = if let Some(q) = query {
-        super::utils::apply_jmespath(&response, q)?
-    } else {
-        response
-    };
-
-    super::utils::print_formatted_output(response, output_format).map_err(|e| anyhow::anyhow!(e))
-}
-
-async fn handle_license_expiry(
-    conn_mgr: &crate::connection::ConnectionManager,
-    profile_name: Option<&str>,
-    output_format: OutputFormat,
-    query: Option<&str>,
-) -> AnyhowResult<()> {
-    let client = conn_mgr.create_enterprise_client(profile_name).await?;
-
-    let license = client
-        .get::<Value>("/v1/license")
-        .await
-        .map_err(RedisCtlError::from)?;
-
-    // Extract expiration information
-    let expiry_info = serde_json::json!({
-        "expired": license.get("expired").and_then(|v| v.as_bool()).unwrap_or(false),
-        "expiration_date": license.get("expiration_date").and_then(|v| v.as_str()).unwrap_or("unknown"),
-        "days_remaining": calculate_days_remaining(license.get("expiration_date").and_then(|v| v.as_str())),
-        "warning": should_warn_expiry(license.get("expiration_date").and_then(|v| v.as_str())),
-    });
-
-    let response = if let Some(q) = query {
-        super::utils::apply_jmespath(&expiry_info, q)?
-    } else {
-        expiry_info
-    };
-
-    super::utils::print_formatted_output(response, output_format).map_err(|e| anyhow::anyhow!(e))
-}
-
-async fn handle_license_features(
-    conn_mgr: &crate::connection::ConnectionManager,
-    profile_name: Option<&str>,
-    output_format: OutputFormat,
-    query: Option<&str>,
-) -> AnyhowResult<()> {
-    let client = conn_mgr.create_enterprise_client(profile_name).await?;
-
-    let license = client
-        .get::<Value>("/v1/license")
-        .await
-        .map_err(RedisCtlError::from)?;
-
-    // Extract feature information
-    let features = if let Some(features) = license.get("features") {
-        features.clone()
-    } else {
-        // Construct features from license capabilities
-        serde_json::json!({
-            "shards_limit": license.get("shards_limit"),
-            "ram_limit": license.get("ram_limit"),
-            "flash_enabled": license.get("flash_enabled"),
-            "rack_awareness": license.get("rack_awareness"),
-            "multi_ip": license.get("multi_ip"),
-            "ipv6": license.get("ipv6"),
-            "redis_pack": license.get("redis_pack"),
-            "modules": license.get("modules"),
-        })
-    };
-
-    let response = if let Some(q) = query {
-        super::utils::apply_jmespath(&features, q)?
-    } else {
-        features
-    };
-
-    super::utils::print_formatted_output(response, output_format).map_err(|e| anyhow::anyhow!(e))
-}
-
-async fn handle_license_usage(
-    conn_mgr: &crate::connection::ConnectionManager,
-    profile_name: Option<&str>,
-    output_format: OutputFormat,
-    query: Option<&str>,
-) -> AnyhowResult<()> {
-    let client = conn_mgr.create_enterprise_client(profile_name).await?;
-
-    // Get license information
-    let license = client
-        .get::<Value>("/v1/license")
-        .await
-        .map_err(RedisCtlError::from)?;
-
-    // Get cluster stats for current usage
-    let cluster = client
-        .get::<Value>("/v1/cluster")
-        .await
-        .map_err(RedisCtlError::from)?;
-
-    // Calculate usage vs limits
-    let usage_info = serde_json::json!({
-        "shards": {
-            "limit": license.get("shards_limit").and_then(|v| v.as_i64()).unwrap_or(0),
-            "used": cluster.get("shards_used").and_then(|v| v.as_i64()).unwrap_or(0),
-            "available": calculate_available(
-                license.get("shards_limit").and_then(|v| v.as_i64()),
-                cluster.get("shards_used").and_then(|v| v.as_i64())
-            ),
-        },
-        "ram": {
-            "limit_bytes": license.get("ram_limit").and_then(|v| v.as_i64()).unwrap_or(0),
-            "limit_gb": bytes_to_gb(license.get("ram_limit").and_then(|v| v.as_i64()).unwrap_or(0)),
-            "used_bytes": cluster.get("ram_used").and_then(|v| v.as_i64()).unwrap_or(0),
-            "used_gb": bytes_to_gb(cluster.get("ram_used").and_then(|v| v.as_i64()).unwrap_or(0)),
-            "available_bytes": calculate_available(
-                license.get("ram_limit").and_then(|v| v.as_i64()),
-                cluster.get("ram_used").and_then(|v| v.as_i64())
-            ),
-            "available_gb": bytes_to_gb(calculate_available(
-                license.get("ram_limit").and_then(|v| v.as_i64()),
-                cluster.get("ram_used").and_then(|v| v.as_i64())
-            )),
-        },
-        "nodes": {
-            "limit": license.get("nodes_limit").and_then(|v| v.as_i64()).unwrap_or(0),
-            "used": cluster.get("nodes_count").and_then(|v| v.as_i64()).unwrap_or(0),
-        },
-        "expiration": {
-            "date": license.get("expiration_date").and_then(|v| v.as_str()).unwrap_or("unknown"),
-            "expired": license.get("expired").and_then(|v| v.as_bool()).unwrap_or(false),
+        EnterpriseLicenseCommands::Update { license_key, data } => {
+            license_impl::update_license(
+                conn_mgr,
+                profile_name,
+                license_key.as_deref(),
+                data.as_deref(),
+                output_format,
+                query,
+            )
+            .await
         }
-    });
-
-    let response = if let Some(q) = query {
-        super::utils::apply_jmespath(&usage_info, q)?
-    } else {
-        usage_info
+        EnterpriseLicenseCommands::Upload { file } => {
+            license_impl::upload_license(conn_mgr, profile_name, file, output_format, query).await
+        }
+        EnterpriseLicenseCommands::Validate { license_key, data } => {
+            license_impl::validate_license(
+                conn_mgr,
+                profile_name,
+                license_key.as_deref(),
+                data.as_deref(),
+                output_format,
+                query,
+            )
+            .await
+        }
+        EnterpriseLicenseCommands::Expiry => {
+            license_impl::license_expiry(conn_mgr, profile_name, output_format, query).await
+        }
+        EnterpriseLicenseCommands::Features => {
+            license_impl::license_features(conn_mgr, profile_name, output_format, query).await
+        }
+        EnterpriseLicenseCommands::Usage => {
+            license_impl::license_usage(conn_mgr, profile_name, output_format, query).await
+        }
     };
 
-    super::utils::print_formatted_output(response, output_format).map_err(|e| anyhow::anyhow!(e))
-}
-
-// Helper functions
-pub fn calculate_days_remaining(expiration_date: Option<&str>) -> i64 {
-    if let Some(date_str) = expiration_date {
-        // Try parsing as ISO8601 datetime first (e.g., "2025-10-15T00:18:29Z")
-        if let Ok(datetime) = chrono::DateTime::parse_from_rfc3339(date_str) {
-            let today = chrono::Local::now().naive_local().date();
-            let exp_date = datetime.naive_local().date();
-            let duration = exp_date.signed_duration_since(today);
-            return duration.num_days();
-        }
-        // Fall back to parsing as date only (e.g., "2025-10-15")
-        if let Ok(exp_date) = chrono::NaiveDate::parse_from_str(date_str, "%Y-%m-%d") {
-            let today = chrono::Local::now().naive_local().date();
-            let duration = exp_date.signed_duration_since(today);
-            return duration.num_days();
-        }
-    }
-    -1
-}
-
-pub fn should_warn_expiry(expiration_date: Option<&str>) -> bool {
-    let days = calculate_days_remaining(expiration_date);
-    (0..=30).contains(&days)
-}
-
-pub fn calculate_available(limit: Option<i64>, used: Option<i64>) -> i64 {
-    match (limit, used) {
-        (Some(l), Some(u)) => (l - u).max(0),
-        _ => 0,
-    }
-}
-
-pub fn bytes_to_gb(bytes: i64) -> f64 {
-    bytes as f64 / (1024.0 * 1024.0 * 1024.0)
+    result.map_err(RedisCtlError::from)
 }
 
 #[cfg(test)]
@@ -433,58 +66,32 @@ mod tests {
         // Test that all license commands can be constructed
 
         // Get command
-        let _cmd = LicenseCommands::Get;
+        let _cmd = EnterpriseLicenseCommands::Get;
 
         // Update command
-        let _cmd = LicenseCommands::Update {
+        let _cmd = EnterpriseLicenseCommands::Update {
             license_key: Some("ABC123".to_string()),
             data: None,
         };
 
         // Upload command
-        let _cmd = LicenseCommands::Upload {
+        let _cmd = EnterpriseLicenseCommands::Upload {
             file: "/path/to/license".to_string(),
         };
 
         // Validate command
-        let _cmd = LicenseCommands::Validate {
+        let _cmd = EnterpriseLicenseCommands::Validate {
             license_key: Some("ABC123".to_string()),
             data: None,
         };
 
         // Expiry command
-        let _cmd = LicenseCommands::Expiry;
+        let _cmd = EnterpriseLicenseCommands::Expiry;
 
         // Features command
-        let _cmd = LicenseCommands::Features;
+        let _cmd = EnterpriseLicenseCommands::Features;
 
         // Usage command
-        let _cmd = LicenseCommands::Usage;
-    }
-
-    #[test]
-    fn test_calculate_days_remaining() {
-        // Test with invalid date
-        assert_eq!(calculate_days_remaining(None), -1);
-        assert_eq!(calculate_days_remaining(Some("invalid")), -1);
-
-        // Test with valid date (would need mocking for actual date comparison)
-        // For now, just verify it doesn't panic
-        let _ = calculate_days_remaining(Some("2025-12-31"));
-    }
-
-    #[test]
-    fn test_bytes_to_gb() {
-        assert_eq!(bytes_to_gb(0), 0.0);
-        assert_eq!(bytes_to_gb(1073741824), 1.0); // 1 GB
-        assert_eq!(bytes_to_gb(2147483648), 2.0); // 2 GB
-    }
-
-    #[test]
-    fn test_calculate_available() {
-        assert_eq!(calculate_available(Some(100), Some(30)), 70);
-        assert_eq!(calculate_available(Some(50), Some(60)), 0); // Can't be negative
-        assert_eq!(calculate_available(None, Some(10)), 0);
-        assert_eq!(calculate_available(Some(100), None), 0);
+        let _cmd = EnterpriseLicenseCommands::Usage;
     }
 }

--- a/crates/redisctl/src/commands/enterprise/license_impl.rs
+++ b/crates/redisctl/src/commands/enterprise/license_impl.rs
@@ -1,0 +1,357 @@
+//! Implementation of enterprise license commands
+
+use anyhow::{Context, Result as AnyhowResult};
+use serde_json::Value;
+use std::path::Path;
+
+use crate::cli::OutputFormat;
+use crate::connection::ConnectionManager;
+use crate::error::RedisCtlError;
+
+pub async fn get_license(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> AnyhowResult<()> {
+    let client = conn_mgr.create_enterprise_client(profile_name).await?;
+
+    let response = client
+        .get::<Value>("/v1/license")
+        .await
+        .map_err(RedisCtlError::from)?;
+
+    let response = if let Some(q) = query {
+        super::utils::apply_jmespath(&response, q)?
+    } else {
+        response
+    };
+
+    super::utils::print_formatted_output(response, output_format).map_err(|e| anyhow::anyhow!(e))
+}
+
+pub async fn update_license(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    license_key: Option<&str>,
+    data: Option<&str>,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> AnyhowResult<()> {
+    let client = conn_mgr.create_enterprise_client(profile_name).await?;
+
+    // Start with JSON from --data if provided, otherwise empty object
+    let mut json_data = if let Some(data_str) = data {
+        super::utils::read_json_data(data_str)?
+    } else {
+        serde_json::json!({})
+    };
+
+    let data_obj = json_data.as_object_mut().unwrap();
+
+    // CLI parameters override JSON values
+    if let Some(key) = license_key {
+        data_obj.insert("license".to_string(), serde_json::json!(key));
+    }
+
+    let response = client
+        .put::<_, Value>("/v1/license", &json_data)
+        .await
+        .map_err(RedisCtlError::from)?;
+
+    let response = if let Some(q) = query {
+        super::utils::apply_jmespath(&response, q)?
+    } else {
+        response
+    };
+
+    super::utils::print_formatted_output(response, output_format).map_err(|e| anyhow::anyhow!(e))
+}
+
+pub async fn upload_license(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    file: &str,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> AnyhowResult<()> {
+    let client = conn_mgr.create_enterprise_client(profile_name).await?;
+
+    // Read the license file
+    let path = Path::new(file);
+    if !path.exists() {
+        anyhow::bail!("License file not found: {}", file);
+    }
+
+    let license_content = std::fs::read_to_string(path)
+        .with_context(|| format!("Failed to read license file: {}", file))?;
+
+    // Try to parse as JSON first
+    let license_data = if let Ok(json) = serde_json::from_str::<Value>(&license_content) {
+        json
+    } else {
+        // If not JSON, wrap the content as a license string
+        serde_json::json!({
+            "license": license_content.trim()
+        })
+    };
+
+    let response = client
+        .put::<_, Value>("/v1/license", &license_data)
+        .await
+        .map_err(RedisCtlError::from)?;
+
+    let response = if let Some(q) = query {
+        super::utils::apply_jmespath(&response, q)?
+    } else {
+        response
+    };
+
+    super::utils::print_formatted_output(response, output_format).map_err(|e| anyhow::anyhow!(e))
+}
+
+pub async fn validate_license(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    license_key: Option<&str>,
+    data: Option<&str>,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> AnyhowResult<()> {
+    let client = conn_mgr.create_enterprise_client(profile_name).await?;
+
+    // Start with JSON from --data if provided, otherwise empty object
+    let mut json_data = if let Some(data_str) = data {
+        super::utils::read_json_data(data_str)?
+    } else {
+        serde_json::json!({})
+    };
+
+    let data_obj = json_data.as_object_mut().unwrap();
+
+    // CLI parameters override JSON values
+    if let Some(key) = license_key {
+        data_obj.insert("license".to_string(), serde_json::json!(key));
+    }
+
+    // The validation endpoint might not exist, so we'll use the regular PUT with dry_run if available
+    // Otherwise, we'll just try to parse and validate the license locally
+    let response = client
+        .put::<_, Value>("/v1/license?dry_run=true", &json_data)
+        .await
+        .or_else(|_| -> Result<Value, anyhow::Error> {
+            // If dry_run is not supported, just get current license and check format
+            Ok(serde_json::json!({
+                "valid": json_data.get("license").is_some() || json_data.get("key").is_some(),
+                "message": "License format appears valid (server validation not available)"
+            }))
+        })
+        .context("Failed to validate license")?;
+
+    let response = if let Some(q) = query {
+        super::utils::apply_jmespath(&response, q)?
+    } else {
+        response
+    };
+
+    super::utils::print_formatted_output(response, output_format).map_err(|e| anyhow::anyhow!(e))
+}
+
+pub async fn license_expiry(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> AnyhowResult<()> {
+    let client = conn_mgr.create_enterprise_client(profile_name).await?;
+
+    let license = client
+        .get::<Value>("/v1/license")
+        .await
+        .map_err(RedisCtlError::from)?;
+
+    // Extract expiration information
+    let expiry_info = serde_json::json!({
+        "expired": license.get("expired").and_then(|v| v.as_bool()).unwrap_or(false),
+        "expiration_date": license.get("expiration_date").and_then(|v| v.as_str()).unwrap_or("unknown"),
+        "days_remaining": calculate_days_remaining(license.get("expiration_date").and_then(|v| v.as_str())),
+        "warning": should_warn_expiry(license.get("expiration_date").and_then(|v| v.as_str())),
+    });
+
+    let response = if let Some(q) = query {
+        super::utils::apply_jmespath(&expiry_info, q)?
+    } else {
+        expiry_info
+    };
+
+    super::utils::print_formatted_output(response, output_format).map_err(|e| anyhow::anyhow!(e))
+}
+
+pub async fn license_features(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> AnyhowResult<()> {
+    let client = conn_mgr.create_enterprise_client(profile_name).await?;
+
+    let license = client
+        .get::<Value>("/v1/license")
+        .await
+        .map_err(RedisCtlError::from)?;
+
+    // Extract feature information
+    let features = if let Some(features) = license.get("features") {
+        features.clone()
+    } else {
+        // Construct features from license capabilities
+        serde_json::json!({
+            "shards_limit": license.get("shards_limit"),
+            "ram_limit": license.get("ram_limit"),
+            "flash_enabled": license.get("flash_enabled"),
+            "rack_awareness": license.get("rack_awareness"),
+            "multi_ip": license.get("multi_ip"),
+            "ipv6": license.get("ipv6"),
+            "redis_pack": license.get("redis_pack"),
+            "modules": license.get("modules"),
+        })
+    };
+
+    let response = if let Some(q) = query {
+        super::utils::apply_jmespath(&features, q)?
+    } else {
+        features
+    };
+
+    super::utils::print_formatted_output(response, output_format).map_err(|e| anyhow::anyhow!(e))
+}
+
+pub async fn license_usage(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> AnyhowResult<()> {
+    let client = conn_mgr.create_enterprise_client(profile_name).await?;
+
+    // Get license information
+    let license = client
+        .get::<Value>("/v1/license")
+        .await
+        .map_err(RedisCtlError::from)?;
+
+    // Get cluster stats for current usage
+    let cluster = client
+        .get::<Value>("/v1/cluster")
+        .await
+        .map_err(RedisCtlError::from)?;
+
+    // Calculate usage vs limits
+    let usage_info = serde_json::json!({
+        "shards": {
+            "limit": license.get("shards_limit").and_then(|v| v.as_i64()).unwrap_or(0),
+            "used": cluster.get("shards_used").and_then(|v| v.as_i64()).unwrap_or(0),
+            "available": calculate_available(
+                license.get("shards_limit").and_then(|v| v.as_i64()),
+                cluster.get("shards_used").and_then(|v| v.as_i64())
+            ),
+        },
+        "ram": {
+            "limit_bytes": license.get("ram_limit").and_then(|v| v.as_i64()).unwrap_or(0),
+            "limit_gb": bytes_to_gb(license.get("ram_limit").and_then(|v| v.as_i64()).unwrap_or(0)),
+            "used_bytes": cluster.get("ram_used").and_then(|v| v.as_i64()).unwrap_or(0),
+            "used_gb": bytes_to_gb(cluster.get("ram_used").and_then(|v| v.as_i64()).unwrap_or(0)),
+            "available_bytes": calculate_available(
+                license.get("ram_limit").and_then(|v| v.as_i64()),
+                cluster.get("ram_used").and_then(|v| v.as_i64())
+            ),
+            "available_gb": bytes_to_gb(calculate_available(
+                license.get("ram_limit").and_then(|v| v.as_i64()),
+                cluster.get("ram_used").and_then(|v| v.as_i64())
+            )),
+        },
+        "nodes": {
+            "limit": license.get("nodes_limit").and_then(|v| v.as_i64()).unwrap_or(0),
+            "used": cluster.get("nodes_count").and_then(|v| v.as_i64()).unwrap_or(0),
+        },
+        "expiration": {
+            "date": license.get("expiration_date").and_then(|v| v.as_str()).unwrap_or("unknown"),
+            "expired": license.get("expired").and_then(|v| v.as_bool()).unwrap_or(false),
+        }
+    });
+
+    let response = if let Some(q) = query {
+        super::utils::apply_jmespath(&usage_info, q)?
+    } else {
+        usage_info
+    };
+
+    super::utils::print_formatted_output(response, output_format).map_err(|e| anyhow::anyhow!(e))
+}
+
+// Helper functions
+pub fn calculate_days_remaining(expiration_date: Option<&str>) -> i64 {
+    if let Some(date_str) = expiration_date {
+        // Try parsing as ISO8601 datetime first (e.g., "2025-10-15T00:18:29Z")
+        if let Ok(datetime) = chrono::DateTime::parse_from_rfc3339(date_str) {
+            let today = chrono::Local::now().naive_local().date();
+            let exp_date = datetime.naive_local().date();
+            let duration = exp_date.signed_duration_since(today);
+            return duration.num_days();
+        }
+        // Fall back to parsing as date only (e.g., "2025-10-15")
+        if let Ok(exp_date) = chrono::NaiveDate::parse_from_str(date_str, "%Y-%m-%d") {
+            let today = chrono::Local::now().naive_local().date();
+            let duration = exp_date.signed_duration_since(today);
+            return duration.num_days();
+        }
+    }
+    -1
+}
+
+pub fn should_warn_expiry(expiration_date: Option<&str>) -> bool {
+    let days = calculate_days_remaining(expiration_date);
+    (0..=30).contains(&days)
+}
+
+pub fn calculate_available(limit: Option<i64>, used: Option<i64>) -> i64 {
+    match (limit, used) {
+        (Some(l), Some(u)) => (l - u).max(0),
+        _ => 0,
+    }
+}
+
+pub fn bytes_to_gb(bytes: i64) -> f64 {
+    bytes as f64 / (1024.0 * 1024.0 * 1024.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_calculate_days_remaining() {
+        // Test with invalid date
+        assert_eq!(calculate_days_remaining(None), -1);
+        assert_eq!(calculate_days_remaining(Some("invalid")), -1);
+
+        // Test with valid date (would need mocking for actual date comparison)
+        // For now, just verify it doesn't panic
+        let _ = calculate_days_remaining(Some("2025-12-31"));
+    }
+
+    #[test]
+    fn test_bytes_to_gb() {
+        assert_eq!(bytes_to_gb(0), 0.0);
+        assert_eq!(bytes_to_gb(1073741824), 1.0); // 1 GB
+        assert_eq!(bytes_to_gb(2147483648), 2.0); // 2 GB
+    }
+
+    #[test]
+    fn test_calculate_available() {
+        assert_eq!(calculate_available(Some(100), Some(30)), 70);
+        assert_eq!(calculate_available(Some(50), Some(60)), 0); // Can't be negative
+        assert_eq!(calculate_available(None, Some(10)), 0);
+        assert_eq!(calculate_available(Some(100), None), 0);
+    }
+}

--- a/crates/redisctl/src/commands/enterprise/license_workflow.rs
+++ b/crates/redisctl/src/commands/enterprise/license_workflow.rs
@@ -1,478 +1,63 @@
-use anyhow::Result as AnyhowResult;
-use clap::Subcommand;
-use redisctl_core::Config;
-use serde_json::Value;
+//! Enterprise license workflow command handler
 
-use crate::cli::OutputFormat;
+use crate::cli::{EnterpriseLicenseWorkflowCommands, OutputFormat};
+use crate::connection::ConnectionManager;
+use crate::error::{RedisCtlError, Result as CliResult};
 
-#[derive(Debug, Subcommand)]
-pub enum LicenseWorkflowCommands {
-    /// Audit licenses across all configured profiles
-    Audit {
-        /// Only show profiles with expiring licenses (within 30 days)
-        #[arg(long)]
-        expiring: bool,
-        /// Only show profiles with expired licenses
-        #[arg(long)]
-        expired: bool,
-    },
-    /// Update license across multiple profiles
-    #[command(name = "bulk-update")]
-    BulkUpdate {
-        /// Profiles to update (comma-separated, or 'all' for all enterprise profiles)
-        #[arg(long)]
-        profiles: String,
-        /// License data as JSON string or @file.json
-        #[arg(long)]
-        data: String,
-        /// Dry run - show what would be updated without making changes
-        #[arg(long)]
-        dry_run: bool,
-    },
-    /// Generate license compliance report
-    Report {
-        /// Output format for report (csv for spreadsheet export)
-        #[arg(long, default_value = "table")]
-        format: String,
-    },
-    /// Monitor license expiration and send alerts
-    Monitor {
-        /// Days before expiration to trigger warning
-        #[arg(long, default_value = "30")]
-        warning_days: i64,
-        /// Exit with error code if any licenses are expiring
-        #[arg(long)]
-        fail_on_warning: bool,
-    },
-}
+use super::license_workflow_impl;
 
-impl LicenseWorkflowCommands {
-    pub async fn execute(
-        &self,
-        config: &Config,
-        output_format: OutputFormat,
-        query: Option<&str>,
-    ) -> AnyhowResult<()> {
-        match self {
-            Self::Audit { expiring, expired } => {
-                handle_license_audit(config, *expiring, *expired, output_format, query).await
-            }
-            Self::BulkUpdate {
+/// Handle enterprise license workflow commands
+pub async fn handle_license_workflow_command(
+    conn_mgr: &ConnectionManager,
+    command: &EnterpriseLicenseWorkflowCommands,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()> {
+    let result = match command {
+        EnterpriseLicenseWorkflowCommands::Audit { expiring, expired } => {
+            license_workflow_impl::license_audit(
+                conn_mgr,
+                *expiring,
+                *expired,
+                output_format,
+                query,
+            )
+            .await
+        }
+        EnterpriseLicenseWorkflowCommands::BulkUpdate {
+            profiles,
+            data,
+            dry_run,
+        } => {
+            license_workflow_impl::bulk_update(
+                conn_mgr,
                 profiles,
                 data,
-                dry_run,
-            } => handle_bulk_update(config, profiles, data, *dry_run, output_format, query).await,
-            Self::Report { format } => {
-                handle_license_report(config, format, output_format, query).await
-            }
-            Self::Monitor {
-                warning_days,
-                fail_on_warning,
-            } => {
-                handle_license_monitor(
-                    config,
-                    *warning_days,
-                    *fail_on_warning,
-                    output_format,
-                    query,
-                )
-                .await
-            }
-        }
-    }
-}
-
-async fn handle_license_audit(
-    config: &Config,
-    expiring_only: bool,
-    expired_only: bool,
-    output_format: OutputFormat,
-    query: Option<&str>,
-) -> AnyhowResult<()> {
-    let mut audit_results = Vec::new();
-    let conn_manager = crate::connection::ConnectionManager::new(config.clone());
-
-    // Get all enterprise profiles
-    for (profile_name, profile) in config.profiles.iter() {
-        if profile.deployment_type != redisctl_core::DeploymentType::Enterprise {
-            continue;
-        }
-
-        // Try to get license info for this profile
-        match conn_manager
-            .create_enterprise_client(Some(profile_name))
+                *dry_run,
+                output_format,
+                query,
+            )
             .await
-        {
-            Ok(client) => {
-                match client.get::<Value>("/v1/license").await {
-                    Ok(license) => {
-                        let expired = license
-                            .get("expired")
-                            .and_then(|v| v.as_bool())
-                            .unwrap_or(false);
-                        let expiration_date = license
-                            .get("expiration_date")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("unknown");
-                        let days_remaining =
-                            super::license::calculate_days_remaining(Some(expiration_date));
-                        let is_expiring = (0..=30).contains(&days_remaining);
-
-                        // Apply filters
-                        if expired_only && !expired {
-                            continue;
-                        }
-                        if expiring_only && !is_expiring && !expired {
-                            continue;
-                        }
-
-                        audit_results.push(serde_json::json!({
-                            "profile": profile_name,
-                            "cluster_name": license.get("cluster_name").and_then(|v| v.as_str()).unwrap_or("unknown"),
-                            "expiration_date": expiration_date,
-                            "days_remaining": days_remaining,
-                            "expired": expired,
-                            "expiring_soon": is_expiring,
-                            "shards_limit": license.get("shards_limit"),
-                            "ram_limit_gb": super::license::bytes_to_gb(
-                                license.get("ram_limit").and_then(|v| v.as_i64()).unwrap_or(0)
-                            ),
-                            "status": if expired {
-                                "EXPIRED"
-                            } else if is_expiring {
-                                "EXPIRING"
-                            } else {
-                                "OK"
-                            }
-                        }));
-                    }
-                    Err(e) => {
-                        audit_results.push(serde_json::json!({
-                            "profile": profile_name,
-                            "error": format!("Failed to get license: {}", e),
-                            "status": "ERROR"
-                        }));
-                    }
-                }
-            }
-            Err(e) => {
-                audit_results.push(serde_json::json!({
-                    "profile": profile_name,
-                    "error": format!("Failed to connect: {}", e),
-                    "status": "ERROR"
-                }));
-            }
         }
-    }
-
-    let response = Value::Array(audit_results);
-    let response = if let Some(q) = query {
-        super::utils::apply_jmespath(&response, q)?
-    } else {
-        response
-    };
-
-    super::utils::print_formatted_output(response, output_format).map_err(|e| anyhow::anyhow!(e))
-}
-
-async fn handle_bulk_update(
-    config: &Config,
-    profiles: &str,
-    data: &str,
-    dry_run: bool,
-    output_format: OutputFormat,
-    query: Option<&str>,
-) -> AnyhowResult<()> {
-    let conn_manager = crate::connection::ConnectionManager::new(config.clone());
-    let license_data = super::utils::read_json_data(data)?;
-
-    // Determine which profiles to update
-    let target_profiles: Vec<String> = if profiles == "all" {
-        config
-            .profiles
-            .iter()
-            .filter(|(_, p)| p.deployment_type == redisctl_core::DeploymentType::Enterprise)
-            .map(|(name, _)| name.clone())
-            .collect()
-    } else {
-        profiles.split(',').map(|s| s.trim().to_string()).collect()
-    };
-
-    let mut update_results = Vec::new();
-
-    for profile_name in target_profiles {
-        if !config.profiles.contains_key(&profile_name) {
-            update_results.push(serde_json::json!({
-                "profile": profile_name,
-                "status": "SKIPPED",
-                "message": "Profile not found"
-            }));
-            continue;
+        EnterpriseLicenseWorkflowCommands::Report { format } => {
+            license_workflow_impl::license_report(conn_mgr, format, output_format, query).await
         }
-
-        if dry_run {
-            update_results.push(serde_json::json!({
-                "profile": profile_name,
-                "status": "DRY_RUN",
-                "message": "Would update license"
-            }));
-        } else {
-            match conn_manager
-                .create_enterprise_client(Some(&profile_name))
-                .await
-            {
-                Ok(client) => match client.put::<_, Value>("/v1/license", &license_data).await {
-                    Ok(_) => {
-                        update_results.push(serde_json::json!({
-                            "profile": profile_name,
-                            "status": "SUCCESS",
-                            "message": "License updated successfully"
-                        }));
-                    }
-                    Err(e) => {
-                        update_results.push(serde_json::json!({
-                            "profile": profile_name,
-                            "status": "FAILED",
-                            "message": format!("Failed to update license: {}", e)
-                        }));
-                    }
-                },
-                Err(e) => {
-                    update_results.push(serde_json::json!({
-                        "profile": profile_name,
-                        "status": "FAILED",
-                        "message": format!("Failed to connect: {}", e)
-                    }));
-                }
-            }
-        }
-    }
-
-    let response = Value::Array(update_results);
-    let response = if let Some(q) = query {
-        super::utils::apply_jmespath(&response, q)?
-    } else {
-        response
-    };
-
-    super::utils::print_formatted_output(response, output_format).map_err(|e| anyhow::anyhow!(e))
-}
-
-async fn handle_license_report(
-    config: &Config,
-    format: &str,
-    output_format: OutputFormat,
-    query: Option<&str>,
-) -> AnyhowResult<()> {
-    let conn_manager = crate::connection::ConnectionManager::new(config.clone());
-    let mut report_data = Vec::new();
-
-    for (profile_name, profile) in config.profiles.iter() {
-        if profile.deployment_type != redisctl_core::DeploymentType::Enterprise {
-            continue;
-        }
-
-        match conn_manager
-            .create_enterprise_client(Some(profile_name))
+        EnterpriseLicenseWorkflowCommands::Monitor {
+            warning_days,
+            fail_on_warning,
+        } => {
+            license_workflow_impl::license_monitor(
+                conn_mgr,
+                *warning_days,
+                *fail_on_warning,
+                output_format,
+                query,
+            )
             .await
-        {
-            Ok(client) => {
-                // Get license info
-                let license = client.get::<Value>("/v1/license").await.ok();
-                // Get cluster info for usage
-                let cluster = client.get::<Value>("/v1/cluster").await.ok();
-
-                if let (Some(license), Some(cluster)) = (license, cluster) {
-                    report_data.push(serde_json::json!({
-                        "profile": profile_name,
-                        "cluster_name": license.get("cluster_name").and_then(|v| v.as_str()).unwrap_or("unknown"),
-                        "activation_date": license.get("activation_date").and_then(|v| v.as_str()).unwrap_or("unknown"),
-                        "expiration_date": license.get("expiration_date").and_then(|v| v.as_str()).unwrap_or("unknown"),
-                        "days_remaining": super::license::calculate_days_remaining(
-                            license.get("expiration_date").and_then(|v| v.as_str())
-                        ),
-                        "expired": license.get("expired").and_then(|v| v.as_bool()).unwrap_or(false),
-                        "shards_limit": license.get("shards_limit").and_then(|v| v.as_i64()).unwrap_or(0),
-                        "shards_used": cluster.get("shards_used").and_then(|v| v.as_i64()).unwrap_or(0),
-                        "ram_limit_gb": super::license::bytes_to_gb(
-                            license.get("ram_limit").and_then(|v| v.as_i64()).unwrap_or(0)
-                        ),
-                        "ram_used_gb": super::license::bytes_to_gb(
-                            cluster.get("ram_used").and_then(|v| v.as_i64()).unwrap_or(0)
-                        ),
-                        "nodes_count": cluster.get("nodes_count").and_then(|v| v.as_i64()).unwrap_or(0),
-                        "flash_enabled": license.get("flash_enabled").and_then(|v| v.as_bool()).unwrap_or(false),
-                        "rack_awareness": license.get("rack_awareness").and_then(|v| v.as_bool()).unwrap_or(false),
-                    }));
-                }
-            }
-            Err(_) => continue,
         }
-    }
-
-    // Format as CSV if requested
-    if format == "csv" {
-        if !report_data.is_empty() {
-            println!(
-                "profile,cluster_name,activation_date,expiration_date,days_remaining,expired,shards_limit,shards_used,ram_limit_gb,ram_used_gb,nodes_count,flash_enabled,rack_awareness"
-            );
-            for item in report_data {
-                if let Some(obj) = item.as_object() {
-                    println!(
-                        "{},{},{},{},{},{},{},{},{:.2},{:.2},{},{},{}",
-                        obj.get("profile").and_then(|v| v.as_str()).unwrap_or(""),
-                        obj.get("cluster_name")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or(""),
-                        obj.get("activation_date")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or(""),
-                        obj.get("expiration_date")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or(""),
-                        obj.get("days_remaining")
-                            .and_then(|v| v.as_i64())
-                            .unwrap_or(-1),
-                        obj.get("expired")
-                            .and_then(|v| v.as_bool())
-                            .unwrap_or(false),
-                        obj.get("shards_limit")
-                            .and_then(|v| v.as_i64())
-                            .unwrap_or(0),
-                        obj.get("shards_used").and_then(|v| v.as_i64()).unwrap_or(0),
-                        obj.get("ram_limit_gb")
-                            .and_then(|v| v.as_f64())
-                            .unwrap_or(0.0),
-                        obj.get("ram_used_gb")
-                            .and_then(|v| v.as_f64())
-                            .unwrap_or(0.0),
-                        obj.get("nodes_count").and_then(|v| v.as_i64()).unwrap_or(0),
-                        obj.get("flash_enabled")
-                            .and_then(|v| v.as_bool())
-                            .unwrap_or(false),
-                        obj.get("rack_awareness")
-                            .and_then(|v| v.as_bool())
-                            .unwrap_or(false),
-                    );
-                }
-            }
-            Ok(())
-        } else {
-            println!("No enterprise profiles found");
-            Ok(())
-        }
-    } else {
-        let response = Value::Array(report_data);
-        let response = if let Some(q) = query {
-            super::utils::apply_jmespath(&response, q)?
-        } else {
-            response
-        };
-
-        super::utils::print_formatted_output(response, output_format)
-            .map_err(|e| anyhow::anyhow!(e))
-    }
-}
-
-async fn handle_license_monitor(
-    config: &Config,
-    warning_days: i64,
-    fail_on_warning: bool,
-    output_format: OutputFormat,
-    query: Option<&str>,
-) -> AnyhowResult<()> {
-    let conn_manager = crate::connection::ConnectionManager::new(config.clone());
-    let mut warnings = Vec::new();
-    let mut errors = Vec::new();
-
-    for (profile_name, profile) in config.profiles.iter() {
-        if profile.deployment_type != redisctl_core::DeploymentType::Enterprise {
-            continue;
-        }
-
-        match conn_manager
-            .create_enterprise_client(Some(profile_name))
-            .await
-        {
-            Ok(client) => match client.get::<Value>("/v1/license").await {
-                Ok(license) => {
-                    let expired = license
-                        .get("expired")
-                        .and_then(|v| v.as_bool())
-                        .unwrap_or(false);
-                    let expiration_date = license
-                        .get("expiration_date")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("unknown");
-                    let days_remaining =
-                        super::license::calculate_days_remaining(Some(expiration_date));
-
-                    if expired {
-                        errors.push(serde_json::json!({
-                                "profile": profile_name,
-                                "cluster_name": license.get("cluster_name").and_then(|v| v.as_str()).unwrap_or("unknown"),
-                                "message": format!("License EXPIRED on {}", expiration_date),
-                                "severity": "ERROR"
-                            }));
-                    } else if days_remaining >= 0 && days_remaining <= warning_days {
-                        warnings.push(serde_json::json!({
-                                "profile": profile_name,
-                                "cluster_name": license.get("cluster_name").and_then(|v| v.as_str()).unwrap_or("unknown"),
-                                "message": format!("License expiring in {} days ({})", days_remaining, expiration_date),
-                                "severity": "WARNING"
-                            }));
-                    }
-                }
-                Err(e) => {
-                    errors.push(serde_json::json!({
-                        "profile": profile_name,
-                        "message": format!("Failed to check license: {}", e),
-                        "severity": "ERROR"
-                    }));
-                }
-            },
-            Err(e) => {
-                errors.push(serde_json::json!({
-                    "profile": profile_name,
-                    "message": format!("Failed to connect: {}", e),
-                    "severity": "ERROR"
-                }));
-            }
-        }
-    }
-
-    let response = serde_json::json!({
-        "summary": {
-            "total_profiles_checked": config.profiles.iter().filter(|(_, p)| p.deployment_type == redisctl_core::DeploymentType::Enterprise).count(),
-            "warnings_count": warnings.len(),
-            "errors_count": errors.len(),
-            "status": if !errors.is_empty() {
-                "ERROR"
-            } else if !warnings.is_empty() {
-                "WARNING"
-            } else {
-                "OK"
-            }
-        },
-        "warnings": warnings,
-        "errors": errors
-    });
-
-    let response = if let Some(q) = query {
-        super::utils::apply_jmespath(&response, q)?
-    } else {
-        response
     };
 
-    super::utils::print_formatted_output(response.clone(), output_format)
-        .map_err(|e| anyhow::anyhow!(e))?;
-
-    // Exit with error code if requested
-    if fail_on_warning && (!warnings.is_empty() || !errors.is_empty()) {
-        std::process::exit(1);
-    }
-
-    Ok(())
+    result.map_err(RedisCtlError::from)
 }
 
 #[cfg(test)]
@@ -484,25 +69,25 @@ mod tests {
         // Test that all workflow commands can be constructed
 
         // Audit command
-        let _cmd = LicenseWorkflowCommands::Audit {
+        let _cmd = EnterpriseLicenseWorkflowCommands::Audit {
             expiring: false,
             expired: false,
         };
 
         // Bulk update command
-        let _cmd = LicenseWorkflowCommands::BulkUpdate {
+        let _cmd = EnterpriseLicenseWorkflowCommands::BulkUpdate {
             profiles: "all".to_string(),
             data: "{}".to_string(),
             dry_run: true,
         };
 
         // Report command
-        let _cmd = LicenseWorkflowCommands::Report {
+        let _cmd = EnterpriseLicenseWorkflowCommands::Report {
             format: "csv".to_string(),
         };
 
         // Monitor command
-        let _cmd = LicenseWorkflowCommands::Monitor {
+        let _cmd = EnterpriseLicenseWorkflowCommands::Monitor {
             warning_days: 30,
             fail_on_warning: false,
         };

--- a/crates/redisctl/src/commands/enterprise/license_workflow_impl.rs
+++ b/crates/redisctl/src/commands/enterprise/license_workflow_impl.rs
@@ -1,0 +1,385 @@
+//! Implementation of enterprise license workflow commands
+
+use anyhow::Result as AnyhowResult;
+use serde_json::Value;
+
+use crate::cli::OutputFormat;
+use crate::connection::ConnectionManager;
+
+use super::license_impl::{bytes_to_gb, calculate_days_remaining};
+
+pub async fn license_audit(
+    conn_mgr: &ConnectionManager,
+    expiring_only: bool,
+    expired_only: bool,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> AnyhowResult<()> {
+    let mut audit_results = Vec::new();
+
+    // Get all enterprise profiles
+    for (profile_name, profile) in conn_mgr.config.profiles.iter() {
+        if profile.deployment_type != redisctl_core::DeploymentType::Enterprise {
+            continue;
+        }
+
+        // Try to get license info for this profile
+        match conn_mgr.create_enterprise_client(Some(profile_name)).await {
+            Ok(client) => {
+                match client.get::<Value>("/v1/license").await {
+                    Ok(license) => {
+                        let expired = license
+                            .get("expired")
+                            .and_then(|v| v.as_bool())
+                            .unwrap_or(false);
+                        let expiration_date = license
+                            .get("expiration_date")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("unknown");
+                        let days_remaining = calculate_days_remaining(Some(expiration_date));
+                        let is_expiring = (0..=30).contains(&days_remaining);
+
+                        // Apply filters
+                        if expired_only && !expired {
+                            continue;
+                        }
+                        if expiring_only && !is_expiring && !expired {
+                            continue;
+                        }
+
+                        audit_results.push(serde_json::json!({
+                            "profile": profile_name,
+                            "cluster_name": license.get("cluster_name").and_then(|v| v.as_str()).unwrap_or("unknown"),
+                            "expiration_date": expiration_date,
+                            "days_remaining": days_remaining,
+                            "expired": expired,
+                            "expiring_soon": is_expiring,
+                            "shards_limit": license.get("shards_limit"),
+                            "ram_limit_gb": bytes_to_gb(
+                                license.get("ram_limit").and_then(|v| v.as_i64()).unwrap_or(0)
+                            ),
+                            "status": if expired {
+                                "EXPIRED"
+                            } else if is_expiring {
+                                "EXPIRING"
+                            } else {
+                                "OK"
+                            }
+                        }));
+                    }
+                    Err(e) => {
+                        audit_results.push(serde_json::json!({
+                            "profile": profile_name,
+                            "error": format!("Failed to get license: {}", e),
+                            "status": "ERROR"
+                        }));
+                    }
+                }
+            }
+            Err(e) => {
+                audit_results.push(serde_json::json!({
+                    "profile": profile_name,
+                    "error": format!("Failed to connect: {}", e),
+                    "status": "ERROR"
+                }));
+            }
+        }
+    }
+
+    let response = Value::Array(audit_results);
+    let response = if let Some(q) = query {
+        super::utils::apply_jmespath(&response, q)?
+    } else {
+        response
+    };
+
+    super::utils::print_formatted_output(response, output_format).map_err(|e| anyhow::anyhow!(e))
+}
+
+pub async fn bulk_update(
+    conn_mgr: &ConnectionManager,
+    profiles: &str,
+    data: &str,
+    dry_run: bool,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> AnyhowResult<()> {
+    let license_data = super::utils::read_json_data(data)?;
+
+    // Determine which profiles to update
+    let target_profiles: Vec<String> = if profiles == "all" {
+        conn_mgr
+            .config
+            .profiles
+            .iter()
+            .filter(|(_, p)| p.deployment_type == redisctl_core::DeploymentType::Enterprise)
+            .map(|(name, _)| name.clone())
+            .collect()
+    } else {
+        profiles.split(',').map(|s| s.trim().to_string()).collect()
+    };
+
+    let mut update_results = Vec::new();
+
+    for profile_name in target_profiles {
+        if !conn_mgr.config.profiles.contains_key(&profile_name) {
+            update_results.push(serde_json::json!({
+                "profile": profile_name,
+                "status": "SKIPPED",
+                "message": "Profile not found"
+            }));
+            continue;
+        }
+
+        if dry_run {
+            update_results.push(serde_json::json!({
+                "profile": profile_name,
+                "status": "DRY_RUN",
+                "message": "Would update license"
+            }));
+        } else {
+            match conn_mgr.create_enterprise_client(Some(&profile_name)).await {
+                Ok(client) => match client.put::<_, Value>("/v1/license", &license_data).await {
+                    Ok(_) => {
+                        update_results.push(serde_json::json!({
+                            "profile": profile_name,
+                            "status": "SUCCESS",
+                            "message": "License updated successfully"
+                        }));
+                    }
+                    Err(e) => {
+                        update_results.push(serde_json::json!({
+                            "profile": profile_name,
+                            "status": "FAILED",
+                            "message": format!("Failed to update license: {}", e)
+                        }));
+                    }
+                },
+                Err(e) => {
+                    update_results.push(serde_json::json!({
+                        "profile": profile_name,
+                        "status": "FAILED",
+                        "message": format!("Failed to connect: {}", e)
+                    }));
+                }
+            }
+        }
+    }
+
+    let response = Value::Array(update_results);
+    let response = if let Some(q) = query {
+        super::utils::apply_jmespath(&response, q)?
+    } else {
+        response
+    };
+
+    super::utils::print_formatted_output(response, output_format).map_err(|e| anyhow::anyhow!(e))
+}
+
+pub async fn license_report(
+    conn_mgr: &ConnectionManager,
+    format: &str,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> AnyhowResult<()> {
+    let mut report_data = Vec::new();
+
+    for (profile_name, profile) in conn_mgr.config.profiles.iter() {
+        if profile.deployment_type != redisctl_core::DeploymentType::Enterprise {
+            continue;
+        }
+
+        match conn_mgr.create_enterprise_client(Some(profile_name)).await {
+            Ok(client) => {
+                // Get license info
+                let license = client.get::<Value>("/v1/license").await.ok();
+                // Get cluster info for usage
+                let cluster = client.get::<Value>("/v1/cluster").await.ok();
+
+                if let (Some(license), Some(cluster)) = (license, cluster) {
+                    report_data.push(serde_json::json!({
+                        "profile": profile_name,
+                        "cluster_name": license.get("cluster_name").and_then(|v| v.as_str()).unwrap_or("unknown"),
+                        "activation_date": license.get("activation_date").and_then(|v| v.as_str()).unwrap_or("unknown"),
+                        "expiration_date": license.get("expiration_date").and_then(|v| v.as_str()).unwrap_or("unknown"),
+                        "days_remaining": calculate_days_remaining(
+                            license.get("expiration_date").and_then(|v| v.as_str())
+                        ),
+                        "expired": license.get("expired").and_then(|v| v.as_bool()).unwrap_or(false),
+                        "shards_limit": license.get("shards_limit").and_then(|v| v.as_i64()).unwrap_or(0),
+                        "shards_used": cluster.get("shards_used").and_then(|v| v.as_i64()).unwrap_or(0),
+                        "ram_limit_gb": bytes_to_gb(
+                            license.get("ram_limit").and_then(|v| v.as_i64()).unwrap_or(0)
+                        ),
+                        "ram_used_gb": bytes_to_gb(
+                            cluster.get("ram_used").and_then(|v| v.as_i64()).unwrap_or(0)
+                        ),
+                        "nodes_count": cluster.get("nodes_count").and_then(|v| v.as_i64()).unwrap_or(0),
+                        "flash_enabled": license.get("flash_enabled").and_then(|v| v.as_bool()).unwrap_or(false),
+                        "rack_awareness": license.get("rack_awareness").and_then(|v| v.as_bool()).unwrap_or(false),
+                    }));
+                }
+            }
+            Err(_) => continue,
+        }
+    }
+
+    // Format as CSV if requested
+    if format == "csv" {
+        if !report_data.is_empty() {
+            println!(
+                "profile,cluster_name,activation_date,expiration_date,days_remaining,expired,shards_limit,shards_used,ram_limit_gb,ram_used_gb,nodes_count,flash_enabled,rack_awareness"
+            );
+            for item in report_data {
+                if let Some(obj) = item.as_object() {
+                    println!(
+                        "{},{},{},{},{},{},{},{},{:.2},{:.2},{},{},{}",
+                        obj.get("profile").and_then(|v| v.as_str()).unwrap_or(""),
+                        obj.get("cluster_name")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or(""),
+                        obj.get("activation_date")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or(""),
+                        obj.get("expiration_date")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or(""),
+                        obj.get("days_remaining")
+                            .and_then(|v| v.as_i64())
+                            .unwrap_or(-1),
+                        obj.get("expired")
+                            .and_then(|v| v.as_bool())
+                            .unwrap_or(false),
+                        obj.get("shards_limit")
+                            .and_then(|v| v.as_i64())
+                            .unwrap_or(0),
+                        obj.get("shards_used").and_then(|v| v.as_i64()).unwrap_or(0),
+                        obj.get("ram_limit_gb")
+                            .and_then(|v| v.as_f64())
+                            .unwrap_or(0.0),
+                        obj.get("ram_used_gb")
+                            .and_then(|v| v.as_f64())
+                            .unwrap_or(0.0),
+                        obj.get("nodes_count").and_then(|v| v.as_i64()).unwrap_or(0),
+                        obj.get("flash_enabled")
+                            .and_then(|v| v.as_bool())
+                            .unwrap_or(false),
+                        obj.get("rack_awareness")
+                            .and_then(|v| v.as_bool())
+                            .unwrap_or(false),
+                    );
+                }
+            }
+            Ok(())
+        } else {
+            println!("No enterprise profiles found");
+            Ok(())
+        }
+    } else {
+        let response = Value::Array(report_data);
+        let response = if let Some(q) = query {
+            super::utils::apply_jmespath(&response, q)?
+        } else {
+            response
+        };
+
+        super::utils::print_formatted_output(response, output_format)
+            .map_err(|e| anyhow::anyhow!(e))
+    }
+}
+
+pub async fn license_monitor(
+    conn_mgr: &ConnectionManager,
+    warning_days: i64,
+    fail_on_warning: bool,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> AnyhowResult<()> {
+    let mut warnings = Vec::new();
+    let mut errors = Vec::new();
+
+    for (profile_name, profile) in conn_mgr.config.profiles.iter() {
+        if profile.deployment_type != redisctl_core::DeploymentType::Enterprise {
+            continue;
+        }
+
+        match conn_mgr.create_enterprise_client(Some(profile_name)).await {
+            Ok(client) => match client.get::<Value>("/v1/license").await {
+                Ok(license) => {
+                    let expired = license
+                        .get("expired")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false);
+                    let expiration_date = license
+                        .get("expiration_date")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("unknown");
+                    let days_remaining = calculate_days_remaining(Some(expiration_date));
+
+                    if expired {
+                        errors.push(serde_json::json!({
+                                "profile": profile_name,
+                                "cluster_name": license.get("cluster_name").and_then(|v| v.as_str()).unwrap_or("unknown"),
+                                "message": format!("License EXPIRED on {}", expiration_date),
+                                "severity": "ERROR"
+                            }));
+                    } else if days_remaining >= 0 && days_remaining <= warning_days {
+                        warnings.push(serde_json::json!({
+                                "profile": profile_name,
+                                "cluster_name": license.get("cluster_name").and_then(|v| v.as_str()).unwrap_or("unknown"),
+                                "message": format!("License expiring in {} days ({})", days_remaining, expiration_date),
+                                "severity": "WARNING"
+                            }));
+                    }
+                }
+                Err(e) => {
+                    errors.push(serde_json::json!({
+                        "profile": profile_name,
+                        "message": format!("Failed to check license: {}", e),
+                        "severity": "ERROR"
+                    }));
+                }
+            },
+            Err(e) => {
+                errors.push(serde_json::json!({
+                    "profile": profile_name,
+                    "message": format!("Failed to connect: {}", e),
+                    "severity": "ERROR"
+                }));
+            }
+        }
+    }
+
+    let response = serde_json::json!({
+        "summary": {
+            "total_profiles_checked": conn_mgr.config.profiles.iter().filter(|(_, p)| p.deployment_type == redisctl_core::DeploymentType::Enterprise).count(),
+            "warnings_count": warnings.len(),
+            "errors_count": errors.len(),
+            "status": if !errors.is_empty() {
+                "ERROR"
+            } else if !warnings.is_empty() {
+                "WARNING"
+            } else {
+                "OK"
+            }
+        },
+        "warnings": warnings,
+        "errors": errors
+    });
+
+    let response = if let Some(q) = query {
+        super::utils::apply_jmespath(&response, q)?
+    } else {
+        response
+    };
+
+    super::utils::print_formatted_output(response.clone(), output_format)
+        .map_err(|e| anyhow::anyhow!(e))?;
+
+    // Exit with error code if requested
+    if fail_on_warning && (!warnings.is_empty() || !errors.is_empty()) {
+        std::process::exit(1);
+    }
+
+    Ok(())
+}

--- a/crates/redisctl/src/commands/enterprise/mod.rs
+++ b/crates/redisctl/src/commands/enterprise/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod actions;
 pub mod alerts;
+pub mod alerts_impl;
 pub mod bdb_group;
 pub mod bootstrap;
 pub mod cluster;
@@ -19,7 +20,9 @@ pub mod job_scheduler;
 pub mod jsonschema;
 pub mod ldap;
 pub mod license;
+pub mod license_impl;
 pub mod license_workflow;
+pub mod license_workflow_impl;
 pub mod local;
 pub mod logs;
 pub mod logs_impl;

--- a/crates/redisctl/src/main.rs
+++ b/crates/redisctl/src/main.rs
@@ -662,10 +662,12 @@ async fn execute_enterprise_command(
             )
             .await
         }
-        Alerts(alerts_cmd) => alerts_cmd
-            .execute(&conn_mgr.config, profile, output, query)
+        Alerts(alerts_cmd) => {
+            commands::enterprise::alerts::handle_alerts_command(
+                conn_mgr, profile, alerts_cmd, output, query,
+            )
             .await
-            .map_err(RedisCtlError::from),
+        }
         BdbGroup(bdb_group_cmd) => {
             commands::enterprise::bdb_group::handle_bdb_group_command(
                 conn_mgr,
@@ -844,10 +846,16 @@ async fn execute_enterprise_command(
             )
             .await
         }
-        License(license_cmd) => license_cmd
-            .execute(&conn_mgr.config, profile, output, query)
+        License(license_cmd) => {
+            commands::enterprise::license::handle_license_command(
+                conn_mgr,
+                profile,
+                license_cmd,
+                output,
+                query,
+            )
             .await
-            .map_err(RedisCtlError::from),
+        }
         Migration(migration_cmd) => {
             commands::enterprise::migration::handle_migration_command(
                 conn_mgr,
@@ -1098,10 +1106,15 @@ async fn handle_enterprise_workflow_command(
             }
             Ok(())
         }
-        License(license_workflow_cmd) => license_workflow_cmd
-            .execute(&conn_mgr.config, output, None)
+        License(license_workflow_cmd) => {
+            commands::enterprise::license_workflow::handle_license_workflow_command(
+                conn_mgr,
+                license_workflow_cmd,
+                output,
+                None,
+            )
             .await
-            .map_err(RedisCtlError::from),
+        }
         InitCluster {
             name,
             username,


### PR DESCRIPTION
Part of #1049 (Phase 3, CODE-09).

## Problem

`alerts`, `license` and `workflow license` were the last enterprise command groups using an in-file dispatch pattern:

```rust
#[derive(Debug, Subcommand)]
pub enum AlertsCommands { /* ... */ }

impl AlertsCommands {
    pub async fn execute(&self, config: &Config, /* ... */) -> AnyhowResult<()> {
        let conn_manager = ConnectionManager::new(config.clone());
        // match + handler calls, all in the same file
    }
}
```

Every other group (`database`, `cluster`, `node`, `crdb`, `logs`, `module`, `rbac`) uses:

```rust
pub async fn handle_x_command(
    conn_mgr: &ConnectionManager,
    profile_name: Option<&str>,
    command: &XCommands,
    output_format: OutputFormat,
    query: Option<&str>,
) -> CliResult<()>
```

with the enum declared separately and the handler bodies in a `*_impl.rs` module.

## Change

- Moved the three enums into `cli/enterprise.rs` as `EnterpriseAlertsCommands`, `EnterpriseLicenseCommands` and `EnterpriseLicenseWorkflowCommands`, matching the `Enterprise*Commands` naming of its neighbours.
- Added `alerts_impl.rs`, `license_impl.rs` and `license_workflow_impl.rs` holding the handler functions.
- `alerts.rs`, `license.rs` and `license_workflow.rs` are now dispatch-only, exposing `handle_alerts_command`, `handle_license_command` and `handle_license_workflow_command`.
- Handlers take `&ConnectionManager` rather than constructing one from `&Config`. The workflow handlers, which need the profile list, read it off `conn_mgr.config`.
- `license_workflow_impl.rs` imports `calculate_days_remaining` and `bytes_to_gb` from `license_impl` instead of reaching into `super::license` from a sibling command module.

## Behavior

None intended. The clap attributes, subcommand names, aliases, `after_help` examples and handler bodies all move verbatim. `enterprise alerts --help`, `enterprise license --help` and `enterprise workflow license --help` render the same command lists as before.

Two things were deliberately left alone:

- `handle_enterprise_workflow_command` still passes `None` for `query` to the license workflow (main.rs). That drops the global `--query`/`-q` for `enterprise workflow license`, but it is pre-existing and orthogonal to the dispatch shape.
- `license_workflow_impl::license_monitor` still calls `std::process::exit(1)` for `--fail-on-warning`. That belongs with the exit-code taxonomy work in #1045.

## Checks

`cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings` and `cargo test` all pass locally. `cargo doc --no-deps --all-features` produces only the two pre-existing warnings in `cli/enterprise.rs` (module `:args` and a bare cluster URL), unchanged by this diff.

## Follow-up

The "add a command" checklist for AGENTS.md, also listed under #1049 Phase 3, is a separate docs-only change and is not in this PR.
