### PR TITLE
feat(cli): add `cloud workflow quick-database | database-credentials`

### DIFF
--- a/crates/redisctl/src/cli/cloud.rs
+++ b/crates/redisctl/src/cli/cloud.rs
@@ -1702,6 +1702,12 @@ pub enum CloudWorkflowCommands {
     /// Complete subscription setup with optional database
     #[command(name = "subscription-setup")]
     SubscriptionSetup(crate::workflows::cloud::subscription_setup::SubscriptionSetupArgs),
+    /// Create or reuse a free database and write its connection string to a file
+    #[command(name = "quick-database")]
+    QuickDatabase(crate::workflows::cloud::quick_database::QuickDatabaseArgs),
+    /// Write an existing database's connection string to a file (no provisioning)
+    #[command(name = "database-credentials")]
+    DatabaseCredentials(crate::workflows::cloud::quick_database::DatabaseCredentialsArgs),
 }
 
 /// Cloud Cost Report Commands (Beta)

--- a/crates/redisctl/src/main.rs
+++ b/crates/redisctl/src/main.rs
@@ -1001,7 +1001,11 @@ async fn handle_cloud_workflow_command(
             // Filter to show only cloud workflows
             let cloud_workflows: Vec<_> = workflows
                 .into_iter()
-                .filter(|(name, _)| name.contains("subscription") || name.contains("cloud"))
+                .filter(|(name, _)| {
+                    name.contains("subscription")
+                        || name.contains("cloud")
+                        || name.contains("database")
+                })
                 .collect();
 
             match output {
@@ -1071,6 +1075,110 @@ async fn handle_cloud_workflow_command(
                 _ => {
                     // Human output
                     println!("{}", result.message);
+                }
+            }
+
+            Ok(())
+        }
+        QuickDatabase(args) => {
+            use crate::structured_error::StructuredError;
+            use redisctl_core::cloud::quick_database::QuickDatabaseError;
+
+            let mut workflow_args = WorkflowArgs::new();
+            workflow_args.insert("args", args);
+
+            let context = WorkflowContext {
+                conn_mgr: conn_mgr.clone(),
+                profile_name: profile.map(String::from),
+                output_format: output,
+            };
+
+            let registry = WorkflowRegistry::new();
+            let workflow =
+                registry
+                    .get("quick-database")
+                    .ok_or_else(|| RedisCtlError::ApiError {
+                        message: "Workflow not found".to_string(),
+                    })?;
+
+            let result = workflow
+                .execute(context, workflow_args)
+                .await
+                .map_err(|e| {
+                    // Recover the typed error to build the structured exit contract.
+                    let se = match e.downcast::<QuickDatabaseError>() {
+                        Ok(qde) => StructuredError::from(qde),
+                        Err(other) => StructuredError::unknown(other.to_string()),
+                    };
+                    RedisCtlError::Structured(Box::new(se))
+                })?;
+
+            if !result.success {
+                return Err(RedisCtlError::Structured(Box::new(
+                    StructuredError::unknown(result.message),
+                )));
+            }
+
+            // The typed report is the agent contract: emit it verbatim (not wrapped in the
+            // generic workflow envelope) so callers can branch on a stable schema.
+            let report = result
+                .outputs
+                .get(crate::workflows::cloud::quick_database::REPORT_KEY);
+            match output {
+                cli::OutputFormat::Json | cli::OutputFormat::Yaml => {
+                    if let Some(report) = report {
+                        crate::output::print_output(report, output, None)?;
+                    }
+                }
+                _ => {
+                    println!("{}", result.message);
+                }
+            }
+
+            Ok(())
+        }
+        DatabaseCredentials(args) => {
+            use crate::structured_error::StructuredError;
+            use redisctl_core::cloud::quick_database::{
+                QuickDatabaseError, existing_database_report,
+            };
+
+            // Build a cloud client; a missing/bad credential is a not_authenticated precondition.
+            let client = conn_mgr
+                .create_cloud_client(profile)
+                .await
+                .map_err(|e| match e {
+                    RedisCtlError::MissingCredentials { .. }
+                    | RedisCtlError::NoProfileConfigured
+                    | RedisCtlError::ProfileNotFound { .. }
+                    | RedisCtlError::AuthenticationFailed { .. } => {
+                        RedisCtlError::Structured(Box::new(StructuredError::not_authenticated(
+                            format!("{e}. Run `redisctl cloud auth login` first."),
+                        )))
+                    }
+                    other => other,
+                })?;
+
+            let params = args.to_params();
+            let report =
+                existing_database_report(&client, args.subscription_id, args.database_id, &params)
+                    .await
+                    .map_err(|e: QuickDatabaseError| {
+                        RedisCtlError::Structured(Box::new(StructuredError::from(e)))
+                    })?;
+
+            match output {
+                cli::OutputFormat::Json | cli::OutputFormat::Yaml => {
+                    crate::output::print_output(serde_json::to_value(&report)?, output, None)?;
+                }
+                _ => {
+                    println!(
+                        "Wrote credentials for database '{}' (id {}) to {} as {}.",
+                        report.database.name,
+                        report.database.id,
+                        report.credentials_written_to,
+                        report.credentials_variable,
+                    );
                 }
             }
 

--- a/crates/redisctl/src/structured_error.rs
+++ b/crates/redisctl/src/structured_error.rs
@@ -111,6 +111,22 @@ impl StructuredError {
     }
 }
 
+impl From<redisctl_core::cloud::quick_database::QuickDatabaseError> for StructuredError {
+    fn from(err: redisctl_core::cloud::quick_database::QuickDatabaseError) -> Self {
+        use redisctl_core::cloud::quick_database::QuickDatabaseError as E;
+        match err {
+            E::InvalidName(m) => Self::invalid_name(m),
+            E::NameConflict(m) => Self::name_conflict(m),
+            E::FreeDbExists(m) => Self::free_db_exists(m),
+            E::QuotaExceeded(m) => Self::quota_exceeded(m),
+            E::NotAuthenticated(m) => Self::not_authenticated(m),
+            E::Transient(m) => Self::transient_api_error(m),
+            E::RateLimited(m) => Self::rate_limited(m),
+            E::Other(m) => Self::unknown(m),
+        }
+    }
+}
+
 impl From<AuthError> for StructuredError {
     fn from(err: AuthError) -> Self {
         match err {
@@ -179,6 +195,32 @@ mod tests {
             StructuredError::from(AuthError::Protocol("boom".into())).code,
             "sm_exchange_failed"
         );
+    }
+
+    #[test]
+    fn quick_database_error_mapping() {
+        use redisctl_core::cloud::quick_database::QuickDatabaseError as E;
+        // Each core provisioning error maps to its inventory code with the expected exit class.
+        let cases = [
+            (E::InvalidName("x".into()), "invalid_name", 2u8),
+            (E::NameConflict("x".into()), "name_conflict", 2),
+            (E::FreeDbExists("x".into()), "free_db_exists", 4),
+            (E::QuotaExceeded("x".into()), "quota_exceeded", 4),
+            (E::NotAuthenticated("x".into()), "not_authenticated", 2),
+            (E::Transient("x".into()), "transient_api_error", 3),
+            (E::RateLimited("x".into()), "rate_limited", 3),
+            (E::Other("x".into()), "unknown", 1),
+        ];
+        for (err, code, exit) in cases {
+            let se = StructuredError::from(err);
+            assert_eq!(se.code, code);
+            assert_eq!(se.exit_code, exit, "{code}: exit code");
+            assert_eq!(
+                se.retryable,
+                exit == 3,
+                "{code}: retryable aligns with exit 3"
+            );
+        }
     }
 
     #[test]

--- a/crates/redisctl/src/workflows/cloud/mod.rs
+++ b/crates/redisctl/src/workflows/cloud/mod.rs
@@ -1,1 +1,2 @@
+pub mod quick_database;
 pub mod subscription_setup;

--- a/crates/redisctl/src/workflows/cloud/quick_database.rs
+++ b/crates/redisctl/src/workflows/cloud/quick_database.rs
@@ -1,0 +1,218 @@
+//! `redisctl cloud workflow quick-database` — thin CLI wrapper over the shared engine in
+//! [`redisctl_core::cloud::quick_database`].
+//!
+//! This layer owns only CLI concerns: clap arg parsing, the terminal spinner, and wrapping
+//! the [`QuickDatabaseReport`] into a [`WorkflowResult`]. The provisioning logic itself lives
+//! in `redisctl-core` so the MCP server reuses it directly. Error → exit-code mapping lives
+//! in [`crate::structured_error`].
+
+use super::super::{Workflow, WorkflowArgs, WorkflowContext, WorkflowResult};
+use crate::error::RedisCtlError;
+use anyhow::Result;
+use clap::Args;
+use indicatif::{ProgressBar, ProgressStyle};
+use redisctl_core::cloud::quick_database::{QuickDatabaseError, QuickDatabaseParams, provision};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::future::Future;
+use std::path::PathBuf;
+use std::pin::Pin;
+use std::time::Duration;
+
+/// Key under which the typed report is stored in `WorkflowResult.outputs`.
+pub const REPORT_KEY: &str = "report";
+
+#[derive(Args, Debug, Clone, Serialize, Deserialize)]
+pub struct QuickDatabaseArgs {
+    /// Database name (also used, prefixed with `redisctl-`, for the subscription).
+    /// Must match `^[a-z][a-z0-9-]{1,38}[a-z0-9]$` (no leading/trailing/double hyphen).
+    #[arg(long)]
+    pub name: String,
+
+    /// File to write the connection string into (created if missing; managed keys updated
+    /// in place, other lines preserved).
+    #[arg(long, default_value = "./.env")]
+    #[serde(default = "default_output")]
+    pub output_credentials: PathBuf,
+
+    /// Environment variable name to write.
+    #[arg(long, default_value = "REDIS_URL")]
+    #[serde(default = "default_variable")]
+    pub variable: String,
+
+    /// Maximum time to wait for each async operation, in seconds.
+    #[arg(long, default_value = "600")]
+    #[serde(default = "default_wait_timeout")]
+    pub wait_timeout: u32,
+
+    /// Polling interval for async operations, in seconds.
+    #[arg(long, default_value = "5")]
+    #[serde(default = "default_wait_interval")]
+    pub wait_interval: u32,
+}
+
+impl QuickDatabaseArgs {
+    fn to_params(&self) -> QuickDatabaseParams {
+        QuickDatabaseParams {
+            name: self.name.clone(),
+            output_credentials: self.output_credentials.clone(),
+            variable: self.variable.clone(),
+            wait_timeout: self.wait_timeout,
+            wait_interval: self.wait_interval,
+        }
+    }
+}
+
+/// Args for `cloud workflow database-credentials` — write an EXISTING database's connection
+/// string to a file (no provisioning). The heavy lifting is `core::…::existing_database_report`.
+#[derive(Args, Debug, Clone)]
+pub struct DatabaseCredentialsArgs {
+    /// Subscription id of the existing Essentials database.
+    #[arg(long)]
+    pub subscription_id: i32,
+    /// Database id within that subscription.
+    #[arg(long)]
+    pub database_id: i32,
+    /// File to write the connection string into.
+    #[arg(long, default_value = "./.env")]
+    pub output_credentials: PathBuf,
+    /// Environment variable name to write.
+    #[arg(long, default_value = "REDIS_URL")]
+    pub variable: String,
+    /// Maximum time to wait for the endpoint to be readable, in seconds.
+    #[arg(long, default_value = "600")]
+    pub wait_timeout: u32,
+    /// Polling interval in seconds.
+    #[arg(long, default_value = "5")]
+    pub wait_interval: u32,
+}
+
+impl DatabaseCredentialsArgs {
+    pub(crate) fn to_params(&self) -> QuickDatabaseParams {
+        QuickDatabaseParams {
+            // `name` is only a report fallback here; the database's own name overrides it.
+            name: format!("database-{}", self.database_id),
+            output_credentials: self.output_credentials.clone(),
+            variable: self.variable.clone(),
+            wait_timeout: self.wait_timeout,
+            wait_interval: self.wait_interval,
+        }
+    }
+}
+
+fn default_output() -> PathBuf {
+    PathBuf::from("./.env")
+}
+fn default_variable() -> String {
+    "REDIS_URL".to_string()
+}
+fn default_wait_timeout() -> u32 {
+    600
+}
+fn default_wait_interval() -> u32 {
+    5
+}
+
+pub struct QuickDatabaseWorkflow;
+
+impl Workflow for QuickDatabaseWorkflow {
+    fn name(&self) -> &str {
+        "quick-database"
+    }
+
+    fn description(&self) -> &str {
+        "Create or reuse a free Redis database and write its connection string to a file"
+    }
+
+    fn execute(
+        &self,
+        context: WorkflowContext,
+        args: WorkflowArgs,
+    ) -> Pin<Box<dyn Future<Output = Result<WorkflowResult>> + Send>> {
+        Box::pin(async move {
+            let args: QuickDatabaseArgs = args
+                .get("args")
+                .ok_or_else(|| anyhow::anyhow!("Missing workflow arguments"))?;
+            // Box the typed error into anyhow; main.rs downcasts it for the exit contract.
+            run(context, args).await.map_err(anyhow::Error::new)
+        })
+    }
+}
+
+async fn run(
+    context: WorkflowContext,
+    args: QuickDatabaseArgs,
+) -> std::result::Result<WorkflowResult, QuickDatabaseError> {
+    let quiet = context.output_format.is_json() || context.output_format.is_yaml();
+
+    let client = context
+        .conn_mgr
+        .create_cloud_client(context.profile_name.as_deref())
+        .await
+        .map_err(client_setup_error)?;
+
+    let pb = spinner(quiet, "Provisioning free database…");
+    let result = provision(&client, &args.to_params()).await;
+    finish(pb);
+    let report = result?;
+
+    let human = format!(
+        "{} database '{}' (id {}). Connection string written to {} as {}.",
+        if report.status == "reused" {
+            "Reused"
+        } else {
+            "Provisioned"
+        },
+        report.database.name,
+        report.database.id,
+        report.credentials_written_to,
+        report.credentials_variable,
+    );
+
+    let mut outputs = HashMap::new();
+    outputs.insert(
+        REPORT_KEY.to_string(),
+        serde_json::to_value(&report)
+            .map_err(|e| QuickDatabaseError::Other(format!("failed to serialize report: {e}")))?,
+    );
+    Ok(WorkflowResult {
+        success: true,
+        message: human,
+        outputs,
+    })
+}
+
+/// Map a client-construction failure (before any API call) to a branchable error. A missing
+/// or bad credential means the caller needs to authenticate.
+fn client_setup_error(err: RedisCtlError) -> QuickDatabaseError {
+    match err {
+        RedisCtlError::MissingCredentials { .. }
+        | RedisCtlError::NoProfileConfigured
+        | RedisCtlError::ProfileNotFound { .. }
+        | RedisCtlError::AuthenticationFailed { .. } => QuickDatabaseError::NotAuthenticated(
+            format!("{err}. Run `redisctl cloud auth login` first."),
+        ),
+        other => QuickDatabaseError::Other(other.to_string()),
+    }
+}
+
+fn spinner(quiet: bool, message: &str) -> Option<ProgressBar> {
+    if quiet {
+        return None;
+    }
+    let pb = ProgressBar::new_spinner();
+    pb.set_style(
+        ProgressStyle::with_template("{spinner:.green} {msg}")
+            .unwrap()
+            .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]),
+    );
+    pb.set_message(message.to_string());
+    pb.enable_steady_tick(Duration::from_millis(100));
+    Some(pb)
+}
+
+fn finish(pb: Option<ProgressBar>) {
+    if let Some(pb) = pb {
+        pb.finish_and_clear();
+    }
+}

--- a/crates/redisctl/src/workflows/mod.rs
+++ b/crates/redisctl/src/workflows/mod.rs
@@ -113,6 +113,7 @@ impl WorkflowRegistry {
         registry.register(Box::new(
             cloud::subscription_setup::SubscriptionSetupWorkflow,
         ));
+        registry.register(Box::new(cloud::quick_database::QuickDatabaseWorkflow));
 
         registry
     }

--- a/crates/redisctl/tests/cloud_quick_database_tests.rs
+++ b/crates/redisctl/tests/cloud_quick_database_tests.rs
@@ -1,0 +1,739 @@
+//! Mocked end-to-end tests for `cloud workflow quick-database`.
+//!
+//! Each test points a cloud profile at a wiremock CAPI and drives the real binary. Every
+//! scenario asserts the secret-leak guard: the mock password and the `rediss://…@` URL must
+//! appear in the credentials file but NEVER on stdout/stderr.
+
+use assert_cmd::Command;
+use serde_json::{Value, json};
+use tempfile::TempDir;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const MOCK_PASSWORD: &str = "s3cr3t-mock-pw";
+const MOCK_ENDPOINT: &str = "mock-host.example.com:12000";
+const DB_NAME: &str = "quick-db-test";
+const SUB_ID: i64 = 501;
+const DB_ID: i64 = 9001;
+
+fn write_cloud_profile(temp_dir: &TempDir, api_url: &str) {
+    let config = format!(
+        r#"
+[profiles.test]
+deployment_type = "cloud"
+api_key = "test-api-key"
+api_secret = "test-api-secret"
+api_url = "{api_url}"
+
+default_cloud = "test"
+"#
+    );
+    std::fs::write(temp_dir.path().join("config.toml"), config).unwrap();
+}
+
+fn run_quick_database(
+    temp_dir: &TempDir,
+    env_path: &std::path::Path,
+) -> assert_cmd::assert::Assert {
+    let mut cmd = Command::cargo_bin("redisctl").unwrap();
+    cmd.env_remove("REDIS_CLOUD_API_KEY");
+    cmd.env_remove("REDIS_CLOUD_SECRET_KEY");
+    cmd.env_remove("REDIS_CLOUD_API_URL");
+    cmd.env_remove("REDISCTL_PROFILE");
+    cmd.arg("--config-file")
+        .arg(temp_dir.path().join("config.toml"))
+        .arg("cloud")
+        .arg("workflow")
+        .arg("quick-database")
+        .arg("--name")
+        .arg(DB_NAME)
+        .arg("--output-credentials")
+        .arg(env_path)
+        .arg("--wait-interval")
+        .arg("1")
+        .arg("--wait-timeout")
+        .arg("30")
+        .arg("-o")
+        .arg("json");
+    cmd.assert()
+}
+
+fn fixed_database_body() -> Value {
+    json!({
+        "databaseId": DB_ID,
+        "name": DB_NAME,
+        "region": "us-east-1",
+        "publicEndpoint": MOCK_ENDPOINT,
+        "security": { "enableTls": true, "password": MOCK_PASSWORD }
+    })
+}
+
+async fn mock_free_plan(server: &MockServer) {
+    Mock::given(method("GET"))
+        .and(path("/fixed/plans"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "plans": [
+                { "id": 34, "name": "Standard", "price": 5 },
+                { "id": 12, "name": "Free", "price": 0, "provider": "AWS", "region": "us-east-1" }
+            ]
+        })))
+        .mount(server)
+        .await;
+}
+
+async fn mock_task_completed(server: &MockServer, task_id: &str, resource_id: i64) {
+    Mock::given(method("GET"))
+        .and(path(format!("/tasks/{task_id}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "taskId": task_id,
+            "status": "processing-completed",
+            "response": { "resourceId": resource_id }
+        })))
+        .mount(server)
+        .await;
+}
+
+/// Assert the leak guard: secrets in the file, never in the captured output.
+fn assert_no_secret_leak(stdout: &[u8], stderr: &[u8]) {
+    let out = String::from_utf8_lossy(stdout);
+    let err = String::from_utf8_lossy(stderr);
+    for stream in [&out, &err] {
+        assert!(
+            !stream.contains(MOCK_PASSWORD),
+            "password leaked into output: {stream}"
+        );
+        assert!(
+            !stream.contains("rediss://default:"),
+            "connection URL leaked into output: {stream}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn fresh_create_writes_env_and_prints_schema() {
+    let temp = TempDir::new().unwrap();
+    let server = MockServer::start().await;
+    write_cloud_profile(&temp, &server.uri());
+    let env_path = temp.path().join(".env");
+
+    // No existing subscription → fresh provisioning.
+    Mock::given(method("GET"))
+        .and(path("/fixed/subscriptions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "subscriptions": [] })))
+        .mount(&server)
+        .await;
+    mock_free_plan(&server).await;
+    Mock::given(method("POST"))
+        .and(path("/fixed/subscriptions"))
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({
+            "taskId": "task-sub", "status": "received"
+        })))
+        .mount(&server)
+        .await;
+    mock_task_completed(&server, "task-sub", SUB_ID).await;
+    Mock::given(method("POST"))
+        .and(path(format!("/fixed/subscriptions/{SUB_ID}/databases")))
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({
+            "taskId": "task-db", "status": "received"
+        })))
+        .mount(&server)
+        .await;
+    mock_task_completed(&server, "task-db", DB_ID).await;
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/fixed/subscriptions/{SUB_ID}/databases/{DB_ID}"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(fixed_database_body()))
+        .mount(&server)
+        .await;
+
+    let output = run_quick_database(&temp, &env_path)
+        .success()
+        .get_output()
+        .clone();
+    assert_no_secret_leak(&output.stdout, &output.stderr);
+
+    // Schema lock (PRD §5.2): exact key set, exact values.
+    let report: Value = serde_json::from_slice(&output.stdout).expect("stdout is JSON");
+    assert_eq!(report["status"], "ok");
+    assert_eq!(report["database"]["id"], DB_ID.to_string());
+    assert_eq!(report["database"]["name"], DB_NAME);
+    assert_eq!(report["database"]["region"], "us-east-1");
+    assert_eq!(report["database"]["plan"], "free");
+    assert_eq!(report["database"]["tls"], true);
+    assert_eq!(report["credentials_variable"], "REDIS_URL");
+    assert_eq!(
+        report["credentials_written_to"],
+        env_path.display().to_string()
+    );
+    // Key set is locked (serializer emits keys sorted, so compare sorted).
+    let mut top_keys: Vec<&str> = report
+        .as_object()
+        .unwrap()
+        .keys()
+        .map(String::as_str)
+        .collect();
+    top_keys.sort_unstable();
+    assert_eq!(
+        top_keys,
+        [
+            "credentials_variable",
+            "credentials_written_to",
+            "database",
+            "status"
+        ]
+    );
+    let mut db_keys: Vec<&str> = report["database"]
+        .as_object()
+        .unwrap()
+        .keys()
+        .map(String::as_str)
+        .collect();
+    db_keys.sort_unstable();
+    assert_eq!(db_keys, ["id", "name", "plan", "region", "tls"]);
+
+    // The credentials file holds the full connection string plus broken-out fields.
+    let env_body = std::fs::read_to_string(&env_path).unwrap();
+    assert!(env_body.contains(&format!(
+        "REDIS_URL=rediss://default:{MOCK_PASSWORD}@{MOCK_ENDPOINT}"
+    )));
+    assert!(env_body.contains("REDIS_HOST=mock-host.example.com"));
+    assert!(env_body.contains("REDIS_PORT=12000"));
+    assert!(env_body.contains(&format!("REDIS_PASSWORD={MOCK_PASSWORD}")));
+    assert!(env_body.contains("REDIS_USERNAME=default"));
+    assert!(env_body.contains("REDIS_TLS=true"));
+}
+
+#[tokio::test]
+async fn second_run_reuses_without_writes() {
+    let temp = TempDir::new().unwrap();
+    let server = MockServer::start().await;
+    write_cloud_profile(&temp, &server.uri());
+    let env_path = temp.path().join(".env");
+
+    // Our subscription already exists, with a database. No POST mocks are mounted, so any
+    // create attempt would 404 and fail the run — proving reuse performs no writes.
+    Mock::given(method("GET"))
+        .and(path("/fixed/subscriptions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "subscriptions": [ { "id": SUB_ID, "name": format!("redisctl-{DB_NAME}"), "status": "active" } ]
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(format!("/fixed/subscriptions/{SUB_ID}/databases")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "subscription": { "subscriptionId": SUB_ID, "databases": [ fixed_database_body() ] }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/fixed/subscriptions/{SUB_ID}/databases/{DB_ID}"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(fixed_database_body()))
+        .mount(&server)
+        .await;
+
+    let output = run_quick_database(&temp, &env_path)
+        .success()
+        .get_output()
+        .clone();
+    assert_no_secret_leak(&output.stdout, &output.stderr);
+    let report: Value = serde_json::from_slice(&output.stdout).expect("stdout is JSON");
+    assert_eq!(report["status"], "reused");
+    assert_eq!(report["database"]["id"], DB_ID.to_string());
+
+    let env_body = std::fs::read_to_string(&env_path).unwrap();
+    assert!(env_body.contains(MOCK_PASSWORD));
+}
+
+/// The public endpoint can lag behind task completion on a fresh create. The workflow must
+/// poll the database GET until it appears, not fail the first read.
+#[tokio::test]
+async fn waits_for_public_endpoint_to_appear() {
+    let temp = TempDir::new().unwrap();
+    let server = MockServer::start().await;
+    write_cloud_profile(&temp, &server.uri());
+    let env_path = temp.path().join(".env");
+
+    // Reuse path: our subscription + database already exist.
+    Mock::given(method("GET"))
+        .and(path("/fixed/subscriptions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "subscriptions": [ { "id": SUB_ID, "name": format!("redisctl-{DB_NAME}"), "status": "active" } ]
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(format!("/fixed/subscriptions/{SUB_ID}/databases")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "subscription": { "subscriptionId": SUB_ID, "databases": [ { "databaseId": DB_ID } ] }
+        })))
+        .mount(&server)
+        .await;
+    // First GET has no endpoint yet (mounted first, capped at one match); the retry succeeds.
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/fixed/subscriptions/{SUB_ID}/databases/{DB_ID}"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "databaseId": DB_ID,
+            "name": DB_NAME,
+            "security": { "enableTls": true, "password": MOCK_PASSWORD }
+        })))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/fixed/subscriptions/{SUB_ID}/databases/{DB_ID}"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(fixed_database_body()))
+        .mount(&server)
+        .await;
+
+    let output = run_quick_database(&temp, &env_path)
+        .success()
+        .get_output()
+        .clone();
+    assert_no_secret_leak(&output.stdout, &output.stderr);
+    let env_body = std::fs::read_to_string(&env_path).unwrap();
+    assert!(env_body.contains(&format!(
+        "REDIS_URL=rediss://default:{MOCK_PASSWORD}@{MOCK_ENDPOINT}"
+    )));
+}
+
+/// If the endpoint never appears within the timeout, that's transient (exit 3), not `unknown`.
+#[tokio::test]
+async fn missing_endpoint_past_timeout_is_transient() {
+    let temp = TempDir::new().unwrap();
+    let server = MockServer::start().await;
+    write_cloud_profile(&temp, &server.uri());
+    let env_path = temp.path().join(".env");
+
+    Mock::given(method("GET"))
+        .and(path("/fixed/subscriptions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "subscriptions": [ { "id": SUB_ID, "name": format!("redisctl-{DB_NAME}"), "status": "active" } ]
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(format!("/fixed/subscriptions/{SUB_ID}/databases")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "subscription": { "subscriptionId": SUB_ID, "databases": [ { "databaseId": DB_ID } ] }
+        })))
+        .mount(&server)
+        .await;
+    // The endpoint never populates.
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/fixed/subscriptions/{SUB_ID}/databases/{DB_ID}"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "databaseId": DB_ID,
+            "name": DB_NAME,
+            "security": { "enableTls": true, "password": MOCK_PASSWORD }
+        })))
+        .mount(&server)
+        .await;
+
+    let mut cmd = Command::cargo_bin("redisctl").unwrap();
+    cmd.env_remove("REDIS_CLOUD_API_KEY");
+    cmd.env_remove("REDIS_CLOUD_SECRET_KEY");
+    cmd.env_remove("REDIS_CLOUD_API_URL");
+    cmd.env_remove("REDISCTL_PROFILE");
+    let output = cmd
+        .arg("--config-file")
+        .arg(temp.path().join("config.toml"))
+        .args([
+            "cloud",
+            "workflow",
+            "quick-database",
+            "--name",
+            DB_NAME,
+            "--wait-timeout",
+            "1",
+            "--wait-interval",
+            "1",
+            "-o",
+            "json",
+        ])
+        .arg("--output-credentials")
+        .arg(&env_path)
+        .assert()
+        .code(3)
+        .get_output()
+        .clone();
+    let env: Value = serde_json::from_slice(&output.stdout).expect("stdout is JSON");
+    assert_eq!(env["error"]["code"], "transient_api_error");
+    assert_eq!(env["error"]["retryable"], true);
+    assert!(!env_path.exists());
+}
+
+/// PRD §7.2 leak guard: even at max verbosity (`-vvv`), the password — which flows through
+/// the CAPI response bodies on the reuse path — must not reach stdout or stderr.
+#[tokio::test]
+async fn no_secret_leak_at_max_verbosity() {
+    let temp = TempDir::new().unwrap();
+    let server = MockServer::start().await;
+    write_cloud_profile(&temp, &server.uri());
+    let env_path = temp.path().join(".env");
+
+    Mock::given(method("GET"))
+        .and(path("/fixed/subscriptions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "subscriptions": [ { "id": SUB_ID, "name": format!("redisctl-{DB_NAME}"), "status": "active" } ]
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(format!("/fixed/subscriptions/{SUB_ID}/databases")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "subscription": { "subscriptionId": SUB_ID, "databases": [ fixed_database_body() ] }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/fixed/subscriptions/{SUB_ID}/databases/{DB_ID}"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(fixed_database_body()))
+        .mount(&server)
+        .await;
+
+    let mut cmd = Command::cargo_bin("redisctl").unwrap();
+    cmd.env_remove("REDIS_CLOUD_API_KEY");
+    cmd.env_remove("REDIS_CLOUD_SECRET_KEY");
+    cmd.env_remove("REDIS_CLOUD_API_URL");
+    cmd.env_remove("REDISCTL_PROFILE");
+    cmd.env_remove("RUST_LOG"); // don't let the runner's RUST_LOG change verbosity
+    let output = cmd
+        .arg("--config-file")
+        .arg(temp.path().join("config.toml"))
+        .arg("-vvv")
+        .args([
+            "cloud",
+            "workflow",
+            "quick-database",
+            "--name",
+            DB_NAME,
+            "-o",
+            "json",
+        ])
+        .arg("--output-credentials")
+        .arg(&env_path)
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+
+    assert_no_secret_leak(&output.stdout, &output.stderr);
+    // Sanity: the secret really did travel through the API responses (so the guard is meaningful).
+    assert!(
+        std::fs::read_to_string(&env_path)
+            .unwrap()
+            .contains(MOCK_PASSWORD)
+    );
+}
+
+#[tokio::test]
+async fn resume_after_partial_create() {
+    let temp = TempDir::new().unwrap();
+    let server = MockServer::start().await;
+    write_cloud_profile(&temp, &server.uri());
+    let env_path = temp.path().join(".env");
+
+    // Subscription exists but has NO database (crashed between the two creates). The workflow
+    // must resume by creating only the database — no subscription POST is mounted.
+    Mock::given(method("GET"))
+        .and(path("/fixed/subscriptions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "subscriptions": [ { "id": SUB_ID, "name": format!("redisctl-{DB_NAME}"), "status": "active" } ]
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(format!("/fixed/subscriptions/{SUB_ID}/databases")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "subscription": { "subscriptionId": SUB_ID, "databases": [] }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path(format!("/fixed/subscriptions/{SUB_ID}/databases")))
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({
+            "taskId": "task-db", "status": "received"
+        })))
+        .mount(&server)
+        .await;
+    mock_task_completed(&server, "task-db", DB_ID).await;
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/fixed/subscriptions/{SUB_ID}/databases/{DB_ID}"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(fixed_database_body()))
+        .mount(&server)
+        .await;
+
+    let output = run_quick_database(&temp, &env_path)
+        .success()
+        .get_output()
+        .clone();
+    assert_no_secret_leak(&output.stdout, &output.stderr);
+    let report: Value = serde_json::from_slice(&output.stdout).expect("stdout is JSON");
+    assert_eq!(report["status"], "ok");
+    assert_eq!(report["database"]["id"], DB_ID.to_string());
+}
+
+#[tokio::test]
+async fn task_failure_surfaces_error() {
+    let temp = TempDir::new().unwrap();
+    let server = MockServer::start().await;
+    write_cloud_profile(&temp, &server.uri());
+    let env_path = temp.path().join(".env");
+
+    Mock::given(method("GET"))
+        .and(path("/fixed/subscriptions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "subscriptions": [] })))
+        .mount(&server)
+        .await;
+    mock_free_plan(&server).await;
+    Mock::given(method("POST"))
+        .and(path("/fixed/subscriptions"))
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({
+            "taskId": "task-sub", "status": "received"
+        })))
+        .mount(&server)
+        .await;
+    // The create task fails mid-flight.
+    Mock::given(method("GET"))
+        .and(path("/tasks/task-sub"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "taskId": "task-sub",
+            "status": "processing-error",
+            "response": { "error": "provisioning blew up" }
+        })))
+        .mount(&server)
+        .await;
+
+    let output = run_quick_database(&temp, &env_path)
+        .code(1)
+        .get_output()
+        .clone();
+    assert_no_secret_leak(&output.stdout, &output.stderr);
+    // In JSON mode the error envelope is on stdout (agents parse stdout).
+    let env: Value = serde_json::from_slice(&output.stdout).expect("stdout is JSON");
+    assert_eq!(env["status"], "error");
+    assert_eq!(env["error"]["code"], "unknown");
+    assert!(
+        env["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("provisioning blew up")
+    );
+    assert!(!env_path.exists(), "no credentials file on failure");
+}
+
+#[tokio::test]
+async fn free_plan_gate_rejection_is_actionable() {
+    let temp = TempDir::new().unwrap();
+    let server = MockServer::start().await;
+    write_cloud_profile(&temp, &server.uri());
+    let env_path = temp.path().join(".env");
+
+    Mock::given(method("GET"))
+        .and(path("/fixed/subscriptions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "subscriptions": [] })))
+        .mount(&server)
+        .await;
+    mock_free_plan(&server).await;
+    // The public CAPI rejects free-plan creation when the trusted-UA / payment gate is unmet.
+    Mock::given(method("POST"))
+        .and(path("/fixed/subscriptions"))
+        .respond_with(ResponseTemplate::new(400).set_body_json(json!({
+            "description": "FREE_PLAN_IS_ALLOWED_ONLY_FOR_ACCOUNTS_WITH_VALID_PAYMENT_INFO"
+        })))
+        .mount(&server)
+        .await;
+
+    let output = run_quick_database(&temp, &env_path)
+        .code(4)
+        .get_output()
+        .clone();
+    let env: Value = serde_json::from_slice(&output.stdout).expect("stdout is JSON");
+    assert_eq!(env["status"], "error");
+    assert_eq!(env["error"]["code"], "free_db_exists");
+    assert_eq!(env["error"]["retryable"], false);
+    assert!(!env_path.exists());
+}
+
+/// The one-free-subscription limit is reported by the API as an *async task* failure (not a
+/// synchronous 4xx), so it must still classify as `free_db_exists` (exit 4), not `unknown`.
+#[tokio::test]
+async fn free_sub_limit_via_task_error_is_free_db_exists() {
+    let temp = TempDir::new().unwrap();
+    let server = MockServer::start().await;
+    write_cloud_profile(&temp, &server.uri());
+    let env_path = temp.path().join(".env");
+
+    Mock::given(method("GET"))
+        .and(path("/fixed/subscriptions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "subscriptions": [] })))
+        .mount(&server)
+        .await;
+    mock_free_plan(&server).await;
+    Mock::given(method("POST"))
+        .and(path("/fixed/subscriptions"))
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({
+            "taskId": "task-sub", "status": "received"
+        })))
+        .mount(&server)
+        .await;
+    // The create task fails asynchronously with the one-free-sub message.
+    Mock::given(method("GET"))
+        .and(path("/tasks/task-sub"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "taskId": "task-sub",
+            "status": "processing-error",
+            "response": { "error": "The account already has a free plan Essentials subscription." }
+        })))
+        .mount(&server)
+        .await;
+
+    let output = run_quick_database(&temp, &env_path)
+        .code(4)
+        .get_output()
+        .clone();
+    let env: Value = serde_json::from_slice(&output.stdout).expect("stdout is JSON");
+    assert_eq!(env["error"]["code"], "free_db_exists");
+    assert!(!env_path.exists());
+}
+
+#[tokio::test]
+async fn invalid_name_is_rejected_before_any_call() {
+    let temp = TempDir::new().unwrap();
+    let server = MockServer::start().await;
+    write_cloud_profile(&temp, &server.uri());
+    let env_path = temp.path().join(".env");
+
+    // No mocks mounted: a valid run would hit the API, but validation must fail first.
+    let mut cmd = Command::cargo_bin("redisctl").unwrap();
+    cmd.env_remove("REDIS_CLOUD_API_KEY");
+    cmd.env_remove("REDIS_CLOUD_SECRET_KEY");
+    cmd.env_remove("REDIS_CLOUD_API_URL");
+    let output = cmd
+        .arg("--config-file")
+        .arg(temp.path().join("config.toml"))
+        .args([
+            "cloud",
+            "workflow",
+            "quick-database",
+            "--name",
+            "Invalid_Name",
+            "-o",
+            "json",
+        ])
+        .arg("--output-credentials")
+        .arg(&env_path)
+        .assert()
+        .code(2)
+        .get_output()
+        .clone();
+    let env: Value = serde_json::from_slice(&output.stdout).expect("stdout is JSON");
+    assert_eq!(env["status"], "error");
+    assert_eq!(env["error"]["code"], "invalid_name");
+    assert!(
+        env["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("invalid database name")
+    );
+    assert!(!env_path.exists());
+}
+
+#[tokio::test]
+async fn persistent_5xx_is_retryable_exit_3() {
+    let temp = TempDir::new().unwrap();
+    let server = MockServer::start().await;
+    write_cloud_profile(&temp, &server.uri());
+    let env_path = temp.path().join(".env");
+
+    // The very first CAPI call (list subscriptions) fails with a persistent 503.
+    Mock::given(method("GET"))
+        .and(path("/fixed/subscriptions"))
+        .respond_with(ResponseTemplate::new(503).set_body_json(json!({
+            "description": "service temporarily unavailable"
+        })))
+        .mount(&server)
+        .await;
+
+    let output = run_quick_database(&temp, &env_path)
+        .code(3)
+        .get_output()
+        .clone();
+    let env: Value = serde_json::from_slice(&output.stdout).expect("stdout is JSON");
+    assert_eq!(env["status"], "error");
+    assert_eq!(env["error"]["code"], "transient_api_error");
+    assert_eq!(env["error"]["retryable"], true);
+    assert!(!env_path.exists());
+}
+
+/// `database-credentials`: write an EXISTING database's connection string to a file with no
+/// provisioning (single GET). Report status is "existing"; the leak guard still holds.
+#[tokio::test]
+async fn database_credentials_writes_existing_db_without_provisioning() {
+    let temp = TempDir::new().unwrap();
+    let server = MockServer::start().await;
+    write_cloud_profile(&temp, &server.uri());
+    let env_path = temp.path().join(".env");
+
+    // Only a GET on the database — no list/plan/create mocks, so any provisioning attempt 404s.
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/fixed/subscriptions/{SUB_ID}/databases/{DB_ID}"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(fixed_database_body()))
+        .mount(&server)
+        .await;
+
+    let mut cmd = Command::cargo_bin("redisctl").unwrap();
+    cmd.env_remove("REDIS_CLOUD_API_KEY");
+    cmd.env_remove("REDIS_CLOUD_SECRET_KEY");
+    cmd.env_remove("REDIS_CLOUD_API_URL");
+    cmd.env_remove("REDISCTL_PROFILE");
+    let output = cmd
+        .arg("--config-file")
+        .arg(temp.path().join("config.toml"))
+        .args([
+            "cloud",
+            "workflow",
+            "database-credentials",
+            "--subscription-id",
+            &SUB_ID.to_string(),
+            "--database-id",
+            &DB_ID.to_string(),
+            "-o",
+            "json",
+        ])
+        .arg("--output-credentials")
+        .arg(&env_path)
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+
+    assert_no_secret_leak(&output.stdout, &output.stderr);
+    let report: Value = serde_json::from_slice(&output.stdout).expect("stdout is JSON");
+    assert_eq!(report["status"], "existing");
+    assert_eq!(report["database"]["id"], DB_ID.to_string());
+    assert_eq!(report["database"]["name"], DB_NAME);
+    assert_eq!(report["database"]["plan"], "essentials");
+
+    let env_body = std::fs::read_to_string(&env_path).unwrap();
+    assert!(env_body.contains(&format!(
+        "REDIS_URL=rediss://default:{MOCK_PASSWORD}@{MOCK_ENDPOINT}"
+    )));
+    assert!(env_body.contains("REDIS_HOST=mock-host.example.com"));
+}


### PR DESCRIPTION
Wraps the core provisioning engine (RED-210016) as two CLI workflows under `cloud workflow`.

## Commands

- **`cloud workflow quick-database --name <name>`** — create or reuse a free (Essentials) Redis database and write its connection string to a file. Idempotent: re-running with the same `--name` reuses the existing subscription/database and can resume a half-finished create.
- **`cloud workflow database-credentials --subscription-id <id> --database-id <id>`** — export an existing database's connection string to a file. No provisioning.

Both are thin wrappers over `redisctl_core::cloud::quick_database`; the CLI layer owns only arg parsing, the spinner, and output. The MCP layer will reuse the same core engine.

## Usage

```bash
# Provision (or reuse) a free db, writing REDIS_URL into ./.env
redisctl cloud workflow quick-database --name my-app

# Custom file + variable name
redisctl cloud workflow quick-database --name my-app \
  --output-credentials .env.local --variable CACHE_URL

# Machine-readable report for agents/scripts
redisctl -o json cloud workflow quick-database --name my-app

# Export an existing database's connection string
redisctl cloud workflow database-credentials --subscription-id 12345 --database-id 67890
```

Secrets are written to the file only — never to stdout/stderr. In `-o json` / `-o yaml` mode the command emits the typed report verbatim; failures produce the machine-branchable envelope (`{"status":"error","error":{code,message,retryable}}`) with mapped exit codes (2 precondition / 3 transient / 4 quota).

## Testing

- `cargo test -p redisctl` — new unit test (`quick_database_error_mapping`, the error → exit-code contract) + 12 mocked end-to-end tests (`cloud_quick_database_tests.rs`) driving the real binary against a wiremock CAPI: fresh create, reuse, crash-resume, endpoint polling, timeout / persistent-5xx / task-failure error classes, name validation, and the secret-leak guard (password + URL land in the file, never on stdout/stderr).
- `cargo clippy -p redisctl --all-targets` and `cargo fmt --check` clean.
