### PR TITLE
chore: harden project maintenance and release hygiene

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -34,17 +34,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@7b1c307e0dcbda6122208f10795a713336a9b35a # stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
           toolchain: stable
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
 
       - name: Install and run cargo-deny
         run: |
-          cargo install cargo-deny --version 0.18.9 --locked
+          cargo install cargo-deny --version 0.20.2 --locked
           cargo deny --all-features check ${{ matrix.checks }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,15 +10,10 @@ on:
       - "LICENSE*"
       - ".gitignore"
       - ".env.example"
+  # Run the complete gate for every pull request, including stacked PRs that
+  # target a feature branch and documentation-only changes. This guarantees
+  # that the stable "CI Status" check is always emitted.
   pull_request:
-    branches: [main]
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
-      - ".github/*.md"
-      - "LICENSE*"
-      - ".gitignore"
-      - ".env.example"
 
 env:
   CARGO_TERM_COLOR: always
@@ -38,16 +33,16 @@ jobs:
     name: Quick Checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@7b1c307e0dcbda6122208f10795a713336a9b35a # stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
           toolchain: stable
           components: rustfmt, clippy
 
       - name: Cache cargo registry and build
-        uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
           prefix-key: "v1-rust"
           shared-key: "quick"
@@ -78,15 +73,15 @@ jobs:
           - package: redisctl-mcp
             targets: "--lib --bins"
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@7b1c307e0dcbda6122208f10795a713336a9b35a # stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
           toolchain: stable
 
       - name: Cache cargo registry and build
-        uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
           prefix-key: "v1-rust"
           shared-key: "test-${{ matrix.package }}"
@@ -100,15 +95,15 @@ jobs:
     needs: quick-checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@7b1c307e0dcbda6122208f10795a713336a9b35a # stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
           toolchain: stable
 
       - name: Cache cargo registry and build
-        uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
           prefix-key: "v1-rust"
           shared-key: "integration"
@@ -133,15 +128,15 @@ jobs:
             required: false
     continue-on-error: ${{ !matrix.required }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@7b1c307e0dcbda6122208f10795a713336a9b35a # stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
           toolchain: stable
 
       - name: Cache cargo registry and build
-        uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
           prefix-key: "v1-rust"
           shared-key: "build"
@@ -161,21 +156,21 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@7b1c307e0dcbda6122208f10795a713336a9b35a # stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
           toolchain: stable
 
       - name: Cache cargo registry and build
-        uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
           prefix-key: "v1-rust"
           shared-key: "coverage"
 
       - name: Install tarpaulin
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
         with:
           tool: cargo-tarpaulin@0.31.2
 
@@ -183,7 +178,7 @@ jobs:
         run: cargo tarpaulin --workspace --all-features --out xml --timeout 300
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@1e68e06f1dbfde0e4cefc87efeba9e4643565303 # v5.1.1
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         with:
           files: ./cobertura.xml
           fail_ci_if_error: false

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,7 +32,7 @@ jobs:
             runner: ubuntu-24.04-arm
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Prepare platform tag
         id: prep
@@ -41,10 +41,10 @@ jobs:
           echo "pair=${platform//\//-}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -52,7 +52,7 @@ jobs:
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: ./docker/Dockerfile
@@ -68,7 +68,7 @@ jobs:
           touch "${{ runner.temp }}/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: digests-${{ steps.prep.outputs.pair }}
           path: ${{ runner.temp }}/digests/*
@@ -86,7 +86,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -94,12 +94,12 @@ jobs:
       - name: Extract version
         id: version
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
             # For manual dispatch, use the current ref name or extract from Cargo.toml
-            if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
               # Running from a tag
               VERSION=${GITHUB_REF#refs/tags/v}
-            elif [[ "${{ github.ref }}" == refs/tags/redisctl-v* ]]; then
+            elif [[ "$GITHUB_REF" == refs/tags/redisctl-v* ]]; then
               # Running from a redisctl-v tag
               VERSION=${GITHUB_REF#refs/tags/redisctl-v}
             else
@@ -109,7 +109,7 @@ jobs:
             fi
           else
             # Tag push event
-            if [[ "${{ github.ref }}" == refs/tags/redisctl-v* ]]; then
+            if [[ "$GITHUB_REF" == refs/tags/redisctl-v* ]]; then
               VERSION=${GITHUB_REF#refs/tags/redisctl-v}
             else
               VERSION=${GITHUB_REF#refs/tags/v}
@@ -123,22 +123,24 @@ jobs:
           fi
 
           echo "Final version: $VERSION"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "major=$(echo "$VERSION" | cut -d. -f1)" >> "$GITHUB_OUTPUT"
-          echo "minor=$(echo "$VERSION" | cut -d. -f1-2)" >> "$GITHUB_OUTPUT"
+          {
+            echo "version=$VERSION"
+            echo "major=${VERSION%%.*}"
+            echo "minor=${VERSION%.*}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: ${{ runner.temp }}/digests
           pattern: digests-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,7 +11,6 @@ on:
       - "CONTRIBUTING.md"
       - "CLAUDE.md"
   pull_request:
-    branches: [main]
     paths:
       - "**.md"
       - "docs/**"
@@ -31,10 +30,10 @@ jobs:
     name: Markdown Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "20"
 
@@ -55,15 +54,15 @@ jobs:
     name: Build Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
 
       - name: Cache pip
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-mkdocs-material
@@ -78,7 +77,7 @@ jobs:
           mkdocs build --strict
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: docs-site
           path: docs/site
@@ -89,10 +88,10 @@ jobs:
     name: Check Links
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Link Checker
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
         with:
           args: >
             --verbose
@@ -114,15 +113,15 @@ jobs:
     name: Validate Rust Docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@7b1c307e0dcbda6122208f10795a713336a9b35a # stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
           toolchain: stable
 
       - name: Cache cargo registry
-        uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
           prefix-key: "v1-rust"
           shared-key: "doc"
@@ -162,10 +161,10 @@ jobs:
     # Only deploy on push to main, not on PRs
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
 
@@ -179,7 +178,7 @@ jobs:
           mkdocs build
 
       - name: Deploy to redisctl-docs
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
         with:
           personal_token: ${{ secrets.DOCS_DEPLOY_TOKEN }}
           external_repository: redis-field-engineering/redisctl-docs

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -24,16 +24,16 @@ jobs:
     environment: crates-io
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
 
       - name: Run release-plz
-        uses: MarcoIeni/release-plz-action@v0.5
+        uses: MarcoIeni/release-plz-action@2eb1d8bcb770b4c48ccfaad919734b38b51958c9 # v0.5.131
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           # Uses OIDC Trusted Publishing - no CARGO_REGISTRY_TOKEN needed

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ on:
   pull_request:
   push:
     tags:
-      - "**[0-9]+.[0-9]+.[0-9]+*"
+      - '**[0-9]+.[0-9]+.[0-9]+*'
 
 jobs:
   # Run 'dist plan' (or host) to determine what tasks we need to do
@@ -56,7 +56,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
         with:
           persist-credentials: false
           submodules: recursive
@@ -64,9 +64,9 @@ jobs:
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.30.1/cargo-dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.32.0/cargo-dist-installer.sh | sh"
       - name: Cache dist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/dist
@@ -82,7 +82,7 @@ jobs:
           cat plan-dist-manifest.json
           echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: artifacts-plan-dist-manifest
           path: plan-dist-manifest.json
@@ -116,7 +116,7 @@ jobs:
       - name: enable windows longpaths
         run: |
           git config --global core.longpaths true
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
         with:
           persist-credentials: false
           submodules: recursive
@@ -131,7 +131,7 @@ jobs:
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
       - name: Fetch local artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -158,7 +158,7 @@ jobs:
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: artifacts-build-local-${{ join(matrix.targets, '_') }}
           path: |
@@ -175,19 +175,19 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
         with:
           persist-credentials: false
           submodules: recursive
       - name: Install cached dist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/dist
       # Get all the local artifacts for the global tasks to use (for e.g. checksums)
       - name: Fetch local artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -205,7 +205,7 @@ jobs:
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: artifacts-build-global
           path: |
@@ -225,19 +225,19 @@ jobs:
     outputs:
       val: ${{ steps.host.outputs.manifest }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
         with:
           persist-credentials: false
           submodules: recursive
       - name: Install cached dist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/dist
       # Fetch artifacts from scratch-storage
       - name: Fetch artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -250,14 +250,14 @@ jobs:
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           # Overwrite the previous copy
           name: artifacts-dist-manifest
           path: dist-manifest.json
       # Create a GitHub Release while uploading all files to it
       - name: "Download GitHub Artifacts"
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           pattern: artifacts-*
           path: artifacts
@@ -278,140 +278,33 @@ jobs:
 
           gh release create "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
 
-  # Update Homebrew formulas after successful release
-  # NOTE: This job is manually maintained - cargo-dist regenerates release.yml
-  # and will remove this job. Re-add it after running `dist generate` or `dist init`.
-  #
-  # Handles both redisctl and redisctl-mcp releases, updating all platform
-  # URLs and SHA256 hashes in the corresponding formula.
-  update-homebrew:
+  custom-update-homebrew:
     needs:
       - plan
       - host
-    # Run for redisctl and redisctl-mcp releases (not redisctl-core or redisctl-config)
-    if: ${{ always() && needs.host.result == 'success' && (startsWith(needs.plan.outputs.tag, 'redisctl-v') || startsWith(needs.plan.outputs.tag, 'redisctl-mcp-v')) }}
-    runs-on: "ubuntu-22.04"
-    steps:
-      - name: Determine formula and version
-        id: meta
-        run: |
-          TAG="${{ needs.plan.outputs.tag }}"
-          if [[ "$TAG" == redisctl-mcp-v* ]]; then
-            echo "crate=redisctl-mcp" >> $GITHUB_OUTPUT
-            echo "formula=redisctl-mcp" >> $GITHUB_OUTPUT
-            echo "formula_class=RedisctlMcp" >> $GITHUB_OUTPUT
-            echo "version=${TAG#redisctl-mcp-v}" >> $GITHUB_OUTPUT
-            echo "binary=redisctl-mcp" >> $GITHUB_OUTPUT
-          else
-            echo "crate=redisctl" >> $GITHUB_OUTPUT
-            echo "formula=redisctl" >> $GITHUB_OUTPUT
-            echo "formula_class=Redisctl" >> $GITHUB_OUTPUT
-            echo "version=${TAG#redisctl-v}" >> $GITHUB_OUTPUT
-            echo "binary=redisctl" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Download SHA256 sums
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          TAG="${{ needs.plan.outputs.tag }}"
-          CRATE="${{ steps.meta.outputs.crate }}"
-          gh release download "$TAG" \
-            --repo "${{ github.repository }}" \
-            --pattern "${CRATE}-aarch64-apple-darwin.tar.xz.sha256" \
-            --pattern "${CRATE}-x86_64-apple-darwin.tar.xz.sha256" \
-            --pattern "${CRATE}-x86_64-unknown-linux-gnu.tar.xz.sha256"
-
-          # Extract just the hash from each file (format: "hash *filename")
-          echo "sha_arm_mac=$(awk '{print $1}' ${CRATE}-aarch64-apple-darwin.tar.xz.sha256)" >> $GITHUB_ENV
-          echo "sha_intel_mac=$(awk '{print $1}' ${CRATE}-x86_64-apple-darwin.tar.xz.sha256)" >> $GITHUB_ENV
-          echo "sha_linux=$(awk '{print $1}' ${CRATE}-x86_64-unknown-linux-gnu.tar.xz.sha256)" >> $GITHUB_ENV
-
-      - name: Clone homebrew-tap
-        env:
-          COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
-        run: |
-          git clone "https://x-access-token:${COMMITTER_TOKEN}@github.com/redis/homebrew-tap.git" tap
-          cd tap
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Generate formula
-        run: |
-          TAG="${{ needs.plan.outputs.tag }}"
-          VERSION="${{ steps.meta.outputs.version }}"
-          CRATE="${{ steps.meta.outputs.crate }}"
-          FORMULA="${{ steps.meta.outputs.formula }}"
-          CLASS="${{ steps.meta.outputs.formula_class }}"
-          BINARY="${{ steps.meta.outputs.binary }}"
-          BASE_URL="https://github.com/${{ github.repository }}/releases/download/${TAG}"
-
-          cat > "tap/Formula/${FORMULA}.rb" << RUBY
-          class ${CLASS} < Formula
-            desc "$( [ "$CRATE" = "redisctl-mcp" ] && echo "MCP server for AI-powered Redis management" || echo "CLI for Redis Cloud and Enterprise management" )"
-            homepage "https://github.com/${{ github.repository }}"
-            version "${VERSION}"
-            license any_of: ["MIT", "Apache-2.0"]
-
-            on_macos do
-              on_arm do
-                url "${BASE_URL}/${CRATE}-aarch64-apple-darwin.tar.xz"
-                sha256 "${sha_arm_mac}"
-              end
-              on_intel do
-                url "${BASE_URL}/${CRATE}-x86_64-apple-darwin.tar.xz"
-                sha256 "${sha_intel_mac}"
-              end
-            end
-
-            on_linux do
-              on_intel do
-                url "${BASE_URL}/${CRATE}-x86_64-unknown-linux-gnu.tar.xz"
-                sha256 "${sha_linux}"
-              end
-            end
-
-            def install
-              bin.install "${BINARY}"
-            end
-
-            test do
-              assert_match "${BINARY}", shell_output("#{bin}/${BINARY} --version")
-            end
-          end
-          RUBY
-
-          # Remove leading whitespace from heredoc indentation
-          sed -i 's/^          //' "tap/Formula/${FORMULA}.rb"
-
-      - name: Commit and push
-        env:
-          COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
-        run: |
-          cd tap
-          FORMULA="${{ steps.meta.outputs.formula }}"
-          VERSION="${{ steps.meta.outputs.version }}"
-          git add "Formula/${FORMULA}.rb"
-          if git diff --cached --quiet; then
-            echo "No changes to formula"
-            exit 0
-          fi
-          git commit -m "Update ${FORMULA} to ${VERSION}"
-          git push
+    if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases }}
+    uses: ./.github/workflows/update-homebrew.yml
+    with:
+      plan: ${{ needs.plan.outputs.val }}
+    secrets: inherit
+    # publish jobs get escalated permissions
+    permissions:
+      "contents": "read"
 
   announce:
     needs:
       - plan
       - host
+      - custom-update-homebrew
     # use "always() && ..." to allow us to wait for all publish jobs while
     # still allowing individual publish jobs to skip themselves (for prereleases).
     # "host" however must run to completion, no skipping allowed!
-    if: ${{ always() && needs.host.result == 'success' }}
+    if: ${{ always() && needs.host.result == 'success' && (needs.custom-update-homebrew.result == 'skipped' || needs.custom-update-homebrew.result == 'success') }}
     runs-on: "ubuntu-22.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
         with:
           persist-credentials: false
           submodules: recursive

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -29,19 +29,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@7b1c307e0dcbda6122208f10795a713336a9b35a # stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
-          toolchain: 1.89
+          toolchain: 1.90
 
       - name: Cache cargo registry
-        uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab # v2.7.5
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
           cache-on-failure: true
 
       - name: Install and run cargo-audit
         run: |
-          cargo install cargo-audit --version 0.22.0 --locked
+          cargo install cargo-audit --version 0.22.2 --locked
           cargo audit --deny warnings

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -1,0 +1,137 @@
+name: Update Homebrew
+
+on:
+  workflow_call:
+    inputs:
+      plan:
+        description: cargo-dist plan JSON
+        required: true
+        type: string
+    secrets:
+      COMMITTER_TOKEN:
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  update-homebrew:
+    if: >-
+      ${{
+        startsWith(fromJson(inputs.plan).announcement_tag, 'redisctl-v') ||
+        startsWith(fromJson(inputs.plan).announcement_tag, 'redisctl-mcp-v')
+      }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Determine formula and version
+        id: meta
+        env:
+          TAG: ${{ fromJson(inputs.plan).announcement_tag }}
+        run: |
+          if [[ "$TAG" == redisctl-mcp-v* ]]; then
+            {
+              echo "crate=redisctl-mcp"
+              echo "formula=redisctl-mcp"
+              echo "formula_class=RedisctlMcp"
+              echo "version=${TAG#redisctl-mcp-v}"
+              echo "binary=redisctl-mcp"
+            } >> "$GITHUB_OUTPUT"
+          else
+            {
+              echo "crate=redisctl"
+              echo "formula=redisctl"
+              echo "formula_class=Redisctl"
+              echo "version=${TAG#redisctl-v}"
+              echo "binary=redisctl"
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download SHA256 sums
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ fromJson(inputs.plan).announcement_tag }}
+          CRATE: ${{ steps.meta.outputs.crate }}
+        run: |
+          gh release download "$TAG" \
+            --repo "${{ github.repository }}" \
+            --pattern "${CRATE}-aarch64-apple-darwin.tar.xz.sha256" \
+            --pattern "${CRATE}-x86_64-apple-darwin.tar.xz.sha256" \
+            --pattern "${CRATE}-x86_64-unknown-linux-gnu.tar.xz.sha256"
+
+          {
+            echo "sha_arm_mac=$(awk '{print $1}' "${CRATE}-aarch64-apple-darwin.tar.xz.sha256")"
+            echo "sha_intel_mac=$(awk '{print $1}' "${CRATE}-x86_64-apple-darwin.tar.xz.sha256")"
+            echo "sha_linux=$(awk '{print $1}' "${CRATE}-x86_64-unknown-linux-gnu.tar.xz.sha256")"
+          } >> "$GITHUB_ENV"
+
+      - name: Clone Homebrew tap
+        env:
+          COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
+        run: |
+          git clone "https://x-access-token:${COMMITTER_TOKEN}@github.com/redis/homebrew-tap.git" tap
+          cd tap
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Generate formula
+        env:
+          TAG: ${{ fromJson(inputs.plan).announcement_tag }}
+          VERSION: ${{ steps.meta.outputs.version }}
+          CRATE: ${{ steps.meta.outputs.crate }}
+          FORMULA: ${{ steps.meta.outputs.formula }}
+          FORMULA_CLASS: ${{ steps.meta.outputs.formula_class }}
+          BINARY: ${{ steps.meta.outputs.binary }}
+        run: |
+          BASE_URL="https://github.com/${{ github.repository }}/releases/download/${TAG}"
+
+          cat > "tap/Formula/${FORMULA}.rb" << RUBY
+          class ${FORMULA_CLASS} < Formula
+            desc "$( [ "$CRATE" = "redisctl-mcp" ] && echo "MCP server for AI-powered Redis management" || echo "CLI for Redis Cloud and Enterprise management" )"
+            homepage "https://github.com/${{ github.repository }}"
+            version "${VERSION}"
+            license any_of: ["MIT", "Apache-2.0"]
+
+            on_macos do
+              on_arm do
+                url "${BASE_URL}/${CRATE}-aarch64-apple-darwin.tar.xz"
+                sha256 "${sha_arm_mac}"
+              end
+              on_intel do
+                url "${BASE_URL}/${CRATE}-x86_64-apple-darwin.tar.xz"
+                sha256 "${sha_intel_mac}"
+              end
+            end
+
+            on_linux do
+              on_intel do
+                url "${BASE_URL}/${CRATE}-x86_64-unknown-linux-gnu.tar.xz"
+                sha256 "${sha_linux}"
+              end
+            end
+
+            def install
+              bin.install "${BINARY}"
+            end
+
+            test do
+              assert_match "${BINARY}", shell_output("#{bin}/${BINARY} --version")
+            end
+          end
+          RUBY
+
+          sed -i 's/^          //' "tap/Formula/${FORMULA}.rb"
+
+      - name: Commit and push
+        env:
+          COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
+          FORMULA: ${{ steps.meta.outputs.formula }}
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          cd tap
+          git add "Formula/${FORMULA}.rb"
+          if git diff --cached --quiet; then
+            echo "No changes to formula"
+            exit 0
+          fi
+          git commit -m "Update ${FORMULA} to ${VERSION}"
+          git push

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,8 @@ Context and instructions for AI coding agents working on the redisctl project.
 
 ## Project Overview
 
-redisctl is a Rust workspace with three crates that share a lockstep version (currently 0.9.1):
+redisctl is a Rust workspace with three crates that share the lockstep version
+declared in the root `Cargo.toml`:
 
 | Crate | Path | Purpose |
 |-------|------|---------|

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ Each issue has detailed guidance in the comments. Don't hesitate to ask question
    cd redisctl
    ```
 
-2. **Install Rust toolchain (1.89+)**
+2. **Install Rust toolchain (1.90+)**
    ```bash
    rustup update stable
    ```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,18 +51,18 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "ansi-str"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cf4578926a981ab0ca955dc023541d19de37112bc24c1a197bd806d3d86ad1d"
+checksum = "060de1453b69f46304b28274f382132f4e72c55637cf362920926a70d090890d"
 dependencies = [
  "ansitok",
 ]
 
 [[package]]
 name = "ansitok"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "220044e6a1bb31ddee4e3db724d29767f352de47445a6cd75e1a173142136c83"
+checksum = "c0a8acea8c2f1c60f0a92a8cd26bf96ca97db56f10bbcab238bbe0cceba659ee"
 dependencies = [
  "nom 7.1.3",
  "vte",
@@ -159,9 +159,9 @@ checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "arrayvec"
-version = "0.5.2"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "assert-json-diff"
@@ -208,7 +208,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]
@@ -219,7 +219,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]
@@ -241,7 +241,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
- "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -538,10 +537,10 @@ version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]
@@ -892,7 +891,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]
@@ -963,7 +962,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]
@@ -984,7 +983,7 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 [[package]]
 name = "docker-wrapper"
 version = "0.10.2"
-source = "git+https://github.com/joshrotenberg/docker-wrapper#e122332360311e4acf4914ab4b8c97bc84b30ac1"
+source = "git+https://github.com/joshrotenberg/docker-wrapper?rev=e122332360311e4acf4914ab4b8c97bc84b30ac1#e122332360311e4acf4914ab4b8c97bc84b30ac1"
 dependencies = [
  "async-trait",
  "reqwest 0.12.23",
@@ -1055,7 +1054,7 @@ checksum = "685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]
@@ -1272,7 +1271,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]
@@ -1423,12 +1422,6 @@ checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
  "hashbrown 0.15.5",
 ]
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -1878,7 +1871,7 @@ dependencies = [
  "form_urlencoded",
  "geohash",
  "geoutils",
- "heck 0.5.0",
+ "heck",
  "hex",
  "hmac",
  "interim",
@@ -1948,23 +1941,6 @@ checksum = "a5a3cc660ba5d72bce0b3bb295bf20847ccbb40fd423f3f05b61273672e561fe"
 dependencies = [
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "jsonwebtoken"
-version = "10.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
-dependencies = [
- "aws-lc-rs",
- "base64 0.22.1",
- "getrandom 0.2.16",
- "js-sys",
- "pem",
- "serde",
- "serde_json",
- "signature",
- "simple_asn1",
 ]
 
 [[package]]
@@ -2091,7 +2067,7 @@ dependencies = [
  "quote",
  "regex-syntax",
  "rustc_version",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]
@@ -2339,7 +2315,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]
@@ -2394,9 +2370,9 @@ dependencies = [
 
 [[package]]
 name = "papergrid"
-version = "0.13.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b0f8def1f117e13c895f3eda65a7b5650688da29d6ad04635f61bc7b92eebd"
+checksum = "d0984e668274d34691bc2b262ef0d115de5fa9973bcdee7ae32213f93099153e"
 dependencies = [
  "ansi-str",
  "ansitok",
@@ -2451,16 +2427,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pem"
-version = "3.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
-dependencies = [
- "base64 0.22.1",
- "serde_core",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2496,7 +2462,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]
@@ -2658,7 +2624,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]
@@ -3043,7 +3009,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]
@@ -3168,7 +3134,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.16",
  "libc",
- "untrusted 0.9.0",
+ "untrusted",
  "windows-sys 0.52.0",
 ]
 
@@ -3363,7 +3329,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted 0.9.0",
+ "untrusted",
 ]
 
 [[package]]
@@ -3418,7 +3384,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]
@@ -3508,7 +3474,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]
@@ -3519,7 +3485,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]
@@ -3602,7 +3568,7 @@ checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]
@@ -3673,31 +3639,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "signature"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-dependencies = [
- "rand_core 0.6.4",
-]
-
-[[package]]
 name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
-
-[[package]]
-name = "simple_asn1"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
-dependencies = [
- "num-bigint",
- "num-traits",
- "thiserror 2.0.17",
- "time",
-]
 
 [[package]]
 name = "siphasher"
@@ -3766,17 +3711,6 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
@@ -3803,7 +3737,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]
@@ -3829,27 +3763,28 @@ dependencies = [
 
 [[package]]
 name = "tabled"
-version = "0.17.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6709222f3973137427ce50559cd564dc187a95b9cfe01613d2f4e93610e510a"
+checksum = "b5dc662e6da844ad6e428ad16b57967c9d33c82e16bb1c258326c0c078605dff"
 dependencies = [
  "ansi-str",
  "ansitok",
  "papergrid",
  "tabled_derive",
+ "testing_table",
 ]
 
 [[package]]
 name = "tabled_derive"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "931be476627d4c54070a1f3a9739ccbfec9b36b39815106a20cce2243bbcefe1"
+checksum = "0ea5d1b13ca6cff1f9231ffd62f15eefd72543dab5e468735f1a456728a02846"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -3893,6 +3828,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
+name = "testing_table"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f8daae29995a24f65619e19d8d31dea5b389f3d853d8bf297bbf607cd0014cc"
+dependencies = [
+ "ansitok",
+ "unicode-width",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3918,7 +3863,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]
@@ -3929,7 +3874,7 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]
@@ -3948,12 +3893,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
  "time-core",
- "time-macros",
 ]
 
 [[package]]
@@ -3961,16 +3904,6 @@ name = "time-core"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
-
-[[package]]
-name = "time-macros"
-version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
-dependencies = [
- "num-conv",
- "time-core",
-]
 
 [[package]]
 name = "tiny-keccak"
@@ -4041,7 +3974,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]
@@ -4195,7 +4128,6 @@ dependencies = [
  "http",
  "http-body-util",
  "hyper",
- "jsonwebtoken",
  "pin-project-lite",
  "regex",
  "schemars",
@@ -4310,7 +4242,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]
@@ -4405,7 +4337,7 @@ checksum = "3c36781cc0e46a83726d9879608e4cf6c2505237e263a8eb8c24502989cfdb28"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]
@@ -4483,12 +4415,6 @@ checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
-name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
@@ -4560,23 +4486,12 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vte"
-version = "0.10.1"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cbce692ab4ca2f1f3047fcf732430249c0e971bfdd2b234cf2c47ad93af5983"
+checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
 dependencies = [
  "arrayvec",
- "utf8parse",
- "vte_generate_state_changes",
-]
-
-[[package]]
-name = "vte_generate_state_changes"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e369bee1b05d510a7b4ed645f5faa90619e05437111783ea5848f28d97d3c2e"
-dependencies = [
- "proc-macro2",
- "quote",
+ "memchr",
 ]
 
 [[package]]
@@ -4654,7 +4569,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -4689,7 +4604,7 @@ checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4825,7 +4740,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]
@@ -4836,7 +4751,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]
@@ -5220,7 +5135,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
  "synstructure",
 ]
 
@@ -5241,7 +5156,7 @@ checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]
@@ -5261,7 +5176,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
  "synstructure",
 ]
 
@@ -5282,7 +5197,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]
@@ -5315,7 +5230,7 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ documentation = "https://docs.rs/redisctl"
 # Config for 'dist'
 [workspace.metadata.dist]
 # The preferred dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "0.30.1"
+cargo-dist-version = "0.32.0"
 # CI backends to support
 ci = "github"
 # The installers to generate for each app
@@ -42,8 +42,16 @@ create-release = true
 install-path = "CARGO_HOME"
 # Whether to install an updater program
 install-updater = false
-# Skip checking whether the specified configuration files are up to date
-allow-dirty = ["ci"]
+# Keep the Redis Homebrew tap update outside the generated release workflow.
+publish-jobs = ["./update-homebrew"]
+github-custom-job-permissions = { "update-homebrew" = { contents = "read" } }
+
+[workspace.metadata.dist.github-action-commits]
+# Dependabot updates the generated workflow references. Copy those revisions
+# here and rerun `dist generate --mode ci` so this remains the source of truth.
+"actions/checkout" = "d23441a48e516b6c34aea4fa41551a30e30af803" # v6.1.0
+"actions/upload-artifact" = "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" # v7.0.1
+"actions/download-artifact" = "3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c" # v8.0.1
 
 [workspace.dependencies]
 # Core dependencies

--- a/crates/redisctl-core/src/config/credential.rs
+++ b/crates/redisctl-core/src/config/credential.rs
@@ -18,7 +18,6 @@ const SERVICE_NAME: &str = "redisctl";
 
 /// Storage backend for credentials
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub enum CredentialStorage {
     /// Store in OS keyring
     #[cfg(feature = "secure-storage")]
@@ -29,7 +28,7 @@ pub enum CredentialStorage {
 
 /// Credential store abstraction
 pub struct CredentialStore {
-    #[allow(dead_code)]
+    #[cfg(feature = "secure-storage")]
     storage: CredentialStorage,
 }
 
@@ -57,9 +56,7 @@ impl CredentialStore {
         }
         #[cfg(not(feature = "secure-storage"))]
         {
-            Self {
-                storage: CredentialStorage::Plaintext,
-            }
+            Self {}
         }
     }
 
@@ -78,7 +75,6 @@ impl CredentialStore {
     }
 
     /// Store a credential value
-    #[allow(dead_code)]
     pub fn store_credential(&self, key: &str, value: &str) -> Result<String> {
         #[cfg(feature = "secure-storage")]
         {
@@ -154,7 +150,6 @@ impl CredentialStore {
     }
 
     /// Delete a credential from storage
-    #[allow(dead_code)]
     pub fn delete_credential(&self, key: &str) -> Result<()> {
         #[cfg(feature = "secure-storage")]
         {
@@ -182,13 +177,11 @@ impl CredentialStore {
     }
 
     /// Check if a value is a keyring reference
-    #[allow(dead_code)]
     pub fn is_keyring_reference(value: &str) -> bool {
         value.starts_with(KEYRING_PREFIX)
     }
 
     /// Get the current storage backend
-    #[allow(dead_code)]
     pub fn storage_backend(&self) -> &str {
         #[cfg(feature = "secure-storage")]
         {

--- a/crates/redisctl-mcp/Cargo.toml
+++ b/crates/redisctl-mcp/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 # MCP framework
-tower-mcp = { version = "0.8.2", features = ["http", "oauth", "dynamic-tools"] }
+tower-mcp = { version = "0.8.2", features = ["http", "dynamic-tools"] }
 schemars = "1.2"
 
 # Internal crates
@@ -51,7 +51,7 @@ async-trait = { workspace = true }
 # CLI
 clap = { workspace = true }
 
-# HTTP/OAuth
+# HTTP middleware
 tower = { workspace = true }
 
 [features]
@@ -71,4 +71,4 @@ serde_json = { workspace = true }
 anyhow = { workspace = true }
 redis = { workspace = true }
 serial_test = { workspace = true }
-docker-wrapper = { git = "https://github.com/joshrotenberg/docker-wrapper", features = ["testing", "template-redis"] }
+docker-wrapper = { git = "https://github.com/joshrotenberg/docker-wrapper", rev = "e122332360311e4acf4914ab4b8c97bc84b30ac1", features = ["testing", "template-redis"] }

--- a/crates/redisctl-mcp/README.md
+++ b/crates/redisctl-mcp/README.md
@@ -60,8 +60,8 @@ redisctl-mcp
 # Use a specific profile
 redisctl-mcp --profile production
 
-# Read-only mode (disables write operations)
-redisctl-mcp --profile production --read-only
+# Enable write operations (read-only is the default)
+redisctl-mcp --profile production --read-only=false
 
 # With a direct Redis database connection
 redisctl-mcp --database-url redis://localhost:6379
@@ -69,19 +69,15 @@ redisctl-mcp --database-url redis://localhost:6379
 
 ### HTTP Transport
 
-For shared deployments accessible over the network:
+The HTTP transport is unauthenticated. Keep the default loopback bind for local
+use, or put shared deployments behind a trusted gateway or reverse proxy that
+provides authentication, authorization, and TLS.
 
 ```bash
-# Basic HTTP server
+# Local HTTP server
 redisctl-mcp --transport http --port 8080
 
-# With OAuth authentication
-redisctl-mcp --transport http --port 8080 \
-  --oauth \
-  --oauth-issuer https://accounts.google.com \
-  --oauth-audience my-app-id
-
-# With custom rate limiting
+# With custom concurrency and timeout limits
 redisctl-mcp --transport http --port 8080 \
   --max-concurrent 20 \
   --request-timeout-secs 60
@@ -140,7 +136,8 @@ insecure = true
 
 ### Environment Variables
 
-For OAuth/HTTP mode or when not using profiles:
+For deployments that use environment-backed credentials instead of storing
+credential values directly in profiles:
 
 ```bash
 # Redis Cloud
@@ -164,19 +161,19 @@ Options:
   -t, --transport <TRANSPORT>      Transport mode [default: stdio]
                                    - stdio: For CLI integrations
                                    - http: For web deployments
-  -p, --profile <PROFILE>          Profile name for credentials
-      --read-only                  Disable write operations
+  -p, --profile <PROFILE>          Profile name(s) for credentials; repeatable
+      --read-only <BOOL>           Read-only mode [default: true]
+      --policy <PATH>              TOML policy file
       --database-url <URL>         Redis URL for direct connections
+      --cluster                    Enable Redis Cluster mode
+      --client-name <NAME>         Redis client name [default: redisctl-mcp]
+      --tools <SPECS>              Toolsets or sub-modules to expose
+      --skills-dir <PATH>          Directory of SKILL.md prompt packages
 
   HTTP Options:
       --host <HOST>                Bind host [default: 127.0.0.1]
       --port <PORT>                Bind port [default: 8080]
-      --oauth                      Enable OAuth authentication
-      --oauth-issuer <URL>         OAuth issuer URL
-      --oauth-audience <AUD>       OAuth audience
-      --jwks-uri <URI>             JWKS URI (auto-discovered if not set)
       --max-concurrent <N>         Max concurrent requests [default: 10]
-      --rate-limit-ms <MS>         Rate limit interval [default: 100]
       --request-timeout-secs <S>   Request timeout [default: 30]
 
   Logging:
@@ -207,7 +204,7 @@ let router = McpRouter::new()
 
 ## Security Considerations
 
-- Use `--read-only` mode in production to prevent accidental modifications
-- For HTTP transport, always enable OAuth in production environments
+- Keep the default read-only mode unless write tools are explicitly required
+- Keep HTTP bound to loopback or protect it with an authenticating gateway
 - Store credentials using environment variables or secure credential storage
 - The server respects profile-based credential isolation

--- a/crates/redisctl-mcp/src/main.rs
+++ b/crates/redisctl-mcp/src/main.rs
@@ -12,26 +12,20 @@ use clap::{Parser, ValueEnum};
 use redisctl_core::Config;
 #[cfg(any(feature = "cloud", feature = "enterprise", feature = "database"))]
 use redisctl_core::DeploymentType;
+use redisctl_mcp::{
+    audit::{self, AuditLayer},
+    policy::{self, Policy, PolicyConfig, SafetyTier, ToolsetKind},
+    presets::{self, ToolVisibility, ToolsConfig},
+    prompts,
+    state::{AppState, CredentialSource},
+    tools,
+};
 use tower_mcp::{
     CapabilityFilter, DenialBehavior, DynamicPromptRegistry, McpRouter, PromptBuilder, Tool,
     transport::StdioTransport,
 };
 use tracing::info;
 use tracing_subscriber::{EnvFilter, fmt, prelude::*};
-
-mod audit;
-mod policy;
-mod presets;
-mod prompts;
-mod resources;
-mod serde_helpers;
-mod state;
-mod tools;
-
-use audit::AuditLayer;
-use policy::{Policy, PolicyConfig, SafetyTier, ToolsetKind};
-use presets::{ToolVisibility, ToolsConfig};
-use state::{AppState, CredentialSource};
 
 /// Transport mode for the MCP server
 #[derive(Debug, Clone, Copy, Default, ValueEnum)]
@@ -130,13 +124,13 @@ impl EnabledToolsets {
     }
 
     /// Check whether a toolset is enabled (with any selection).
-    #[allow(dead_code)]
+    #[cfg(test)]
     fn contains(&self, toolset: &Toolset) -> bool {
         self.selections.contains_key(toolset)
     }
 
     /// Get the sub-module selection for a toolset.
-    #[allow(dead_code)]
+    #[cfg(test)]
     fn selection(&self, toolset: &Toolset) -> Option<&SubModuleSelection> {
         self.selections.get(toolset)
     }
@@ -827,10 +821,10 @@ fn build_router(
     }
 
     // Register built-in prompts
-    prompt_registry.register(crate::prompts::troubleshoot_database_prompt());
-    prompt_registry.register(crate::prompts::analyze_performance_prompt());
-    prompt_registry.register(crate::prompts::capacity_planning_prompt());
-    prompt_registry.register(crate::prompts::migration_planning_prompt());
+    prompt_registry.register(prompts::troubleshoot_database_prompt());
+    prompt_registry.register(prompts::analyze_performance_prompt());
+    prompt_registry.register(prompts::capacity_planning_prompt());
+    prompt_registry.register(prompts::migration_planning_prompt());
 
     // Load skills as dynamic prompts
     if let Some(dir) = skills_dir {
@@ -884,8 +878,9 @@ fn build_router(
     }
 
     let suffix = "\n## Authentication\n\n\
-         In stdio mode, credentials are resolved from redisctl profiles.\n\
-         In HTTP mode with OAuth, credentials can be passed via JWT claims.";
+         Credentials are resolved from redisctl profiles in both transport modes.\n\
+         HTTP transport does not authenticate clients; keep it on loopback or place it \
+         behind a trusted gateway that provides authentication, authorization, and TLS.";
 
     router = router.auto_instructions_with(Some(prefix), Some(suffix));
 
@@ -1004,7 +999,7 @@ mod tests {
     fn test_state() -> Arc<AppState> {
         Arc::new(
             AppState::new(
-                state::CredentialSource::Profiles(vec![]),
+                CredentialSource::Profiles(vec![]),
                 AppState::test_policy(),
                 None,
                 false,

--- a/crates/redisctl-mcp/src/state.rs
+++ b/crates/redisctl-mcp/src/state.rs
@@ -1,5 +1,6 @@
 //! Application state and credential resolution
 
+#[cfg(any(feature = "cloud", feature = "enterprise", feature = "database"))]
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -11,13 +12,13 @@ use redis_cloud::CloudClient;
 #[cfg(feature = "enterprise")]
 use redis_enterprise::EnterpriseClient;
 use redisctl_core::Config;
+#[cfg(any(feature = "cloud", feature = "enterprise", feature = "database"))]
 use tokio::sync::RwLock;
 
 use crate::policy::{Policy, SafetyTier};
 
 /// How credentials are resolved
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub enum CredentialSource {
     /// Resolve from redisctl profiles (local mode)
     /// Empty vec means use default profiles from config
@@ -25,6 +26,7 @@ pub enum CredentialSource {
 }
 
 /// Cached API clients and connections (per-profile for multi-cluster support)
+#[cfg(any(feature = "cloud", feature = "enterprise", feature = "database"))]
 pub struct CachedClients {
     #[cfg(feature = "cloud")]
     pub cloud: HashMap<String, CloudClient>,
@@ -51,7 +53,7 @@ pub struct AppState {
     /// Configured profiles (for multi-cluster support)
     profiles: Vec<String>,
     /// Cached API clients (keyed by profile name, "_default" for default)
-    #[allow(dead_code)]
+    #[cfg(any(feature = "cloud", feature = "enterprise", feature = "database"))]
     clients: RwLock<CachedClients>,
     /// Session-scoped command aliases (name → list of command arg arrays)
     #[cfg(feature = "database")]
@@ -82,6 +84,7 @@ impl AppState {
             client_name,
             config,
             profiles,
+            #[cfg(any(feature = "cloud", feature = "enterprise", feature = "database"))]
             clients: RwLock::new(CachedClients {
                 #[cfg(feature = "cloud")]
                 cloud: HashMap::new(),
@@ -96,7 +99,6 @@ impl AppState {
     }
 
     /// Get the list of configured profiles
-    #[allow(dead_code)]
     pub fn available_profiles(&self) -> &[String] {
         &self.profiles
     }
@@ -130,7 +132,6 @@ impl AppState {
 
     /// Get or create Cloud API client (uses default profile)
     #[cfg(feature = "cloud")]
-    #[allow(dead_code)]
     pub async fn cloud_client(&self) -> Result<CloudClient> {
         self.cloud_client_for_profile(None).await
     }
@@ -167,7 +168,6 @@ impl AppState {
 
     /// Get or create Enterprise API client (uses default profile)
     #[cfg(feature = "enterprise")]
-    #[allow(dead_code)]
     pub async fn enterprise_client(&self) -> Result<EnterpriseClient> {
         self.enterprise_client_for_profile(None).await
     }
@@ -393,7 +393,6 @@ impl AppState {
     ///
     /// Returns `true` for `ReadWrite` and `Full` tiers.
     /// Used for defense-in-depth in non-destructive write tool handlers.
-    #[allow(dead_code)]
     pub fn is_write_allowed(&self) -> bool {
         matches!(
             self.policy.global_tier(),
@@ -405,7 +404,6 @@ impl AppState {
     ///
     /// Returns `true` only for `Full` tier.
     /// Used for defense-in-depth in destructive tool handlers.
-    #[allow(dead_code)]
     pub fn is_destructive_allowed(&self) -> bool {
         matches!(self.policy.global_tier(), SafetyTier::Full)
     }
@@ -452,6 +450,7 @@ impl Clone for AppState {
             client_name: self.client_name.clone(),
             config: self.config.clone(),
             profiles: self.profiles.clone(),
+            #[cfg(any(feature = "cloud", feature = "enterprise", feature = "database"))]
             clients: RwLock::new(CachedClients {
                 #[cfg(feature = "cloud")]
                 cloud: HashMap::new(),
@@ -467,7 +466,6 @@ impl Clone for AppState {
 }
 
 /// Test helpers for creating AppState with pre-configured clients
-#[allow(dead_code)]
 impl AppState {
     /// Create a default read-only policy for tests
     pub fn test_policy() -> Arc<Policy> {

--- a/crates/redisctl-mcp/src/tools/macros.rs
+++ b/crates/redisctl-mcp/src/tools/macros.rs
@@ -31,6 +31,7 @@
 ///     }
 /// );
 /// ```
+#[cfg(feature = "database")]
 macro_rules! database_tool {
     // --- Permission guard dispatch ---
 
@@ -162,6 +163,7 @@ macro_rules! database_tool {
         database_tool!(@impl_stateful destructive, destructive_guard, $($rest)*);
     };
 }
+#[cfg(feature = "database")]
 pub(crate) use database_tool;
 
 /// Define an MCP tool for Redis Cloud API operations.
@@ -374,6 +376,7 @@ pub(crate) use enterprise_tool;
 ///         .tool(dbsize(state.clone()))
 /// }
 /// ```
+#[cfg(any(feature = "cloud", feature = "enterprise", feature = "database"))]
 macro_rules! mcp_module {
     { $( $fn_name:ident => $tool_name:literal ),* $(,)? } => {
         pub(super) const TOOL_NAMES: &[&str] = &[$($tool_name),*];
@@ -386,4 +389,5 @@ macro_rules! mcp_module {
         }
     };
 }
+#[cfg(any(feature = "cloud", feature = "enterprise", feature = "database"))]
 pub(crate) use mcp_module;

--- a/crates/redisctl/Cargo.toml
+++ b/crates/redisctl/Cargo.toml
@@ -39,7 +39,7 @@ rpassword = { workspace = true }
 urlencoding = { workspace = true }
 dialoguer = "0.11"
 colored = "2.1"
-tabled = { version = "0.17", features = ["ansi"] }
+tabled = { version = "0.21", features = ["ansi"] }
 terminal_size = "0.4"
 indicatif = "0.18"
 unicode-segmentation = "1.12"
@@ -88,7 +88,7 @@ tokio = { workspace = true }
 serde_json = { workspace = true }
 redis = { workspace = true }
 # Using git until testing feature is released
-docker-wrapper = { git = "https://github.com/joshrotenberg/docker-wrapper", features = ["testing", "template-redis"] }
+docker-wrapper = { git = "https://github.com/joshrotenberg/docker-wrapper", rev = "e122332360311e4acf4914ab4b8c97bc84b30ac1", features = ["testing", "template-redis"] }
 
 [[bench]]
 name = "api_performance"

--- a/crates/redisctl/src/commands/api.rs
+++ b/crates/redisctl/src/commands/api.rs
@@ -2,7 +2,7 @@
 
 use crate::cli::{HttpMethod, OutputFormat};
 use crate::connection::ConnectionManager;
-use crate::error::Result as CliResult;
+use crate::error::{RedisCtlError, Result as CliResult};
 use crate::output::print_output;
 use anyhow::Context;
 use redisctl_core::{Config, DeploymentType};
@@ -53,14 +53,14 @@ pub async fn handle_api_command(params: ApiCommandParams) -> CliResult<()> {
             )
             .await
         }
-        DeploymentType::Database => Err(anyhow::anyhow!(
-            "Raw API access is not supported for database profiles. Database profiles are for direct Redis connections."
-        ).into()),
+        DeploymentType::Database => Err(RedisCtlError::UnsupportedDeploymentType {
+            deployment_type: "database".to_string(),
+        }),
     }
 }
 
 /// Handle Cloud API calls
-#[allow(dead_code, clippy::too_many_arguments)] // Used by binary target
+#[allow(clippy::too_many_arguments)]
 async fn handle_cloud_api(
     connection_manager: ConnectionManager,
     profile_name: Option<&str>,
@@ -132,7 +132,7 @@ async fn handle_cloud_api(
 }
 
 /// Handle Enterprise API calls
-#[allow(dead_code, clippy::too_many_arguments)] // Used by binary target
+#[allow(clippy::too_many_arguments)]
 async fn handle_enterprise_api(
     connection_manager: ConnectionManager,
     profile_name: Option<&str>,

--- a/crates/redisctl/src/commands/curl.rs
+++ b/crates/redisctl/src/commands/curl.rs
@@ -21,6 +21,7 @@ pub fn format_cloud_curl(
 
     parts.push(format!("'{}{}'", info.base_url, path));
     parts.push("-H 'Accept: application/json'".to_string());
+    parts.push(format!("-H 'User-Agent: {}'", info.user_agent));
     parts.push("-H 'x-api-key: <REDACTED>'".to_string());
     parts.push("-H 'x-api-secret-key: <REDACTED>'".to_string());
 
@@ -51,6 +52,7 @@ pub fn format_enterprise_curl(
 
     parts.push(format!("'{}{}'", info.base_url, path));
     parts.push("-H 'Accept: application/json'".to_string());
+    parts.push(format!("-H 'User-Agent: {}'", info.user_agent));
     parts.push("-u '<REDACTED>:<REDACTED>'".to_string());
 
     if let Some(ref ca_cert_path) = info.ca_cert {
@@ -73,8 +75,6 @@ mod tests {
     fn cloud_get_no_body() {
         let info = CloudConnectionInfo {
             base_url: "https://api.redislabs.com/v1".to_string(),
-            api_key: "test-key".to_string(),
-            api_secret: "test-secret".to_string(),
             user_agent: "redisctl/test".to_string(),
         };
         let result = format_cloud_curl(&info, &HttpMethod::Get, "/subscriptions", None);
@@ -83,6 +83,7 @@ mod tests {
         assert!(result.contains("'https://api.redislabs.com/v1/subscriptions'"));
         assert!(result.contains("x-api-key: <REDACTED>"));
         assert!(result.contains("x-api-secret-key: <REDACTED>"));
+        assert!(result.contains("User-Agent: redisctl/test"));
         assert!(!result.contains("-d "));
         assert!(!result.contains("Content-Type"));
     }
@@ -91,8 +92,6 @@ mod tests {
     fn cloud_post_with_body() {
         let info = CloudConnectionInfo {
             base_url: "https://api.redislabs.com/v1".to_string(),
-            api_key: "test-key".to_string(),
-            api_secret: "test-secret".to_string(),
             user_agent: "redisctl/test".to_string(),
         };
         let body = serde_json::json!({"name": "test"});
@@ -106,8 +105,6 @@ mod tests {
     fn enterprise_get_insecure() {
         let info = EnterpriseConnectionInfo {
             base_url: "https://cluster:9443".to_string(),
-            username: "admin".to_string(),
-            password: Some("pass".to_string()),
             insecure: true,
             ca_cert: None,
             user_agent: "redisctl/test".to_string(),
@@ -117,6 +114,7 @@ mod tests {
         assert!(result.contains("-X GET"));
         assert!(result.contains("'https://cluster:9443/v1/cluster'"));
         assert!(result.contains("-u '<REDACTED>:<REDACTED>'"));
+        assert!(result.contains("User-Agent: redisctl/test"));
         assert!(!result.contains("--cacert"));
     }
 
@@ -124,8 +122,6 @@ mod tests {
     fn enterprise_with_ca_cert() {
         let info = EnterpriseConnectionInfo {
             base_url: "https://cluster:9443".to_string(),
-            username: "admin".to_string(),
-            password: Some("pass".to_string()),
             insecure: false,
             ca_cert: Some("/path/to/ca.crt".to_string()),
             user_agent: "redisctl/test".to_string(),
@@ -139,8 +135,6 @@ mod tests {
     fn enterprise_post_with_body() {
         let info = EnterpriseConnectionInfo {
             base_url: "https://cluster:9443".to_string(),
-            username: "admin".to_string(),
-            password: None,
             insecure: true,
             ca_cert: None,
             user_agent: "redisctl/test".to_string(),

--- a/crates/redisctl/src/commands/enterprise/support_package.rs
+++ b/crates/redisctl/src/commands/enterprise/support_package.rs
@@ -548,7 +548,19 @@ async fn generate_cluster_package(
     // Output based on format
     match output_format {
         OutputFormat::Json => {
-            let mut result = SupportPackageResult {
+            #[cfg(feature = "upload")]
+            let message = if uploaded_path.is_some() {
+                format!(
+                    "Support package {} and uploaded to Files.com",
+                    if should_save { "created" } else { "uploaded" }
+                )
+            } else {
+                "Support package created successfully".to_string()
+            };
+            #[cfg(not(feature = "upload"))]
+            let message = "Support package created successfully".to_string();
+
+            let result = SupportPackageResult {
                 success: true,
                 package_type: "cluster".to_string(),
                 file_path: output_path.display().to_string(),
@@ -557,17 +569,9 @@ async fn generate_cluster_package(
                 elapsed_seconds: elapsed.as_secs(),
                 cluster_name,
                 cluster_version,
-                message: "Support package created successfully".to_string(),
+                message,
                 timestamp: chrono::Utc::now().to_rfc3339(),
             };
-
-            #[cfg(feature = "upload")]
-            if uploaded_path.is_some() {
-                result.message = format!(
-                    "Support package {} and uploaded to Files.com",
-                    if should_save { "created" } else { "uploaded" }
-                );
-            }
 
             println!("{}", serde_json::to_string_pretty(&result)?);
         }
@@ -747,7 +751,19 @@ async fn generate_database_package(
     // Output based on format
     match output_format {
         OutputFormat::Json => {
-            let mut result = SupportPackageResult {
+            #[cfg(feature = "upload")]
+            let message = if uploaded_path.is_some() {
+                format!(
+                    "Database support package {} and uploaded to Files.com",
+                    if should_save { "created" } else { "uploaded" }
+                )
+            } else {
+                "Database support package created successfully".to_string()
+            };
+            #[cfg(not(feature = "upload"))]
+            let message = "Database support package created successfully".to_string();
+
+            let result = SupportPackageResult {
                 success: true,
                 package_type: format!("database-{}", uid),
                 file_path: output_path.display().to_string(),
@@ -756,17 +772,9 @@ async fn generate_database_package(
                 elapsed_seconds: elapsed.as_secs(),
                 cluster_name: Some(format!("Database {}", uid)),
                 cluster_version: database_name,
-                message: "Database support package created successfully".to_string(),
+                message,
                 timestamp: chrono::Utc::now().to_rfc3339(),
             };
-
-            #[cfg(feature = "upload")]
-            if uploaded_path.is_some() {
-                result.message = format!(
-                    "Database support package {} and uploaded to Files.com",
-                    if should_save { "created" } else { "uploaded" }
-                );
-            }
 
             println!("{}", serde_json::to_string_pretty(&result)?);
         }
@@ -976,7 +984,26 @@ async fn generate_node_package(
                 "nodes".to_string()
             };
 
-            let mut result = SupportPackageResult {
+            #[cfg(feature = "upload")]
+            let message = if uploaded_path.is_some() {
+                format!(
+                    "{} support package {} and uploaded to Files.com",
+                    if uid.is_some() { "Node" } else { "Nodes" },
+                    if should_save { "created" } else { "uploaded" }
+                )
+            } else if uid.is_some() {
+                "Node support package created successfully".to_string()
+            } else {
+                "Nodes support package created successfully".to_string()
+            };
+            #[cfg(not(feature = "upload"))]
+            let message = if uid.is_some() {
+                "Node support package created successfully".to_string()
+            } else {
+                "Nodes support package created successfully".to_string()
+            };
+
+            let result = SupportPackageResult {
                 success: true,
                 package_type,
                 file_path: output_path.display().to_string(),
@@ -985,22 +1012,9 @@ async fn generate_node_package(
                 elapsed_seconds: elapsed.as_secs(),
                 cluster_name: uid.map(|id| format!("Node {}", id)),
                 cluster_version: node_address,
-                message: if uid.is_some() {
-                    "Node support package created successfully".to_string()
-                } else {
-                    "Nodes support package created successfully".to_string()
-                },
+                message,
                 timestamp: chrono::Utc::now().to_rfc3339(),
             };
-
-            #[cfg(feature = "upload")]
-            if uploaded_path.is_some() {
-                result.message = format!(
-                    "{} support package {} and uploaded to Files.com",
-                    if uid.is_some() { "Node" } else { "Nodes" },
-                    if should_save { "created" } else { "uploaded" }
-                );
-            }
 
             println!("{}", serde_json::to_string_pretty(&result)?);
         }

--- a/crates/redisctl/src/connection.rs
+++ b/crates/redisctl/src/connection.rs
@@ -1,6 +1,6 @@
 //! Connection management for Redis Cloud and Enterprise clients
 
-use crate::error::Result as CliResult;
+use crate::error::{RedisCtlError, Result as CliResult};
 use anyhow::Context;
 use redisctl_core::{Config, DeploymentType};
 use tracing::{debug, info, trace};
@@ -9,25 +9,14 @@ use tracing::{debug, info, trace};
 const REDISCTL_USER_AGENT: &str = concat!("redisctl/", env!("CARGO_PKG_VERSION"));
 
 /// Resolved Cloud connection details (without creating an HTTP client)
-// The credential fields are populated but not yet read by the curl builder in
-// commands/curl.rs, so `api ... --curl` output omits its auth headers. Kept
-// pending that fix (see #1049); do not delete the fields without fixing curl.
-#[allow(dead_code)]
 pub struct CloudConnectionInfo {
     pub base_url: String,
-    pub api_key: String,
-    pub api_secret: String,
     pub user_agent: String,
 }
 
 /// Resolved Enterprise connection details (without creating an HTTP client)
-// See CloudConnectionInfo: credential fields populated but not read by the curl
-// builder, so `api ... --curl` output omits auth. Kept pending fix (see #1049).
-#[allow(dead_code)]
 pub struct EnterpriseConnectionInfo {
     pub base_url: String,
-    pub username: String,
-    pub password: Option<String>,
     pub insecure: bool,
     pub ca_cert: Option<String>,
     pub user_agent: String,
@@ -65,11 +54,9 @@ impl ConnectionManager {
         &self,
         profile_name: Option<&str>,
     ) -> CliResult<CloudConnectionInfo> {
-        let (api_key, api_secret, base_url) = self.resolve_cloud_credentials(profile_name)?;
+        let (_, _, base_url) = self.resolve_cloud_credentials(profile_name)?;
         Ok(CloudConnectionInfo {
             base_url,
-            api_key,
-            api_secret,
             user_agent: REDISCTL_USER_AGENT.to_string(),
         })
     }
@@ -196,8 +183,11 @@ impl ConnectionManager {
             // Use the new resolve method which handles keyring lookup
             let (api_key, api_secret, api_url) = profile
                 .resolve_cloud_credentials()
-                .context("Failed to resolve Cloud credentials")?
-                .context("Profile is not configured for Redis Cloud")?;
+                .map_err(RedisCtlError::from)?
+                .ok_or_else(|| RedisCtlError::MissingCredentials {
+                    name: resolved_profile_name.clone(),
+                    missing_fields: "api_key and api_secret".to_string(),
+                })?;
 
             // Check for partial overrides before consuming the Options
             let has_overrides =
@@ -226,12 +216,9 @@ impl ConnectionManager {
         &self,
         profile_name: Option<&str>,
     ) -> CliResult<EnterpriseConnectionInfo> {
-        let (url, username, password, insecure, ca_cert) =
-            self.resolve_enterprise_credentials(profile_name)?;
+        let (url, _, _, insecure, ca_cert) = self.resolve_enterprise_credentials(profile_name)?;
         Ok(EnterpriseConnectionInfo {
             base_url: url,
-            username,
-            password,
             insecure,
             ca_cert,
             user_agent: REDISCTL_USER_AGENT.to_string(),
@@ -411,8 +398,11 @@ impl ConnectionManager {
             // Use the new resolve method which handles keyring lookup
             let (url, username, password, insecure, profile_ca_cert) = profile
                 .resolve_enterprise_credentials()
-                .context("Failed to resolve Enterprise credentials")?
-                .context("Profile is not configured for Redis Enterprise")?;
+                .map_err(RedisCtlError::from)?
+                .ok_or_else(|| RedisCtlError::MissingCredentials {
+                    name: resolved_profile_name.clone(),
+                    missing_fields: "url and username".to_string(),
+                })?;
 
             // Check for partial overrides before consuming the Options
             let has_overrides = env_url.is_some()

--- a/crates/redisctl/src/error.rs
+++ b/crates/redisctl/src/error.rs
@@ -120,14 +120,12 @@ pub enum RedisCtlError {
         available_profiles: Vec<String>,
     },
 
-    // Intended error types that no code path constructs yet: the CLI currently
-    // reports these conditions with generic errors instead. Kept (with their
-    // messages and suggestions) to be wired up rather than cut; see #1049.
-    #[allow(dead_code)]
-    #[error("No profile configured. Use 'redisctl profile set' to configure a profile.")]
-    NoProfileConfigured,
+    #[error("No {deployment_type} profiles configured. {suggestion}")]
+    NoProfileConfigured {
+        deployment_type: String,
+        suggestion: String,
+    },
 
-    #[allow(dead_code)]
     #[error("Missing credentials for profile '{name}': {missing_fields}")]
     MissingCredentials {
         name: String,
@@ -149,7 +147,6 @@ pub enum RedisCtlError {
     #[error("Cancelled at the confirmation prompt: {prompt}")]
     Cancelled { prompt: String },
 
-    #[allow(dead_code)] // intended but not yet produced by any code path; see #1049
     #[error("Command not supported for deployment type '{deployment_type}'")]
     UnsupportedDeploymentType { deployment_type: String },
     #[error("File error for '{path}': {message}")]
@@ -177,9 +174,13 @@ impl RedisCtlError {
                 format!("Create profile '{}': redisctl profile set {}", name, name),
                 format!("Check profile name spelling"),
             ],
-            RedisCtlError::NoProfileConfigured => vec![
+            RedisCtlError::NoProfileConfigured {
+                deployment_type, ..
+            } => vec![
                 "Run the setup wizard: redisctl profile init".to_string(),
-                "Or create manually: redisctl profile set <name> --type <cloud|enterprise|database> ...".to_string(),
+                format!(
+                    "Or create manually: redisctl profile set <name> --type {deployment_type} ..."
+                ),
                 "View profile help: redisctl profile set --help".to_string(),
             ],
             RedisCtlError::MissingCredentials { name, .. } => vec![
@@ -199,21 +200,30 @@ impl RedisCtlError {
                     "Refresh credentials: redisctl profile set {} --type <type> ... (preserves other settings)",
                     profile_name,
                 ));
-                suggestions.push(
-                    "Test connectivity: redisctl profile validate --connect".to_string(),
-                );
+                suggestions
+                    .push("Test connectivity: redisctl profile validate --connect".to_string());
                 suggestions
             }
-            RedisCtlError::ConnectionError { message } if message.contains("certificate") || message.contains("SSL") || message.contains("tls") => vec![
-                "For self-signed certificates, recreate profile with --insecure".to_string(),
-                "Or provide a CA cert: --ca-cert /path/to/ca.pem".to_string(),
-                "Verify the URL uses the correct port (9443 for Enterprise admin)".to_string(),
-            ],
-            RedisCtlError::ConnectionError { message } if message.contains("Connection refused") => vec![
-                "The server is not accepting connections on this address/port".to_string(),
-                "Verify the URL: redisctl profile show <profile>".to_string(),
-                "Check that the server is running and the port is correct".to_string(),
-            ],
+            RedisCtlError::ConnectionError { message }
+                if message.contains("certificate")
+                    || message.contains("SSL")
+                    || message.contains("tls") =>
+            {
+                vec![
+                    "For self-signed certificates, recreate profile with --insecure".to_string(),
+                    "Or provide a CA cert: --ca-cert /path/to/ca.pem".to_string(),
+                    "Verify the URL uses the correct port (9443 for Enterprise admin)".to_string(),
+                ]
+            }
+            RedisCtlError::ConnectionError { message }
+                if message.contains("Connection refused") =>
+            {
+                vec![
+                    "The server is not accepting connections on this address/port".to_string(),
+                    "Verify the URL: redisctl profile show <profile>".to_string(),
+                    "Check that the server is running and the port is correct".to_string(),
+                ]
+            }
             RedisCtlError::ConnectionError { message } if message.contains("timed out") => vec![
                 "The server did not respond in time".to_string(),
                 "Check network connectivity and firewall rules".to_string(),
@@ -289,7 +299,7 @@ impl RedisCtlError {
             RedisCtlError::Other(_) => "error",
             RedisCtlError::ProfileNotFound { .. } => "profile_not_found",
             RedisCtlError::ProfileTypeMismatch { .. } => "profile_type_mismatch",
-            RedisCtlError::NoProfileConfigured => "no_profile_configured",
+            RedisCtlError::NoProfileConfigured { .. } => "no_profile_configured",
             RedisCtlError::MissingCredentials { .. } => "missing_credentials",
             RedisCtlError::AuthenticationFailed { .. } => "authentication_failed",
             RedisCtlError::ApiError { .. } => "api_error",
@@ -315,7 +325,7 @@ impl RedisCtlError {
             RedisCtlError::Configuration(_)
             | RedisCtlError::ProfileNotFound { .. }
             | RedisCtlError::ProfileTypeMismatch { .. }
-            | RedisCtlError::NoProfileConfigured
+            | RedisCtlError::NoProfileConfigured { .. }
             | RedisCtlError::MissingCredentials { .. } => exit_code::CONFIG,
 
             RedisCtlError::AuthenticationFailed { .. } => exit_code::AUTH,
@@ -487,7 +497,19 @@ impl From<anyhow::Error> for RedisCtlError {
 
 impl From<redisctl_core::ConfigError> for RedisCtlError {
     fn from(err: redisctl_core::ConfigError) -> Self {
-        RedisCtlError::Configuration(err.to_string())
+        match err {
+            redisctl_core::ConfigError::ProfileNotFound { name } => {
+                RedisCtlError::ProfileNotFound { name }
+            }
+            redisctl_core::ConfigError::NoProfilesOfType {
+                deployment_type,
+                suggestion,
+            } => RedisCtlError::NoProfileConfigured {
+                deployment_type,
+                suggestion,
+            },
+            other => RedisCtlError::Configuration(other.to_string()),
+        }
     }
 }
 
@@ -619,7 +641,10 @@ mod tests {
     #[test]
     fn classified_variants_do_not_return_generic() {
         for err in [
-            RedisCtlError::NoProfileConfigured,
+            RedisCtlError::NoProfileConfigured {
+                deployment_type: "cloud".into(),
+                suggestion: "create one".into(),
+            },
             RedisCtlError::MissingCredentials {
                 name: "p".into(),
                 missing_fields: "api_key".into(),
@@ -631,5 +656,28 @@ mod tests {
         ] {
             assert_ne!(err.exit_code(), exit_code::GENERIC, "{err}");
         }
+    }
+
+    #[test]
+    fn config_errors_keep_actionable_profile_types() {
+        let missing = RedisCtlError::from(redisctl_core::ConfigError::ProfileNotFound {
+            name: "missing".into(),
+        });
+        assert!(matches!(
+            missing,
+            RedisCtlError::ProfileNotFound { ref name } if name == "missing"
+        ));
+
+        let empty = RedisCtlError::from(redisctl_core::ConfigError::NoProfilesOfType {
+            deployment_type: "cloud".into(),
+            suggestion: "create one".into(),
+        });
+        assert!(matches!(
+            empty,
+            RedisCtlError::NoProfileConfigured {
+                ref deployment_type,
+                ref suggestion,
+            } if deployment_type == "cloud" && suggestion == "create one"
+        ));
     }
 }

--- a/deny.toml
+++ b/deny.toml
@@ -69,4 +69,6 @@ skip = [
 unknown-registry = "warn"
 unknown-git = "warn"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-allow-git = []
+# Development-only integration test helper. Keep this explicit so new git
+# dependencies continue to be surfaced by cargo-deny.
+allow-git = ["https://github.com/joshrotenberg/docker-wrapper"]

--- a/docs/docs/mcp/architecture.md
+++ b/docs/docs/mcp/architecture.md
@@ -22,7 +22,7 @@ redisctl-mcp
     |       +-- Database tools -> redis crate -> Redis protocol
     |       +-- App tools -> redisctl-core -> local config
     |
-    +-- Credential resolution (profiles or OAuth)
+    +-- Credential resolution (profiles or direct database URL)
 ```
 
 ## Feature Flags
@@ -34,7 +34,7 @@ The binary is compiled with feature flags that gate platform-specific dependenci
 | `cloud` | yes | `redis-cloud` crate + cloud toolset |
 | `enterprise` | yes | `redis-enterprise` crate + enterprise toolset |
 | `database` | yes | `redis` crate + database toolset |
-| `http` | yes | HTTP/SSE transport with optional OAuth |
+| `http` | yes | Unauthenticated HTTP/SSE transport |
 
 Profile/app tools and the two system tools are always compiled in (they only depend on `redisctl-core`).
 
@@ -102,14 +102,10 @@ HTTP transport with Server-Sent Events for streaming. Useful for shared deployme
 redisctl-mcp --transport http --host 0.0.0.0 --port 8080
 ```
 
-Optional OAuth authentication protects the HTTP endpoint:
-
-```bash
-redisctl-mcp --transport http --oauth \
-  --oauth-issuer https://auth.example.com \
-  --oauth-audience my-audience \
-  --jwks-uri https://auth.example.com/.well-known/jwks.json
-```
+The HTTP transport does not provide built-in authentication. Keep the default
+loopback bind for local use. Shared deployments must put the server behind a
+trusted gateway or reverse proxy that provides authentication, authorization,
+and TLS.
 
 ## Credential Resolution
 
@@ -122,10 +118,6 @@ Credentials are resolved at tool invocation time, not at server startup. This al
 3. If no CLI profile, fall back to the default profile from `~/.config/redisctl/config.toml`
 4. Resolve credentials from the profile (including keyring lookups)
 5. Build or reuse a cached API client for that profile
-
-### OAuth-based (HTTP mode)
-
-In HTTP mode with OAuth enabled, credentials come from environment variables (`REDIS_CLOUD_API_KEY`, `REDIS_ENTERPRISE_URL`, etc.) rather than profiles.
 
 ## Policy Engine
 
@@ -141,12 +133,11 @@ The evaluation flow:
 
 A tower middleware (`AuditLayer`) sits between the transport and the tool router. It intercepts every tool call and emits structured events via the `tracing` crate with `target: "audit"`. See [Audit Logging](audit-logging.md) for configuration details.
 
-## Concurrency and Rate Limiting
+## Concurrency and Timeouts
 
-The server enforces concurrency and rate limits via CLI flags:
+The server bounds request concurrency and HTTP request duration via CLI flags:
 
 - `--max-concurrent 10` -- maximum parallel tool calls (default: 10)
-- `--rate-limit-ms 100` -- minimum interval between calls in milliseconds (default: 100)
 - `--request-timeout-secs 30` -- per-request timeout for HTTP transport (default: 30)
 
 ## Request Flow

--- a/docs/docs/mcp/configuration.md
+++ b/docs/docs/mcp/configuration.md
@@ -17,17 +17,21 @@ This page covers all three, with emphasis on `--tools` for controlling the tool 
 | `--read-only` | -- | -- | `true` | Read-only mode; use `--read-only=false` for writes. Ignored when a policy file is active |
 | `--policy` | -- | `REDISCTL_MCP_POLICY` | -- | Path to TOML policy file for granular access control. Overrides `--read-only` |
 | `--database-url` | -- | `REDIS_URL` | -- | Redis URL for direct database connections |
+| `--cluster` | -- | `REDIS_CLUSTER` | `false` | Enable Redis Cluster mode for direct database connections |
+| `--client-name` | -- | `REDIS_CLIENT_NAME` | `redisctl-mcp` | Client name shown in Redis `CLIENT LIST` |
 | `--tools` | -- | -- | -- | Comma-delimited toolset/sub-module selection (see below) |
+| `--skills-dir` | -- | `REDISCTL_MCP_SKILLS_DIR` | -- | Directory containing Agent Skills to expose as MCP prompts |
 | `--host` | -- | -- | `127.0.0.1` | HTTP bind host (HTTP transport only) |
 | `--port` | -- | -- | `8080` | HTTP bind port (HTTP transport only) |
-| `--oauth` | -- | -- | `false` | Enable OAuth authentication (HTTP transport only) |
-| `--oauth-issuer` | -- | `OAUTH_ISSUER` | -- | OAuth issuer URL |
-| `--oauth-audience` | -- | `OAUTH_AUDIENCE` | -- | OAuth audience |
-| `--jwks-uri` | -- | `OAUTH_JWKS_URI` | -- | JWKS URI for token validation |
 | `--max-concurrent` | -- | -- | `10` | Maximum concurrent requests |
-| `--rate-limit-ms` | -- | -- | `100` | Rate limit interval in milliseconds |
 | `--request-timeout-secs` | -- | -- | `30` | Request timeout in seconds (HTTP transport only) |
 | `--log-level` | -- | `RUST_LOG` | `info` | Log level |
+
+!!! warning "HTTP transport does not provide built-in authentication"
+    Keep the default loopback bind unless the server is protected by a trusted
+    gateway or reverse proxy that provides authentication, authorization, and
+    TLS. Do not expose an unprotected `redisctl-mcp` HTTP endpoint to an
+    untrusted network.
 
 ## The `--tools` Flag
 

--- a/docs/docs/presentation/slides.html
+++ b/docs/docs/presentation/slides.html
@@ -101,7 +101,7 @@
                     </h1>
                     <h3>The CLI for Redis Cloud and Enterprise</h3>
                     <p class="small" style="margin-top: 2em">
-                        github.com/redis-developer/redisctl
+                        github.com/redis/redisctl
                     </p>
                 </section>
 
@@ -596,19 +596,19 @@ redisctl-mcp --profile my-cluster</code></pre>
                     <h2>Using with Docker</h2>
                     <p>No installation required</p>
                     <pre><code class="language-bash"># Run any command
-docker run --rm ghcr.io/redis-developer/redisctl \
+docker run --rm ghcr.io/redis/redisctl \
   cloud subscription list
 
 # With environment variables
 docker run --rm \
   -e REDIS_CLOUD_API_KEY=$KEY \
   -e REDIS_CLOUD_SECRET_KEY=$SECRET \
-  ghcr.io/redis-developer/redisctl cloud database list
+  ghcr.io/redis/redisctl cloud database list
 
 # Or mount your config
 docker run --rm \
   -v ~/.config/redisctl:/root/.config/redisctl \
-  ghcr.io/redis-developer/redisctl --profile prod cloud database list</code></pre>
+  ghcr.io/redis/redisctl --profile prod cloud database list</code></pre>
                 </section>
 
                 <!-- CI/CD -->
@@ -725,10 +725,10 @@ cargo install redisctl
 cargo install redisctl --features secure-storage
 
 # Docker
-docker run -it ghcr.io/redis-developer/redisctl --help
+docker run -it ghcr.io/redis/redisctl --help
 
 # From releases (Linux x86_64)
-curl -L https://github.com/redis-developer/redisctl/releases/latest/download/redisctl-x86_64-unknown-linux-gnu.tar.gz | tar xz
+curl -L https://github.com/redis/redisctl/releases/latest/download/redisctl-x86_64-unknown-linux-gnu.tar.gz | tar xz
 ./redisctl --help</code></pre>
                 </section>
 
@@ -745,7 +745,7 @@ redisctl profile set mycloud --type cloud --api-key $KEY --api-secret $SECRET
 redisctl cloud subscription list
 redisctl cloud database list --subscription-id 123456</code></pre>
                     <p style="margin-top: 1.5em"><br /></p>
-                    <h3>github.com/redis-developer/redisctl</h3>
+                    <h3>github.com/redis/redisctl</h3>
                     <p class="small">
                         Docs: redis-field-engineering.github.io/redisctl-docs
                     </p>

--- a/presentations/mcp-deep-dive/index.html
+++ b/presentations/mcp-deep-dive/index.html
@@ -141,8 +141,8 @@
         <ul>
           <li>Shared deployments</li>
           <li>Multi-agent access</li>
-          <li>OAuth support (JWT)</li>
-          <li><code>--host</code>, <code>--port</code>, rate limiting</li>
+          <li>Gateway-protected shared access</li>
+          <li><code>--host</code>, <code>--port</code>, concurrency limits</li>
         </ul>
       </div>
     </div>
@@ -168,7 +168,7 @@
     <div class="medium" style="text-align: left; max-width: 700px; margin: 0 auto;">
       <p><strong>Docker</strong></p>
       <pre><code>docker run -i --rm --network host \
-  ghcr.io/redis-developer/redisctl \
+  ghcr.io/redis/redisctl \
   redisctl-mcp --tools database</code></pre>
 
       <p><strong>Cargo</strong></p>
@@ -613,10 +613,10 @@ url = "redis://localhost:6379"
   <section>
     <h2>What's Next</h2>
     <div class="medium" style="text-align: left; max-width: 700px; margin: 0 auto;">
-      <p><span class="highlight-red">OAuth for HTTP mode</span> &mdash; shared deployments with auth</p>
+      <p><span class="highlight-red">HTTP deployment hardening</span> &mdash; formalize the authentication trust boundary</p>
       <p><span class="highlight-green">More skills</span> &mdash; data modeling, performance testing, tutorials</p>
       <p><span class="highlight-blue">redis/agent-skills integration</span> &mdash; unified skill ecosystem</p>
-      <p><span class="highlight-yellow">Audit logging</span> &mdash; track what agents do in production</p>
+      <p><span class="highlight-yellow">Coverage expansion</span> &mdash; exercise more live Cloud and Enterprise paths</p>
     </div>
   </section>
 </section>
@@ -627,7 +627,7 @@ url = "redis://localhost:6379"
 <section>
   <h1>Questions?</h1>
   <p class="medium" style="margin-top: 2em;">
-    <code>github.com/redis-developer/redisctl</code>
+    <code>github.com/redis/redisctl</code>
   </p>
 </section>
 


### PR DESCRIPTION
## Summary

- make the stable CI gate run for every pull request, including stacked and documentation-only changes
- pin GitHub Actions to immutable revisions, add automated updates, and make cargo-dist release generation reproducible
- remove stale MCP OAuth surface and documentation, tighten HTTP deployment guidance, and modernize project dependencies and maintenance metadata
- improve CLI error classification, credential handling, and secret-safe diagnostics

## Impact

This establishes a cleaner official-product baseline without changing the contributed Cloud onboarding work. The active `main` ruleset already requires the stable `CI Status` check added here.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo deny check`
- cargo-dist generation check and release plan
- actionlint and workflow YAML validation
- `mkdocs build --strict`

Closes #1038
Closes #1068
