### PR TITLE
feat(cli): give failures a taxonomy exit code instead of a blanket 1

### DIFF
--- a/crates/redisctl/src/error.rs
+++ b/crates/redisctl/src/error.rs
@@ -67,6 +67,39 @@ impl CliDiagnostic {
     }
 }
 
+/// Process exit codes, so a script can branch on the kind of failure rather
+/// than on the text of the message.
+///
+/// `USAGE` is 2 to match clap, which already exits 2 when argument parsing
+/// fails: both mean the invocation itself was wrong. `GENERIC` stays 1 so
+/// anything not yet classified keeps the previous behavior.
+pub mod exit_code {
+    /// An error with no more specific classification.
+    pub const GENERIC: i32 = 1;
+    /// The command was invoked incorrectly.
+    pub const USAGE: i32 = 2;
+    /// Local configuration or profile problem.
+    pub const CONFIG: i32 = 3;
+    /// Credentials were rejected by the server.
+    pub const AUTH: i32 = 4;
+    /// The requested resource does not exist.
+    pub const NOT_FOUND: i32 = 5;
+    /// Input was well-formed but not valid.
+    pub const VALIDATION: i32 = 6;
+    /// The request conflicts with the current server state.
+    pub const CONFLICT: i32 = 7;
+    /// The server failed to service an otherwise valid request.
+    pub const UPSTREAM: i32 = 8;
+    /// The server is rate limiting; retry later.
+    pub const RATE_LIMITED: i32 = 9;
+    /// The server could not be reached.
+    pub const NETWORK: i32 = 10;
+    /// The operation did not complete in time.
+    pub const TIMEOUT: i32 = 11;
+    /// The operation was not confirmed, so nothing was done.
+    pub const CANCELLED: i32 = 12;
+}
+
 /// Main error type for the redisctl application
 #[derive(Error, Debug)]
 pub enum RedisCtlError {
@@ -271,11 +304,63 @@ impl RedisCtlError {
         }
     }
 
+    /// The process exit code for this error.
+    ///
+    /// Exhaustive on purpose: a new variant must declare its code. Several
+    /// variants share one code, because the taxonomy classifies what a script
+    /// should do about the failure, not which variant produced it.
+    pub fn exit_code(&self) -> i32 {
+        match self {
+            // Local configuration: the profile is missing, incomplete, or the
+            // wrong type for the command.
+            RedisCtlError::Configuration(_)
+            | RedisCtlError::ProfileNotFound { .. }
+            | RedisCtlError::ProfileTypeMismatch { .. }
+            | RedisCtlError::NoProfileConfigured
+            | RedisCtlError::MissingCredentials { .. } => exit_code::CONFIG,
+
+            RedisCtlError::AuthenticationFailed { .. } => exit_code::AUTH,
+
+            // The only variant that carries a server status, so it is the only
+            // place not-found, conflict and rate-limited can come from. The
+            // status is recovered from the message, as `suggestions` already
+            // does for 404.
+            RedisCtlError::ApiError { message } => {
+                if message.contains("404") {
+                    exit_code::NOT_FOUND
+                } else if message.contains("409") {
+                    exit_code::CONFLICT
+                } else if message.contains("429") {
+                    exit_code::RATE_LIMITED
+                } else {
+                    exit_code::UPSTREAM
+                }
+            }
+
+            RedisCtlError::InvalidInput { .. } => exit_code::VALIDATION,
+            RedisCtlError::Cancelled { .. } => exit_code::CANCELLED,
+
+            // The command does not apply to this deployment, or names a file
+            // that could not be read: in both cases the invocation was wrong.
+            RedisCtlError::UnsupportedDeploymentType { .. } | RedisCtlError::FileError { .. } => {
+                exit_code::USAGE
+            }
+
+            RedisCtlError::ConnectionError { .. } => exit_code::NETWORK,
+            RedisCtlError::Timeout { .. } => exit_code::TIMEOUT,
+
+            // `Other` is the anyhow catch-all and `OutputError` covers
+            // serialization and IO; neither is classified yet.
+            RedisCtlError::Other(_) | RedisCtlError::OutputError { .. } => exit_code::GENERIC,
+        }
+    }
+
     /// The structured error object emitted under -o json/-o yaml.
     fn envelope(&self) -> serde_json::Value {
         serde_json::json!({
             "error": {
                 "code": self.code(),
+                "exit_code": self.exit_code(),
                 "message": self.to_string(),
                 "tips": self.suggestions(),
             }
@@ -424,6 +509,128 @@ impl From<redisctl_core::error::CoreError> for RedisCtlError {
             redisctl_core::error::CoreError::Enterprise(enterprise_err) => {
                 RedisCtlError::from(enterprise_err)
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn api(message: &str) -> RedisCtlError {
+        RedisCtlError::ApiError {
+            message: message.to_string(),
+        }
+    }
+
+    #[test]
+    fn variants_map_to_their_taxonomy_codes() {
+        assert_eq!(
+            RedisCtlError::Configuration("bad".into()).exit_code(),
+            exit_code::CONFIG
+        );
+        assert_eq!(
+            RedisCtlError::ProfileNotFound { name: "p".into() }.exit_code(),
+            exit_code::CONFIG
+        );
+        assert_eq!(
+            RedisCtlError::AuthenticationFailed {
+                message: "no".into(),
+                profile_name: "p".into(),
+            }
+            .exit_code(),
+            exit_code::AUTH
+        );
+        assert_eq!(
+            RedisCtlError::InvalidInput {
+                message: "no".into(),
+            }
+            .exit_code(),
+            exit_code::VALIDATION
+        );
+        assert_eq!(
+            RedisCtlError::Cancelled {
+                prompt: "delete?".into(),
+            }
+            .exit_code(),
+            exit_code::CANCELLED
+        );
+        assert_eq!(
+            RedisCtlError::FileError {
+                path: "/nope".into(),
+                message: "missing".into(),
+            }
+            .exit_code(),
+            exit_code::USAGE
+        );
+        assert_eq!(
+            RedisCtlError::ConnectionError {
+                message: "refused".into(),
+            }
+            .exit_code(),
+            exit_code::NETWORK
+        );
+        assert_eq!(
+            RedisCtlError::Timeout {
+                message: "slow".into(),
+            }
+            .exit_code(),
+            exit_code::TIMEOUT
+        );
+        assert_eq!(
+            RedisCtlError::Other("unclassified".into()).exit_code(),
+            exit_code::GENERIC
+        );
+    }
+
+    #[test]
+    fn api_errors_split_by_status() {
+        assert_eq!(
+            api("404 Not Found: no such database").exit_code(),
+            exit_code::NOT_FOUND
+        );
+        assert_eq!(
+            api("HTTP 409: database already exists").exit_code(),
+            exit_code::CONFLICT
+        );
+        assert_eq!(
+            api("HTTP 429: slow down").exit_code(),
+            exit_code::RATE_LIMITED
+        );
+        assert_eq!(
+            api("Server error (5xx): boom").exit_code(),
+            exit_code::UPSTREAM
+        );
+    }
+
+    // The envelope is the script-facing contract: it must carry the same exit
+    // code the process actually returns.
+    #[test]
+    fn envelope_carries_the_exit_code() {
+        let err = RedisCtlError::Timeout {
+            message: "slow".into(),
+        };
+        let envelope = err.envelope();
+        assert_eq!(envelope["error"]["exit_code"], exit_code::TIMEOUT);
+        assert_eq!(envelope["error"]["code"], "timeout");
+    }
+
+    // Nothing is allowed to collapse back to a bare 1 except the two variants
+    // that are explicitly unclassified.
+    #[test]
+    fn classified_variants_do_not_return_generic() {
+        for err in [
+            RedisCtlError::NoProfileConfigured,
+            RedisCtlError::MissingCredentials {
+                name: "p".into(),
+                missing_fields: "api_key".into(),
+            },
+            RedisCtlError::UnsupportedDeploymentType {
+                deployment_type: "cloud".into(),
+            },
+            api("HTTP 500: boom"),
+        ] {
+            assert_ne!(err.exit_code(), exit_code::GENERIC, "{err}");
         }
     }
 }

--- a/crates/redisctl/src/main.rs
+++ b/crates/redisctl/src/main.rs
@@ -324,7 +324,8 @@ fn maybe_inject_prefix(args: Vec<String>) -> Vec<String> {
                                 error::CliDiagnostic::error(&format!("{}", e)).print();
                             }
                         }
-                        std::process::exit(1);
+                        // Every arm above is a profile or config-file problem.
+                        std::process::exit(error::exit_code::CONFIG);
                     }
                 }
             }
@@ -349,7 +350,9 @@ fn maybe_inject_prefix(args: Vec<String>) -> Vec<String> {
                     ],
                 )
                 .print();
-                std::process::exit(1);
+                // The command is ambiguous as invoked: the platform has to be
+                // named or inferable.
+                std::process::exit(error::exit_code::USAGE);
             }
         }
     } else {
@@ -414,7 +417,7 @@ async fn main() -> Result<()> {
     // Execute command
     if let Err(e) = execute_command(&cli, &conn_mgr).await {
         e.print_diagnostic(cli.output);
-        std::process::exit(1);
+        std::process::exit(e.exit_code());
     }
 
     Ok(())

--- a/crates/redisctl/tests/cli_integration_mocked_tests.rs
+++ b/crates/redisctl/tests/cli_integration_mocked_tests.rs
@@ -161,6 +161,25 @@ fn json_output_emits_structured_error_envelope() {
     assert_eq!(v["error"]["code"], "profile_type_mismatch");
     assert!(v["error"]["message"].is_string());
     assert!(v["error"]["tips"].is_array());
+    // The envelope's exit_code is the code the process actually returned.
+    assert_eq!(v["error"]["exit_code"], 3);
+    assert_eq!(output.status.code(), Some(3));
+}
+
+// A config problem exits 3 rather than the blanket 1, so a script can tell
+// "your config is wrong" from any other failure. Regression for
+// GAP-AUTOMATION-02.
+#[test]
+fn config_failure_exits_with_the_config_code() {
+    let temp_dir = TempDir::new().unwrap();
+    // Only a cloud profile exists, so an enterprise command has nothing to
+    // resolve: a configuration failure, before any network call.
+    create_cloud_profile(&temp_dir, "https://cloud.invalid").unwrap();
+
+    test_cmd(&temp_dir)
+        .args(["enterprise", "database", "list"])
+        .assert()
+        .code(3);
 }
 
 #[tokio::test]


### PR DESCRIPTION
Part of #1045, item 3 (GAP-AUTOMATION-02).

## Problem

Every runtime failure exited 1, from a blanket `process::exit(1)`. A script could tell that `redisctl` failed but not why, so branching on failure type meant matching on message text.

## Change

`crates/redisctl/src/error.rs` gains an `exit_code` module holding the taxonomy the issue names, and `RedisCtlError::exit_code()` mapping each variant to one:

| Code | Name | Variants |
| --- | --- | --- |
| 1 | `GENERIC` | `Other`, `OutputError` |
| 2 | `USAGE` | `UnsupportedDeploymentType`, `FileError` |
| 3 | `CONFIG` | `Configuration`, `ProfileNotFound`, `ProfileTypeMismatch`, `NoProfileConfigured`, `MissingCredentials` |
| 4 | `AUTH` | `AuthenticationFailed` |
| 5 | `NOT_FOUND` | `ApiError` (404) |
| 6 | `VALIDATION` | `InvalidInput` |
| 7 | `CONFLICT` | `ApiError` (409) |
| 8 | `UPSTREAM` | `ApiError` (other) |
| 9 | `RATE_LIMITED` | `ApiError` (429) |
| 10 | `NETWORK` | `ConnectionError` |
| 11 | `TIMEOUT` | `Timeout` |
| 12 | `CANCELLED` | `Cancelled` |

The match is exhaustive, so a new variant has to declare its code, the same way `code()` already works.

`main.rs` exits with `e.exit_code()` rather than 1. The two pre-dispatch exits in the prefix-inference layer do not have a `RedisCtlError` in hand, so they name their code directly: the `ConfigError` arms exit `CONFIG`, and the "cannot determine platform" arm exits `USAGE`.

The `-o json`/`-o yaml` envelope now carries `exit_code` alongside `code`. That is the field #1048 explicitly deferred to this change.

## Choices worth flagging

- **`USAGE` is 2** because clap already exits 2 when argument parsing fails. Both mean the invocation was wrong, so a script sees one code for that class rather than two.
- **`GENERIC` stays 1**, so anything not yet classified keeps its current behavior. `Other` is the anyhow catch-all and `OutputError` covers serialization and IO.
- **`ApiError` sniffs the status out of its message.** It is the only variant that carries a server status, so without this, not-found, conflict and rate-limited would be unreachable codes. `suggestions()` already does the same for 404. The real fix is a status field on the variant, which belongs with the `Config`/`Configuration` merge in item 2 of #1045.

## Gap found while testing

`--profile <nonexistent>` still exits 1, not 3. It never reaches `RedisCtlError::ProfileNotFound`: `connection.rs:174` and `connection.rs:389` report it through `anyhow::Context::with_context`, which lands in `Other`. This is the "354 error paths collapse into a generic variant" problem described in item 2 of #1045, and fixing it means changing `connection.rs`, which is outside this change. Worth doing next, since a nonexistent profile is the most common config failure there is.

## Behavior

Exit codes only. No message, format or control-flow changes. Success still exits 0.

```
$ redisctl enterprise database list; echo $?
error: Configuration error: No enterprise profiles configured
3
```

## Checks

`cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings` and `cargo test` all pass locally (full suite green). `cargo doc --no-deps --all-features` produces only the pre-existing warnings in `cli/enterprise.rs` and `redisctl-mcp`, unchanged by this diff.

Tests added: four unit tests in `error.rs` covering the per-variant mapping, the `ApiError` status split, the envelope carrying the code, and an assertion that no classified variant falls back to 1. The existing `-o json` envelope test now also asserts the process exit code matches the envelope, plus one integration test that a config failure exits 3.
