### PR TITLE
fix(cli): report a nonexistent profile as ProfileNotFound

### DIFF
--- a/crates/redisctl/src/connection.rs
+++ b/crates/redisctl/src/connection.rs
@@ -167,11 +167,11 @@ impl ConnectionManager {
             let resolved_profile_name = self.config.resolve_cloud_profile(profile_name)?;
             info!("Using Redis Cloud profile: {}", resolved_profile_name);
 
-            let profile = self
-                .config
-                .profiles
-                .get(&resolved_profile_name)
-                .with_context(|| format!("Profile '{}' not found", resolved_profile_name))?;
+            let profile = self.config.profiles.get(&resolved_profile_name).ok_or(
+                crate::error::RedisCtlError::ProfileNotFound {
+                    name: resolved_profile_name.clone(),
+                },
+            )?;
 
             // Verify it's a cloud profile
             if profile.deployment_type != DeploymentType::Cloud {
@@ -382,11 +382,11 @@ impl ConnectionManager {
             let resolved_profile_name = self.config.resolve_enterprise_profile(profile_name)?;
             info!("Using Redis Enterprise profile: {}", resolved_profile_name);
 
-            let profile = self
-                .config
-                .profiles
-                .get(&resolved_profile_name)
-                .with_context(|| format!("Profile '{}' not found", resolved_profile_name))?;
+            let profile = self.config.profiles.get(&resolved_profile_name).ok_or(
+                crate::error::RedisCtlError::ProfileNotFound {
+                    name: resolved_profile_name.clone(),
+                },
+            )?;
 
             // Verify it's an enterprise profile
             if profile.deployment_type != DeploymentType::Enterprise {

--- a/crates/redisctl/tests/cli_integration_mocked_tests.rs
+++ b/crates/redisctl/tests/cli_integration_mocked_tests.rs
@@ -184,6 +184,52 @@ fn config_failure_exits_with_the_config_code() {
         .code(3);
 }
 
+// Naming a profile that does not exist is a config failure, so it exits 3 and
+// reports the missing profile by name with its tips, rather than landing in the
+// anyhow catch-all and exiting the blanket 1. Follow-up to #1058, part of the
+// item 2 work in #1045 (un-collapsing anyhow-wrapped error paths).
+#[test]
+fn nonexistent_profile_reports_profile_not_found() {
+    let temp_dir = TempDir::new().unwrap();
+    create_cloud_profile(&temp_dir, "https://cloud.invalid/v1").unwrap();
+
+    let output = test_cmd(&temp_dir)
+        .args([
+            "--profile",
+            "nope",
+            "-o",
+            "json",
+            "cloud",
+            "database",
+            "list",
+        ])
+        .assert()
+        .code(3)
+        .get_output()
+        .clone();
+
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    let v: serde_json::Value =
+        serde_json::from_str(stderr.trim()).expect("stderr under -o json must be valid JSON");
+    assert_eq!(v["error"]["code"], "profile_not_found");
+    assert_eq!(v["error"]["exit_code"], 3);
+}
+
+// The enterprise resolution path has its own profile lookup, so it needs its
+// own regression: the same nonexistent profile must classify the same way.
+#[test]
+fn nonexistent_enterprise_profile_reports_profile_not_found() {
+    let temp_dir = TempDir::new().unwrap();
+    create_enterprise_profile(&temp_dir, "https://enterprise.invalid:9443").unwrap();
+
+    test_cmd(&temp_dir)
+        .args(["--profile", "nope", "enterprise", "database", "list"])
+        .assert()
+        .code(3)
+        .stderr(predicate::str::contains("Profile 'nope' not found"))
+        .stderr(predicate::str::contains("redisctl profile list"));
+}
+
 #[tokio::test]
 async fn test_api_cloud_get_with_auth_headers() {
     let temp_dir = TempDir::new().unwrap();


### PR DESCRIPTION
Part of #1045, item 2 (GAP-AUTOMATION-03 / CODE-01). This is the concrete gap #1058 documented under "Gap found while testing".

## Problem

Both profile lookups in `crates/redisctl/src/connection.rs` resolved a profile name and then fetched the profile with anyhow context:

```rust
let profile = self
    .config
    .profiles
    .get(&resolved_profile_name)
    .with_context(|| format!("Profile '{}' not found", resolved_profile_name))?;
```

`resolve_cloud_profile` / `resolve_enterprise_profile` return an explicit `--profile <name>` unchanged without checking that it exists, so this `.get()` is exactly where a nonexistent profile fails. `From<anyhow::Error>` routes it into `RedisCtlError::Other`, which is the unclassified catch-all.

`RedisCtlError::ProfileNotFound { name }` already existed with the same message, three suggestions, the `profile_not_found` envelope code, and a `CONFIG` exit code. None of it was reachable on the path that produces the error.

Before:

```
$ redisctl --profile nope cloud database list; echo $?
error: Profile 'nope' not found
1
```

No tips, and exit 1 tells a script nothing beyond "it failed".

## Change

Both sites return `ProfileNotFound` directly instead of wrapping in anyhow context. The message text is unchanged; what changes is that the error is now classified.

After:

```
$ redisctl --profile nope cloud database list; echo $?
error: Profile 'nope' not found

  tip: List available profiles: redisctl profile list

  tip: Create profile 'nope': redisctl profile set nope

  tip: Check profile name spelling
3
```

Under `-o json`/`-o yaml` the envelope now carries `"code": "profile_not_found"` and `"exit_code": 3` rather than the generic error's `1`.

## Exit code

3 (`CONFIG`), not 5 (`NOT_FOUND`). `NOT_FOUND` in the #1058 taxonomy means a resource the server does not have (an `ApiError` carrying a 404); a missing profile is a local configuration problem, which is why `exit_code()` already groups `ProfileNotFound` with `Configuration` and `ProfileTypeMismatch`. No taxonomy values change in this PR.

## Scope

Two lookups, and nothing else. The other five `.context(...)` sites in `connection.rs` wrap client construction and credential resolution, which are different failures and belong with the rest of the item 2 work (the `Config`/`Configuration` merge and the remaining anyhow-collapsed paths).

## Checks

`cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings` and `cargo test` all pass locally (0 failures across every target). `cargo doc --no-deps --all-features` produces only the pre-existing warnings in `cli/enterprise.rs` and `redisctl-mcp`, unchanged by this diff.

Tests: two integration tests in `cli_integration_mocked_tests.rs`, one per resolution path, since cloud and enterprise have separate lookups. The cloud test asserts the `-o json` envelope's `code` and `exit_code`; the enterprise test asserts the exit code, the message and that the tips render.
