### PR TITLE
docs(cloud): quick-database workflow + agent error codes + cookbook

### DIFF
--- a/docs/docs/cloud/workflows.md
+++ b/docs/docs/cloud/workflows.md
@@ -32,6 +32,82 @@ This creates:
 | `--database-memory-gb` | Database memory in GB |
 | `--wait` | Wait for completion |
 
+## Quick Database
+
+Go from nothing to a running **free** database with one command. `quick-database` creates (or
+reuses) a free Essentials subscription and database, waits for it to be ready, and writes the
+connection string to a file:
+
+```bash
+redisctl cloud workflow quick-database --name my-app
+```
+
+It is **idempotent by name**: re-running with the same `--name` returns the existing database
+instead of creating another, and it resumes a half-finished previous run. Requires an
+authenticated profile — see [`cloud auth login`](commands/auth.md).
+
+### Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--name` | *(required)* | Database name; also names the subscription (prefixed `redisctl-`). Must match `^[a-z][a-z0-9-]{1,38}[a-z0-9]$`. |
+| `--output-credentials` | `./.env` | File to write the connection string into (created if missing; managed keys updated in place, other lines preserved). |
+| `--variable` | `REDIS_URL` | Environment-variable name for the primary URL. Broken-out fields derive their prefix from it. |
+| `--wait-timeout` | `600` | Max seconds to wait for each async operation. |
+| `--wait-interval` | `5` | Polling interval in seconds. |
+
+### Output
+
+The connection string and password are written **only to the file** — never to stdout. In
+`-o json` / `-o yaml` mode the command prints a non-secret report:
+
+```json
+{
+  "status": "ok",
+  "database": { "id": "9001", "name": "my-app", "region": "us-east-1", "plan": "free", "tls": true },
+  "credentials_written_to": "./.env",
+  "credentials_variable": "REDIS_URL"
+}
+```
+
+`status` is `ok` when a database was provisioned (or a half-finished run resumed) and `reused`
+when one with that name already existed. The file receives the URL plus broken-out fields:
+
+```dotenv
+REDIS_URL=rediss://default:••••••@host.example.com:12000
+REDIS_HOST=host.example.com
+REDIS_PORT=12000
+REDIS_PASSWORD=••••••
+REDIS_USERNAME=default
+REDIS_TLS=true
+```
+
+It is created `0600` (unix) and auto-added to `.gitignore` inside a git repo. On failure the
+command emits a machine-branchable envelope and a mapped exit code — see
+[Agent Error Codes](../reference/agent-error-codes.md).
+
+## Database Credentials
+
+Export an **existing** database's connection string to a file, without provisioning anything:
+
+```bash
+redisctl cloud workflow database-credentials \
+  --subscription-id 123456 \
+  --database-id 67890
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--subscription-id` | *(required)* | Subscription id of the existing database. |
+| `--database-id` | *(required)* | Database id within that subscription. |
+| `--output-credentials` | `./.env` | File to write the connection string into. |
+| `--variable` | `REDIS_URL` | Environment-variable name for the primary URL. |
+| `--wait-timeout` | `600` | Max seconds to wait for the endpoint to be readable. |
+| `--wait-interval` | `5` | Polling interval in seconds. |
+
+Output matches `quick-database` (same file format and JSON report, with `status: existing`), and
+the same secret-safety applies: credentials go to the file, never to stdout.
+
 ## When to Use Workflows
 
 **Use workflows when:**
@@ -83,6 +159,9 @@ redisctl cloud database list --subscription-id "$SUB_ID" \
 
 ## Related
 
+- [Authentication commands](commands/auth.md) — sign in before `quick-database`
+- [Agent Error Codes](../reference/agent-error-codes.md) — the machine-branchable failure contract
+- [From sign-in to REDIS_URL](../cookbook/cloud/quick-database.md) — the full agent walkthrough
 - [Subscription Commands](commands/subscriptions.md)
 - [Database Commands](commands/databases.md)
 - [Async Operations](../common/async-operations.md)

--- a/docs/docs/cookbook/cloud/quick-database.md
+++ b/docs/docs/cookbook/cloud/quick-database.md
@@ -1,0 +1,96 @@
+# From Sign-In to REDIS_URL
+
+Go from nothing to a working Redis database and a `REDIS_URL` in your `.env` — the full
+agent-native arc: sign in once, provision a free database, connect. Credentials are written to a
+file, never printed, so they can't leak into logs or an agent's captured output.
+
+## Prerequisites
+
+- A Redis Cloud account.
+- redisctl installed (`brew install redis/homebrew-tap/redisctl`).
+
+No API keys to create or paste by hand — `cloud auth login` mints one for you.
+
+## Step 1: Sign in
+
+```bash
+redisctl cloud auth login
+```
+
+On an interactive terminal this opens your browser, signs you in, mints a Cloud API key, and
+stores it in a profile. On a headless machine or from an agent it automatically switches to the
+device flow (prints a URL + code); force it with `--device`. See
+[Authentication commands](../../cloud/commands/auth.md) for the device / `status --wait` split.
+
+Confirm:
+
+```bash
+redisctl cloud auth status
+# → { "authenticated": true, "profile": "…" }
+```
+
+## Step 2: Provision a free database
+
+```bash
+redisctl cloud workflow quick-database --name my-app
+```
+
+This creates (or reuses) a free database and writes the connection string to `./.env`. It's
+idempotent by name — safe to re-run. The command prints only non-secret metadata:
+
+```json
+{
+  "status": "ok",
+  "database": { "id": "9001", "name": "my-app", "region": "us-east-1", "plan": "free", "tls": true },
+  "credentials_written_to": "./.env",
+  "credentials_variable": "REDIS_URL"
+}
+```
+
+Your `.env` now holds the URL plus broken-out fields (created `0600`, auto-gitignored):
+
+```dotenv
+REDIS_URL=rediss://default:••••••@host.example.com:12000
+REDIS_HOST=host.example.com
+REDIS_PORT=12000
+REDIS_PASSWORD=••••••
+REDIS_USERNAME=default
+REDIS_TLS=true
+```
+
+## Step 3: Connect
+
+Read `REDIS_URL` from the file — don't echo it:
+
+```bash
+redis-cli -u "$(grep '^REDIS_URL=' .env | cut -d= -f2-)" PING
+# → PONG
+```
+
+Already have a database and just want its connection string in a file? Use
+`database-credentials` instead of provisioning:
+
+```bash
+redisctl cloud workflow database-credentials --subscription-id 123456 --database-id 67890
+```
+
+## For agents
+
+- **Check before you provision.** `cloud auth status` (or the `cloud_auth_status` MCP tool) is an
+  offline check — branch on `authenticated` before calling `quick-database`.
+- **Branch on the error code, not the message.** Failures print a JSON envelope with a stable
+  `.error.code` and a mapped exit code — see [Agent Error Codes](../../reference/agent-error-codes.md).
+- **Never echo the URL or password.** Pass them by reference (`-u "$REDIS_URL"`), use placeholders
+  in any generated code or docs, and verify with a ping rather than a client that prints the URL.
+
+## MCP
+
+The same flow is available to agents over MCP: `cloud_auth_status` (read-only; check first) and
+`cloud_quick_database` (provisions and writes the file). They call the identical engine as the
+CLI. See the `redisctl-cloud-quickstart` skill.
+
+## Related
+
+- [Authentication commands](../../cloud/commands/auth.md)
+- [Cloud workflows](../../cloud/workflows.md)
+- [Agent Error Codes](../../reference/agent-error-codes.md)

--- a/docs/docs/cookbook/index.md
+++ b/docs/docs/cookbook/index.md
@@ -7,6 +7,7 @@ Step-by-step guides for common tasks.
 | Recipe | Description |
 |--------|-------------|
 | [Create Your First Database](cloud/first-database.md) | From zero to connected in 5 minutes |
+| [From Sign-In to REDIS_URL](cloud/quick-database.md) | Sign in, provision a free database, connect — the agent path |
 | [Set Up VPC Peering](cloud/vpc-peering.md) | Connect your VPC to Redis Cloud |
 | [Configure ACLs](cloud/acls.md) | Secure database access with ACL rules |
 | [Backup and Restore](cloud/backup-restore.md) | Manage database backups |

--- a/docs/docs/reference/agent-error-codes.md
+++ b/docs/docs/reference/agent-error-codes.md
@@ -1,0 +1,76 @@
+# Agent Error Codes
+
+The agent-native surface — `cloud auth login | status | logout` and `cloud workflow
+quick-database | database-credentials` — reports failures in a **machine-branchable** form so
+scripts and agents can branch on a stable code instead of parsing prose.
+
+## The contract
+
+In `-o json` / `-o yaml` mode, a failure on these commands prints an error envelope to
+**stdout** and exits with a mapped code:
+
+```json
+{ "status": "error", "error": { "code": "free_db_exists", "message": "…", "retryable": true } }
+```
+
+- `code` — a stable, append-only identifier. Branch on this.
+- `message` — human, actionable, and always safe to show (never contains secrets).
+- `retryable` — whether re-running the same command unchanged might succeed.
+
+Human (non-JSON) mode is unchanged: the usual diagnostic goes to **stderr** and the process
+keeps today's `0` / `1` exit behavior.
+
+## Exit codes
+
+| Exit | Class | What the caller should do |
+|------|-------|---------------------------|
+| `1` | unknown / backend failure | Treat as a bug or an unexpected backend state; inspect `message`. |
+| `2` | usage / precondition | Fix the input or state (bad name, not signed in), then retry. |
+| `3` | transient / retryable | Back off and retry the same command. |
+| `4` | quota / limit reached | A limit was hit; nothing to retry without changing the account. |
+
+`retryable` is `true` for exactly the exit-`3` class.
+
+## Code inventory
+
+| Code | Exit | Retryable | Meaning |
+|------|------|-----------|---------|
+| `not_authenticated` | 2 | no | No usable credentials for the profile. Run `redisctl cloud auth login`. |
+| `auth_denied` | 2 | no | The sign-in request was denied. |
+| `keyring_unavailable` | 2 | no | No OS keyring available to store the key. Re-run with `--allow-plaintext`. |
+| `invalid_name` | 2 | no | The database name doesn't match the naming rules (see below). |
+| `name_conflict` | 2 | no | The name maps to a conflicting existing resource. |
+| `device_code_expired` | 3 | yes | The device login code expired before approval. Start login again. |
+| `auth_pending` | 3 | yes | Login hasn't been approved yet. Approve it and retry. |
+| `transient_api_error` | 3 | yes | A transient backend error. Retry. |
+| `rate_limited` | 3 | yes | Too many requests. Back off and retry. |
+| `free_db_exists` | 4 | no | The account already has a free database. |
+| `quota_exceeded` | 4 | no | An account quota or limit was reached. |
+| `sm_exchange_failed` | 1 | no | The sign-in / key-mint exchange failed unexpectedly. |
+| `unknown` | 1 | no | Unclassified failure; inspect `message`. |
+
+The list is append-only: existing codes never change meaning or exit class, so a branch written
+today keeps working.
+
+!!! note "Database naming"
+    `quick-database` names must match `^[a-z][a-z0-9-]{1,38}[a-z0-9]$` — 3–40 characters,
+    lowercase letters / digits / hyphens, starting with a letter, no leading, trailing, or
+    doubled hyphen. A violation is reported as `invalid_name` (exit `2`) before any API call.
+
+## Branching example
+
+```bash
+out=$(redisctl cloud workflow quick-database --name my-app -o json) || true
+case "$(printf '%s' "$out" | jq -r '.error.code // empty')" in
+  "")                               echo "ready" ;;                       # success
+  not_authenticated)                redisctl cloud auth login ;;          # then retry
+  transient_api_error|rate_limited) sleep 5; exec "$0" ;;                 # back off
+  free_db_exists)                   echo "account already has a free DB" ;;
+  *)                                printf '%s\n' "$out" >&2; exit 1 ;;
+esac
+```
+
+## See also
+
+- [Authentication commands](../cloud/commands/auth.md)
+- [Cloud workflows](../cloud/workflows.md) — `quick-database`, `database-credentials`

--- a/docs/docs/reference/index.md
+++ b/docs/docs/reference/index.md
@@ -16,6 +16,12 @@ Technical reference documentation.
 |-------|-------------|
 | [Security Guide](security.md) | Credential storage and best practices |
 
+## Agents
+
+| Topic | Description |
+|-------|-------------|
+| [Agent Error Codes](agent-error-codes.md) | Machine-branchable error / exit-code contract |
+
 ## Comparisons
 
 | Topic | Description |

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -149,6 +149,7 @@ nav:
       - cookbook/index.md
       - Redis Cloud:
           - cookbook/cloud/first-database.md
+          - cookbook/cloud/quick-database.md
           - cookbook/cloud/vpc-peering.md
           - cookbook/cloud/acls.md
           - cookbook/cloud/backup-restore.md
@@ -164,6 +165,7 @@ nav:
       - Configuration File: reference/config-file.md
       - Shell Completions: reference/shell-completions.md
       - Security: reference/security.md
+      - Agent Error Codes: reference/agent-error-codes.md
       - rladmin Comparison: reference/rladmin.md
   - MCP:
       - mcp/index.md


### PR DESCRIPTION
The remaining agent-native docs (RED-210019), covering the quick-database workflow and the machine-branchable error contract.

## What's here

- **`cloud/workflows.md`** — reference for `cloud workflow quick-database` and `cloud workflow database-credentials`: flags, the non-secret JSON report, the `.env` file format, idempotency-by-name, and the secret-safety guarantee (credentials go to the file, never stdout).
- **`reference/agent-error-codes.md`** (new) — the machine-branchable failure contract shared by the `cloud auth` and `cloud workflow` surfaces: the stdout error envelope, exit codes `1–4`, and the append-only code inventory (code → exit → retryable → meaning), with a shell branching example.
- **`cookbook/cloud/quick-database.md`** (new) — *"From sign-in to REDIS_URL"*: the full `login → quick-database → connect` arc, plus agent notes (check auth first, branch on `.error.code`, never echo the URL/password) and the MCP tools.
- Nav entries + cookbook/reference index rows.

No internal endpoints or hosts appear in the shipped docs (placeholders only).

## Testing

- `mkdocs build --strict` (deps from `docs/requirements.txt`) succeeds — all nav entries and internal links resolve, no broken-reference warnings; the three pages render.
