### PR TITLE
fix(cli): make a declined confirmation exit non-zero

### DIFF
--- a/crates/redisctl/src/commands/cloud/acl_impl.rs
+++ b/crates/redisctl/src/commands/cloud/acl_impl.rs
@@ -308,11 +308,7 @@ pub async fn delete_redis_rule(
     force: bool,
 ) -> CliResult<()> {
     if !force {
-        let confirm = confirm_action(&format!("delete Redis rule {}", id))?;
-        if !confirm {
-            println!("Operation cancelled");
-            return Ok(());
-        }
+        confirm_action(&format!("delete Redis rule {}", id))?;
     }
 
     let client = params
@@ -449,11 +445,7 @@ pub async fn update_role(
 
 pub async fn delete_role(params: &AclOperationParams<'_>, id: i32, force: bool) -> CliResult<()> {
     if !force {
-        let confirm = confirm_action(&format!("delete ACL role {}", id))?;
-        if !confirm {
-            println!("Operation cancelled");
-            return Ok(());
-        }
+        confirm_action(&format!("delete ACL role {}", id))?;
     }
 
     let client = params
@@ -617,11 +609,7 @@ pub async fn delete_acl_user(
     force: bool,
 ) -> CliResult<()> {
     if !force {
-        let confirm = confirm_action(&format!("delete ACL user {}", id))?;
-        if !confirm {
-            println!("Operation cancelled");
-            return Ok(());
-        }
+        confirm_action(&format!("delete ACL user {}", id))?;
     }
 
     let client = params

--- a/crates/redisctl/src/commands/cloud/cloud_account_impl.rs
+++ b/crates/redisctl/src/commands/cloud/cloud_account_impl.rs
@@ -340,11 +340,7 @@ pub async fn handle_delete(
     force: bool,
 ) -> CliResult<()> {
     if !force {
-        let confirmed = confirm_action(&format!("delete cloud account {}", account_id))?;
-        if !confirmed {
-            println!("Operation cancelled");
-            return Ok(());
-        }
+        confirm_action(&format!("delete cloud account {}", account_id))?;
     }
 
     let response = params

--- a/crates/redisctl/src/commands/cloud/connectivity/private_link.rs
+++ b/crates/redisctl/src/commands/cloud/connectivity/private_link.rs
@@ -406,14 +406,11 @@ async fn handle_delete(
     force: bool,
 ) -> CliResult<()> {
     // Confirmation prompt unless --force is used
-    if !force
-        && !crate::commands::cloud::utils::confirm_action(&format!(
+    if !force {
+        crate::commands::cloud::utils::confirm_action(&format!(
             "Are you sure you want to delete PrivateLink for subscription {}?",
             params.subscription_id
-        ))?
-    {
-        println!("Delete operation cancelled");
-        return Ok(());
+        ))?;
     }
 
     let result = handler

--- a/crates/redisctl/src/commands/cloud/connectivity/psc.rs
+++ b/crates/redisctl/src/commands/cloud/connectivity/psc.rs
@@ -337,10 +337,7 @@ async fn delete_service(params: &ConnectivityOperationParams<'_>, yes: bool) -> 
             "Delete PSC service for subscription {}?",
             params.subscription_id
         );
-        if !confirm_action(&prompt)? {
-            eprintln!("Operation cancelled");
-            return Ok(());
-        }
+        confirm_action(&prompt)?;
     }
 
     let handler = PscHandler::new(params.client.clone());
@@ -485,10 +482,7 @@ async fn delete_endpoint(
             "Delete PSC endpoint {} for subscription {}?",
             endpoint_id, params.subscription_id
         );
-        if !confirm_action(&prompt)? {
-            eprintln!("Operation cancelled");
-            return Ok(());
-        }
+        confirm_action(&prompt)?;
     }
 
     let handler = PscHandler::new(params.client.clone());
@@ -602,10 +596,7 @@ async fn delete_service_aa(
             "Delete Active-Active PSC service for subscription {}?",
             params.subscription_id
         );
-        if !confirm_action(&prompt)? {
-            eprintln!("Operation cancelled");
-            return Ok(());
-        }
+        confirm_action(&prompt)?;
     }
 
     let handler = PscHandler::new(params.client.clone());
@@ -692,10 +683,7 @@ async fn delete_endpoint_aa(
             "Delete Active-Active PSC endpoint {} in region {} for subscription {}?",
             endpoint_id, region_id, params.subscription_id
         );
-        if !confirm_action(&prompt)? {
-            eprintln!("Operation cancelled");
-            return Ok(());
-        }
+        confirm_action(&prompt)?;
     }
 
     let handler = PscHandler::new(params.client.clone());

--- a/crates/redisctl/src/commands/cloud/connectivity/tgw.rs
+++ b/crates/redisctl/src/commands/cloud/connectivity/tgw.rs
@@ -402,10 +402,7 @@ async fn delete_attachment(
             "Delete TGW attachment {} for subscription {}?",
             attachment_id, params.subscription_id
         );
-        if !confirm_action(&prompt)? {
-            eprintln!("Operation cancelled");
-            return Ok(());
-        }
+        confirm_action(&prompt)?;
     }
 
     let handler = TransitGatewayHandler::new(params.client.clone());
@@ -582,10 +579,7 @@ async fn delete_attachment_aa(
             "Delete Active-Active TGW attachment {} in region {} for subscription {}?",
             attachment_id, region_id, params.subscription_id
         );
-        if !confirm_action(&prompt)? {
-            eprintln!("Operation cancelled");
-            return Ok(());
-        }
+        confirm_action(&prompt)?;
     }
 
     let handler = TransitGatewayHandler::new(params.client.clone());

--- a/crates/redisctl/src/commands/cloud/connectivity/vpc_peering.rs
+++ b/crates/redisctl/src/commands/cloud/connectivity/vpc_peering.rs
@@ -441,14 +441,10 @@ async fn handle_delete(
     force: bool,
 ) -> CliResult<()> {
     if !force {
-        let confirmed = confirm_action(&format!(
+        confirm_action(&format!(
             "delete VPC peering {} for subscription {}",
             peering_id, params.subscription_id
         ))?;
-        if !confirmed {
-            println!("Operation cancelled");
-            return Ok(());
-        }
     }
 
     let result = params
@@ -569,14 +565,10 @@ async fn handle_delete_active_active(
     force: bool,
 ) -> CliResult<()> {
     if !force {
-        let confirmed = confirm_action(&format!(
+        confirm_action(&format!(
             "delete Active-Active VPC peering {} for subscription {}",
             peering_id, params.subscription_id
         ))?;
-        if !confirmed {
-            println!("Operation cancelled");
-            return Ok(());
-        }
     }
 
     let result = params

--- a/crates/redisctl/src/commands/cloud/database_impl.rs
+++ b/crates/redisctl/src/commands/cloud/database_impl.rs
@@ -693,14 +693,8 @@ pub async fn delete_database(
     }
 
     // Confirmation prompt unless --force is used
-    if !force
-        && !super::utils::confirm_action(&format!(
-            "Are you sure you want to delete database {}?",
-            id
-        ))?
-    {
-        println!("Database deletion cancelled");
-        return Ok(());
+    if !force {
+        super::utils::confirm_action(&format!("Are you sure you want to delete database {}?", id))?;
     }
 
     // Use Layer 2 workflow when --wait is specified
@@ -1726,14 +1720,11 @@ pub async fn flush_database(
     let (subscription_id, database_id) = parse_database_id(id)?;
 
     // Confirmation prompt unless --force is used
-    if !force
-        && !super::utils::confirm_action(&format!(
+    if !force {
+        super::utils::confirm_action(&format!(
             "Are you sure you want to flush database {}? This will delete all data!",
             id
-        ))?
-    {
-        println!("Flush operation cancelled");
-        return Ok(());
+        ))?;
     }
 
     let client = conn_mgr.create_cloud_client(profile_name).await?;
@@ -1830,14 +1821,11 @@ pub async fn flush_crdb(
     let (subscription_id, database_id) = parse_database_id(id)?;
 
     // Confirmation prompt unless --force is used
-    if !force
-        && !super::utils::confirm_action(&format!(
+    if !force {
+        super::utils::confirm_action(&format!(
             "Are you sure you want to flush Active-Active database {}? This will delete all data!",
             id
-        ))?
-    {
-        println!("Flush operation cancelled");
-        return Ok(());
+        ))?;
     }
 
     let client = conn_mgr.create_cloud_client(profile_name).await?;

--- a/crates/redisctl/src/commands/cloud/fixed_database.rs
+++ b/crates/redisctl/src/commands/cloud/fixed_database.rs
@@ -262,10 +262,7 @@ pub async fn handle_fixed_database_command(
 
             if !yes {
                 let prompt = format!("Delete fixed database {}:{}?", subscription_id, database_id);
-                if !confirm_action(&prompt)? {
-                    eprintln!("Operation cancelled");
-                    return Ok(());
-                }
+                confirm_action(&prompt)?;
             }
 
             let result = handler

--- a/crates/redisctl/src/commands/cloud/fixed_subscription.rs
+++ b/crates/redisctl/src/commands/cloud/fixed_subscription.rs
@@ -269,10 +269,7 @@ pub async fn handle_fixed_subscription_command(
         CloudFixedSubscriptionCommands::Delete { id, yes, async_ops } => {
             if !yes {
                 let prompt = format!("Delete fixed subscription {}?", id);
-                if !confirm_action(&prompt)? {
-                    eprintln!("Operation cancelled");
-                    return Ok(());
-                }
+                confirm_action(&prompt)?;
             }
 
             let result = handler

--- a/crates/redisctl/src/commands/cloud/subscription_impl.rs
+++ b/crates/redisctl/src/commands/cloud/subscription_impl.rs
@@ -235,14 +235,11 @@ pub async fn delete_subscription(
     }
 
     // Confirmation prompt unless --force is used
-    if !force
-        && !super::utils::confirm_action(&format!(
+    if !force {
+        super::utils::confirm_action(&format!(
             "Are you sure you want to delete subscription {}? This will delete all databases in the subscription!",
             id
-        ))?
-    {
-        println!("Subscription deletion cancelled");
-        return Ok(());
+        ))?;
     }
 
     // Use Layer 2 workflow when --wait is specified
@@ -902,13 +899,10 @@ pub async fn delete_aa_regions(
         } else {
             regions.join(", ")
         };
-        if !super::utils::confirm_action(&format!(
+        super::utils::confirm_action(&format!(
             "Are you sure you want to delete regions ({}) from Active-Active subscription {}?",
             region_list, id
-        ))? {
-            println!("Region deletion cancelled");
-            return Ok(());
-        }
+        ))?;
     }
 
     let client = conn_mgr.create_cloud_client(profile_name).await?;

--- a/crates/redisctl/src/commands/cloud/utils.rs
+++ b/crates/redisctl/src/commands/cloud/utils.rs
@@ -191,22 +191,28 @@ pub use crate::output::{apply_jmespath, handle_output, print_formatted_output, r
 /// Prompt to confirm a destructive action. Shared by all cloud and enterprise
 /// commands (enterprise re-exports this one).
 ///
-/// Returns `Ok(true)` when confirmed and `Ok(false)` when the user
-/// interactively declines. When stdin is not a terminal there is no way to
-/// answer, so this returns `Err(RedisCtlError::Cancelled)` rather than a value:
-/// a non-interactive run without `--force` must never be mistaken for success
-/// and exit 0.
-pub fn confirm_action(message: &str) -> CliResult<bool> {
+/// Returns `Ok(())` only when the user confirms. Both ways of not confirming
+/// return `Err(RedisCtlError::Cancelled)`: stdin not being a terminal, so the
+/// prompt cannot be answered at all, and the user interactively declining.
+/// Neither is success, so neither may exit 0 -- a caller that treated a
+/// decline as a no-op would report "nothing went wrong" for an action it
+/// never performed.
+pub fn confirm_action(message: &str) -> CliResult<()> {
+    let cancelled = || RedisCtlError::Cancelled {
+        prompt: message.to_string(),
+    };
+
     if !io::stdin().is_terminal() {
-        return Err(RedisCtlError::Cancelled {
-            prompt: message.to_string(),
-        });
+        return Err(cancelled());
     }
-    Ok(dialoguer::Confirm::new()
+
+    let confirmed = dialoguer::Confirm::new()
         .with_prompt(message)
         .default(false)
         .interact()
-        .context("Failed to read confirmation")?)
+        .context("Failed to read confirmation")?;
+
+    if confirmed { Ok(()) } else { Err(cancelled()) }
 }
 
 /// Read file input, supporting @filename notation
@@ -226,6 +232,22 @@ pub fn read_file_input(input: &str) -> CliResult<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Not confirming is an error, never a value. `cargo test` runs without a
+    // terminal on stdin, so this exercises the unanswerable-prompt branch; the
+    // interactive decline branch reaches the same `Err` by construction, since
+    // the signature leaves no `Ok` for it to return.
+    #[test]
+    fn confirm_action_without_a_terminal_is_an_error() {
+        let err = confirm_action("Delete database 5?").unwrap_err();
+
+        assert!(
+            matches!(&err, RedisCtlError::Cancelled { prompt } if prompt == "Delete database 5?"),
+            "expected Cancelled carrying the prompt, got {:?}",
+            err
+        );
+        assert_eq!(err.code(), "cancelled");
+    }
 
     #[test]
     fn test_truncate_string_ascii() {

--- a/crates/redisctl/src/commands/enterprise/bdb_group.rs
+++ b/crates/redisctl/src/commands/enterprise/bdb_group.rs
@@ -237,10 +237,8 @@ impl BdbGroupCommands {
             }
 
             BdbGroupCommands::Delete { uid, force } => {
-                if !force
-                    && !super::utils::confirm_action(&format!("Delete database group {}?", uid))?
-                {
-                    return Ok(());
+                if !force {
+                    super::utils::confirm_action(&format!("Delete database group {}?", uid))?;
                 }
 
                 client

--- a/crates/redisctl/src/commands/enterprise/cluster_impl.rs
+++ b/crates/redisctl/src/commands/enterprise/cluster_impl.rs
@@ -487,10 +487,7 @@ pub async fn reset_cluster(
     if !force {
         eprintln!("WARNING: This will completely reset the cluster!");
         eprintln!("All data, configurations, and databases will be lost.");
-        if !confirm_action("Are you absolutely sure you want to reset the cluster?")? {
-            println!("Operation cancelled");
-            return Ok(());
-        }
+        confirm_action("Are you absolutely sure you want to reset the cluster?")?;
     }
 
     let client = conn_mgr.create_enterprise_client(profile_name).await?;

--- a/crates/redisctl/src/commands/enterprise/cm_settings.rs
+++ b/crates/redisctl/src/commands/enterprise/cm_settings.rs
@@ -134,8 +134,8 @@ impl CmSettingsCommands {
                 data,
                 force,
             } => {
-                if !*force && !super::utils::confirm_action("Update cluster manager settings?")? {
-                    return Ok(());
+                if !*force {
+                    super::utils::confirm_action("Update cluster manager settings?")?;
                 }
 
                 // Start with JSON from --data if provided, otherwise empty object
@@ -171,9 +171,8 @@ impl CmSettingsCommands {
             }
 
             CmSettingsCommands::SetValue { name, value, force } => {
-                if !force && !super::utils::confirm_action(&format!("Update setting '{}'?", name))?
-                {
-                    return Ok(());
+                if !force {
+                    super::utils::confirm_action(&format!("Update setting '{}'?", name))?;
                 }
 
                 // Get current settings
@@ -220,12 +219,10 @@ impl CmSettingsCommands {
             }
 
             CmSettingsCommands::Reset { force } => {
-                if !force
-                    && !super::utils::confirm_action(
+                if !force {
+                    super::utils::confirm_action(
                         "Reset all cluster manager settings to defaults?",
-                    )?
-                {
-                    return Ok(());
+                    )?;
                 }
 
                 // Reset by sending empty object
@@ -263,10 +260,8 @@ impl CmSettingsCommands {
             }
 
             CmSettingsCommands::Import { file, force } => {
-                if !force
-                    && !super::utils::confirm_action("Import cluster manager settings from file?")?
-                {
-                    return Ok(());
+                if !force {
+                    super::utils::confirm_action("Import cluster manager settings from file?")?;
                 }
 
                 let json_data = super::utils::read_json_data(file)?;

--- a/crates/redisctl/src/commands/enterprise/crdb_impl.rs
+++ b/crates/redisctl/src/commands/enterprise/crdb_impl.rs
@@ -170,9 +170,8 @@ pub async fn delete_crdb(
     output_format: OutputFormat,
     query: Option<&str>,
 ) -> CliResult<()> {
-    if !force && !confirm_action(&format!("Delete CRDB {}?", id))? {
-        println!("Operation cancelled");
-        return Ok(());
+    if !force {
+        confirm_action(&format!("Delete CRDB {}?", id))?;
     }
 
     let client = conn_mgr.create_enterprise_client(profile_name).await?;
@@ -284,9 +283,8 @@ pub async fn remove_cluster_from_crdb(
     output_format: OutputFormat,
     query: Option<&str>,
 ) -> CliResult<()> {
-    if !force && !confirm_action(&format!("Remove cluster {} from CRDB {}?", cluster_id, id))? {
-        println!("Operation cancelled");
-        return Ok(());
+    if !force {
+        confirm_action(&format!("Remove cluster {} from CRDB {}?", cluster_id, id))?;
     }
 
     let client = conn_mgr.create_enterprise_client(profile_name).await?;
@@ -410,14 +408,11 @@ pub async fn flush_crdb_instance(
     output_format: OutputFormat,
     query: Option<&str>,
 ) -> CliResult<()> {
-    if !force
-        && !confirm_action(&format!(
+    if !force {
+        confirm_action(&format!(
             "Flush data for instance {} in CRDB {}? This will delete all data!",
             instance_id, crdb_id
-        ))?
-    {
-        println!("Operation cancelled");
-        return Ok(());
+        ))?;
     }
 
     let client = conn_mgr.create_enterprise_client(profile_name).await?;

--- a/crates/redisctl/src/commands/enterprise/crdb_task.rs
+++ b/crates/redisctl/src/commands/enterprise/crdb_task.rs
@@ -268,8 +268,8 @@ impl CrdbTaskCommands {
             }
 
             CrdbTaskCommands::Cancel { task_id, force } => {
-                if !force && !super::utils::confirm_action(&format!("Cancel task {}?", task_id))? {
-                    return Ok(());
+                if !force {
+                    super::utils::confirm_action(&format!("Cancel task {}?", task_id))?;
                 }
 
                 // Cancel the task

--- a/crates/redisctl/src/commands/enterprise/database_impl.rs
+++ b/crates/redisctl/src/commands/enterprise/database_impl.rs
@@ -594,9 +594,8 @@ pub async fn delete_database(
         return Ok(());
     }
 
-    if !force && !confirm_action(&format!("Delete database {}?", id))? {
-        println!("Operation cancelled");
-        return Ok(());
+    if !force {
+        confirm_action(&format!("Delete database {}?", id))?;
     }
 
     let client = conn_mgr.create_enterprise_client(profile_name).await?;
@@ -1086,14 +1085,11 @@ pub async fn flush_database(
     output_format: OutputFormat,
     query: Option<&str>,
 ) -> CliResult<()> {
-    if !force
-        && !confirm_action(&format!(
+    if !force {
+        confirm_action(&format!(
             "Flush all data from database {}? This will delete all data!",
             id
-        ))?
-    {
-        println!("Operation cancelled");
-        return Ok(());
+        ))?;
     }
 
     let client = conn_mgr.create_enterprise_client(profile_name).await?;

--- a/crates/redisctl/src/commands/enterprise/job_scheduler.rs
+++ b/crates/redisctl/src/commands/enterprise/job_scheduler.rs
@@ -296,13 +296,8 @@ impl JobSchedulerCommands {
             }
 
             JobSchedulerCommands::Delete { job_id, force } => {
-                if !force
-                    && !super::utils::confirm_action(&format!(
-                        "Delete scheduled job '{}'?",
-                        job_id
-                    ))?
-                {
-                    return Ok(());
+                if !force {
+                    super::utils::confirm_action(&format!("Delete scheduled job '{}'?", job_id))?;
                 }
 
                 client

--- a/crates/redisctl/src/commands/enterprise/migration.rs
+++ b/crates/redisctl/src/commands/enterprise/migration.rs
@@ -399,8 +399,8 @@ async fn handle_migration_command_impl(
         }
 
         MigrationCommands::Cancel { uid, force } => {
-            if !force && !super::utils::confirm_action(&format!("Cancel migration {}?", uid))? {
-                return Ok(());
+            if !force {
+                super::utils::confirm_action(&format!("Cancel migration {}?", uid))?;
             }
 
             client

--- a/crates/redisctl/src/commands/enterprise/module_impl.rs
+++ b/crates/redisctl/src/commands/enterprise/module_impl.rs
@@ -390,10 +390,7 @@ async fn handle_delete(
     // Confirm deletion if not forced
     if !force {
         let message = format!("Are you sure you want to delete module '{}'?", uid);
-        if !crate::commands::enterprise::utils::confirm_action(&message)? {
-            println!("Module deletion cancelled");
-            return Ok(());
-        }
+        crate::commands::enterprise::utils::confirm_action(&message)?;
     }
 
     let client = conn_mgr.create_enterprise_client(profile_name).await?;

--- a/crates/redisctl/src/commands/enterprise/node_impl.rs
+++ b/crates/redisctl/src/commands/enterprise/node_impl.rs
@@ -204,9 +204,8 @@ pub async fn remove_node(
     _output_format: OutputFormat,
     _query: Option<&str>,
 ) -> CliResult<()> {
-    if !force && !confirm_action(&format!("Remove node {} from cluster?", id))? {
-        println!("Operation cancelled");
-        return Ok(());
+    if !force {
+        confirm_action(&format!("Remove node {} from cluster?", id))?;
     }
 
     let client = conn_mgr.create_enterprise_client(profile_name).await?;
@@ -437,9 +436,8 @@ pub async fn restart_node(
     output_format: OutputFormat,
     query: Option<&str>,
 ) -> CliResult<()> {
-    if !force && !confirm_action(&format!("Restart node {} services?", id))? {
-        println!("Operation cancelled");
-        return Ok(());
+    if !force {
+        confirm_action(&format!("Restart node {} services?", id))?;
     }
 
     let client = conn_mgr.create_enterprise_client(profile_name).await?;

--- a/crates/redisctl/src/commands/enterprise/rbac_impl.rs
+++ b/crates/redisctl/src/commands/enterprise/rbac_impl.rs
@@ -262,9 +262,8 @@ pub async fn delete_user(
     _output_format: OutputFormat,
     _query: Option<&str>,
 ) -> CliResult<()> {
-    if !force && !confirm_action(&format!("Delete user {}?", id))? {
-        println!("Operation cancelled");
-        return Ok(());
+    if !force {
+        confirm_action(&format!("Delete user {}?", id))?;
     }
 
     let client = conn_mgr.create_enterprise_client(profile_name).await?;
@@ -537,9 +536,8 @@ pub async fn delete_role(
     _output_format: OutputFormat,
     _query: Option<&str>,
 ) -> CliResult<()> {
-    if !force && !confirm_action(&format!("Delete role {}?", id))? {
-        println!("Operation cancelled");
-        return Ok(());
+    if !force {
+        confirm_action(&format!("Delete role {}?", id))?;
     }
 
     let client = conn_mgr.create_enterprise_client(profile_name).await?;
@@ -783,9 +781,8 @@ pub async fn delete_acl(
     _output_format: OutputFormat,
     _query: Option<&str>,
 ) -> CliResult<()> {
-    if !force && !confirm_action(&format!("Delete ACL {}?", id))? {
-        println!("Operation cancelled");
-        return Ok(());
+    if !force {
+        confirm_action(&format!("Delete ACL {}?", id))?;
     }
 
     let client = conn_mgr.create_enterprise_client(profile_name).await?;

--- a/crates/redisctl/src/commands/enterprise/shard.rs
+++ b/crates/redisctl/src/commands/enterprise/shard.rs
@@ -260,8 +260,8 @@ impl ShardCommands {
             }
 
             ShardCommands::Failover { uid, force } => {
-                if !force && !super::utils::confirm_action(&format!("Failover shard {}?", uid))? {
-                    return Ok(());
+                if !force {
+                    super::utils::confirm_action(&format!("Failover shard {}?", uid))?;
                 }
 
                 let _: serde_json::Value = client
@@ -280,13 +280,11 @@ impl ShardCommands {
                 target_node,
                 force,
             } => {
-                if !force
-                    && !super::utils::confirm_action(&format!(
+                if !force {
+                    super::utils::confirm_action(&format!(
                         "Migrate shard {} to node {}?",
                         uid, target_node
-                    ))?
-                {
-                    return Ok(());
+                    ))?;
                 }
 
                 let migrate_data = serde_json::json!({
@@ -309,8 +307,8 @@ impl ShardCommands {
                 data,
                 force,
             } => {
-                if !force && !super::utils::confirm_action("Perform bulk shard failover?")? {
-                    return Ok(());
+                if !force {
+                    super::utils::confirm_action("Perform bulk shard failover?")?;
                 }
 
                 // Start with JSON from --data if provided, otherwise empty object
@@ -342,8 +340,8 @@ impl ShardCommands {
                 data,
                 force,
             } => {
-                if !force && !super::utils::confirm_action("Perform bulk shard migration?")? {
-                    return Ok(());
+                if !force {
+                    super::utils::confirm_action("Perform bulk shard migration?")?;
                 }
 
                 // Start with JSON from --data if provided, otherwise empty object

--- a/crates/redisctl/src/commands/enterprise/suffix.rs
+++ b/crates/redisctl/src/commands/enterprise/suffix.rs
@@ -272,8 +272,8 @@ async fn handle_suffix_command_impl(
         }
 
         SuffixCommands::Delete { name, force } => {
-            if !force && !super::utils::confirm_action(&format!("Delete DNS suffix '{}'?", name))? {
-                return Ok(());
+            if !force {
+                super::utils::confirm_action(&format!("Delete DNS suffix '{}'?", name))?;
             }
 
             client

--- a/crates/redisctl/src/error.rs
+++ b/crates/redisctl/src/error.rs
@@ -113,9 +113,7 @@ pub enum RedisCtlError {
     #[error("Invalid input: {message}")]
     InvalidInput { message: String },
 
-    #[error(
-        "Confirmation required: {prompt} Re-run with --force to proceed in a non-interactive session."
-    )]
+    #[error("Cancelled at the confirmation prompt: {prompt}")]
     Cancelled { prompt: String },
 
     #[allow(dead_code)] // intended but not yet produced by any code path; see #1049
@@ -239,6 +237,7 @@ impl RedisCtlError {
             RedisCtlError::Cancelled { .. } => vec![
                 "Re-run with --force to skip the confirmation prompt".to_string(),
                 "Confirmation prompts require an interactive terminal".to_string(),
+                "A declined or unanswerable prompt is a failure, not a no-op".to_string(),
             ],
             RedisCtlError::Configuration(_) => vec![
                 "Check the profile: redisctl profile show <name>".to_string(),

--- a/crates/redisctl/tests/cli_integration_mocked_tests.rs
+++ b/crates/redisctl/tests/cli_integration_mocked_tests.rs
@@ -94,7 +94,9 @@ fn non_interactive_destructive_without_force_exits_nonzero() {
         .write_stdin("")
         .assert()
         .failure()
-        .stderr(predicate::str::contains("Confirmation required"))
+        .stderr(predicate::str::contains(
+            "Cancelled at the confirmation prompt",
+        ))
         .stderr(predicate::str::contains("--force"));
 }
 
@@ -111,7 +113,7 @@ fn destructive_with_force_skips_confirmation() {
         .write_stdin("")
         .assert()
         .failure()
-        .stderr(predicate::str::contains("Confirmation required").not());
+        .stderr(predicate::str::contains("Cancelled at the confirmation prompt").not());
 }
 
 // A failing command must not write tracing output (ANSI escapes or the


### PR DESCRIPTION
Part of #1042, item 3 (GAP-AUTOMATION-04). Finishes what #1044 started.

## Problem

#1044 fixed half of GAP-AUTOMATION-04: a destructive command in a non-interactive session without `--force` now fails instead of exiting 0. The other half was left in place.

`confirm_action` returned `CliResult<bool>`:

- `Err(Cancelled)` when stdin is not a terminal, so the prompt cannot be answered
- `Ok(false)` when the user is at a terminal and answers "no"

All 44 call sites turned that `Ok(false)` into the same thing:

```rust
if !force && !confirm_action(&format!("Delete database {}?", id))? {
    println!("Operation cancelled");
    return Ok(());
}
```

So declining a prompt exited 0. The issue asks for the opposite: "a declined prompt also exits non-zero, never 0". A caller cannot distinguish "deleted it" from "asked, was refused, did nothing".

## Change

`confirm_action` now returns `CliResult<()>`. `Ok(())` means confirmed; both ways of not confirming return `Err(RedisCtlError::Cancelled)`.

This is what makes the property hold rather than depending on 44 sites each remembering to do the right thing: there is no longer an `Ok` value a decline could be reported as, so the exhaustiveness is the type's, not the reviewer's.

Call sites collapse accordingly:

```rust
if !force {
    confirm_action(&format!("Delete database {}?", id))?;
}
```

The per-site `println!("Operation cancelled")` lines go away. The error path prints the message and its tips to stderr, which also moves that text off stdout, where it was polluting the `-o json` payload on the sites that used `println!`.

## Message wording

`Cancelled`'s message was written for the non-TTY case alone:

> Confirmation required: {prompt} Re-run with --force to proceed in a non-interactive session.

That reads wrong for someone who deliberately answered no. It is now neutral:

> Cancelled at the confirmation prompt: {prompt}

The `--force` hint is not lost. `suggestions()` already carried it, and those render as `tip:` lines in the human diagnostic and as `tips` in the `-o json`/`-o yaml` envelope. A third line was added noting that a declined or unanswerable prompt is a failure rather than a no-op.

## Exit code

On this base every failure exits 1, so a decline goes from 0 to 1. The taxonomy in #1058 maps `Cancelled` to 12 (`CANCELLED`); when that lands, this path picks up 12 with no further change here. Either way it is non-zero, which is what #1042 asks for.

## Scope

Behavior changes only for the decline path. `--force` still skips the prompt entirely, confirming still proceeds, and the non-TTY path keeps the behavior #1044 gave it. The 24 files touched are all call-site rewrites of the shape above.

## Checks

`cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings` and `cargo test` all pass locally (1096 tests, 0 failures). `cargo doc --no-deps --all-features` produces only the pre-existing warnings in `cli/enterprise.rs` and `redisctl-mcp`, unchanged by this diff.

Tests: one unit test in `cloud/utils.rs` asserting `confirm_action` returns `Cancelled` carrying the prompt when stdin is not a terminal. The two existing integration tests in `cli_integration_mocked_tests.rs` were updated for the new message; they still assert that a non-interactive delete without `--force` fails and that `--force` skips the prompt.

The interactive decline branch itself cannot be exercised in a test without a TTY, which is exactly why it is expressed in the signature rather than as a convention.
