### PR TITLE
docs(cloud): document `cloud auth login | status | logout`

### DIFF
--- a/docs/docs/cloud/commands/auth.md
+++ b/docs/docs/cloud/commands/auth.md
@@ -1,0 +1,160 @@
+# Authentication Commands
+
+Sign in to Redis Cloud and manage the stored session.
+
+`cloud auth login` is a credential **bootstrapper**: it runs a standard OIDC sign-in, mints a
+Redis Cloud API key for your account, and writes it into a normal profile — so you never have to
+create and paste an API key by hand. Afterward every other `cloud` command works with that profile.
+
+!!! note "Prerequisite"
+    The profile needs its login endpoints — a `[cloud_auth.<profile>]` section, or the built-in
+    production defaults. See [Configuration](#configuration) below.
+
+## Log In
+
+```bash
+redisctl cloud auth login
+```
+
+Opens your browser to sign in (the interactive default), then stores the minted API key in the
+profile's secure storage.
+
+### Examples
+
+```bash
+# Interactive browser sign-in for the default cloud profile
+redisctl cloud auth login
+
+# A specific profile
+redisctl cloud auth login --profile qa
+
+# Headless machine with no local browser — use the device flow
+redisctl cloud auth login --device
+
+# Store credentials in the config file when no OS keyring is available
+redisctl cloud auth login --allow-plaintext
+```
+
+| Flag | Description |
+|------|-------------|
+| `--device` | Use the device-authorization flow (print a URL + code) instead of opening a browser. |
+| `--wait` | With `--device`: block until approved (one-shot). Without it, `login --device` returns immediately and `auth status --wait` completes the login. |
+| `--allow-plaintext` | Store credentials in the config file (`0600`) when no OS keyring is available. |
+
+### Browser (loopback) flow
+
+The default on an interactive terminal — a single command opens the browser and completes:
+
+```mermaid
+sequenceDiagram
+    actor U as User
+    participant CLI as redisctl
+    participant OK as Okta (OIDC)
+    participant SM as Redis Cloud API
+    participant CFG as profile and keyring
+    U->>CLI: cloud auth login
+    Note over CLI: bind loopback port, build PKCE and state
+    CLI->>OK: open browser to authorize (PKCE challenge, state)
+    U->>OK: sign in
+    OK-->>CLI: redirect to loopback callback (code, state)
+    Note over CLI: validate state BEFORE responding, then success page
+    CLI->>OK: exchange code and PKCE verifier for tokens
+    OK-->>CLI: access and refresh tokens
+    CLI->>SM: sign in, enable programmatic access, mint an API key
+    SM-->>CLI: account API key and user secret
+    CLI->>CFG: write cloud profile (secrets to keyring)
+    CLI-->>U: signed in - profile ready
+```
+
+### Device flow (headless / agents)
+
+With `--device`, `login` is **non-blocking**: it prints the verification URL + code and returns, so
+an agent can relay them; `auth status --wait` then completes the login. `login --device --wait`
+collapses both into one blocking call for a human.
+
+```mermaid
+sequenceDiagram
+    actor A as Agent
+    actor H as Human
+    participant CLI as redisctl
+    participant OK as Okta (OIDC)
+    participant SM as Redis Cloud API
+    A->>CLI: cloud auth login --device
+    CLI->>OK: request device authorization
+    OK-->>CLI: user_code, verification_uri, device_code
+    CLI-->>A: authorization_pending and code (writes pending record)
+    A->>H: relay verification URL and code
+    H->>OK: open URL, sign in, confirm code
+    A->>CLI: cloud auth status --wait
+    CLI->>OK: poll for tokens until approved
+    OK-->>CLI: access and refresh tokens
+    CLI->>SM: sign in, enable access, mint an API key
+    SM-->>CLI: account API key and user secret
+    CLI-->>A: authenticated and account_id
+```
+
+## Status
+
+```bash
+redisctl cloud auth status
+```
+
+Reports whether the profile is authenticated. With `--wait`, it completes a pending device login.
+
+### Examples
+
+```bash
+redisctl cloud auth status
+
+# Complete a pending `login --device`, waiting up to 5 minutes
+redisctl cloud auth status --wait --timeout 300
+```
+
+| Flag | Description |
+|------|-------------|
+| `--wait` | Block until a pending device login is approved (or is denied / the code expires), then run the exchange and persist. |
+| `--timeout <secs>` | Max seconds to wait with `--wait` (default 600). If it elapses while still pending, exits `0` reporting `authorization_pending` — run again to keep waiting. |
+
+## Log Out
+
+```bash
+redisctl cloud auth logout
+```
+
+Removes the locally stored credentials for the profile (keyring entries and the profile), while
+preserving the `[cloud_auth.<profile>]` login endpoints so you can log in again.
+
+!!! note
+    The minted API key still exists in the Redis Cloud console until you revoke it there —
+    server-side revocation on logout is a planned follow-up.
+
+## Configuration
+
+`cloud auth login` reads its OIDC endpoints from a `[cloud_auth.<profile>]` section, falling back
+to built-in production defaults (so for production you usually need no section at all):
+
+```toml
+[cloud_auth.myenv]
+okta_issuer    = "https://<your-okta-issuer>/oauth2/default"
+okta_client_id = "<public-client-id>"
+sm_api_url     = "https://<sm-api-host>/api/v1"
+capi_url       = "https://api.redislabs.com/v1"
+```
+
+## Error handling (agents)
+
+In `-o json` / `-o yaml` mode, failures on this surface print a machine-branchable envelope to
+**stdout** and exit with a mapped code, so scripts and agents can branch on `.error.code` instead
+of parsing prose:
+
+```json
+{ "status": "error", "error": { "code": "device_code_expired", "message": "...", "retryable": true } }
+```
+
+| Exit code | Meaning | Example codes |
+|-----------|---------|---------------|
+| `1` | unknown / backend failure | `sm_exchange_failed` |
+| `2` | usage / precondition to fix | `not_authenticated`, `auth_denied`, `keyring_unavailable` |
+| `3` | transient / retryable | `device_code_expired`, `transient_api_error`, `rate_limited` |
+
+Human (non-JSON) mode prints the usual diagnostic to stderr and keeps today's `0`/`1` exit behavior.

--- a/docs/docs/cloud/commands/index.md
+++ b/docs/docs/cloud/commands/index.md
@@ -6,6 +6,7 @@ All Redis Cloud CLI commands.
 
 | Command Group | Description |
 |---------------|-------------|
+| [auth](auth.md) | Sign in to Redis Cloud and manage the session |
 | [subscription](subscriptions.md) | Manage Pro subscriptions |
 | [database](databases.md) | Manage Pro databases |
 | [fixed-subscription](fixed-subscriptions.md) | Manage Essentials subscriptions |

--- a/docs/docs/getting-started/authentication.md
+++ b/docs/docs/getting-started/authentication.md
@@ -10,6 +10,22 @@ redisctl supports three credential sources, in order of precedence:
 2. **Environment variables** - Good for CI/CD
 3. **Profiles** - Best for daily use
 
+## Redis Cloud: sign in with `cloud auth login`
+
+For Redis Cloud, the easiest way to authenticate is to let redisctl mint the API key for you:
+
+```bash
+redisctl cloud auth login
+```
+
+This runs a browser OIDC sign-in, creates a Cloud API key for your account, and stores it in a
+profile — no manual key creation or copying. On a headless machine or from an agent, use
+`redisctl cloud auth login --device`. See **[Authentication commands](../cloud/commands/auth.md)**
+for the full flow (browser and device), `status` / `logout`, and the error-code contract.
+
+The manual methods below (environment variables, hand-created API keys) still work if you prefer to
+manage keys yourself.
+
 ## Credential Method Comparison
 
 | Method | Security | Persistence | Best for |

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -120,6 +120,7 @@ nav:
       - cloud/index.md
       - Commands:
           - cloud/commands/index.md
+          - Authentication: cloud/commands/auth.md
           - Subscriptions: cloud/commands/subscriptions.md
           - Databases: cloud/commands/databases.md
           - Essentials Subscriptions: cloud/commands/fixed-subscriptions.md


### PR DESCRIPTION
Documents the `cloud auth login | status | logout` surface (RED-210680).

## What's here

- **New** `docs/docs/cloud/commands/auth.md` — command reference for `cloud auth login | status | logout`:
  - the interactive **browser (loopback)** flow and the headless **device** flow, each with a Mermaid sequence diagram;
  - the `--device` / `--wait` / `--timeout` / `--allow-plaintext` flags;
  - the agent-native "initiate `login --device`, then complete with `status --wait`" split;
  - the machine-branchable error-code / exit-code contract for `-o json` / `-o yaml`.
- **Updated** `getting-started/authentication.md` — features `cloud auth login` as the zero-manual-key bootstrapper, alongside the existing manual API-key methods (which are preserved).
- **Nav** — registered the new page under Redis Cloud → Commands → Authentication (`mkdocs.yml`), and added a row to the Cloud commands index.

No internal endpoints or client IDs appear in the shipped docs — the `[cloud_auth.<profile>]` example uses placeholders only.

## Testing

- Built locally with the pinned docs deps (`docs/requirements.txt`): `mkdocs build --strict` succeeds — all nav entries and internal links resolve, with no broken-reference warnings.
- The new `auth.md` renders with both Mermaid sequence diagrams (browser/loopback and device flow) via the Material `pymdownx.superfences` mermaid fence.
