### PR TITLE
docs: add an "add a command" checklist to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,74 @@ cli/
   mod.rs          # Top-level command tree
 ```
 
+## Adding a Command
+
+Enterprise command groups (`database`, `cluster`, `node`, `crdb`, `logs`, `module`, `rbac`) share
+one dispatch shape. Follow it when adding a group or a subcommand; do not introduce a new pattern.
+
+The group is split across three places:
+
+1. **The clap enum.** A `#[derive(Subcommand)]` enum holding the subcommands, their `#[arg]`
+   attributes, aliases and `after_help` examples.
+2. **The dispatch module** (`commands/enterprise/<name>.rs`): one free function that matches on the
+   enum and calls a handler per variant. No API calls, no output formatting.
+3. **The implementation module** (`commands/enterprise/<name>_impl.rs`): one function per
+   subcommand, holding the API call, the table types and the output formatting.
+
+### Checklist
+
+- [ ] **Declare the enum.** Placement varies by group and both existing choices are fine:
+      `cli/enterprise.rs` as `Enterprise<Name>Commands` (used by `database`, `cluster`, `node`,
+      `crdb`), or the group's own `commands/enterprise/<name>.rs` as `<Name>Commands` (used by
+      `logs`, `module`). Prefer `cli/enterprise.rs` for a group whose variants carry many flags,
+      so the CLI surface stays readable in one file.
+- [ ] **Add the variant** to `EnterpriseCommands` in `cli/enterprise.rs` wrapping the new enum.
+- [ ] **Write the dispatch function** in `commands/enterprise/<name>.rs` with the signature shown
+      below. Take `&ConnectionManager`; never build one from a `&Config`. `conn_mgr.config` is
+      public if a handler needs the profile list. `CliResult` is `crate::error::Result`.
+- [ ] **Write the handlers** in `commands/enterprise/<name>_impl.rs`, one per subcommand, each
+      taking `conn_mgr`/`profile_name` plus its own arguments and returning `CliResult<()>`.
+- [ ] **Register both modules** in `commands/enterprise/mod.rs` (`pub mod <name>;` and
+      `pub mod <name>_impl;`).
+- [ ] **Wire the dispatch** in the `EnterpriseCommands` match in `main.rs`, passing
+      `conn_mgr, profile, cmd, output, query`.
+- [ ] **Run the checks**: `cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`,
+      `cargo test --workspace`.
+
+### Dispatch signature
+
+```rust
+pub async fn handle_<name>_command(
+    conn_mgr: &ConnectionManager,
+    profile_name: Option<&str>,
+    command: &<Name>Commands,
+    output_format: OutputFormat,
+    query: Option<&str>,
+) -> CliResult<()>
+```
+
+### Handler body
+
+```rust
+let client = conn_mgr.create_enterprise_client(profile_name).await?;
+let response = client.get_raw("/v1/...").await.map_err(RedisCtlError::from)?;
+
+let data = handle_output(response, output_format, query)?;
+if matches!(resolve_auto(output_format), OutputFormat::Table) {
+    print_<name>_table(&data)?;
+} else {
+    print_formatted_output(data, output_format)?;
+}
+Ok(())
+```
+
+`handle_output`, `print_formatted_output` and `resolve_auto` come from `super::utils::*`, which
+re-exports them from `crate::output`.
+
+Two variations exist in the tree and are not worth churning: `logs` keeps its dispatch function in
+`logs_impl.rs` rather than `logs.rs`, and a few older groups still pass their command enum by value
+(`cmd.clone()`) at the `main.rs` call site. New groups should take the enum by reference.
+
 ## Conventions
 
 ### Commits


### PR DESCRIPTION
Part of #1049 (Phase 3, CODE-09). Docs-only; no code touched.

## Problem

The enterprise command groups share one dispatch shape, but it is only discoverable by reading an existing module and inferring the convention. #1049 Phase 3 calls for writing it down.

## Change

A new `## Adding a Command` section in AGENTS.md, between the module-organization notes and the conventions section. It covers:

- The three-way split: clap enum, dispatch module (`commands/enterprise/<name>.rs`), implementation module (`commands/enterprise/<name>_impl.rs`).
- A checklist: declare the enum, add the `EnterpriseCommands` variant, write the dispatch function, write the handlers, register both modules in `mod.rs`, wire the match arm in `main.rs`, run fmt/clippy/test.
- The dispatch signature verbatim:

```rust
pub async fn handle_<name>_command(
    conn_mgr: &ConnectionManager,
    profile_name: Option<&str>,
    command: &<Name>Commands,
    output_format: OutputFormat,
    query: Option<&str>,
) -> CliResult<()>
```

- A handler-body sketch showing `conn_mgr.create_enterprise_client(profile_name)`, `handle_output`, `resolve_auto` and `print_formatted_output`, and where those helpers come from (`super::utils::*`, re-exporting `crate::output`).

## Placement conventions

Enum placement genuinely varies in the tree and both forms are current, so the checklist records both rather than declaring one wrong:

- `cli/enterprise.rs` as `Enterprise<Name>Commands` for `database`, `cluster`, `node`, `crdb`
- `commands/enterprise/<name>.rs` as `<Name>Commands` for `logs`, `module`

It suggests `cli/enterprise.rs` for flag-heavy groups, and notes two pre-existing variations that are not worth churning: `logs` keeps its dispatch function in `logs_impl.rs`, and some older `main.rs` call sites pass the command enum by value.

## Checks

`markdownlint AGENTS.md --disable MD013 MD033 MD041` (the flags CI uses) reports no errors in the new section. The pre-existing errors elsewhere in the file are unchanged, and that job is `continue-on-error` in `docs.yml` regardless. No Rust changed.

## Relationship to #1056

Independent. #1056 converts `alerts`/`license`/`license_workflow` to this pattern; this PR documents the pattern. Either can land first. Together they close #1049 Phase 3.
