### PR TITLE
feat(core): add free-tier provisioning + dotenv delivery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2981,6 +2981,7 @@ dependencies = [
 name = "redisctl-core"
 version = "0.11.1"
 dependencies = [
+ "chrono",
  "clap",
  "directories",
  "keyring",
@@ -2998,6 +2999,7 @@ dependencies = [
  "toml",
  "tracing",
  "url",
+ "urlencoding",
  "wiremock",
 ]
 

--- a/crates/redisctl-core/Cargo.toml
+++ b/crates/redisctl-core/Cargo.toml
@@ -30,6 +30,10 @@ oauth2 = { workspace = true }
 reqwest = { workspace = true }
 url = { workspace = true }
 
+# Free-tier provisioning + dotenv delivery (cloud::quick_database / cloud::env_delivery)
+chrono = { workspace = true }
+urlencoding = { workspace = true }
+
 # Logging
 tracing = { workspace = true }
 

--- a/crates/redisctl-core/src/cloud/env_delivery.rs
+++ b/crates/redisctl-core/src/cloud/env_delivery.rs
@@ -1,0 +1,407 @@
+//! Credential delivery to a dotenv file (PRD §4.4/§5.3).
+//!
+//! The `quick-database` workflow never prints the connection string to stdout/stderr; it
+//! writes it to a file so it can't leak into terminal scrollback, CI logs, or an agent's
+//! captured output. This module owns that file I/O and the git-hygiene follow-up, with no
+//! dependency on the API layer so it can be unit-tested in isolation.
+
+use std::fs;
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum DeliveryError {
+    #[error("failed to access {path}: {source}")]
+    Io {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+impl DeliveryError {
+    fn io(path: &Path, source: std::io::Error) -> Self {
+        Self::Io {
+            path: path.display().to_string(),
+            source,
+        }
+    }
+}
+
+/// What `deliver`/`deliver_vars` did, for reporting and tests.
+#[derive(Debug, Clone)]
+pub struct DeliveryOutcome {
+    /// The file that was written.
+    pub path: PathBuf,
+    /// The primary variable name written into it (the first of the set).
+    pub variable: String,
+    /// True when the target file did not exist and was created fresh.
+    pub created: bool,
+    /// True when at least one existing `VAR=` line was replaced (re-run / reuse path).
+    pub replaced: bool,
+}
+
+/// Append (or replace) a single `variable=value` in the dotenv file at `path`.
+/// Convenience wrapper over [`deliver_vars`].
+pub fn deliver(path: &Path, variable: &str, value: &str) -> Result<DeliveryOutcome, DeliveryError> {
+    deliver_vars(path, &[(variable, value)])
+}
+
+/// Write a set of `KEY=value` pairs into the dotenv file at `path` in one pass.
+///
+/// - target exists → each existing `KEY=` line is replaced in place rather than duplicated
+///   (idempotent re-run), all other lines are preserved byte-for-byte, and any genuinely new
+///   keys are appended under a single `# --- added by redisctl … ---` marker. The file is
+///   only rewritten when the content actually changes.
+/// - target missing → created with mode `0o600` (unix), a marker, and all pairs.
+///
+/// No backups are made: unrelated lines are never touched, so the only thing an overwrite
+/// changes is the managed keys — exactly what the caller asked for.
+///
+/// `vars` must be non-empty; the first pair is treated as the primary variable for reporting.
+pub fn deliver_vars(path: &Path, vars: &[(&str, &str)]) -> Result<DeliveryOutcome, DeliveryError> {
+    let primary = vars.first().map(|(k, _)| k.to_string()).unwrap_or_default();
+
+    if path.exists() {
+        let original = fs::read_to_string(path).map_err(|e| DeliveryError::io(path, e))?;
+        let (rewritten, replaced) = upsert_vars(&original, vars);
+        if rewritten != original {
+            fs::write(path, &rewritten).map_err(|e| DeliveryError::io(path, e))?;
+        }
+        // The file holds credentials now — ensure it isn't group/world-readable, even if it
+        // pre-existed with looser permissions (a fresh file is created 0600 below, but an
+        // existing 0644 .env would otherwise stay readable after we write the password).
+        restrict_permissions(path)?;
+        Ok(DeliveryOutcome {
+            path: path.to_path_buf(),
+            variable: primary,
+            created: false,
+            replaced,
+        })
+    } else {
+        let mut contents = format!("{}\n", marker_comment());
+        for (k, v) in vars {
+            contents.push_str(&format!("{k}={v}\n"));
+        }
+        write_new_private(path, &contents)?;
+        Ok(DeliveryOutcome {
+            path: path.to_path_buf(),
+            variable: primary,
+            created: true,
+            replaced: false,
+        })
+    }
+}
+
+/// If `path` sits inside a git working tree and isn't already ignored, append it to the
+/// repo-root `.gitignore`. Outside a git repo this is a silent no-op (PRD §7.2). Returns
+/// `true` iff `.gitignore` was modified.
+pub fn ensure_gitignored(path: &Path) -> Result<bool, DeliveryError> {
+    let abs = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        match std::env::current_dir() {
+            Ok(cwd) => cwd.join(path),
+            Err(_) => return Ok(false),
+        }
+    };
+
+    let Some(repo_root) = find_repo_root(&abs) else {
+        return Ok(false); // not a git repo → skip
+    };
+
+    // Entry to add: path relative to the repo root when possible, else the bare file name.
+    let entry = abs
+        .strip_prefix(&repo_root)
+        .ok()
+        .map(|p| p.to_string_lossy().replace('\\', "/"))
+        .or_else(|| abs.file_name().map(|n| n.to_string_lossy().into_owned()))
+        .unwrap_or_default();
+    if entry.is_empty() {
+        return Ok(false);
+    }
+    let file_name = abs
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_default();
+
+    let gitignore = repo_root.join(".gitignore");
+    let existing = fs::read_to_string(&gitignore).unwrap_or_default();
+    if already_ignored(&existing, &entry, &file_name) {
+        return Ok(false);
+    }
+
+    let mut contents = existing;
+    if !contents.is_empty() && !contents.ends_with('\n') {
+        contents.push('\n');
+    }
+    contents.push_str(&entry);
+    contents.push('\n');
+    fs::write(&gitignore, &contents).map_err(|e| DeliveryError::io(&gitignore, e))?;
+    Ok(true)
+}
+
+fn marker_comment() -> String {
+    format!(
+        "# --- added by redisctl on {} ---",
+        chrono::Local::now().format("%Y-%m-%d")
+    )
+}
+
+/// Replace each existing `KEY=…` line in place; append the remaining (new) keys under a
+/// single marker. Returns the new content and whether at least one line was replaced. All
+/// non-matching lines are preserved byte-for-byte.
+fn upsert_vars(original: &str, vars: &[(&str, &str)]) -> (String, bool) {
+    let mut remaining: Vec<(&str, &str)> = vars.to_vec();
+    let mut replaced_any = false;
+    let mut out_lines: Vec<String> = Vec::new();
+
+    for line in original.lines() {
+        let trimmed = line.trim_start();
+        if let Some(pos) = remaining
+            .iter()
+            .position(|(k, _)| trimmed.starts_with(&format!("{k}=")))
+        {
+            let (k, v) = remaining.remove(pos);
+            out_lines.push(format!("{k}={v}"));
+            replaced_any = true;
+        } else {
+            out_lines.push(line.to_string());
+        }
+    }
+
+    let mut out = out_lines.join("\n");
+    // Preserve a trailing newline if the original had one (byte-for-byte for the kept lines).
+    if original.ends_with('\n') {
+        out.push('\n');
+    }
+
+    // Append any keys that had no existing line, under one marker.
+    if !remaining.is_empty() {
+        if !out.is_empty() && !out.ends_with('\n') {
+            out.push('\n');
+        }
+        out.push_str(&marker_comment());
+        out.push('\n');
+        for (k, v) in &remaining {
+            out.push_str(&format!("{k}={v}\n"));
+        }
+    }
+
+    (out, replaced_any)
+}
+
+#[cfg(unix)]
+fn write_new_private(path: &Path, contents: &str) -> Result<(), DeliveryError> {
+    use std::os::unix::fs::OpenOptionsExt;
+    let mut file = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(path)
+        .map_err(|e| DeliveryError::io(path, e))?;
+    file.write_all(contents.as_bytes())
+        .map_err(|e| DeliveryError::io(path, e))
+}
+
+// Windows has no POSIX mode bits; create the file normally and rely on the user profile's
+// ACLs. Documented limitation (PRD §5.3).
+#[cfg(not(unix))]
+fn write_new_private(path: &Path, contents: &str) -> Result<(), DeliveryError> {
+    fs::write(path, contents).map_err(|e| DeliveryError::io(path, e))
+}
+
+/// Tighten an existing credentials file to owner-only (`0o600`) on unix. No-op elsewhere.
+#[cfg(unix)]
+fn restrict_permissions(path: &Path) -> Result<(), DeliveryError> {
+    use std::os::unix::fs::PermissionsExt;
+    fs::set_permissions(path, fs::Permissions::from_mode(0o600))
+        .map_err(|e| DeliveryError::io(path, e))
+}
+
+#[cfg(not(unix))]
+fn restrict_permissions(_path: &Path) -> Result<(), DeliveryError> {
+    Ok(())
+}
+
+fn find_repo_root(start: &Path) -> Option<PathBuf> {
+    // `start` is a file path; begin at its directory.
+    let mut dir = start.parent();
+    while let Some(d) = dir {
+        if d.join(".git").exists() {
+            return Some(d.to_path_buf());
+        }
+        dir = d.parent();
+    }
+    None
+}
+
+fn already_ignored(gitignore: &str, entry: &str, file_name: &str) -> bool {
+    gitignore.lines().any(|line| {
+        let l = line.trim();
+        if l.is_empty() || l.starts_with('#') {
+            return false;
+        }
+        let l = l.trim_start_matches("./");
+        l == entry || l == file_name
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn creates_fresh_file_with_marker() {
+        let dir = tempdir().unwrap();
+        let env = dir.path().join(".env");
+        let out = deliver(&env, "REDIS_URL", "rediss://x@h:1").unwrap();
+        assert!(out.created);
+        assert!(!out.replaced);
+        let body = fs::read_to_string(&env).unwrap();
+        assert!(body.contains("REDIS_URL=rediss://x@h:1"));
+        assert!(body.contains("added by redisctl"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn existing_loose_file_is_tightened_to_0600() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempdir().unwrap();
+        let env = dir.path().join(".env");
+        fs::write(&env, "EXISTING=1\n").unwrap();
+        fs::set_permissions(&env, fs::Permissions::from_mode(0o644)).unwrap();
+        // Writing secrets into a pre-existing world-readable file must tighten it.
+        deliver(&env, "REDIS_URL", "rediss://x@h:1").unwrap();
+        let mode = fs::metadata(&env).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "expected 0600, got {mode:o}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn fresh_file_is_0600() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempdir().unwrap();
+        let env = dir.path().join(".env");
+        deliver(&env, "REDIS_URL", "rediss://x@h:1").unwrap();
+        let mode = fs::metadata(&env).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "expected 0600, got {mode:o}");
+    }
+
+    #[test]
+    fn existing_file_is_appended_preserving_others() {
+        let dir = tempdir().unwrap();
+        let env = dir.path().join(".env");
+        fs::write(&env, "EXISTING=1\nOTHER=two\n").unwrap();
+        let out = deliver(&env, "REDIS_URL", "rediss://x@h:1").unwrap();
+        assert!(!out.created);
+        assert!(!out.replaced);
+        let body = fs::read_to_string(&env).unwrap();
+        // Unrelated lines preserved byte-for-byte at the head; no backup file created.
+        assert!(body.starts_with("EXISTING=1\nOTHER=two\n"));
+        assert!(body.contains("REDIS_URL=rediss://x@h:1"));
+        assert_eq!(
+            fs::read_dir(dir.path()).unwrap().count(),
+            1,
+            "only .env exists, no backup"
+        );
+    }
+
+    #[test]
+    fn writes_multiple_vars_and_reruns_cleanly() {
+        let dir = tempdir().unwrap();
+        let env = dir.path().join(".env");
+        let vars = [
+            ("REDIS_URL", "rediss://default:p@h:1"),
+            ("REDIS_HOST", "h"),
+            ("REDIS_PORT", "1"),
+        ];
+        let out = deliver_vars(&env, &vars).unwrap();
+        assert!(out.created);
+        assert_eq!(out.variable, "REDIS_URL");
+        let body = fs::read_to_string(&env).unwrap();
+        for (k, v) in vars {
+            assert!(body.contains(&format!("{k}={v}")), "missing {k}");
+        }
+
+        // Re-run with new values: every key is replaced in place, none duplicated.
+        let vars2 = [
+            ("REDIS_URL", "rediss://default:p2@h2:2"),
+            ("REDIS_HOST", "h2"),
+            ("REDIS_PORT", "2"),
+        ];
+        let out2 = deliver_vars(&env, &vars2).unwrap();
+        assert!(out2.replaced);
+        let body2 = fs::read_to_string(&env).unwrap();
+        assert_eq!(body2.matches("REDIS_URL=").count(), 1);
+        assert_eq!(body2.matches("REDIS_HOST=").count(), 1);
+        assert_eq!(body2.matches("REDIS_PORT=").count(), 1);
+        assert!(body2.contains("REDIS_HOST=h2"));
+        assert!(!body2.contains("REDIS_HOST=h\n"));
+    }
+
+    #[test]
+    fn unchanged_rerun_is_noop() {
+        let dir = tempdir().unwrap();
+        let env = dir.path().join(".env");
+        deliver(&env, "REDIS_URL", "rediss://x@h:1").unwrap();
+        let before = fs::read_to_string(&env).unwrap();
+
+        // Identical re-run: content stable, no extra files.
+        let out = deliver(&env, "REDIS_URL", "rediss://x@h:1").unwrap();
+        assert!(!out.created);
+        assert_eq!(fs::read_to_string(&env).unwrap(), before);
+        assert_eq!(fs::read_dir(dir.path()).unwrap().count(), 1);
+    }
+
+    #[test]
+    fn rerun_replaces_not_duplicates() {
+        let dir = tempdir().unwrap();
+        let env = dir.path().join(".env");
+        deliver(&env, "REDIS_URL", "rediss://old@h:1").unwrap();
+        let out = deliver(&env, "REDIS_URL", "rediss://new@h:2").unwrap();
+        assert!(out.replaced);
+        let body = fs::read_to_string(&env).unwrap();
+        assert_eq!(body.matches("REDIS_URL=").count(), 1, "no duplicate var");
+        assert!(body.contains("REDIS_URL=rediss://new@h:2"));
+        assert!(!body.contains("rediss://old@h:1"));
+    }
+
+    #[test]
+    fn gitignore_appended_in_repo() {
+        let dir = tempdir().unwrap();
+        fs::create_dir(dir.path().join(".git")).unwrap();
+        let env = dir.path().join(".env");
+        fs::write(&env, "A=1\n").unwrap();
+        let changed = ensure_gitignored(&env).unwrap();
+        assert!(changed);
+        let gi = fs::read_to_string(dir.path().join(".gitignore")).unwrap();
+        assert!(gi.lines().any(|l| l.trim() == ".env"));
+    }
+
+    #[test]
+    fn gitignore_skipped_outside_repo() {
+        let dir = tempdir().unwrap();
+        let env = dir.path().join(".env");
+        fs::write(&env, "A=1\n").unwrap();
+        assert!(!ensure_gitignored(&env).unwrap());
+        assert!(!dir.path().join(".gitignore").exists());
+    }
+
+    #[test]
+    fn gitignore_not_duplicated_when_already_ignored() {
+        let dir = tempdir().unwrap();
+        fs::create_dir(dir.path().join(".git")).unwrap();
+        fs::write(dir.path().join(".gitignore"), "node_modules\n.env\n").unwrap();
+        let env = dir.path().join(".env");
+        fs::write(&env, "A=1\n").unwrap();
+        let changed = ensure_gitignored(&env).unwrap();
+        assert!(!changed);
+        let gi = fs::read_to_string(dir.path().join(".gitignore")).unwrap();
+        assert_eq!(gi.matches(".env").count(), 1);
+    }
+}

--- a/crates/redisctl-core/src/cloud/mod.rs
+++ b/crates/redisctl-core/src/cloud/mod.rs
@@ -3,7 +3,9 @@
 //! This module provides higher-level operations that compose Layer 1 calls
 //! for Redis Cloud. For simple operations, use `redis_cloud` directly.
 
+pub mod env_delivery;
 pub mod params;
+pub mod quick_database;
 pub mod workflows;
 
 pub use params::*;

--- a/crates/redisctl-core/src/cloud/quick_database.rs
+++ b/crates/redisctl-core/src/cloud/quick_database.rs
@@ -1,0 +1,609 @@
+//! Idempotent free-tier provisioning — the engine behind `redisctl cloud workflow
+//! quick-database` and the `cloud_quick_database` MCP tool.
+//!
+//! [`provision`] is pure: given a [`redis_cloud::CloudClient`] and [`QuickDatabaseParams`] it
+//! creates (or reuses) a free Essentials subscription + database and writes the connection
+//! string to a dotenv file (via [`super::env_delivery`]). It has no front-end concerns — no
+//! clap, no exit codes, no spinner — so both the CLI and the MCP server call it directly.
+//!
+//! The connection string is written only to the credentials file, never returned in a form
+//! that a caller is expected to print. Failures are typed ([`QuickDatabaseError`]) so front
+//! ends can map them to their own contracts (CLI exit codes / MCP tool errors).
+//!
+//! Recognizability / safety: the subscription is always named `redisctl-<name>`. That prefix
+//! is how a re-run finds and reuses its own resource, and it guarantees we never touch a
+//! subscription a human created under a bare name (D6).
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use redis_cloud::fixed::databases::{FixedDatabase, FixedDatabaseCreateRequest};
+use redis_cloud::fixed::subscriptions::FixedSubscriptionCreateRequest;
+use redis_cloud::{CloudClient, CloudError};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::error::CoreError;
+use crate::progress::poll_task;
+
+const SUBSCRIPTION_PREFIX: &str = "redisctl-";
+const DEFAULT_USER: &str = "default";
+
+/// Branchable failures for the quick-database flow. Front-ends map these to their own
+/// contracts (see the CLI's `StructuredError` / the MCP tool error).
+#[derive(Debug, Error)]
+pub enum QuickDatabaseError {
+    #[error("{0}")]
+    InvalidName(String),
+    #[error("{0}")]
+    NameConflict(String),
+    #[error("{0}")]
+    FreeDbExists(String),
+    #[error("{0}")]
+    QuotaExceeded(String),
+    #[error("{0}")]
+    NotAuthenticated(String),
+    #[error("{0}")]
+    Transient(String),
+    #[error("{0}")]
+    RateLimited(String),
+    #[error("{0}")]
+    Other(String),
+}
+
+type QResult<T> = std::result::Result<T, QuickDatabaseError>;
+
+/// Inputs to [`provision`]. Plain data — front-ends build it from their own arg parsing.
+#[derive(Debug, Clone)]
+pub struct QuickDatabaseParams {
+    /// Database name (also used, prefixed with `redisctl-`, for the subscription).
+    pub name: String,
+    /// File to write the credentials into.
+    pub output_credentials: PathBuf,
+    /// Primary URL variable name (e.g. `REDIS_URL`); broken-out fields derive their prefix.
+    pub variable: String,
+    /// Max seconds to wait for each async operation.
+    pub wait_timeout: u32,
+    /// Polling interval in seconds.
+    pub wait_interval: u32,
+}
+
+impl QuickDatabaseParams {
+    /// Params for `name` with the conventional defaults (`./.env`, `REDIS_URL`, 600s/5s).
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            output_credentials: PathBuf::from("./.env"),
+            variable: "REDIS_URL".to_string(),
+            wait_timeout: 600,
+            wait_interval: 5,
+        }
+    }
+}
+
+/// PRD §5.2 report — the agent contract. Serialized verbatim by both front-ends.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QuickDatabaseReport {
+    /// `ok` for fresh/resumed provisioning, `reused` when an existing DB was returned.
+    pub status: String,
+    pub database: DatabaseSummary,
+    pub credentials_written_to: String,
+    pub credentials_variable: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DatabaseSummary {
+    pub id: String,
+    pub name: String,
+    pub region: Option<String>,
+    pub plan: String,
+    pub tls: bool,
+}
+
+/// Create or reuse a free database for `params.name` and deliver its credentials to a file.
+///
+/// The `client` must already be authenticated (the caller builds it from its own credential
+/// source); `provision` never touches login state.
+pub async fn provision(
+    client: &CloudClient,
+    params: &QuickDatabaseParams,
+) -> QResult<QuickDatabaseReport> {
+    validate_name(&params.name)?;
+    let sub_name = format!("{SUBSCRIPTION_PREFIX}{}", params.name);
+
+    // Find our subscription (idempotent re-run / crash resume).
+    let (subscription_id, database_id, status) = match find_subscription(client, &sub_name).await? {
+        Some(sub_id) => match first_database_id(client, sub_id).await? {
+            Some(db_id) => (sub_id, db_id, "reused"),
+            // Half-provisioned: subscription created but DB create never finished.
+            None => (sub_id, create_database(client, sub_id, params).await?, "ok"),
+        },
+        None => {
+            let sub_id = create_subscription(client, &sub_name, params).await?;
+            (sub_id, create_database(client, sub_id, params).await?, "ok")
+        }
+    };
+
+    // Fetch full details, polling until the public endpoint is populated (it can lag a few
+    // seconds behind task completion on a fresh create).
+    let db = fetch_ready_database(client, subscription_id, database_id, params).await?;
+    deliver_and_report(&db, params, database_id, status, "free")
+}
+
+/// Write an EXISTING Essentials database's credentials to the file, without provisioning.
+/// Identified by subscription + database id; `params` supplies the output path / variable /
+/// wait settings (its `name` is only a report fallback, overridden by the database's name).
+pub async fn existing_database_report(
+    client: &CloudClient,
+    subscription_id: i32,
+    database_id: i32,
+    params: &QuickDatabaseParams,
+) -> QResult<QuickDatabaseReport> {
+    let db = fetch_ready_database(client, subscription_id, database_id, params).await?;
+    deliver_and_report(&db, params, database_id, "existing", "essentials")
+}
+
+/// Shared tail: build the connection parts, write the URL + broken-out fields to the
+/// credentials file, and assemble the report. Used by both `provision` and
+/// `existing_database_report`.
+fn deliver_and_report(
+    db: &FixedDatabase,
+    params: &QuickDatabaseParams,
+    database_id: i32,
+    status: &str,
+    plan: &str,
+) -> QResult<QuickDatabaseReport> {
+    let parts = connection_parts(db)?;
+
+    // Deliver the primary URL plus broken-out fields so apps can read whichever form they
+    // expect. The discrete fields share a prefix derived from the URL var name.
+    let prefix = params
+        .variable
+        .strip_suffix("_URL")
+        .unwrap_or(&params.variable);
+    let host_key = format!("{prefix}_HOST");
+    let port_key = format!("{prefix}_PORT");
+    let password_key = format!("{prefix}_PASSWORD");
+    let username_key = format!("{prefix}_USERNAME");
+    let tls_key = format!("{prefix}_TLS");
+    let tls_val = parts.tls.to_string();
+    let vars: Vec<(&str, &str)> = vec![
+        (params.variable.as_str(), parts.url.as_str()),
+        (host_key.as_str(), parts.host.as_str()),
+        (port_key.as_str(), parts.port.as_str()),
+        (password_key.as_str(), parts.password.as_str()),
+        (username_key.as_str(), parts.username.as_str()),
+        (tls_key.as_str(), tls_val.as_str()),
+    ];
+    let outcome = super::env_delivery::deliver_vars(&params.output_credentials, &vars)
+        .map_err(|e| QuickDatabaseError::Other(format!("failed to write credentials file: {e}")))?;
+    let _ = super::env_delivery::ensure_gitignored(&params.output_credentials);
+
+    Ok(QuickDatabaseReport {
+        status: status.to_string(),
+        database: DatabaseSummary {
+            id: database_id.to_string(),
+            name: db.name.clone().unwrap_or_else(|| params.name.clone()),
+            region: db.region.clone(),
+            plan: plan.to_string(),
+            tls: parts.tls,
+        },
+        credentials_written_to: outcome.path.display().to_string(),
+        credentials_variable: outcome.variable,
+    })
+}
+
+/// PRD §5.1.1 name rules: lowercase alnum + hyphens, 3–40 chars, no leading/trailing hyphen,
+/// no `--`.
+fn validate_name(name: &str) -> QResult<()> {
+    let ok = (3..=40).contains(&name.len())
+        && name
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+        && name.chars().next().is_some_and(|c| c.is_ascii_lowercase())
+        && name
+            .chars()
+            .last()
+            .is_some_and(|c| c.is_ascii_lowercase() || c.is_ascii_digit())
+        && !name.contains("--");
+    if !ok {
+        return Err(QuickDatabaseError::InvalidName(format!(
+            "invalid database name '{name}': must be 3-40 chars, lowercase letters/digits/hyphens, \
+             start with a letter, end with a letter or digit, and contain no '--'"
+        )));
+    }
+    Ok(())
+}
+
+async fn find_subscription(client: &CloudClient, sub_name: &str) -> QResult<Option<i32>> {
+    let subs = client
+        .fixed_subscriptions()
+        .list()
+        .await
+        .map_err(|e| classify_cloud_error("list subscriptions", e))?;
+    Ok(subs
+        .subscriptions
+        .unwrap_or_default()
+        .into_iter()
+        .find(|s| {
+            s.name
+                .as_deref()
+                .is_some_and(|n| n.eq_ignore_ascii_case(sub_name))
+        })
+        .and_then(|s| s.id))
+}
+
+async fn first_database_id(client: &CloudClient, subscription_id: i32) -> QResult<Option<i32>> {
+    let list = client
+        .fixed_databases()
+        .list(subscription_id, None, None)
+        .await
+        .map_err(|e| classify_cloud_error("list databases", e))?;
+    Ok(list
+        .subscription
+        .map(|info| info.databases)
+        .unwrap_or_default()
+        .into_iter()
+        .find_map(|d| d.database_id))
+}
+
+async fn create_subscription(
+    client: &CloudClient,
+    sub_name: &str,
+    params: &QuickDatabaseParams,
+) -> QResult<i32> {
+    let plan_id = pick_free_plan(client).await?;
+    // Free plan: no paymentMethod / paymentMethodId sent (a non-null value is rejected).
+    let request = FixedSubscriptionCreateRequest::builder()
+        .name(sub_name.to_string())
+        .plan_id(plan_id)
+        .build();
+    let task = client
+        .fixed_subscriptions()
+        .create(&request)
+        .await
+        .map_err(classify_create_error)?;
+    run_task(client, task.task_id, params).await
+}
+
+async fn create_database(
+    client: &CloudClient,
+    subscription_id: i32,
+    params: &QuickDatabaseParams,
+) -> QResult<i32> {
+    let request = FixedDatabaseCreateRequest::builder()
+        .name(params.name.clone())
+        .build();
+    let task = client
+        .fixed_databases()
+        .create(subscription_id, &request)
+        .await
+        .map_err(|e| classify_cloud_error("create database", e))?;
+    run_task(client, task.task_id, params).await
+}
+
+/// Poll a create task to completion (via core's [`poll_task`]) and return the resource id.
+/// Task-level failures are re-classified so the one-free-sub limit maps to `free_db_exists`.
+async fn run_task(
+    client: &CloudClient,
+    task_id: Option<String>,
+    params: &QuickDatabaseParams,
+) -> QResult<i32> {
+    let task_id = task_id.ok_or_else(|| {
+        QuickDatabaseError::Other("create response did not include a task id".to_string())
+    })?;
+    let timeout = Duration::from_secs(params.wait_timeout as u64);
+    let interval = Duration::from_secs(params.wait_interval.max(1) as u64);
+
+    match poll_task(client, &task_id, timeout, interval, None).await {
+        Ok(completed) => completed
+            .response
+            .and_then(|r| r.resource_id)
+            .ok_or_else(|| {
+                QuickDatabaseError::Other("completed task did not return a resource id".to_string())
+            }),
+        Err(CoreError::TaskFailed(msg)) => Err(classify_task_error(&msg)),
+        Err(CoreError::TaskTimeout(_)) => Err(QuickDatabaseError::Transient(format!(
+            "operation timed out after {}s; retry in a moment",
+            params.wait_timeout
+        ))),
+        Err(CoreError::Cloud(e)) => Err(classify_cloud_error("poll task", e)),
+        Err(other) => Err(QuickDatabaseError::Other(format!("task failed: {other}"))),
+    }
+}
+
+/// Choose a free Essentials plan (`price == 0`). The region is server-chosen for the free
+/// tier, so the first free plan is fine.
+async fn pick_free_plan(client: &CloudClient) -> QResult<i32> {
+    let plans = client
+        .fixed_subscriptions()
+        .list_plans(None, None)
+        .await
+        .map_err(|e| classify_cloud_error("list plans", e))?;
+    plans
+        .plans
+        .unwrap_or_default()
+        .into_iter()
+        .find(|p| p.price == Some(0))
+        .and_then(|p| p.id)
+        .ok_or_else(|| {
+            QuickDatabaseError::Other(
+                "no free Essentials plan is available on this account".to_string(),
+            )
+        })
+}
+
+/// Read the database, polling until its `public_endpoint` is populated. A persistent absence
+/// past `wait_timeout` is reported as transient (retryable) rather than an unknown error.
+async fn fetch_ready_database(
+    client: &CloudClient,
+    subscription_id: i32,
+    database_id: i32,
+    params: &QuickDatabaseParams,
+) -> QResult<FixedDatabase> {
+    let start = std::time::Instant::now();
+    let timeout = Duration::from_secs(params.wait_timeout as u64);
+    let interval = Duration::from_secs(params.wait_interval.max(1) as u64);
+
+    loop {
+        let db = client
+            .fixed_databases()
+            .get_by_id(subscription_id, database_id)
+            .await
+            .map_err(|e| classify_cloud_error("read database details", e))?;
+        if db.public_endpoint.as_deref().is_some_and(|s| !s.is_empty()) {
+            return Ok(db);
+        }
+        if start.elapsed() > timeout {
+            return Err(QuickDatabaseError::Transient(format!(
+                "database {database_id} has no public endpoint after {}s; it may still be \
+                 provisioning — retry in a moment",
+                params.wait_timeout
+            )));
+        }
+        tokio::time::sleep(interval).await;
+    }
+}
+
+/// Connection details pulled from a database read, for credential-file delivery.
+struct ConnParts {
+    url: String,
+    host: String,
+    port: String,
+    password: String,
+    username: String,
+    tls: bool,
+}
+
+/// Extract connection parts (URL + broken-out fields) from a database read. The password is
+/// only present on the GET response, not the list.
+fn connection_parts(db: &FixedDatabase) -> QResult<ConnParts> {
+    let endpoint = db
+        .public_endpoint
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            QuickDatabaseError::Other("database has no public endpoint yet".to_string())
+        })?;
+    let security = db.security.as_ref();
+    let tls = security.and_then(|s| s.enable_tls).unwrap_or(true);
+    let password = security
+        .and_then(|s| s.password.as_deref())
+        .ok_or_else(|| {
+            QuickDatabaseError::Other(
+                "database password was not returned by the API (the account may have \
+             'enable-capi-return-empty-bdb-passwords' set); cannot build a connection string"
+                    .to_string(),
+            )
+        })?;
+    let (host, port) = endpoint.rsplit_once(':').unwrap_or((endpoint, ""));
+    let scheme = if tls { "rediss" } else { "redis" };
+    // Percent-encode the password for the URL userinfo: a raw `@`, `:`, `/`, `#`, `%`, … would
+    // otherwise break authority parsing or be mis-decoded by the client. The broken-out
+    // `password` field below stays raw (apps use it directly, not inside a URL).
+    let encoded_password = urlencoding::encode(password);
+    Ok(ConnParts {
+        url: format!("{scheme}://{DEFAULT_USER}:{encoded_password}@{endpoint}"),
+        host: host.to_string(),
+        port: port.to_string(),
+        password: password.to_string(),
+        username: DEFAULT_USER.to_string(),
+        tls,
+    })
+}
+
+/// Classify a subscription-create failure. The public CAPI rejects free-plan creation when
+/// the account has no payment method and the caller is not on the trusted User-Agent
+/// allowlist — treated as "a free database already exists / is not permitted".
+fn classify_create_error(err: CloudError) -> QuickDatabaseError {
+    if err.to_string().to_uppercase().contains("PAYMENT") {
+        QuickDatabaseError::FreeDbExists(
+            "free database creation was rejected: the account either already has a free \
+             database, or is not eligible for the free tier (a payment method may be \
+             required). Check the Redis Cloud console."
+                .to_string(),
+        )
+    } else {
+        classify_cloud_error("create subscription", err)
+    }
+}
+
+/// Classify an async task failure. The one-free-subscription limit and payment/free-plan
+/// rejections come back here (as a task `ProcessingError`), not as a synchronous 4xx, so they
+/// must map to the same `free_db_exists` / `quota_exceeded` codes rather than `unknown`.
+fn classify_task_error(msg: &str) -> QuickDatabaseError {
+    let up = msg.to_uppercase();
+    if up.contains("FREE PLAN") || up.contains("FREE-PLAN") || up.contains("PAYMENT") {
+        QuickDatabaseError::FreeDbExists(format!("task failed: {msg}"))
+    } else if is_quota_message(msg) {
+        QuickDatabaseError::QuotaExceeded(format!("task failed: {msg}"))
+    } else {
+        QuickDatabaseError::Other(format!("task failed: {msg}"))
+    }
+}
+
+/// Map a generic CAPI error to a branchable class. 5xx / network / connection are transient;
+/// 429 is rate-limited; quota messages map to quota_exceeded; everything else is `Other`.
+fn classify_cloud_error(action: &str, err: CloudError) -> QuickDatabaseError {
+    match err {
+        CloudError::RateLimited { message } => {
+            QuickDatabaseError::RateLimited(format!("{action}: {message}"))
+        }
+        CloudError::ServiceUnavailable { message }
+        | CloudError::InternalServerError { message } => {
+            QuickDatabaseError::Transient(format!("{action}: {message}"))
+        }
+        CloudError::Request(m) | CloudError::ConnectionError(m) => {
+            QuickDatabaseError::Transient(format!("{action}: {m}"))
+        }
+        CloudError::ApiError { code, message } if (500..=599).contains(&code) => {
+            QuickDatabaseError::Transient(format!("{action}: {message}"))
+        }
+        CloudError::ApiError { code: 429, message } => {
+            QuickDatabaseError::RateLimited(format!("{action}: {message}"))
+        }
+        CloudError::BadRequest { message } if is_quota_message(&message) => {
+            QuickDatabaseError::QuotaExceeded(format!("{action}: {message}"))
+        }
+        other => QuickDatabaseError::Other(format!("{action}: {other}")),
+    }
+}
+
+fn is_quota_message(message: &str) -> bool {
+    let m = message.to_uppercase();
+    m.contains("QUOTA") || m.contains("LIMIT") || m.contains("EXCEED")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_valid_names() {
+        for n in ["abc", "my-db", "test-123", "a1b2c3"] {
+            assert!(validate_name(n).is_ok(), "{n} should be valid");
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_names() {
+        for n in [
+            "ab",
+            "-abc",
+            "abc-",
+            "ab--cd",
+            "Abc",
+            "my_db",
+            "1abc",
+            &"a".repeat(41),
+        ] {
+            assert!(validate_name(n).is_err(), "{n} should be rejected");
+        }
+    }
+
+    #[test]
+    fn connection_parts_splits_host_and_port() {
+        let db: FixedDatabase = serde_json::from_value(serde_json::json!({
+            "publicEndpoint": "host.example.com:12000",
+            "security": { "enableTls": true, "password": "s3cr3t" }
+        }))
+        .unwrap();
+        let p = connection_parts(&db).unwrap();
+        assert_eq!(p.host, "host.example.com");
+        assert_eq!(p.port, "12000");
+        assert_eq!(p.username, "default");
+        assert!(p.tls);
+        assert_eq!(p.url, "rediss://default:s3cr3t@host.example.com:12000");
+    }
+
+    #[test]
+    fn password_is_percent_encoded_in_url_but_raw_in_field() {
+        // A password with URL-reserved characters must not corrupt the connection string.
+        let db: FixedDatabase = serde_json::from_value(serde_json::json!({
+            "publicEndpoint": "h:1",
+            "security": { "enableTls": true, "password": "p@ss/w#rd%20x" }
+        }))
+        .unwrap();
+        let p = connection_parts(&db).unwrap();
+        // URL userinfo is percent-encoded (@ / # % all escaped), so the authority isn't
+        // corrupted and the host/port stay intact after the userinfo.
+        assert_eq!(p.url, "rediss://default:p%40ss%2Fw%23rd%2520x@h:1");
+        // The encoded userinfo round-trips back to the original password (what a client does).
+        assert_eq!(
+            urlencoding::decode("p%40ss%2Fw%23rd%2520x").unwrap(),
+            "p@ss/w#rd%20x"
+        );
+        // The broken-out field stays raw for apps that read it directly.
+        assert_eq!(p.password, "p@ss/w#rd%20x");
+    }
+
+    #[test]
+    fn plain_url_when_tls_off() {
+        let db: FixedDatabase = serde_json::from_value(serde_json::json!({
+            "publicEndpoint": "h:1",
+            "security": { "enableTls": false, "password": "p" }
+        }))
+        .unwrap();
+        assert_eq!(connection_parts(&db).unwrap().url, "redis://default:p@h:1");
+    }
+
+    #[test]
+    fn errors_when_password_missing() {
+        let db: FixedDatabase = serde_json::from_value(serde_json::json!({
+            "publicEndpoint": "h:1",
+            "security": { "enableTls": true }
+        }))
+        .unwrap();
+        assert!(connection_parts(&db).is_err());
+    }
+
+    #[test]
+    fn free_gate_error_classifies_as_free_db_exists() {
+        let err = CloudError::BadRequest {
+            message: "FREE_PLAN_IS_ALLOWED_ONLY_FOR_ACCOUNTS_WITH_VALID_PAYMENT_INFO".to_string(),
+        };
+        assert!(matches!(
+            classify_create_error(err),
+            QuickDatabaseError::FreeDbExists(_)
+        ));
+    }
+
+    #[test]
+    fn task_free_plan_error_classifies_as_free_db_exists() {
+        let e = classify_task_error("The account already has a free plan Essentials subscription.");
+        assert!(matches!(e, QuickDatabaseError::FreeDbExists(_)));
+    }
+
+    #[test]
+    fn report_serialization_carries_no_secrets() {
+        // The report is the entire tool/CLI response; it must never structurally carry the
+        // password or a connection URL (those go only to the credentials file).
+        let report = QuickDatabaseReport {
+            status: "ok".to_string(),
+            database: DatabaseSummary {
+                id: "9001".to_string(),
+                name: "my-app".to_string(),
+                region: Some("us-east-1".to_string()),
+                plan: "free".to_string(),
+                tls: true,
+            },
+            credentials_written_to: "./.env".to_string(),
+            credentials_variable: "REDIS_URL".to_string(),
+        };
+        let s = serde_json::to_string(&report).unwrap();
+        assert!(!s.contains("password"));
+        assert!(!s.contains("rediss://"));
+        assert!(!s.contains('@'));
+    }
+
+    #[test]
+    fn transient_5xx_classifies_as_transient() {
+        let err = CloudError::ServiceUnavailable {
+            message: "try later".to_string(),
+        };
+        assert!(matches!(
+            classify_cloud_error("x", err),
+            QuickDatabaseError::Transient(_)
+        ));
+    }
+}


### PR DESCRIPTION
## Summary

Adds `redisctl_core::cloud::quick_database` — the engine that takes a Cloud API client from
nothing to a running **free** (Essentials) database and delivers its connection string to a
dotenv file — plus `cloud::env_delivery`, the dotenv writer it uses.

Like the auth library, this is a **pure library with no user-facing surface yet**: it operates on
a `redis_cloud::CloudClient`, is independent of the auth module, and is consumed by the CLI and
MCP layers separately. This PR is the engine and its tests.

Properties baked into `provision`:
- **Idempotent** — re-running with the same name reuses the existing subscription/database
  (matched by the `redisctl-<name>` marker) instead of erroring.
- **Crash-safe** — resumes a half-created subscription (subscription exists, DB create never finished).
- **Free-tier** — auto-selects the $0 Essentials plan; no payment method.
- **Endpoint-ready** — polls until the public endpoint is populated (it lags task completion by a
  few seconds on a fresh create).
- **Secret-safe** — the connection string (percent-encoded password) goes only to the file, at
  `0600`, never to stdout; managed keys are updated in place, unrelated lines preserved.

`QuickDatabaseError` (`InvalidName`, `NameConflict`, `FreeDbExists`, `QuotaExceeded`,
`NotAuthenticated`, `Transient`, `RateLimited`, `Other`) classifies failures so callers can map
them to a machine-branchable error contract.

## Usage

```rust
use redis_cloud::CloudClient;
use redisctl_core::cloud::quick_database::{provision, QuickDatabaseParams, QuickDatabaseError};

async fn make_free_db(client: &CloudClient) -> Result<(), QuickDatabaseError> {
    // Defaults: ./.env, REDIS_URL, 600s timeout / 5s poll. Fields are public to override.
    let params = QuickDatabaseParams::new("my-app"); // subscription becomes "redisctl-my-app"

    // Creates (or idempotently reuses) a free DB, polls until the endpoint is ready, and writes
    // REDIS_URL + broken-out REDIS_HOST/PORT/PASSWORD/... into ./.env (0600).
    let report = provision(client, &params).await?;

    println!("{} {} ({}) -> {} as {}",
        report.status,                    // "ok" (fresh/resumed) or "reused"
        report.database.name,
        report.database.plan,             // "free"
        report.credentials_written_to,
        report.credentials_variable);
    Ok(())
}
```

Export an **existing** database's credentials (no provisioning):

```rust
use redisctl_core::cloud::quick_database::existing_database_report;
let report = existing_database_report(client, subscription_id, database_id, &params).await?;
```

The dotenv writer is usable on its own:

```rust
use std::path::Path;
use redisctl_core::cloud::env_delivery::deliver_vars;
// Updates managed keys in place, preserves other lines, creates the file 0600 if missing.
deliver_vars(Path::new("./.env"), &[("REDIS_URL", "redis://..."), ("REDIS_HOST", "...")])?;
```

## Flow

```
provision(client, params)
  ├─ find subscription "redisctl-<name>"
  │     ├─ found + has DB   → reuse                 (status: reused)
  │     ├─ found, no DB     → create DB             (crash-safe resume)
  │     └─ not found        → create free sub + DB  (status: ok)
  ├─ poll GET database until the public endpoint is populated
  └─ write REDIS_URL + broken-out fields to the dotenv file (0600); return report
```

## Scope

- **Affected areas:** `crates/redisctl-core/src/cloud/` (`quick_database.rs`, `env_delivery.rs`, `mod.rs`); core `Cargo.toml` (`chrono`, `urlencoding`).
- **API surface changes:** new public `cloud::quick_database` + `cloud::env_delivery` modules; independent of auth. No existing APIs change.
- **Docs/tests:** module docs + 20 unit tests (wiremock for provisioning, tempfile for delivery).

## Testing

```cargo test -p redisctl-core --lib   # includes quick_database + env_delivery (20 tests)```
```cargo clippy --workspace --all-targets --all-features -- -D warnings```

No live environment needed — provisioning is wiremock-tested, delivery is tempfile-tested. Tracking: RED-210015.

## Checklist

- [x] Scope and plan documented in this description
- [x] Tests added/updated; both success and error cases covered
- [x] Docs updated (module overviews, examples)
- [x] cargo fmt, clippy (-D warnings), tests pass locally
- [ ] CI status is green
- [ ] Ready for review (remove Draft)
- [ ] Squash and merge when approved
