### PR TITLE
feat(mcp): cloud_auth_status + cloud_quick_database tools + quickstart skill

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3021,6 +3021,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
+ "tempfile",
  "thiserror 2.0.17",
  "tokio",
  "toml",

--- a/crates/redisctl-mcp/Cargo.toml
+++ b/crates/redisctl-mcp/Cargo.toml
@@ -64,6 +64,7 @@ test-support = []
 
 [dev-dependencies]
 tokio = { workspace = true }
+tempfile = { workspace = true }
 redis-cloud = { workspace = true, features = ["test-support"] }
 redis-enterprise = { workspace = true, features = ["test-support"] }
 wiremock = { workspace = true }

--- a/crates/redisctl-mcp/Cargo.toml
+++ b/crates/redisctl-mcp/Cargo.toml
@@ -60,9 +60,6 @@ http = []
 cloud = ["dep:redis-cloud"]
 enterprise = ["dep:redis-enterprise"]
 database = ["dep:redis", "dep:urlencoding"]
-# Resolve `keyring:` credential references (e.g. keys minted by `cloud auth login`,
-# which uses the OS keyring by default). Pure-Rust backend (linux-keyutils on Linux),
-# musl-friendly — same posture as the redisctl CLI.
 secure-storage = ["redisctl-core/secure-storage"]
 test-support = []
 

--- a/crates/redisctl-mcp/Cargo.toml
+++ b/crates/redisctl-mcp/Cargo.toml
@@ -55,11 +55,15 @@ clap = { workspace = true }
 tower = { workspace = true }
 
 [features]
-default = ["http", "cloud", "enterprise", "database"]
+default = ["http", "cloud", "enterprise", "database", "secure-storage"]
 http = []
 cloud = ["dep:redis-cloud"]
 enterprise = ["dep:redis-enterprise"]
 database = ["dep:redis", "dep:urlencoding"]
+# Resolve `keyring:` credential references (e.g. keys minted by `cloud auth login`,
+# which uses the OS keyring by default). Pure-Rust backend (linux-keyutils on Linux),
+# musl-friendly — same posture as the redisctl CLI.
+secure-storage = ["redisctl-core/secure-storage"]
 test-support = []
 
 [dev-dependencies]

--- a/crates/redisctl-mcp/src/state.rs
+++ b/crates/redisctl-mcp/src/state.rs
@@ -221,8 +221,6 @@ impl AppState {
                     .context("Failed to resolve cloud credentials")?
                     .context("No cloud credentials in profile")?;
 
-                // Honor the profile's api_url (e.g. a non-prod/QA endpoint); without this the
-                // client falls back to the prod default and rejects non-prod credentials (401).
                 CloudClient::builder()
                     .api_key(api_key)
                     .api_secret(api_secret)

--- a/crates/redisctl-mcp/src/state.rs
+++ b/crates/redisctl-mcp/src/state.rs
@@ -216,14 +216,17 @@ impl AppState {
                     .with_context(|| format!("Profile '{}' not found", resolved_profile_name))?;
 
                 // Get credentials
-                let (api_key, api_secret, _base_url) = profile
+                let (api_key, api_secret, base_url) = profile
                     .resolve_cloud_credentials()
                     .context("Failed to resolve cloud credentials")?
                     .context("No cloud credentials in profile")?;
 
+                // Honor the profile's api_url (e.g. a non-prod/QA endpoint); without this the
+                // client falls back to the prod default and rejects non-prod credentials (401).
                 CloudClient::builder()
                     .api_key(api_key)
                     .api_secret(api_secret)
+                    .base_url(&base_url)
                     .build()
                     .context("Failed to build Cloud client")
             }

--- a/crates/redisctl-mcp/src/tools/cloud/mod.rs
+++ b/crates/redisctl-mcp/src/tools/cloud/mod.rs
@@ -3,6 +3,7 @@
 mod account;
 mod fixed;
 mod networking;
+mod provisioning;
 mod raw;
 mod subscriptions;
 
@@ -12,6 +13,8 @@ pub use account::*;
 pub use fixed::*;
 #[allow(unused_imports)]
 pub use networking::*;
+#[allow(unused_imports)]
+pub use provisioning::*;
 #[allow(unused_imports)]
 pub use raw::*;
 #[allow(unused_imports)]
@@ -46,6 +49,10 @@ pub const SUB_MODULES: &[SubModule] = &[
         name: "raw",
         tool_names: raw::TOOL_NAMES,
     },
+    SubModule {
+        name: "provisioning",
+        tool_names: provisioning::TOOL_NAMES,
+    },
 ];
 
 /// Get all Cloud tool names as owned strings.
@@ -72,6 +79,7 @@ pub fn sub_router(name: &str, state: Arc<AppState>) -> Option<McpRouter> {
         "networking" => Some(networking::router(state)),
         "fixed" => Some(fixed::router(state)),
         "raw" => Some(raw::router(state)),
+        "provisioning" => Some(provisioning::router(state)),
         _ => None,
     }
 }
@@ -83,5 +91,6 @@ pub fn router(state: Arc<AppState>) -> McpRouter {
         .merge(account::router(state.clone()))
         .merge(networking::router(state.clone()))
         .merge(fixed::router(state.clone()))
-        .merge(raw::router(state))
+        .merge(raw::router(state.clone()))
+        .merge(provisioning::router(state))
 }

--- a/crates/redisctl-mcp/src/tools/cloud/provisioning.rs
+++ b/crates/redisctl-mcp/src/tools/cloud/provisioning.rs
@@ -1,0 +1,104 @@
+//! Agent-native provisioning tools: cloud auth status + quick-database.
+//!
+//! Both reuse the shared engine in `redisctl_core::cloud::quick_database` — the same code the
+//! CLI runs — so there is no logic duplication and no shelling out. The connection string /
+//! password are written only to the credentials file; the tool response carries non-secret
+//! metadata only (`QuickDatabaseReport`).
+
+use redisctl_core::cloud::quick_database::{QuickDatabaseParams, provision};
+use tower_mcp::CallToolResult;
+
+use crate::tools::macros::{cloud_tool, mcp_module};
+
+mcp_module! {
+    cloud_auth_status => "cloud_auth_status",
+    cloud_quick_database => "cloud_quick_database",
+}
+
+/// Input for `cloud_auth_status`.
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct CloudAuthStatusInput {
+    /// Profile name (uses the default / first configured profile if omitted).
+    #[serde(default)]
+    pub profile: Option<String>,
+}
+
+/// `cloud_auth_status` is written by hand (not via `cloud_tool!`) because "not authenticated"
+/// is a valid *result*, not an error — the macro would turn a missing credential into a tool
+/// failure. Read-only; never returns tokens.
+pub fn cloud_auth_status(state: std::sync::Arc<crate::state::AppState>) -> tower_mcp::Tool {
+    tower_mcp::ToolBuilder::new("cloud_auth_status")
+        .description(
+            "Report whether a Redis Cloud profile has credentials configured. Returns \
+             {authenticated, profile}. This is an offline check (credentials resolve and a \
+             client can be built) — it does not call the API to verify they still work. Never \
+             returns tokens or secrets. If authenticated is false, run `redisctl cloud auth \
+             login` in a shell to sign in.",
+        )
+        .read_only_safe()
+        .extractor_handler(
+            state,
+            |tower_mcp::extract::State(state): tower_mcp::extract::State<
+                std::sync::Arc<crate::state::AppState>,
+            >,
+             tower_mcp::extract::Json(input): tower_mcp::extract::Json<CloudAuthStatusInput>| async move {
+                // Building the client resolves credentials (offline); success ⇒ authenticated.
+                let authenticated = state
+                    .cloud_client_for_profile(input.profile.as_deref())
+                    .await
+                    .is_ok();
+                CallToolResult::from_serialize(&serde_json::json!({
+                    "authenticated": authenticated,
+                    "profile": input.profile,
+                    "hint": if authenticated {
+                        serde_json::Value::Null
+                    } else {
+                        serde_json::json!("run `redisctl cloud auth login`")
+                    },
+                }))
+            },
+        )
+        .build()
+}
+
+cloud_tool!(write, cloud_quick_database, "cloud_quick_database",
+    "Create or reuse a FREE Redis database and write its connection string to a file (default \
+     ./.env). Idempotent by name: re-running returns the existing database. Returns database \
+     metadata only — the connection string and password are written to the file, never in the \
+     response. Requires an authenticated profile (see cloud_auth_status).",
+    {
+        /// Database name; also names the subscription (prefixed `redisctl-`). 3-40 chars,
+        /// lowercase letters/digits/hyphens, starts with a letter, no `--`.
+        pub name: String,
+        /// File to write credentials into (default: ./.env).
+        #[serde(default)]
+        pub output_credentials: Option<String>,
+        /// Primary URL variable name (default: REDIS_URL). Broken-out fields derive their prefix.
+        #[serde(default)]
+        pub variable: Option<String>,
+        /// Max seconds to wait for each async operation (default: 600).
+        #[serde(default)]
+        pub wait_timeout: Option<u32>,
+        /// Polling interval in seconds (default: 5).
+        #[serde(default)]
+        pub wait_interval: Option<u32>,
+    } => |client, input| {
+        let mut params = QuickDatabaseParams::new(input.name);
+        if let Some(p) = input.output_credentials {
+            params.output_credentials = p.into();
+        }
+        if let Some(v) = input.variable {
+            params.variable = v;
+        }
+        if let Some(t) = input.wait_timeout {
+            params.wait_timeout = t;
+        }
+        if let Some(i) = input.wait_interval {
+            params.wait_interval = i;
+        }
+        let report = provision(&client, &params)
+            .await
+            .map_err(|e| tower_mcp::Error::tool(e.to_string()))?;
+        CallToolResult::from_serialize(&report)
+    }
+);

--- a/crates/redisctl-mcp/tests/cloud_tools.rs
+++ b/crates/redisctl-mcp/tests/cloud_tools.rs
@@ -4952,3 +4952,130 @@ async fn test_wait_for_cloud_task_timeout() {
         "Expected timeout response from wait_for_cloud_task, got: {result}"
     );
 }
+
+// ============================================================================
+// Provisioning tools (cloud_auth_status, cloud_quick_database): the tool
+// RESPONSE must never carry the password or connection URL — those go only to
+// the credentials file.
+// ============================================================================
+
+const PROV_PASSWORD: &str = "s3cr3t-mock-pw";
+const PROV_ENDPOINT: &str = "mock-host.example.com:12000";
+
+#[tokio::test]
+async fn cloud_auth_status_reports_authenticated_without_secrets() {
+    let server = MockCloudServer::start().await;
+    // An injected client means credentials resolve → authenticated: true (offline check).
+    let state = Arc::new(AppState::with_cloud_client(server.client()));
+    let tool = cloud::cloud_auth_status(state);
+
+    let text = call_tool_text(&tool, json!({})).await;
+    let value: serde_json::Value = serde_json::from_str(&text).expect("valid JSON");
+    assert_eq!(value["authenticated"], true);
+    // No tokens/secrets of any shape in the response.
+    assert!(!text.contains("secret"), "response leaked 'secret': {text}");
+    assert!(!text.to_lowercase().contains("bearer"));
+    assert!(!text.contains("api_secret"));
+}
+
+#[tokio::test]
+async fn cloud_quick_database_response_carries_no_secret() {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
+
+    let server = MockCloudServer::start().await;
+    let m = server.inner();
+
+    let db_body = json!({
+        "databaseId": 9001,
+        "name": "prov-test",
+        "region": "us-east-1",
+        "publicEndpoint": PROV_ENDPOINT,
+        "security": { "enableTls": true, "password": PROV_PASSWORD }
+    });
+
+    // Fresh-create flow: no existing sub → plan → create sub (task) → create db (task) → get db.
+    Mock::given(method("GET"))
+        .and(path("/fixed/subscriptions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "subscriptions": [] })))
+        .mount(m)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/fixed/plans"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "plans": [ { "id": 12, "name": "Free", "price": 0, "provider": "AWS", "region": "us-east-1" } ]
+        })))
+        .mount(m)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/fixed/subscriptions"))
+        .respond_with(
+            ResponseTemplate::new(202)
+                .set_body_json(json!({ "taskId": "task-sub", "status": "received" })),
+        )
+        .mount(m)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/tasks/task-sub"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "taskId": "task-sub", "status": "processing-completed", "response": { "resourceId": 501 }
+        })))
+        .mount(m)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/fixed/subscriptions/501/databases"))
+        .respond_with(
+            ResponseTemplate::new(202)
+                .set_body_json(json!({ "taskId": "task-db", "status": "received" })),
+        )
+        .mount(m)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/tasks/task-db"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "taskId": "task-db", "status": "processing-completed", "response": { "resourceId": 9001 }
+        })))
+        .mount(m)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/fixed/subscriptions/501/databases/9001"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(db_body))
+        .mount(m)
+        .await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let env_path = dir.path().join(".env");
+
+    // write-tier tool → full-policy state so the write guard passes.
+    let state = full_policy_state(server.client());
+    let tool = cloud::cloud_quick_database(state);
+
+    let text = call_tool_text(
+        &tool,
+        json!({
+            "name": "prov-test",
+            "output_credentials": env_path.to_str().unwrap(),
+            "wait_timeout": 30,
+            "wait_interval": 1
+        }),
+    )
+    .await;
+
+    // The report is returned; secrets are NOT in the response.
+    let report: serde_json::Value = serde_json::from_str(&text).expect("valid JSON response");
+    assert_eq!(report["status"], "ok");
+    assert_eq!(report["database"]["id"], "9001");
+    assert!(
+        !text.contains(PROV_PASSWORD),
+        "password leaked into tool response: {text}"
+    );
+    assert!(
+        !text.contains("rediss://"),
+        "connection URL leaked into tool response: {text}"
+    );
+
+    // …but they DID land in the credentials file (so the guard above is meaningful).
+    let env_body = std::fs::read_to_string(&env_path).unwrap();
+    assert!(env_body.contains(PROV_PASSWORD));
+    assert!(env_body.contains(&format!("rediss://default:{PROV_PASSWORD}@{PROV_ENDPOINT}")));
+}

--- a/skills/redisctl-cloud-quickstart/SKILL.md
+++ b/skills/redisctl-cloud-quickstart/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: redisctl-cloud-quickstart
+description: Provision a free Redis Cloud database for an app or agent in one step and connect to it. Use when someone needs a working Redis quickly, wants a REDIS_URL in their .env, or asks to "spin up a Redis database". Covers login, quick-database, and safe credential handling.
+---
+
+## Overview
+
+Go from nothing to a working Redis database with three commands. `redisctl` authenticates the
+user once, provisions a **free** database, and writes the connection string to a file — never
+to stdout — so credentials can't leak into logs or an agent's captured output.
+
+## The sequence
+
+Headless (agent): `auth login` returns the device code immediately; relay it, then block on
+`status --wait`. A human at a terminal can instead run a single blocking `auth login` (browser).
+
+```bash
+# 1. Initiate — returns the code right away, no blocking, no secret.
+redisctl cloud auth login -o json
+#    → {"status":"authorization_pending","verification_uri_complete":"…","user_code":"WDJB-MJHT"}
+
+# 2. Relay URL + code to the human, then block until approved. Mints the Cloud API key into
+#    the profile; every other `redisctl cloud` command works afterward.
+redisctl cloud auth status --wait --timeout 600 -o json
+#    → {"status":"ok","authenticated":true,"account_id":"…"}
+
+# 3. Provision (or reuse) a free database. The connection string is written to ./.env,
+#    NOT printed. JSON on stdout is a non-secret status report.
+redisctl cloud workflow quick-database --name my-app -o json
+
+# 4. Use it. Read REDIS_URL from the file; verify with a ping.
+redis-cli -u "$(grep '^REDIS_URL=' .env | cut -d= -f2-)" PING   # → PONG
+```
+
+Step 2 prints only metadata:
+
+```json
+{
+  "status": "ok",
+  "database": { "id": "9001", "name": "my-app", "region": "us-east-1", "plan": "free", "tls": true },
+  "credentials_written_to": "./.env",
+  "credentials_variable": "REDIS_URL"
+}
+```
+
+## What the credentials file contains
+
+`quick-database` writes the full URL plus broken-out fields, so any app can read whichever form
+it expects:
+
+```dotenv
+REDIS_URL=rediss://default:••••••@host.example.com:12000
+REDIS_HOST=host.example.com
+REDIS_PORT=12000
+REDIS_PASSWORD=••••••
+REDIS_USERNAME=default
+REDIS_TLS=true
+```
+
+The file is created `0600` (unix) and auto-added to `.gitignore` inside a git repo.
+
+## Branching on the result (for agents)
+
+- `"status": "ok"` — a database was provisioned (or a half-finished run was resumed).
+- `"status": "reused"` — a database with this name already existed; nothing was created.
+- On failure, a JSON error envelope is printed to stdout and the process exits non-zero:
+  `2` fix-and-retry (e.g. `invalid_name`, `not_authenticated`), `3` retryable
+  (`transient_api_error`, `rate_limited`), `4` limit reached (`free_db_exists`). Branch on
+  `.error.code`, not the message.
+
+```bash
+out=$(redisctl cloud workflow quick-database --name my-app -o json) || rc=$?
+case "$(printf '%s' "$out" | jq -r '.error.code // empty')" in
+  "")                              echo "ready" ;;
+  not_authenticated)               redisctl cloud auth login ;;   # then retry
+  transient_api_error|rate_limited) sleep 5; exec "$0" ;;
+  free_db_exists)                  echo "account already has a free DB — see the console" ;;
+esac
+```
+
+## Security conventions (important)
+
+- **Never read the credentials file back to display it, and never echo `REDIS_URL`/`REDIS_PASSWORD`.**
+  Pass them through by reference (`-u "$REDIS_URL"`, `$REDIS_PASSWORD`), not by printing.
+- **Use placeholders in any docs, READMEs, or code you generate** (`rediss://…`, `${REDIS_URL}`),
+  never the real value.
+- **Verify connectivity with a ping**, not by importing a client library that echoes the URL.
+- **Don't fetch credentials via `redisctl cloud database get`** — it can print the password by
+  design. Use the file `quick-database` wrote.
+
+## Headless / non-interactive
+
+`cloud auth login` auto-detects no TTY and uses the OIDC device flow (prints a URL + code to
+approve elsewhere). Force it with `redisctl cloud auth login --device`. Where no OS keyring is
+available (many CI/Linux containers), add `--allow-plaintext` to store the key in the config
+file instead.
+
+## MCP
+
+The same flow is exposed as MCP tools: `cloud_auth_status` (read-only; check first) and
+`cloud_quick_database` (write; provisions and writes the file). They call the identical engine
+as the CLI.


### PR DESCRIPTION
Exposes the agent-native provisioning path through MCP (RED-210018), over the same `redisctl_core::cloud::quick_database` engine the CLI uses — no logic duplication, no shelling out.

## Tools (cloud `provisioning` sub-module)

- **`cloud_auth_status`** — read-only, offline check of whether a profile has resolvable Cloud credentials. Returns `{authenticated, profile, hint}`; never returns tokens. Hand-written (not via the `cloud_tool!` macro) so "not authenticated" is a normal result rather than a tool error — an agent checks this before provisioning.
- **`cloud_quick_database`** — write-tier tool that creates or reuses a free database and writes its connection string to a file. Returns database metadata only; the URL and password go to the file, never the tool response.

## Skill

Adds `redisctl-cloud-quickstart` (login → quick-database → connect), including secret-handling conventions (never echo the URL/password; pass by reference; use placeholders).

## Also included (found while testing the tools against a non-production profile)

Two pre-existing gaps that made the cloud MCP tools unusable outside prod — both small, both bring MCP in line with the `redisctl` CLI:

- **`secure-storage` on by default.** `cloud auth login` stores the minted key in the OS keyring by default, but `redisctl-mcp` wasn't built with keyring support, so it couldn't read a normal login (`secure-storage feature is not enabled`). Enabled to match the CLI; pure-Rust backend (linux-keyutils on Linux, musl-friendly), so release builds are unaffected.
- **Honor the profile's `api_url`.** `create_cloud_client` resolved the profile's `api_url` but discarded it, so the Cloud client always used the prod default — a non-prod profile got a `401`. Now passed to the builder, matching the CLI. Prod profiles are unaffected: an unset `api_url` and the client's default are both `https://api.redislabs.com/v1`.

## Testing (automated)

- `cargo test -p redisctl-mcp` — two new tests in `cloud_tools.rs` (`cloud_auth_status_reports_authenticated_without_secrets`, `cloud_quick_database_response_carries_no_secret`; full mocked provision flow via `MockCloudServer`, asserting the response carries no password/URL while the credentials file does). Existing cloud-tool + lib tests still pass.
- `cargo clippy -p redisctl-mcp --all-targets` and `cargo fmt --check` clean.

## Testing manually (via an MCP client)

Assumes you've checked out this branch. The tools run over the MCP server; here's the full local loop.

**1. Authenticate a cloud profile** (the tools read a stored profile, same as the CLI):

```bash
cargo run --bin redisctl -- cloud auth login --profile qa
cargo run --bin redisctl -- cloud auth status --profile qa   # → authenticated: true
```

> Login needs the environment's OIDC endpoints (a `[cloud_auth.<profile>]` section, or the built-in prod defaults). Internal reviewers: the QA endpoints are in RED-210014's testing notes — add that `[cloud_auth.qa]` block to `~/.config/redisctl/config.toml` first.

**2. Add a `.mcp.json` at the repo root** so your MCP client launches the server from this branch (the file is gitignored — create it locally):

```json
{
  "mcpServers": {
    "redisctl-cloud": {
      "command": "cargo",
      "args": ["run", "-q", "-p", "redisctl-mcp", "--", "--profile", "qa", "--read-only=false", "--tools", "cloud:provisioning"]
    }
  }
}
```

`--read-only=false` is required: `cloud_quick_database` is a write tool and is hidden in the default read-only mode (`cloud_auth_status` shows in either).

**3. Reconnect your MCP client** (Claude Code / Desktop) to pick up `.mcp.json`, approve the `redisctl-cloud` server, then call the tools:

- `cloud_auth_status` → `{"authenticated": true, "profile": "qa", ...}` (offline check, safe).
- `cloud_quick_database` with `{"name": "demo-mcp"}` → creates or reuses a free DB and writes the connection string to `./.env`. ⚠️ Real resource: it provisions in the account behind the profile (idempotent by name). The response is metadata only — the URL/password land in the file, never in the tool output.

**No MCP client handy?** Drive the same server over stdio:

```bash
printf '%s\n' \
'{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"t","version":"0"}}}' \
'{"jsonrpc":"2.0","method":"notifications/initialized"}' \
'{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"cloud_auth_status","arguments":{}}}' \
| cargo run -q -p redisctl-mcp -- --profile qa --read-only=false --tools cloud:provisioning
```
