### PR TITLE
refactor(core): adopt the oauth2 crate for the OIDC login flows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2299,6 +2299,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "oauth2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "getrandom 0.2.16",
+ "http",
+ "rand 0.8.6",
+ "reqwest 0.12.23",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2",
+ "thiserror 1.0.69",
+ "url",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2960,19 +2980,16 @@ dependencies = [
 name = "redisctl-core"
 version = "0.11.1"
 dependencies = [
- "base64 0.22.1",
  "clap",
  "directories",
- "getrandom 0.3.3",
  "keyring",
+ "oauth2",
  "redis-cloud",
  "redis-enterprise",
  "reqwest 0.13.1",
  "serde",
  "serde_json",
- "serde_urlencoded",
  "serial_test",
- "sha2",
  "shellexpand",
  "tempfile",
  "thiserror 2.0.17",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,8 @@ async-trait = "0.1"
 
 # HTTP and APIs
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls", "multipart"] }
+# Standards-compliant OAuth2/OIDC (device grant, auth-code+PKCE, refresh); rustls to match reqwest.
+oauth2 = { version = "5", default-features = false, features = ["reqwest", "rustls-tls"] }
 url = "2.5"
 base64 = "0.22"
 sha2 = "0.10"

--- a/crates/redisctl-core/Cargo.toml
+++ b/crates/redisctl-core/Cargo.toml
@@ -24,13 +24,11 @@ thiserror = { workspace = true }
 # Async runtime
 tokio = { workspace = true }
 
-# HTTP client + PKCE for the Okta OIDC flows (device authorization / auth-code loopback)
+# OAuth2/OIDC for the Okta login flows (device authorization / auth-code loopback), via the
+# maintained oauth2 crate. reqwest is the async HTTP backend it uses.
+oauth2 = { workspace = true }
 reqwest = { workspace = true }
-serde_urlencoded = { workspace = true }
 url = { workspace = true }
-base64 = { workspace = true }
-sha2 = { workspace = true }
-getrandom = { workspace = true }
 
 # Logging
 tracing = { workspace = true }

--- a/crates/redisctl-core/src/auth/auth_code_loopback.rs
+++ b/crates/redisctl-core/src/auth/auth_code_loopback.rs
@@ -1,30 +1,29 @@
 //! OIDC Authorization Code + PKCE via a loopback redirect (RFC 8252) — the interactive
 //! human login. The CLI opens the browser to the Okta sign-in page and self-hosts a
-//! one-shot `127.0.0.1` listener to catch the redirect; **no callback page is hosted
-//! anywhere** and the authorization code never leaves the machine.
+//! `127.0.0.1` listener to catch the redirect; **no callback page is hosted anywhere** and the
+//! authorization code never leaves the machine.
 //!
 //! Sequence:
 //! 1. Bind a loopback port on 127.0.0.1 (the redirect target; no page is hosted anywhere).
-//! 2. Build a PKCE S256 verifier/challenge + a random `state`.
+//! 2. Build a PKCE S256 verifier/challenge + a random `state` (both from the [`oauth2`] crate).
 //! 3. Hand the `/v1/authorize` URL to the caller's `open_browser`; the user signs in.
 //! 4. Catch the browser's redirect to `127.0.0.1/callback?code&state` on the listener.
-//! 5. Validate `state` (CSRF guard) and extract the code.
+//! 5. Validate `state` (CSRF guard) and extract the code — *before* rendering any success page.
 //! 6. Exchange the code (+ `code_verifier`) at `/v1/token` for a `TokenSet`.
 //!
-//! Converges on the same [`TokenSet`] and token-endpoint plumbing as the device flow.
+//! Converges on the same [`TokenSet`] and the shared `oidc` plumbing as the device flow.
 
 use std::net::Ipv4Addr;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
-use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
-use sha2::{Digest, Sha256};
+use oauth2::{AuthorizationCode, CsrfToken, PkceCodeChallenge, RedirectUrl, Scope};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use url::Url;
 
-use super::{AuthError, TokenSet, default_http_client, endpoint, form_body, post_token, token_set};
+use super::oidc::{map_basic_token_error, oauth_http_client, okta_client, to_token_set};
+use super::{AuthError, TokenSet};
 
-const AUTH_CODE_GRANT: &str = "authorization_code";
 /// Loopback ports tried in order. Each `http://127.0.0.1:PORT/callback` must be registered
 /// as a redirect URI on the Okta app (or the app configured to allow any loopback port).
 const DEFAULT_PORTS: &[u16] = &[8899, 8898, 8900];
@@ -38,7 +37,6 @@ const REQUEST_READ_TIMEOUT: Duration = Duration::from_secs(10);
 pub struct LoopbackFlowClient {
     issuer: Url,
     client_id: String,
-    http: reqwest::Client,
     ports: Vec<u16>,
     redirect_host: String,
     redirect_path: String,
@@ -52,18 +50,11 @@ impl LoopbackFlowClient {
         Self {
             issuer,
             client_id: client_id.into(),
-            http: default_http_client(),
             ports: DEFAULT_PORTS.to_vec(),
             redirect_host: "127.0.0.1".to_string(),
             redirect_path: "/callback".to_string(),
             timeout: DEFAULT_TIMEOUT,
         }
-    }
-
-    /// Use a caller-provided reqwest client.
-    pub fn with_http_client(mut self, http: reqwest::Client) -> Self {
-        self.http = http;
-        self
     }
 
     /// Override the candidate loopback ports (e.g. `[0]` for an ephemeral port in tests).
@@ -90,15 +81,33 @@ impl LoopbackFlowClient {
             self.redirect_host, port, self.redirect_path
         );
 
-        let pkce = Pkce::generate()?;
-        let state = random_urlsafe(16)?;
-        let url = self.authorize_url(&redirect_uri, scopes, &pkce.challenge, &state);
+        let client = okta_client(&self.issuer, &self.client_id)?.set_redirect_uri(
+            RedirectUrl::new(redirect_uri.clone())
+                .map_err(|e| AuthError::Protocol(format!("invalid redirect URL: {e}")))?,
+        );
 
-        open_browser(&url);
+        let (challenge, verifier) = PkceCodeChallenge::new_random_sha256();
+        let mut request = client
+            .authorize_url(CsrfToken::new_random)
+            .set_pkce_challenge(challenge)
+            .add_extra_param("prompt", "login");
+        for scope in scopes {
+            request = request.add_scope(Scope::new((*scope).to_string()));
+        }
+        let (url, csrf) = request.url();
 
-        let code = self.wait_for_callback(listener, &state).await?;
-        self.exchange_code(&code, &pkce.verifier, &redirect_uri)
+        open_browser(url.as_str());
+
+        let code = self.wait_for_callback(listener, csrf.secret()).await?;
+
+        let http = oauth_http_client()?;
+        let resp = client
+            .exchange_code(AuthorizationCode::new(code))
+            .set_pkce_verifier(verifier)
+            .request_async(&http)
             .await
+            .map_err(map_basic_token_error)?;
+        Ok(to_token_set(&resp))
     }
 
     async fn bind(&self) -> Result<(TcpListener, u16), AuthError> {
@@ -117,131 +126,151 @@ impl LoopbackFlowClient {
         )))
     }
 
-    fn authorize_url(
-        &self,
-        redirect_uri: &str,
-        scopes: &[&str],
-        challenge: &str,
-        state: &str,
-    ) -> String {
-        let scope = scopes.join(" ");
-        let query = form_body(&[
-            ("client_id", self.client_id.as_str()),
-            ("response_type", "code"),
-            ("scope", scope.as_str()),
-            ("redirect_uri", redirect_uri),
-            ("state", state),
-            ("code_challenge", challenge),
-            ("code_challenge_method", "S256"),
-            ("prompt", "login"),
-        ]);
-        format!("{}?{}", endpoint(&self.issuer, "v1/authorize"), query)
-    }
-
+    /// Wait for the browser's redirect, tolerating stray local connections. Two security
+    /// properties this upholds:
+    /// - The success page is written **only after** `state` (and any `error`) is validated, so a
+    ///   forged/mismatched callback never sees a "signed in" page.
+    /// - The listener keeps `accept()`ing (bounded by `self.timeout`) so an unrelated local
+    ///   request — which carries no `state` — is answered briefly and does not end the login; a
+    ///   real callback with a mismatched `state` is still a terminal CSRF rejection.
     async fn wait_for_callback(
         &self,
         listener: TcpListener,
         expected_state: &str,
     ) -> Result<String, AuthError> {
-        let accepted = tokio::time::timeout(self.timeout, listener.accept())
-            .await
-            .map_err(|_| {
-                AuthError::Protocol("timed out waiting for the browser redirect".into())
-            })?;
-        let (mut stream, _) =
-            accepted.map_err(|e| AuthError::Protocol(format!("accept failed: {e}")))?;
+        let deadline = Instant::now() + self.timeout;
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return Err(AuthError::Protocol(
+                    "timed out waiting for the browser redirect".into(),
+                ));
+            }
 
-        let target = tokio::time::timeout(REQUEST_READ_TIMEOUT, read_request_target(&mut stream))
-            .await
-            .map_err(|_| {
-                AuthError::Protocol("timed out reading the browser redirect request".into())
-            })??;
-        write_ok_page(&mut stream).await;
+            let (mut stream, _) = match tokio::time::timeout(remaining, listener.accept()).await {
+                Err(_) => {
+                    return Err(AuthError::Protocol(
+                        "timed out waiting for the browser redirect".into(),
+                    ));
+                }
+                Ok(Err(e)) => return Err(AuthError::Protocol(format!("accept failed: {e}"))),
+                Ok(Ok(pair)) => pair,
+            };
 
-        // The request target is a path+query; parse it against a dummy base to read the query.
-        let parsed = Url::parse(&format!("http://localhost{target}"))
-            .map_err(|e| AuthError::Protocol(format!("could not parse callback URL: {e}")))?;
-        let (mut code, mut state, mut error, mut error_desc) = (None, None, None, None);
-        for (k, v) in parsed.query_pairs() {
-            match k.as_ref() {
-                "code" => code = Some(v.into_owned()),
-                "state" => state = Some(v.into_owned()),
-                "error" => error = Some(v.into_owned()),
-                "error_description" => error_desc = Some(v.into_owned()),
-                _ => {}
+            // A connection that never completes its request must not hang the login: bound the
+            // read; on failure, answer briefly and keep waiting for the real callback.
+            let target =
+                match tokio::time::timeout(REQUEST_READ_TIMEOUT, read_request_target(&mut stream))
+                    .await
+                {
+                    Ok(Ok(t)) => t,
+                    _ => {
+                        write_page(
+                            &mut stream,
+                            400,
+                            "Bad Request",
+                            "Could not read the request.",
+                        )
+                        .await;
+                        continue;
+                    }
+                };
+
+            // The request target is a path+query; parse it against a dummy base to read the query.
+            let parsed = match Url::parse(&format!("http://localhost{target}")) {
+                Ok(u) => u,
+                Err(_) => {
+                    write_page(&mut stream, 400, "Bad Request", "Malformed callback URL.").await;
+                    continue;
+                }
+            };
+            let (mut code, mut state, mut error, mut error_desc) = (None, None, None, None);
+            for (k, v) in parsed.query_pairs() {
+                match k.as_ref() {
+                    "code" => code = Some(v.into_owned()),
+                    "state" => state = Some(v.into_owned()),
+                    "error" => error = Some(v.into_owned()),
+                    "error_description" => error_desc = Some(v.into_owned()),
+                    _ => {}
+                }
+            }
+
+            // Validate BEFORE writing any success page. An explicit IdP `error` is a terminal
+            // outcome for this login.
+            if let Some(err) = error {
+                write_page(
+                    &mut stream,
+                    400,
+                    "Bad Request",
+                    "Login failed. You can close this tab.",
+                )
+                .await;
+                return match err.as_str() {
+                    "access_denied" => Err(AuthError::Denied),
+                    other => Err(AuthError::Protocol(format!(
+                        "authorization error {other}: {}",
+                        error_desc.unwrap_or_default()
+                    ))),
+                };
+            }
+
+            match state.as_deref() {
+                // Our callback with a matching state: only now is a success page correct.
+                Some(s) if s == expected_state => {
+                    return match code {
+                        Some(c) => {
+                            write_page(
+                                &mut stream,
+                                200,
+                                "OK",
+                                "Signed in - you can close this tab.",
+                            )
+                            .await;
+                            Ok(c)
+                        }
+                        None => {
+                            write_page(
+                                &mut stream,
+                                400,
+                                "Bad Request",
+                                "Login failed. You can close this tab.",
+                            )
+                            .await;
+                            Err(AuthError::Protocol(
+                                "callback did not include an authorization code".into(),
+                            ))
+                        }
+                    };
+                }
+                // A callback carrying a mismatched state → CSRF / stale login. Reject with an
+                // error page, never a success page.
+                Some(_) => {
+                    write_page(
+                        &mut stream,
+                        400,
+                        "Bad Request",
+                        "Login failed (state mismatch). You can close this tab.",
+                    )
+                    .await;
+                    return Err(AuthError::Protocol(
+                        "state mismatch on callback (possible CSRF or stale login)".into(),
+                    ));
+                }
+                // No state at all → a stray/unrelated local request. Answer briefly and keep
+                // waiting for the real callback.
+                None => {
+                    write_page(
+                        &mut stream,
+                        404,
+                        "Not Found",
+                        "Waiting for the login callback.",
+                    )
+                    .await;
+                    continue;
+                }
             }
         }
-
-        if let Some(err) = error {
-            return match err.as_str() {
-                "access_denied" => Err(AuthError::Denied),
-                other => Err(AuthError::Protocol(format!(
-                    "authorization error {other}: {}",
-                    error_desc.unwrap_or_default()
-                ))),
-            };
-        }
-        if state.as_deref() != Some(expected_state) {
-            return Err(AuthError::Protocol(
-                "state mismatch on callback (possible CSRF or stale login)".into(),
-            ));
-        }
-        code.ok_or_else(|| {
-            AuthError::Protocol("callback did not include an authorization code".into())
-        })
     }
-
-    async fn exchange_code(
-        &self,
-        code: &str,
-        verifier: &str,
-        redirect_uri: &str,
-    ) -> Result<TokenSet, AuthError> {
-        let tr = post_token(
-            &self.http,
-            &endpoint(&self.issuer, "v1/token"),
-            &[
-                ("client_id", self.client_id.as_str()),
-                ("grant_type", AUTH_CODE_GRANT),
-                ("code", code),
-                ("redirect_uri", redirect_uri),
-                ("code_verifier", verifier),
-            ],
-        )
-        .await?;
-        if let Some(err) = tr.error.as_deref() {
-            return Err(AuthError::Protocol(format!(
-                "token exchange failed ({err}): {}",
-                tr.description()
-            )));
-        }
-        token_set(tr)
-    }
-}
-
-/// A PKCE verifier/challenge pair (S256).
-struct Pkce {
-    verifier: String,
-    challenge: String,
-}
-
-impl Pkce {
-    fn generate() -> Result<Self, AuthError> {
-        let verifier = random_urlsafe(32)?; // 32 bytes -> 43-char base64url (valid PKCE length)
-        let challenge = URL_SAFE_NO_PAD.encode(Sha256::digest(verifier.as_bytes()));
-        Ok(Self {
-            verifier,
-            challenge,
-        })
-    }
-}
-
-/// `n` random bytes, base64url-no-pad encoded — used for the PKCE verifier and `state`.
-fn random_urlsafe(n: usize) -> Result<String, AuthError> {
-    let mut buf = vec![0u8; n];
-    getrandom::fill(&mut buf)
-        .map_err(|e| AuthError::Protocol(format!("secure RNG unavailable: {e}")))?;
-    Ok(URL_SAFE_NO_PAD.encode(&buf))
 }
 
 /// Read the HTTP request line's target (the path+query) from the loopback connection.
@@ -271,15 +300,16 @@ async fn read_request_target(stream: &mut TcpStream) -> Result<String, AuthError
         .ok_or_else(|| AuthError::Protocol("malformed callback request line".into()))
 }
 
-/// Write a minimal "you can close this tab" page and close the connection.
-async fn write_ok_page(stream: &mut TcpStream) {
-    const BODY: &str = "<html><body style=\"font-family:sans-serif\">\
-        <h2>Signed in - you can close this tab.</h2></body></html>";
+/// Write a minimal HTML page and close the connection. Used for both the success page and the
+/// neutral error/"still waiting" pages, so the wording is decided by the caller after validation.
+async fn write_page(stream: &mut TcpStream, status: u16, reason: &str, message: &str) {
+    let body =
+        format!("<html><body style=\"font-family:sans-serif\"><h2>{message}</h2></body></html>");
     let response = format!(
-        "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\n\
+        "HTTP/1.1 {status} {reason}\r\nContent-Type: text/html; charset=utf-8\r\n\
          Content-Length: {}\r\nConnection: close\r\n\r\n{}",
-        BODY.len(),
-        BODY
+        body.len(),
+        body
     );
     let _ = stream.write_all(response.as_bytes()).await;
     let _ = stream.flush().await;
@@ -289,49 +319,21 @@ async fn write_ok_page(stream: &mut TcpStream) {
 mod tests {
     use super::*;
     use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
-    #[test]
-    fn pkce_challenge_matches_verifier() {
-        let p = Pkce::generate().unwrap();
-        assert!((43..=128).contains(&p.verifier.len()));
-        let expected = URL_SAFE_NO_PAD.encode(Sha256::digest(p.verifier.as_bytes()));
-        assert_eq!(p.challenge, expected);
-    }
-
-    #[test]
-    fn random_urlsafe_is_urlsafe_and_unique() {
-        let a = random_urlsafe(16).unwrap();
-        let b = random_urlsafe(16).unwrap();
-        assert_ne!(a, b);
-        assert!(!a.contains('+') && !a.contains('/') && !a.contains('='));
-    }
-
-    fn client_with_issuer(issuer: &str) -> LoopbackFlowClient {
-        LoopbackFlowClient::new(Url::parse(issuer).unwrap(), "cid")
-    }
-
-    #[test]
-    fn authorize_url_has_required_params() {
-        let c = client_with_issuer("https://issuer.example/oauth2/default");
-        let url = c.authorize_url(
-            "http://127.0.0.1:8899/callback",
-            &["openid", "email"],
-            "CHALLENGE",
-            "STATE",
-        );
-        assert!(url.starts_with("https://issuer.example/oauth2/default/v1/authorize?"));
-        let parsed = Url::parse(&url).unwrap();
-        let q: HashMap<_, _> = parsed.query_pairs().into_owned().collect();
-        assert_eq!(q["client_id"], "cid");
-        assert_eq!(q["response_type"], "code");
-        assert_eq!(q["code_challenge_method"], "S256");
-        assert_eq!(q["code_challenge"], "CHALLENGE");
-        assert_eq!(q["state"], "STATE");
-        assert_eq!(q["redirect_uri"], "http://127.0.0.1:8899/callback");
-        assert_eq!(q["scope"], "openid email");
-        assert_eq!(q["prompt"], "login");
+    async fn mount_token(server: &MockServer) {
+        Mock::given(method("POST"))
+            .and(path("/v1/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "AT",
+                "token_type": "Bearer",
+                "refresh_token": "RT",
+                "expires_in": 3600
+            })))
+            .mount(server)
+            .await;
     }
 
     async fn ephemeral(server: &MockServer) -> LoopbackFlowClient {
@@ -340,65 +342,98 @@ mod tests {
             .with_timeout(Duration::from_secs(5))
     }
 
-    /// Simulate the browser: read redirect_uri + state from the authorize URL and GET the
-    /// callback with the given extra query.
-    fn simulate_browser(url: &str, extra: &str) {
-        let parsed = Url::parse(url).unwrap();
-        let q: HashMap<_, _> = parsed.query_pairs().into_owned().collect();
-        let cb = format!("{}?{}&state={}", q["redirect_uri"], extra, q["state"]);
-        tokio::spawn(async move {
-            let _ = reqwest::get(&cb).await;
-        });
+    fn query_of(url: &str) -> HashMap<String, String> {
+        Url::parse(url)
+            .unwrap()
+            .query_pairs()
+            .into_owned()
+            .collect()
     }
 
     #[tokio::test]
-    async fn login_happy_path() {
+    async fn login_happy_path_and_authorize_url_params() {
         let server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .and(path("/v1/token"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "access_token": "AT",
-                "id_token": "IT",
-                "refresh_token": "RT",
-                "expires_in": 3600
-            })))
-            .mount(&server)
-            .await;
+        mount_token(&server).await;
 
+        let captured = Arc::new(Mutex::new(String::new()));
+        let cap = captured.clone();
         let token = ephemeral(&server)
             .await
-            .login(&["openid"], |url| simulate_browser(url, "code=THECODE"))
-            .await
-            .unwrap();
-        assert_eq!(token.access_token, "AT");
-        assert_eq!(token.refresh_token.as_deref(), Some("RT"));
-    }
-
-    #[tokio::test]
-    async fn login_state_mismatch_is_error() {
-        let server = MockServer::start().await;
-        let res = ephemeral(&server)
-            .await
-            .login(&["openid"], |url| {
-                // GET the callback with a wrong state (ignore the real one)
-                let parsed = Url::parse(url).unwrap();
-                let q: HashMap<_, _> = parsed.query_pairs().into_owned().collect();
-                let cb = format!("{}?code=X&state=WRONG", q["redirect_uri"]);
+            .login(&["openid", "email"], move |url| {
+                *cap.lock().unwrap() = url.to_string();
+                let q = query_of(url);
+                let cb = format!("{}?code=THECODE&state={}", q["redirect_uri"], q["state"]);
                 tokio::spawn(async move {
                     let _ = reqwest::get(&cb).await;
                 });
             })
+            .await
+            .unwrap();
+        assert_eq!(token.access_token, "AT");
+        assert_eq!(token.refresh_token.as_deref(), Some("RT"));
+
+        // The authorize URL the browser was handed carries the PKCE + CSRF params.
+        let url = captured.lock().unwrap().clone();
+        assert!(url.contains("/v1/authorize?"));
+        let q = query_of(&url);
+        assert_eq!(q["client_id"], "cid");
+        assert_eq!(q["response_type"], "code");
+        assert_eq!(q["code_challenge_method"], "S256");
+        assert!(q.contains_key("code_challenge"));
+        assert!(q.contains_key("state"));
+        assert_eq!(q["prompt"], "login");
+        assert_eq!(q["scope"], "openid email");
+        assert!(q["redirect_uri"].starts_with("http://127.0.0.1:"));
+        assert!(q["redirect_uri"].ends_with("/callback"));
+    }
+
+    /// Bug fix (a): a callback with a mismatched `state` is rejected AND never receives a
+    /// success page.
+    #[tokio::test]
+    async fn login_state_mismatch_is_rejected_without_success_page() {
+        let server = MockServer::start().await;
+        mount_token(&server).await;
+
+        // Capture the body the "browser" receives so we can assert it is not the success page.
+        let (tx, rx) = tokio::sync::oneshot::channel::<String>();
+        let res = ephemeral(&server)
+            .await
+            .login(&["openid"], move |url| {
+                let q = query_of(url);
+                let cb = format!("{}?code=X&state=WRONG-STATE", q["redirect_uri"]);
+                tokio::spawn(async move {
+                    let body = match reqwest::get(&cb).await {
+                        Ok(r) => r.text().await.unwrap_or_default(),
+                        Err(_) => String::new(),
+                    };
+                    let _ = tx.send(body);
+                });
+            })
             .await;
+
         assert!(matches!(res, Err(AuthError::Protocol(_))));
+        let body = rx.await.unwrap();
+        assert!(
+            !body.contains("Signed in"),
+            "mismatched state must not get a success page, got: {body}"
+        );
     }
 
     #[tokio::test]
     async fn login_access_denied_maps_to_denied() {
         let server = MockServer::start().await;
+        mount_token(&server).await;
         let res = ephemeral(&server)
             .await
             .login(&["openid"], |url| {
-                simulate_browser(url, "error=access_denied")
+                let q = query_of(url);
+                let cb = format!(
+                    "{}?error=access_denied&state={}",
+                    q["redirect_uri"], q["state"]
+                );
+                tokio::spawn(async move {
+                    let _ = reqwest::get(&cb).await;
+                });
             })
             .await;
         assert!(matches!(res, Err(AuthError::Denied)));
@@ -407,11 +442,41 @@ mod tests {
     #[tokio::test]
     async fn login_times_out_without_callback() {
         let server = MockServer::start().await;
+        mount_token(&server).await;
         let res = ephemeral(&server)
             .await
             .with_timeout(Duration::from_millis(150))
             .login(&["openid"], |_url| { /* browser never redirects */ })
             .await;
         assert!(matches!(res, Err(AuthError::Protocol(_))));
+    }
+
+    /// Bug fix (b): a stray request to the loopback port must not end the flow — the real
+    /// callback still succeeds.
+    #[tokio::test]
+    async fn login_ignores_stray_request() {
+        let server = MockServer::start().await;
+        mount_token(&server).await;
+        let token = ephemeral(&server)
+            .await
+            .login(&["openid"], |url| {
+                let q = query_of(url);
+                let redirect = q["redirect_uri"].clone();
+                let state = q["state"].clone();
+                // A stray, unrelated local request (no `state`) arrives first.
+                let stray = redirect.clone();
+                tokio::spawn(async move {
+                    let _ = reqwest::get(&stray).await;
+                });
+                // The legitimate callback follows shortly after.
+                let real = format!("{redirect}?code=THECODE&state={state}");
+                tokio::spawn(async move {
+                    tokio::time::sleep(Duration::from_millis(80)).await;
+                    let _ = reqwest::get(&real).await;
+                });
+            })
+            .await
+            .unwrap();
+        assert_eq!(token.access_token, "AT");
     }
 }

--- a/crates/redisctl-core/src/auth/authenticator.rs
+++ b/crates/redisctl-core/src/auth/authenticator.rs
@@ -86,22 +86,21 @@ impl CloudAuthenticator {
         self
     }
 
-    /// Device-authorization-grant client for headless / agent logins.
+    /// Device-authorization-grant client for headless / agent logins. The flow runs on the
+    /// `oauth2` crate's own HTTP stack, so it does not share this authenticator's SM client.
     pub fn device(&self) -> DeviceFlowClient {
         DeviceFlowClient::new(self.issuer.clone(), self.client_id.clone())
-            .with_http_client(self.http.clone())
     }
 
     /// Auth-code + PKCE loopback client for interactive human logins.
     pub fn loopback(&self) -> LoopbackFlowClient {
         LoopbackFlowClient::new(self.issuer.clone(), self.client_id.clone())
-            .with_http_client(self.http.clone())
     }
 
     /// Refresh an Okta refresh token for a fresh token set (Okta rotates it). The grant is
     /// flow-agnostic, so it goes straight through `oidc` rather than a specific flow client.
     pub async fn refresh(&self, refresh_token: &str) -> Result<TokenSet, AuthError> {
-        super::oidc::refresh(&self.http, &self.issuer, &self.client_id, refresh_token).await
+        super::oidc::refresh(&self.issuer, &self.client_id, refresh_token).await
     }
 
     /// Given tokens from a flow, run the SM exchange and mint a CAPI key named `key_name`.
@@ -280,7 +279,6 @@ mod tests {
         );
         let tokens = TokenSet {
             access_token: "AT".into(),
-            id_token: "IT".into(),
             refresh_token: Some("RT".into()),
             expires_in: 3600,
         };
@@ -314,7 +312,6 @@ mod tests {
         );
         let tokens = TokenSet {
             access_token: "AT".into(),
-            id_token: String::new(),
             refresh_token: None,
             expires_in: 3600,
         };

--- a/crates/redisctl-core/src/auth/device_flow.rs
+++ b/crates/redisctl-core/src/auth/device_flow.rs
@@ -1,70 +1,85 @@
 //! OIDC Device Authorization Grant (RFC 8628) client for the Redis Cloud Okta tenant.
 //!
-//! Two requests against the issuer:
-//! - `POST {issuer}/v1/device/authorize` — start; returns the user code + verification URI.
-//! - `POST {issuer}/v1/token` (device-code grant) — polled until approved/expired/denied.
+//! Two requests against the issuer, handled by the [`oauth2`] crate:
+//! - `POST {issuer}/v1/device/authorize` — [`start`](DeviceFlowClient::start); returns the user
+//!   code + verification URI plus the (secret) device code needed to resume.
+//! - `POST {issuer}/v1/token` (device-code grant) — [`poll`](DeviceFlowClient::poll); the crate
+//!   owns the polling loop (honoring the server's `interval`/`slow_down`) until the request is
+//!   approved, denied, or times out.
 //!
-//! The caller owns the polling loop (so the CLI can print progress and honor `--timeout`);
-//! [`DeviceFlowClient::poll_once`] performs a single attempt. Refreshing a token is
-//! flow-agnostic and lives in [`super::oidc::refresh`].
+//! `login --device` is deliberately split: the CLI calls [`start`](DeviceFlowClient::start),
+//! prints/persists the returned [`DeviceAuthorization`] (which is `serde`-serializable), and
+//! returns. A later `status --wait` — possibly a *different* process — rebuilds the client from
+//! the issuer + client id, deserializes the [`DeviceAuthorization`], and calls
+//! [`poll`](DeviceFlowClient::poll). Refreshing a token is flow-agnostic and lives in
+//! [`super::oidc::refresh`].
 
-use serde::Deserialize;
+use std::time::Duration;
+
+use oauth2::{Scope, StandardDeviceAuthorizationResponse};
+use serde::{Deserialize, Serialize};
 use url::Url;
 
-use super::{
-    AuthError, TokenSet, default_http_client, endpoint, form_body, post_token, token_set, truncate,
+use super::oidc::{
+    map_basic_token_error, map_device_token_error, oauth_http_client, okta_client, to_token_set,
 };
-
-const DEVICE_CODE_GRANT: &str = "urn:ietf:params:oauth:grant-type:device_code";
-/// RFC 8628 default poll interval when the server omits one.
-const DEFAULT_INTERVAL: u64 = 5;
+use super::{AuthError, TokenSet};
 
 /// Device-authorization-grant client bound to one Okta issuer + public client id.
+///
+/// Cheap to construct and holds no network state, so `status --wait` can rebuild it from the
+/// persisted issuer + client id to resume a login started by an earlier `login --device`.
 #[derive(Clone)]
 pub struct DeviceFlowClient {
     issuer: Url,
     client_id: String,
-    http: reqwest::Client,
 }
 
-/// The device-authorization response — what `auth login` surfaces to the developer.
+/// The device-authorization response — what `auth login --device` surfaces to the developer and
+/// persists so a later poll (in any process) can resume.
 ///
-/// `device_code` is retained to poll the token endpoint; it is a secret and is never printed.
-#[derive(Clone)]
+/// Wraps the RFC 8628 response from the [`oauth2`] crate. It is `serde`-serializable so the CLI
+/// can persist it between the non-blocking `login --device` and a later `status --wait`. The
+/// `device_code` it carries is a secret; `Debug` redacts it (as do the other code fields) via
+/// the underlying `oauth2` secret types.
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct DeviceAuthorization {
-    pub device_code: String,
-    pub user_code: String,
+    inner: StandardDeviceAuthorizationResponse,
+}
+
+impl DeviceAuthorization {
+    /// The end-user verification code (shown to the user to type at the verification URI).
+    pub fn user_code(&self) -> &str {
+        self.inner.user_code().secret().as_str()
+    }
+
     /// The page the user opens and then *types* the `user_code` into.
-    pub verification_uri: String,
-    /// The same page with the `user_code` pre-embedded (optional per RFC 8628), so the user
-    /// can just open it and confirm — no manual code entry. Prefer this when present.
-    pub verification_uri_complete: Option<String>,
-    pub expires_in: u64,
-    pub interval: u64,
-}
+    pub fn verification_uri(&self) -> &str {
+        self.inner.verification_uri().as_str()
+    }
 
-/// Outcome of a single token-endpoint poll. The caller decides when to poll again.
-#[derive(Debug)]
-pub enum PollOutcome {
-    /// Still waiting on the user; sleep `interval` and poll again.
-    Pending,
-    /// Server asked us to back off; increase the interval, then keep polling.
-    SlowDown,
-    /// Approved — tokens issued.
-    Ready(TokenSet),
-}
+    /// The same page with the `user_code` pre-embedded (optional per RFC 8628), so the user can
+    /// just open it and confirm — no manual code entry. Prefer this when present.
+    pub fn verification_uri_complete(&self) -> Option<&str> {
+        self.inner
+            .verification_uri_complete()
+            .map(|v| v.secret().as_str())
+    }
 
-/// Raw `/device/authorize` wire response. Kept separate from the public [`DeviceAuthorization`]
-/// so the wire shape (`interval` optional per RFC 8628) stays isolated from the resolved public
-/// type (`interval` defaulted); `start()` maps one to the other.
-#[derive(Deserialize)]
-struct DeviceAuthzResponse {
-    device_code: String,
-    user_code: String,
-    verification_uri: String,
-    verification_uri_complete: Option<String>,
-    expires_in: u64,
-    interval: Option<u64>,
+    /// Lifetime of the device/user code, in seconds.
+    pub fn expires_in(&self) -> u64 {
+        self.inner.expires_in().as_secs()
+    }
+
+    /// Minimum poll interval requested by the server, in seconds.
+    pub fn interval(&self) -> u64 {
+        self.inner.interval().as_secs()
+    }
+
+    /// Borrow the underlying RFC 8628 response (escape hatch for callers that need the raw type).
+    pub fn as_standard(&self) -> &StandardDeviceAuthorizationResponse {
+        &self.inner
+    }
 }
 
 impl DeviceFlowClient {
@@ -74,82 +89,47 @@ impl DeviceFlowClient {
         Self {
             issuer,
             client_id: client_id.into(),
-            http: default_http_client(),
         }
-    }
-
-    /// Use a caller-provided reqwest client (tests / shared client / custom user agent).
-    pub fn with_http_client(mut self, http: reqwest::Client) -> Self {
-        self.http = http;
-        self
     }
 
     /// Start device authorization: `POST /v1/device/authorize`.
+    ///
+    /// Returns the codes to display *and* the device code needed to resume polling — persist the
+    /// returned [`DeviceAuthorization`] and hand it to [`poll`](Self::poll) later.
     pub async fn start(&self, scopes: &[&str]) -> Result<DeviceAuthorization, AuthError> {
-        let scope = scopes.join(" ");
-        let resp = self
-            .http
-            .post(endpoint(&self.issuer, "v1/device/authorize"))
-            .header(
-                reqwest::header::CONTENT_TYPE,
-                "application/x-www-form-urlencoded",
-            )
-            .body(form_body(&[
-                ("client_id", self.client_id.as_str()),
-                ("scope", scope.as_str()),
-            ]))
-            .send()
-            .await?;
-        let status = resp.status();
-        let body = resp.text().await?;
-        if !status.is_success() {
-            return Err(AuthError::Protocol(format!(
-                "device authorize returned {status}: {}",
-                truncate(&body)
-            )));
+        let client = okta_client(&self.issuer, &self.client_id)?;
+        let http = oauth_http_client()?;
+        let mut request = client.exchange_device_code();
+        for scope in scopes {
+            request = request.add_scope(Scope::new((*scope).to_string()));
         }
-        let d: DeviceAuthzResponse = serde_json::from_str(&body).map_err(|e| {
-            AuthError::Protocol(format!("could not parse device-authorize response: {e}"))
-        })?;
-        Ok(DeviceAuthorization {
-            device_code: d.device_code,
-            user_code: d.user_code,
-            verification_uri: d.verification_uri,
-            verification_uri_complete: d.verification_uri_complete,
-            expires_in: d.expires_in,
-            interval: d.interval.unwrap_or(DEFAULT_INTERVAL),
-        })
+        let inner: StandardDeviceAuthorizationResponse = request
+            .request_async(&http)
+            .await
+            .map_err(map_basic_token_error)?;
+        Ok(DeviceAuthorization { inner })
     }
 
-    /// One poll of the token endpoint with the device-code grant. The caller owns the loop.
+    /// Poll the token endpoint until the user approves, the code is denied/expires, or `timeout`
+    /// elapses. The [`oauth2`] crate runs the loop internally (respecting the server's poll
+    /// interval and `slow_down`), so this is a single blocking call.
     ///
-    /// The OAuth device flow returns HTTP 400 with an `error` body for the pending/slow-down/
-    /// error cases, so we read and parse the body regardless of status.
-    pub async fn poll_once(&self, device_code: &str) -> Result<PollOutcome, AuthError> {
-        let tr = post_token(
-            &self.http,
-            &endpoint(&self.issuer, "v1/token"),
-            &[
-                ("client_id", self.client_id.as_str()),
-                ("grant_type", DEVICE_CODE_GRANT),
-                ("device_code", device_code),
-            ],
-        )
-        .await?;
-
-        if let Some(err) = tr.error.as_deref() {
-            return match err {
-                "authorization_pending" => Ok(PollOutcome::Pending),
-                "slow_down" => Ok(PollOutcome::SlowDown),
-                "expired_token" => Err(AuthError::Expired),
-                "access_denied" => Err(AuthError::Denied),
-                other => Err(AuthError::Protocol(format!(
-                    "token endpoint error {other}: {}",
-                    tr.description()
-                ))),
-            };
-        }
-        Ok(PollOutcome::Ready(token_set(tr)?))
+    /// `timeout` bounds the whole wait; `None` falls back to the device code's own lifetime. A
+    /// timeout surfaces as [`AuthError::Expired`]. Callable from a freshly built client after
+    /// deserializing `authz`.
+    pub async fn poll(
+        &self,
+        authz: &DeviceAuthorization,
+        timeout: Option<Duration>,
+    ) -> Result<TokenSet, AuthError> {
+        let client = okta_client(&self.issuer, &self.client_id)?;
+        let http = oauth_http_client()?;
+        let resp = client
+            .exchange_device_access_token(&authz.inner)
+            .request_async(&http, tokio::time::sleep, timeout)
+            .await
+            .map_err(map_device_token_error)?;
+        Ok(to_token_set(&resp))
     }
 }
 
@@ -163,6 +143,14 @@ mod tests {
         DeviceFlowClient::new(Url::parse(&server.uri()).unwrap(), "test-client")
     }
 
+    async fn mount_device_authorize(server: &MockServer, body: serde_json::Value) {
+        Mock::given(method("POST"))
+            .and(path("/v1/device/authorize"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(body))
+            .mount(server)
+            .await;
+    }
+
     async fn mount_token(server: &MockServer, status: u16, body: serde_json::Value) {
         Mock::given(method("POST"))
             .and(path("/v1/token"))
@@ -174,107 +162,102 @@ mod tests {
     #[tokio::test]
     async fn start_parses_device_authorization() {
         let server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .and(path("/v1/device/authorize"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+        mount_device_authorize(
+            &server,
+            serde_json::json!({
                 "device_code": "DC",
                 "user_code": "WDJB-MJHT",
                 "verification_uri": "https://x/activate",
                 "verification_uri_complete": "https://x/activate?user_code=WDJB-MJHT",
                 "expires_in": 600,
                 "interval": 5
-            })))
-            .mount(&server)
-            .await;
+            }),
+        )
+        .await;
 
         let d = client(&server)
             .start(&["openid", "offline_access"])
             .await
             .unwrap();
-        assert_eq!(d.device_code, "DC");
-        assert_eq!(d.user_code, "WDJB-MJHT");
-        assert_eq!(d.interval, 5);
+        assert_eq!(d.user_code(), "WDJB-MJHT");
+        assert_eq!(d.verification_uri(), "https://x/activate");
         assert_eq!(
-            d.verification_uri_complete.as_deref(),
+            d.verification_uri_complete(),
             Some("https://x/activate?user_code=WDJB-MJHT")
         );
+        assert_eq!(d.expires_in(), 600);
+        assert_eq!(d.interval(), 5);
+        // Debug must not leak the secret device code / user code.
+        assert!(!format!("{d:?}").contains("WDJB-MJHT"));
     }
 
     #[tokio::test]
     async fn start_defaults_interval_when_absent() {
         let server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .and(path("/v1/device/authorize"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+        mount_device_authorize(
+            &server,
+            serde_json::json!({
                 "device_code": "DC",
                 "user_code": "U",
                 "verification_uri": "https://x",
                 "expires_in": 600
-            })))
-            .mount(&server)
-            .await;
-
-        let d = client(&server).start(&["openid"]).await.unwrap();
-        assert_eq!(d.interval, DEFAULT_INTERVAL);
-    }
-
-    #[tokio::test]
-    async fn poll_pending() {
-        let server = MockServer::start().await;
-        mount_token(
-            &server,
-            400,
-            serde_json::json!({"error": "authorization_pending"}),
+            }),
         )
         .await;
-        assert!(matches!(
-            client(&server).poll_once("DC").await.unwrap(),
-            PollOutcome::Pending
-        ));
-    }
 
-    #[tokio::test]
-    async fn poll_slow_down() {
-        let server = MockServer::start().await;
-        mount_token(&server, 400, serde_json::json!({"error": "slow_down"})).await;
-        assert!(matches!(
-            client(&server).poll_once("DC").await.unwrap(),
-            PollOutcome::SlowDown
-        ));
+        // RFC 8628 default poll interval when the server omits one.
+        let d = client(&server).start(&["openid"]).await.unwrap();
+        assert_eq!(d.interval(), 5);
     }
 
     #[tokio::test]
     async fn poll_ready_returns_tokens() {
         let server = MockServer::start().await;
+        mount_device_authorize(
+            &server,
+            serde_json::json!({
+                "device_code": "DC", "user_code": "U",
+                "verification_uri": "https://x", "expires_in": 600, "interval": 5
+            }),
+        )
+        .await;
         mount_token(
             &server,
             200,
             serde_json::json!({
                 "access_token": "AT",
-                "id_token": "IT",
+                "token_type": "Bearer",
                 "refresh_token": "RT",
                 "expires_in": 3600
             }),
         )
         .await;
 
-        match client(&server).poll_once("DC").await.unwrap() {
-            PollOutcome::Ready(t) => {
-                assert_eq!(t.access_token, "AT");
-                assert_eq!(t.id_token, "IT");
-                assert_eq!(t.refresh_token.as_deref(), Some("RT"));
-                assert_eq!(t.expires_in, 3600);
-            }
-            other => panic!("expected Ready, got {other:?}"),
-        }
+        let c = client(&server);
+        let authz = c.start(&["openid"]).await.unwrap();
+        let t = c.poll(&authz, Some(Duration::from_secs(5))).await.unwrap();
+        assert_eq!(t.access_token, "AT");
+        assert_eq!(t.refresh_token.as_deref(), Some("RT"));
+        assert_eq!(t.expires_in, 3600);
     }
 
     #[tokio::test]
     async fn poll_expired_maps_to_error() {
         let server = MockServer::start().await;
+        mount_device_authorize(
+            &server,
+            serde_json::json!({
+                "device_code": "DC", "user_code": "U",
+                "verification_uri": "https://x", "expires_in": 600, "interval": 5
+            }),
+        )
+        .await;
         mount_token(&server, 400, serde_json::json!({"error": "expired_token"})).await;
+
+        let c = client(&server);
+        let authz = c.start(&["openid"]).await.unwrap();
         assert!(matches!(
-            client(&server).poll_once("DC").await,
+            c.poll(&authz, Some(Duration::from_secs(5))).await,
             Err(AuthError::Expired)
         ));
     }
@@ -282,39 +265,55 @@ mod tests {
     #[tokio::test]
     async fn poll_denied_maps_to_error() {
         let server = MockServer::start().await;
+        mount_device_authorize(
+            &server,
+            serde_json::json!({
+                "device_code": "DC", "user_code": "U",
+                "verification_uri": "https://x", "expires_in": 600, "interval": 5
+            }),
+        )
+        .await;
         mount_token(&server, 400, serde_json::json!({"error": "access_denied"})).await;
+
+        let c = client(&server);
+        let authz = c.start(&["openid"]).await.unwrap();
         assert!(matches!(
-            client(&server).poll_once("DC").await,
+            c.poll(&authz, Some(Duration::from_secs(5))).await,
             Err(AuthError::Denied)
         ));
     }
 
+    /// The device authorization must survive a serialize/deserialize round-trip and still be
+    /// usable to poll — this is the `login --device` (persist) then `status --wait` (resume,
+    /// possibly in another process) contract.
     #[tokio::test]
-    async fn poll_unknown_error_is_protocol() {
+    async fn device_authorization_round_trips_and_resumes() {
         let server = MockServer::start().await;
-        mount_token(
+        mount_device_authorize(
             &server,
-            400,
-            serde_json::json!({"error": "weird", "error_description": "nope"}),
+            serde_json::json!({
+                "device_code": "DC", "user_code": "U",
+                "verification_uri": "https://x", "expires_in": 600, "interval": 5
+            }),
         )
         .await;
-        assert!(matches!(
-            client(&server).poll_once("DC").await,
-            Err(AuthError::Protocol(_))
-        ));
-    }
+        mount_token(
+            &server,
+            200,
+            serde_json::json!({"access_token": "AT", "token_type": "Bearer", "expires_in": 3600}),
+        )
+        .await;
 
-    #[tokio::test]
-    async fn poll_malformed_body_is_protocol() {
-        let server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .and(path("/v1/token"))
-            .respond_with(ResponseTemplate::new(200).set_body_string("not json"))
-            .mount(&server)
-            .await;
-        assert!(matches!(
-            client(&server).poll_once("DC").await,
-            Err(AuthError::Protocol(_))
-        ));
+        let started = client(&server).start(&["openid"]).await.unwrap();
+        let json = serde_json::to_string(&started).unwrap();
+        let resumed: DeviceAuthorization = serde_json::from_str(&json).unwrap();
+
+        // A freshly built client (as a separate process would build) can complete the poll.
+        let fresh = DeviceFlowClient::new(Url::parse(&server.uri()).unwrap(), "test-client");
+        let t = fresh
+            .poll(&resumed, Some(Duration::from_secs(5)))
+            .await
+            .unwrap();
+        assert_eq!(t.access_token, "AT");
     }
 }

--- a/crates/redisctl-core/src/auth/mod.rs
+++ b/crates/redisctl-core/src/auth/mod.rs
@@ -21,9 +21,10 @@ mod oidc;
 
 pub use auth_code_loopback::LoopbackFlowClient;
 pub use authenticator::{CloudAuthenticator, MintedCredentials};
-pub use device_flow::{DeviceAuthorization, DeviceFlowClient, PollOutcome};
+pub use device_flow::{DeviceAuthorization, DeviceFlowClient};
 pub use oidc::{AuthError, TokenSet};
 pub use sm_api::{CapiKey, SmAccount, SmApiClient, SmUser};
 
-// Crate-private OIDC plumbing shared by the two flow clients (referenced as `super::*`).
-pub(crate) use oidc::{default_http_client, endpoint, form_body, post_token, token_set, truncate};
+// Crate-private OIDC plumbing shared by the SM exchange (referenced as `super::*`). The flow
+// clients pull their `oauth2` helpers directly from `super::oidc`.
+pub(crate) use oidc::{default_http_client, endpoint, truncate};

--- a/crates/redisctl-core/src/auth/oidc.rs
+++ b/crates/redisctl-core/src/auth/oidc.rs
@@ -1,10 +1,17 @@
 //! Shared OIDC vocabulary and token-endpoint plumbing used by both login flows.
 //!
 //! Holds the public [`TokenSet`] / [`AuthError`] types plus the crate-private helpers the
-//! device-flow and loopback clients build on. Kept out of `mod.rs` so that stays a thin
-//! facade, matching the other modules in this crate.
+//! device-flow and loopback clients build on. The OAuth2/OIDC protocol itself is handled by
+//! the maintained [`oauth2`] crate; this module owns the endpoint layout (Okta `v1/*` paths),
+//! the shared HTTP clients, and the mapping from `oauth2` errors to [`AuthError`]. Kept out of
+//! `mod.rs` so that stays a thin facade, matching the other modules in this crate.
 
-use serde::Deserialize;
+use oauth2::basic::{BasicClient, BasicRequestTokenError, BasicTokenResponse};
+use oauth2::{
+    AuthType, AuthUrl, ClientId, DeviceAuthorizationUrl, DeviceCodeErrorResponse,
+    DeviceCodeErrorResponseType, EndpointNotSet, EndpointSet, RefreshToken, RequestTokenError,
+    TokenResponse, TokenUrl,
+};
 use thiserror::Error;
 use url::Url;
 
@@ -14,7 +21,6 @@ use url::Url;
 #[derive(Clone)]
 pub struct TokenSet {
     pub access_token: String,
-    pub id_token: String,
     pub refresh_token: Option<String>,
     /// Access-token lifetime in seconds (0 if the IdP omitted it).
     pub expires_in: u64,
@@ -24,7 +30,6 @@ impl std::fmt::Debug for TokenSet {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("TokenSet")
             .field("access_token", &"<redacted>")
-            .field("id_token", &"<redacted>")
             .field(
                 "refresh_token",
                 &self.refresh_token.as_ref().map(|_| "<redacted>"),
@@ -48,7 +53,8 @@ pub enum AuthError {
     #[error("the login request was denied")]
     Denied,
 
-    /// Network/transport failure talking to the identity provider.
+    /// Network/transport failure talking to the SM API (the `oauth2` flows classify their own
+    /// transport failures as [`AuthError::Protocol`] because they run on a separate HTTP stack).
     #[error("network error contacting the identity provider: {0}")]
     Network(#[from] reqwest::Error),
 
@@ -57,25 +63,10 @@ pub enum AuthError {
     Protocol(String),
 }
 
-/// Raw token-endpoint response — either the token fields or an OAuth `error` object.
-#[derive(Deserialize)]
-pub(crate) struct TokenResponse {
-    pub(crate) access_token: Option<String>,
-    pub(crate) id_token: Option<String>,
-    pub(crate) refresh_token: Option<String>,
-    pub(crate) expires_in: Option<u64>,
-    pub(crate) error: Option<String>,
-    pub(crate) error_description: Option<String>,
-}
-
-impl TokenResponse {
-    /// The `error_description`, or a placeholder — for building error messages.
-    pub(crate) fn description(&self) -> &str {
-        self.error_description
-            .as_deref()
-            .unwrap_or("(no description)")
-    }
-}
+/// A `BasicClient` with the Okta authorize / token / device-authorization endpoints set. The
+/// remaining typestate slots (introspection, revocation) stay unset — we never call those.
+pub(crate) type OktaClient =
+    BasicClient<EndpointSet, EndpointSet, EndpointNotSet, EndpointNotSet, EndpointSet>;
 
 /// Build `{issuer}/{path}`, tolerant of a trailing slash on the issuer.
 pub(crate) fn endpoint(issuer: &Url, path: &str) -> String {
@@ -86,82 +77,89 @@ pub(crate) fn endpoint(issuer: &Url, path: &str) -> String {
     )
 }
 
-/// Encode name/value pairs as an `application/x-www-form-urlencoded` string (body or query).
-pub(crate) fn form_body(pairs: &[(&str, &str)]) -> String {
-    serde_urlencoded::to_string(pairs).unwrap_or_default()
-}
-
-/// POST an `application/x-www-form-urlencoded` body to the token endpoint and parse the
-/// response. Does not treat non-2xx as fatal — the OAuth error body is parsed regardless.
-pub(crate) async fn post_token(
-    http: &reqwest::Client,
-    token_url: &str,
-    form: &[(&str, &str)],
-) -> Result<TokenResponse, AuthError> {
-    let body = http
-        .post(token_url)
-        .header(
-            reqwest::header::CONTENT_TYPE,
-            "application/x-www-form-urlencoded",
-        )
-        .body(form_body(form))
-        .send()
-        .await?
-        .text()
-        .await?;
-    serde_json::from_str(&body)
-        .map_err(|e| AuthError::Protocol(format!("could not parse token response: {e}")))
-}
-
-/// Convert a successful token response into a [`TokenSet`].
-pub(crate) fn token_set(tr: TokenResponse) -> Result<TokenSet, AuthError> {
-    let access_token = tr
-        .access_token
-        .ok_or_else(|| AuthError::Protocol("token response missing access_token".into()))?;
-    Ok(TokenSet {
-        access_token,
-        id_token: tr.id_token.unwrap_or_default(),
-        refresh_token: tr.refresh_token,
-        expires_in: tr.expires_in.unwrap_or(0),
-    })
-}
-
-/// Exchange a refresh token for a fresh [`TokenSet`] via the refresh-token grant.
+/// Configure an [`oauth2`] client for the Okta tenant behind `issuer` as a public client
+/// (no secret; credentials go in the request body via [`AuthType::RequestBody`]).
 ///
-/// Okta rotates the refresh token, so the caller must persist the new one. The grant is
-/// flow-agnostic (a token from either login flow refreshes identically), so it lives here
-/// rather than on a specific flow client.
-pub(crate) async fn refresh(
-    http: &reqwest::Client,
-    issuer: &Url,
-    client_id: &str,
-    refresh_token: &str,
-) -> Result<TokenSet, AuthError> {
-    let tr = post_token(
-        http,
-        &endpoint(issuer, "v1/token"),
-        &[
-            ("client_id", client_id),
-            ("grant_type", "refresh_token"),
-            ("refresh_token", refresh_token),
-        ],
-    )
-    .await?;
-    if let Some(err) = tr.error.as_deref() {
-        return Err(AuthError::Protocol(format!(
-            "refresh failed ({err}): {}",
-            tr.description()
-        )));
-    }
-    token_set(tr)
+/// Okta's endpoints are derived from the issuer: `v1/authorize`, `v1/token`,
+/// `v1/device/authorize`. The loopback flow additionally calls `set_redirect_uri` on the
+/// returned client once it has bound a port.
+pub(crate) fn okta_client(issuer: &Url, client_id: &str) -> Result<OktaClient, AuthError> {
+    let auth = AuthUrl::new(endpoint(issuer, "v1/authorize"))
+        .map_err(|e| AuthError::Protocol(format!("invalid authorize URL: {e}")))?;
+    let token = TokenUrl::new(endpoint(issuer, "v1/token"))
+        .map_err(|e| AuthError::Protocol(format!("invalid token URL: {e}")))?;
+    let device = DeviceAuthorizationUrl::new(endpoint(issuer, "v1/device/authorize"))
+        .map_err(|e| AuthError::Protocol(format!("invalid device-authorization URL: {e}")))?;
+    Ok(BasicClient::new(ClientId::new(client_id.to_string()))
+        .set_auth_uri(auth)
+        .set_token_uri(token)
+        .set_device_authorization_url(device)
+        .set_auth_type(AuthType::RequestBody))
 }
 
-/// A reqwest client with the redisctl user agent.
+/// HTTP client for the [`oauth2`] flows. Redirects are disabled so the token/authorize
+/// requests can never be silently bounced to another host.
+pub(crate) fn oauth_http_client() -> Result<oauth2::reqwest::Client, AuthError> {
+    oauth2::reqwest::Client::builder()
+        .redirect(oauth2::reqwest::redirect::Policy::none())
+        .user_agent(concat!("redisctl/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .map_err(|e| AuthError::Protocol(format!("could not build the OAuth HTTP client: {e}")))
+}
+
+/// A reqwest client with the redisctl user agent (used by the SM API exchange).
 pub(crate) fn default_http_client() -> reqwest::Client {
     reqwest::Client::builder()
         .user_agent(concat!("redisctl/", env!("CARGO_PKG_VERSION")))
         .build()
         .expect("building the reqwest client should not fail")
+}
+
+/// Convert a successful [`oauth2`] token response into a [`TokenSet`].
+pub(crate) fn to_token_set(resp: &BasicTokenResponse) -> TokenSet {
+    TokenSet {
+        access_token: resp.access_token().secret().clone(),
+        refresh_token: resp.refresh_token().map(|r| r.secret().clone()),
+        expires_in: resp.expires_in().map(|d| d.as_secs()).unwrap_or(0),
+    }
+}
+
+/// Map an `oauth2` token/authorize error (with the *basic* error body) to an [`AuthError`].
+///
+/// Used by the auth-code, refresh, and device-authorize requests. Transport failures land in
+/// [`AuthError::Protocol`] because the `oauth2` flows run on `oauth2`'s bundled reqwest, whose
+/// error type differs from the one wrapped by [`AuthError::Network`].
+pub(crate) fn map_basic_token_error<RE>(err: BasicRequestTokenError<RE>) -> AuthError
+where
+    RE: std::error::Error,
+{
+    match err {
+        RequestTokenError::ServerResponse(resp) => match resp.error().as_ref() {
+            "access_denied" => AuthError::Denied,
+            "expired_token" => AuthError::Expired,
+            _ => AuthError::Protocol(format!("identity-provider error: {resp}")),
+        },
+        other => AuthError::Protocol(other.to_string()),
+    }
+}
+
+/// Map an `oauth2` device-access-token error to an [`AuthError`]. The device grant has its own
+/// error vocabulary (`authorization_pending` / `slow_down` are handled inside the crate's poll
+/// loop, so only the terminal outcomes reach here).
+pub(crate) fn map_device_token_error<RE>(
+    err: RequestTokenError<RE, DeviceCodeErrorResponse>,
+) -> AuthError
+where
+    RE: std::error::Error,
+{
+    match err {
+        RequestTokenError::ServerResponse(resp) => match resp.error() {
+            DeviceCodeErrorResponseType::ExpiredToken => AuthError::Expired,
+            DeviceCodeErrorResponseType::AccessDenied => AuthError::Denied,
+            _ => AuthError::Protocol(format!("identity-provider error: {resp}")),
+        },
+        other => AuthError::Protocol(other.to_string()),
+    }
 }
 
 /// Truncate a string for inclusion in an error message (char-boundary safe).
@@ -173,6 +171,26 @@ pub(crate) fn truncate(s: &str) -> String {
         let head: String = s.chars().take(MAX).collect();
         format!("{head}…")
     }
+}
+
+/// Exchange a refresh token for a fresh [`TokenSet`] via the refresh-token grant.
+///
+/// Okta rotates the refresh token, so the caller must persist the new one. The grant is
+/// flow-agnostic (a token from either login flow refreshes identically), so it lives here
+/// rather than on a specific flow client.
+pub(crate) async fn refresh(
+    issuer: &Url,
+    client_id: &str,
+    refresh_token: &str,
+) -> Result<TokenSet, AuthError> {
+    let client = okta_client(issuer, client_id)?;
+    let http = oauth_http_client()?;
+    let resp = client
+        .exchange_refresh_token(&RefreshToken::new(refresh_token.to_string()))
+        .request_async(&http)
+        .await
+        .map_err(map_basic_token_error)?;
+    Ok(to_token_set(&resp))
 }
 
 #[cfg(test)]
@@ -197,6 +215,7 @@ mod tests {
             200,
             serde_json::json!({
                 "access_token": "AT2",
+                "token_type": "Bearer",
                 "refresh_token": "RT2",
                 "expires_in": 3600
             }),
@@ -204,12 +223,11 @@ mod tests {
         .await;
 
         let issuer = Url::parse(&server.uri()).unwrap();
-        let t = refresh(&default_http_client(), &issuer, "test-client", "RT1")
-            .await
-            .unwrap();
+        let t = refresh(&issuer, "test-client", "RT1").await.unwrap();
         assert_eq!(t.access_token, "AT2");
         // Okta rotates the refresh token — the caller must persist the new one.
         assert_eq!(t.refresh_token.as_deref(), Some("RT2"));
+        assert_eq!(t.expires_in, 3600);
     }
 
     #[tokio::test]
@@ -223,8 +241,22 @@ mod tests {
         .await;
         let issuer = Url::parse(&server.uri()).unwrap();
         assert!(matches!(
-            refresh(&default_http_client(), &issuer, "test-client", "RT1").await,
+            refresh(&issuer, "test-client", "RT1").await,
             Err(AuthError::Protocol(_))
         ));
+    }
+
+    #[test]
+    fn token_set_debug_redacts_secrets() {
+        let t = TokenSet {
+            access_token: "AT-should-not-appear".into(),
+            refresh_token: Some("RT-should-not-appear".into()),
+            expires_in: 3600,
+        };
+        let dbg = format!("{t:?}");
+        assert!(dbg.contains("<redacted>"));
+        assert!(!dbg.contains("AT-should-not-appear"));
+        assert!(!dbg.contains("RT-should-not-appear"));
+        assert!(dbg.contains("3600"));
     }
 }

--- a/crates/redisctl-core/src/lib.rs
+++ b/crates/redisctl-core/src/lib.rs
@@ -77,7 +77,7 @@ pub mod enterprise;
 // Re-export commonly used items
 pub use auth::{
     AuthError, CapiKey, CloudAuthenticator, DeviceAuthorization, DeviceFlowClient,
-    LoopbackFlowClient, MintedCredentials, PollOutcome, SmAccount, SmApiClient, SmUser, TokenSet,
+    LoopbackFlowClient, MintedCredentials, SmAccount, SmApiClient, SmUser, TokenSet,
 };
 pub use error::{CoreError, Result};
 pub use progress::{ProgressCallback, ProgressEvent, poll_task};


### PR DESCRIPTION
## Summary

Replaces the hand-rolled OAuth2/OIDC protocol code in `redisctl-core::auth` with the maintained
[`oauth2`](https://docs.rs/oauth2/5) crate (v5), addressing the maintainer feedback on the auth
library. The device authorization grant (RFC 8628), authorization-code + PKCE (S256), CSRF state,
token exchange, and refresh now delegate to `oauth2`; the Okta endpoints are configured directly
(no discovery). No Okta incompatibility surfaced — the crate covers all of it.

The Redis-specific **SM session / CAPI-key exchange (`sm_api`) is unchanged**, behind its narrow
interface. The agent-native `login --device` / `status --wait` split is **preserved** (a
redisctl-owned, serde-serializable pending DTO), now built on the crate rather than reimplementing
the protocol.

### Loopback listener bugs fixed

The one small HTTP listener we still own (to catch the browser redirect on `127.0.0.1`) is rewritten
to fix two issues raised in review:
- the success page is now written **only after** `state`/`error` is validated — a forged or
  mismatched callback gets a neutral error page, never a "signed in" page;
- the listener **loop-accepts** (bounded by the timeout), so a stray local request no longer
  terminates the flow before the legitimate callback arrives.

Both have dedicated tests.

## Scope

- **Affected areas:** `crates/redisctl-core/src/auth/*` (flow clients + shared plumbing rewritten onto `oauth2`; `sm_api.rs` untouched); `Cargo.toml` (+ `oauth2`; drops the hand-rolled `sha2`/`base64`/`getrandom`/`serde_urlencoded`).
- **API surface:** `CloudAuthenticator`'s public methods are unchanged. `DeviceFlowClient::poll_once`/`PollOutcome` are replaced by `poll(&DeviceAuthorization, Option<Duration>)` (the crate owns the poll loop); `DeviceAuthorization` is now a serde wrapper with accessor methods; `TokenSet` drops the unused `id_token`.

## Note / tradeoff

`oauth2` v5 depends on `reqwest` 0.12 while the workspace is on `reqwest` 0.13, so the tree now
compiles **two `reqwest` versions**. Unifying would mean realigning `reqwest` across the workspace
(including `sm_api`, which must keep the workspace client). Flagged for visibility.

## Testing

```cargo test -p redisctl-core```
```cargo clippy --workspace --all-targets --all-features -- -D warnings```

No live environment needed — `wiremock` mocks the token/device endpoints; the two loopback bug fixes
have dedicated tests. Tracking: RED-210662.

## Checklist

- [x] Scope and plan documented in this description
- [x] Tests added/updated; both success and error cases covered
- [x] Docs updated (module overviews, examples)
- [x] cargo fmt, clippy (-D warnings), tests pass locally
- [ ] CI status is green
- [ ] Ready for review (remove Draft)
- [ ] Squash and merge when approved
