### PR TITLE
fix(cli): standardize confirmation bypass flags

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,6 +178,8 @@ Scope by crate when relevant: `feat(mcp):`, `fix(core):`, `docs(cli):`.
 - No `unwrap()` in production code -- use proper error handling
 - Prefer `anyhow` for CLI errors, `tower_mcp::Error` for MCP tool errors
 - Tool descriptions are the primary documentation for MCP tools -- keep them accurate and concise
+- Use long-only `--force` for destructive confirmation bypasses; add new destructive command paths
+  to the command-tree test inventory in `crates/redisctl/src/main.rs`
 
 ### PRs
 

--- a/crates/redisctl/src/cli/cloud.rs
+++ b/crates/redisctl/src/cli/cloud.rs
@@ -275,8 +275,8 @@ pub enum PscCommands {
         /// Subscription ID
         subscription_id: i32,
         /// Skip confirmation prompt
-        #[arg(short, long)]
-        yes: bool,
+        #[arg(long, alias = "yes", short_alias = 'y')]
+        force: bool,
         #[command(flatten)]
         async_ops: crate::commands::cloud::async_utils::AsyncOperationArgs,
     },
@@ -394,8 +394,8 @@ pub enum PscCommands {
         /// Endpoint ID
         endpoint_id: i32,
         /// Skip confirmation prompt
-        #[arg(short, long)]
-        yes: bool,
+        #[arg(long, alias = "yes", short_alias = 'y')]
+        force: bool,
         #[command(flatten)]
         async_ops: crate::commands::cloud::async_utils::AsyncOperationArgs,
     },
@@ -449,8 +449,8 @@ pub enum PscCommands {
         /// Region ID
         region_id: i32,
         /// Skip confirmation prompt
-        #[arg(short, long)]
-        yes: bool,
+        #[arg(long, alias = "yes", short_alias = 'y')]
+        force: bool,
         #[command(flatten)]
         async_ops: crate::commands::cloud::async_utils::AsyncOperationArgs,
     },
@@ -530,8 +530,8 @@ pub enum PscCommands {
         /// Endpoint ID
         endpoint_id: i32,
         /// Skip confirmation prompt
-        #[arg(short, long)]
-        yes: bool,
+        #[arg(long, alias = "yes", short_alias = 'y')]
+        force: bool,
         #[command(flatten)]
         async_ops: crate::commands::cloud::async_utils::AsyncOperationArgs,
     },
@@ -636,8 +636,8 @@ pub enum TgwCommands {
         /// Attachment ID
         attachment_id: String,
         /// Skip confirmation prompt
-        #[arg(short, long)]
-        yes: bool,
+        #[arg(long, alias = "yes", short_alias = 'y')]
+        force: bool,
         #[command(flatten)]
         async_ops: crate::commands::cloud::async_utils::AsyncOperationArgs,
     },
@@ -762,8 +762,8 @@ pub enum TgwCommands {
         /// Attachment ID
         attachment_id: String,
         /// Skip confirmation prompt
-        #[arg(short, long)]
-        yes: bool,
+        #[arg(long, alias = "yes", short_alias = 'y')]
+        force: bool,
         #[command(flatten)]
         async_ops: crate::commands::cloud::async_utils::AsyncOperationArgs,
     },
@@ -1120,8 +1120,8 @@ pub enum CloudFixedDatabaseCommands {
         /// Database ID (format: subscription_id:database_id)
         id: String,
         /// Skip confirmation prompt
-        #[arg(short, long)]
-        yes: bool,
+        #[arg(long, alias = "yes", short_alias = 'y')]
+        force: bool,
         /// Async operation options
         #[command(flatten)]
         async_ops: crate::commands::cloud::async_utils::AsyncOperationArgs,
@@ -1434,8 +1434,8 @@ pub enum CloudFixedSubscriptionCommands {
         /// Subscription ID
         id: i32,
         /// Skip confirmation prompt
-        #[arg(short, long)]
-        yes: bool,
+        #[arg(long, alias = "yes", short_alias = 'y')]
+        force: bool,
         /// Async operation options
         #[command(flatten)]
         async_ops: crate::commands::cloud::async_utils::AsyncOperationArgs,

--- a/crates/redisctl/src/commands/cloud/connectivity/psc.rs
+++ b/crates/redisctl/src/commands/cloud/connectivity/psc.rs
@@ -58,7 +58,7 @@ pub async fn handle_psc_command(
         }
         PscCommands::ServiceDelete {
             subscription_id,
-            yes,
+            force,
             async_ops,
         } => {
             let params = ConnectivityOperationParams {
@@ -70,7 +70,7 @@ pub async fn handle_psc_command(
                 output_format,
                 query,
             };
-            delete_service(&params, *yes).await
+            delete_service(&params, *force).await
         }
 
         // Standard PSC Endpoint operations
@@ -150,7 +150,7 @@ pub async fn handle_psc_command(
             subscription_id,
             psc_service_id,
             endpoint_id,
-            yes,
+            force,
             async_ops,
         } => {
             let params = ConnectivityOperationParams {
@@ -162,7 +162,7 @@ pub async fn handle_psc_command(
                 output_format,
                 query,
             };
-            delete_endpoint(&params, *psc_service_id, *endpoint_id, *yes).await
+            delete_endpoint(&params, *psc_service_id, *endpoint_id, *force).await
         }
         PscCommands::EndpointCreationScript {
             subscription_id,
@@ -205,7 +205,7 @@ pub async fn handle_psc_command(
         PscCommands::AaServiceDelete {
             subscription_id,
             region_id,
-            yes,
+            force,
             async_ops,
         } => {
             let params = ConnectivityOperationParams {
@@ -217,7 +217,7 @@ pub async fn handle_psc_command(
                 output_format,
                 query,
             };
-            delete_service_aa(&params, *region_id, *yes).await
+            delete_service_aa(&params, *region_id, *force).await
         }
 
         // Active-Active PSC Endpoint operations
@@ -271,7 +271,7 @@ pub async fn handle_psc_command(
             region_id,
             psc_service_id,
             endpoint_id,
-            yes,
+            force,
             async_ops,
         } => {
             let params = ConnectivityOperationParams {
@@ -283,7 +283,7 @@ pub async fn handle_psc_command(
                 output_format,
                 query,
             };
-            delete_endpoint_aa(&params, *region_id, *psc_service_id, *endpoint_id, *yes).await
+            delete_endpoint_aa(&params, *region_id, *psc_service_id, *endpoint_id, *force).await
         }
     }
 }
@@ -331,8 +331,8 @@ async fn create_service(params: &ConnectivityOperationParams<'_>) -> CliResult<(
     .await
 }
 
-async fn delete_service(params: &ConnectivityOperationParams<'_>, yes: bool) -> CliResult<()> {
-    if !yes {
+async fn delete_service(params: &ConnectivityOperationParams<'_>, force: bool) -> CliResult<()> {
+    if !force {
         let prompt = format!(
             "Delete PSC service for subscription {}?",
             params.subscription_id
@@ -475,9 +475,9 @@ async fn delete_endpoint(
     params: &ConnectivityOperationParams<'_>,
     psc_service_id: i32,
     endpoint_id: i32,
-    yes: bool,
+    force: bool,
 ) -> CliResult<()> {
-    if !yes {
+    if !force {
         let prompt = format!(
             "Delete PSC endpoint {} for subscription {}?",
             endpoint_id, params.subscription_id
@@ -589,9 +589,9 @@ async fn create_service_aa(
 async fn delete_service_aa(
     params: &ConnectivityOperationParams<'_>,
     region_id: i32,
-    yes: bool,
+    force: bool,
 ) -> CliResult<()> {
-    if !yes {
+    if !force {
         let prompt = format!(
             "Delete Active-Active PSC service for subscription {}?",
             params.subscription_id
@@ -676,9 +676,9 @@ async fn delete_endpoint_aa(
     region_id: i32,
     psc_service_id: i32,
     endpoint_id: i32,
-    yes: bool,
+    force: bool,
 ) -> CliResult<()> {
-    if !yes {
+    if !force {
         let prompt = format!(
             "Delete Active-Active PSC endpoint {} in region {} for subscription {}?",
             endpoint_id, region_id, params.subscription_id

--- a/crates/redisctl/src/commands/cloud/connectivity/tgw.rs
+++ b/crates/redisctl/src/commands/cloud/connectivity/tgw.rs
@@ -107,7 +107,7 @@ pub async fn handle_tgw_command(
         TgwCommands::AttachmentDelete {
             subscription_id,
             attachment_id,
-            yes,
+            force,
             async_ops,
         } => {
             let params = ConnectivityOperationParams {
@@ -119,7 +119,7 @@ pub async fn handle_tgw_command(
                 output_format,
                 query,
             };
-            delete_attachment(&params, attachment_id, *yes).await
+            delete_attachment(&params, attachment_id, *force).await
         }
         TgwCommands::InvitationsList { subscription_id } => {
             list_invitations(&client, *subscription_id, output_format, query).await
@@ -211,7 +211,7 @@ pub async fn handle_tgw_command(
             subscription_id,
             region_id,
             attachment_id,
-            yes,
+            force,
             async_ops,
         } => {
             let params = ConnectivityOperationParams {
@@ -223,7 +223,7 @@ pub async fn handle_tgw_command(
                 output_format,
                 query,
             };
-            delete_attachment_aa(&params, *region_id, attachment_id, *yes).await
+            delete_attachment_aa(&params, *region_id, attachment_id, *force).await
         }
         TgwCommands::AaInvitationsList {
             subscription_id,
@@ -395,9 +395,9 @@ async fn update_attachment_cidrs(
 async fn delete_attachment(
     params: &ConnectivityOperationParams<'_>,
     attachment_id: &str,
-    yes: bool,
+    force: bool,
 ) -> CliResult<()> {
-    if !yes {
+    if !force {
         let prompt = format!(
             "Delete TGW attachment {} for subscription {}?",
             attachment_id, params.subscription_id
@@ -572,9 +572,9 @@ async fn delete_attachment_aa(
     params: &ConnectivityOperationParams<'_>,
     region_id: i32,
     attachment_id: &str,
-    yes: bool,
+    force: bool,
 ) -> CliResult<()> {
-    if !yes {
+    if !force {
         let prompt = format!(
             "Delete Active-Active TGW attachment {} in region {} for subscription {}?",
             attachment_id, region_id, params.subscription_id

--- a/crates/redisctl/src/commands/cloud/fixed_database.rs
+++ b/crates/redisctl/src/commands/cloud/fixed_database.rs
@@ -257,10 +257,14 @@ pub async fn handle_fixed_database_command(
             .await
         }
 
-        CloudFixedDatabaseCommands::Delete { id, yes, async_ops } => {
+        CloudFixedDatabaseCommands::Delete {
+            id,
+            force,
+            async_ops,
+        } => {
             let (subscription_id, database_id) = parse_fixed_database_id(id)?;
 
-            if !yes {
+            if !force {
                 let prompt = format!("Delete fixed database {}:{}?", subscription_id, database_id);
                 confirm_action(&prompt)?;
             }

--- a/crates/redisctl/src/commands/cloud/fixed_subscription.rs
+++ b/crates/redisctl/src/commands/cloud/fixed_subscription.rs
@@ -266,8 +266,12 @@ pub async fn handle_fixed_subscription_command(
             .await
         }
 
-        CloudFixedSubscriptionCommands::Delete { id, yes, async_ops } => {
-            if !yes {
+        CloudFixedSubscriptionCommands::Delete {
+            id,
+            force,
+            async_ops,
+        } => {
+            if !force {
                 let prompt = format!("Delete fixed subscription {}?", id);
                 confirm_action(&prompt)?;
             }

--- a/crates/redisctl/src/commands/enterprise/cm_settings.rs
+++ b/crates/redisctl/src/commands/enterprise/cm_settings.rs
@@ -37,7 +37,7 @@ pub enum CmSettingsCommands {
         data: Option<String>,
 
         /// Force update without confirmation
-        #[arg(short, long)]
+        #[arg(long)]
         force: bool,
     },
 
@@ -52,14 +52,14 @@ pub enum CmSettingsCommands {
         value: String,
 
         /// Force update without confirmation
-        #[arg(short, long)]
+        #[arg(long)]
         force: bool,
     },
 
     /// Reset settings to defaults
     Reset {
         /// Force reset without confirmation
-        #[arg(short, long)]
+        #[arg(long)]
         force: bool,
     },
 

--- a/crates/redisctl/src/commands/enterprise/crdb_task.rs
+++ b/crates/redisctl/src/commands/enterprise/crdb_task.rs
@@ -67,7 +67,7 @@ pub enum CrdbTaskCommands {
         task_id: String,
 
         /// Force cancellation without confirmation
-        #[arg(short, long)]
+        #[arg(long)]
         force: bool,
     },
 

--- a/crates/redisctl/src/commands/enterprise/module.rs
+++ b/crates/redisctl/src/commands/enterprise/module.rs
@@ -33,7 +33,7 @@ pub enum ModuleCommands {
         uid: String,
 
         /// Force deletion without confirmation
-        #[arg(long, short)]
+        #[arg(long)]
         force: bool,
     },
 

--- a/crates/redisctl/src/commands/enterprise/shard.rs
+++ b/crates/redisctl/src/commands/enterprise/shard.rs
@@ -60,7 +60,7 @@ pub enum ShardCommands {
         uid: u32,
 
         /// Force failover without confirmation
-        #[arg(short, long)]
+        #[arg(long)]
         force: bool,
     },
 
@@ -74,7 +74,7 @@ pub enum ShardCommands {
         target_node: u32,
 
         /// Force migration without confirmation
-        #[arg(short, long)]
+        #[arg(long)]
         force: bool,
     },
 
@@ -96,7 +96,7 @@ pub enum ShardCommands {
         #[arg(short, long, value_name = "FILE|JSON")]
         data: Option<String>,
         /// Force without confirmation
-        #[arg(short, long)]
+        #[arg(long)]
         force: bool,
     },
 
@@ -121,7 +121,7 @@ pub enum ShardCommands {
         #[arg(short, long, value_name = "FILE|JSON")]
         data: Option<String>,
         /// Force without confirmation
-        #[arg(short, long)]
+        #[arg(long)]
         force: bool,
     },
 

--- a/crates/redisctl/src/main.rs
+++ b/crates/redisctl/src/main.rs
@@ -1386,9 +1386,152 @@ async fn execute_cloud_command(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::Command;
+
+    const DESTRUCTIVE_COMMANDS: &[&str] = &[
+        "redisctl cloud acl delete-acl-user",
+        "redisctl cloud acl delete-redis-rule",
+        "redisctl cloud acl delete-role",
+        "redisctl cloud connectivity privatelink delete",
+        "redisctl cloud connectivity psc aa-endpoint-delete",
+        "redisctl cloud connectivity psc aa-service-delete",
+        "redisctl cloud connectivity psc endpoint-delete",
+        "redisctl cloud connectivity psc service-delete",
+        "redisctl cloud connectivity tgw aa-attachment-delete",
+        "redisctl cloud connectivity tgw attachment-delete",
+        "redisctl cloud connectivity vpc-peering delete",
+        "redisctl cloud connectivity vpc-peering delete-aa",
+        "redisctl cloud database delete",
+        "redisctl cloud database flush",
+        "redisctl cloud database flush-crdb",
+        "redisctl cloud fixed-database delete",
+        "redisctl cloud fixed-subscription delete",
+        "redisctl cloud provider-account delete",
+        "redisctl cloud subscription delete",
+        "redisctl cloud subscription delete-aa-regions",
+        "redisctl cloud user delete",
+        "redisctl enterprise acl delete",
+        "redisctl enterprise bdb-group delete",
+        "redisctl enterprise cluster reset",
+        "redisctl enterprise cm-settings import",
+        "redisctl enterprise cm-settings reset",
+        "redisctl enterprise cm-settings set",
+        "redisctl enterprise cm-settings set-value",
+        "redisctl enterprise crdb delete",
+        "redisctl enterprise crdb flush-instance",
+        "redisctl enterprise crdb-task cancel",
+        "redisctl enterprise database delete",
+        "redisctl enterprise database flush",
+        "redisctl enterprise database upgrade",
+        "redisctl enterprise job-scheduler delete",
+        "redisctl enterprise migration cancel",
+        "redisctl enterprise module delete",
+        "redisctl enterprise node remove",
+        "redisctl enterprise node restart",
+        "redisctl enterprise role delete",
+        "redisctl enterprise shard bulk-failover",
+        "redisctl enterprise shard bulk-migrate",
+        "redisctl enterprise shard failover",
+        "redisctl enterprise shard migrate",
+        "redisctl enterprise suffix delete",
+        "redisctl enterprise user delete",
+    ];
+
+    const LEGACY_YES_ALIAS_COMMANDS: &[&str] = &[
+        "redisctl cloud connectivity psc aa-endpoint-delete",
+        "redisctl cloud connectivity psc aa-service-delete",
+        "redisctl cloud connectivity psc endpoint-delete",
+        "redisctl cloud connectivity psc service-delete",
+        "redisctl cloud connectivity tgw aa-attachment-delete",
+        "redisctl cloud connectivity tgw attachment-delete",
+        "redisctl cloud fixed-database delete",
+        "redisctl cloud fixed-subscription delete",
+    ];
 
     fn args(s: &str) -> Vec<String> {
         s.split_whitespace().map(String::from).collect()
+    }
+
+    fn inspect_confirmation_args(
+        command: &Command,
+        parents: &[String],
+        force_paths: &mut Vec<String>,
+        legacy_alias_paths: &mut Vec<String>,
+    ) {
+        let mut path = parents.to_vec();
+        path.push(command.get_name().to_string());
+        let display_path = path.join(" ");
+
+        for argument in command.get_arguments() {
+            assert_ne!(
+                argument.get_long(),
+                Some("yes"),
+                "{display_path} exposes non-canonical --yes"
+            );
+
+            if argument.get_long() == Some("force") {
+                assert_eq!(
+                    argument.get_short(),
+                    None,
+                    "{display_path} exposes ambiguous -f confirmation bypass"
+                );
+                force_paths.push(display_path.clone());
+
+                let has_legacy_long = argument
+                    .get_all_aliases()
+                    .is_some_and(|aliases| aliases.contains(&"yes"));
+                let has_legacy_short = argument
+                    .get_all_short_aliases()
+                    .is_some_and(|aliases| aliases.contains(&'y'));
+                assert_eq!(
+                    has_legacy_long, has_legacy_short,
+                    "{display_path} must retain --yes and -y together"
+                );
+
+                if has_legacy_long {
+                    assert!(
+                        argument
+                            .get_visible_aliases()
+                            .is_none_or(|aliases| aliases.is_empty()),
+                        "{display_path} must hide the deprecated --yes alias; visible aliases: {:?}",
+                        argument.get_visible_aliases()
+                    );
+                    assert!(
+                        argument
+                            .get_visible_short_aliases()
+                            .is_none_or(|aliases| aliases.is_empty()),
+                        "{display_path} must hide the deprecated -y alias"
+                    );
+                    legacy_alias_paths.push(display_path.clone());
+                }
+            }
+        }
+
+        for subcommand in command.get_subcommands() {
+            inspect_confirmation_args(subcommand, &path, force_paths, legacy_alias_paths);
+        }
+    }
+
+    #[test]
+    fn command_tree_is_valid() {
+        Cli::command().debug_assert();
+    }
+
+    #[test]
+    fn destructive_commands_use_long_only_force() {
+        let mut force_paths = Vec::new();
+        let mut legacy_alias_paths = Vec::new();
+        inspect_confirmation_args(
+            &Cli::command(),
+            &[],
+            &mut force_paths,
+            &mut legacy_alias_paths,
+        );
+        force_paths.sort();
+        legacy_alias_paths.sort();
+
+        assert_eq!(force_paths, DESTRUCTIVE_COMMANDS);
+        assert_eq!(legacy_alias_paths, LEGACY_YES_ALIAS_COMMANDS);
     }
 
     // --- Passthrough tests ---

--- a/docs/docs/cloud/commands/networking.md
+++ b/docs/docs/cloud/commands/networking.md
@@ -174,7 +174,7 @@ redisctl cloud connectivity psc endpoint-update 123456 \
 ### Delete PSC Endpoint
 
 ```bash
-redisctl cloud connectivity psc endpoint-delete 123456 --endpoint-id 789 --yes --wait
+redisctl cloud connectivity psc endpoint-delete 123456 --endpoint-id 789 --force --wait
 ```
 
 ## Transit Gateway (AWS)
@@ -221,7 +221,7 @@ redisctl cloud connectivity tgw attachment-update 123456 \
 ### Delete Attachment
 
 ```bash
-redisctl cloud connectivity tgw attachment-delete 123456 att-abc123 --yes --wait
+redisctl cloud connectivity tgw attachment-delete 123456 att-abc123 --force --wait
 ```
 
 ### List Invitations

--- a/docs/docs/common/index.md
+++ b/docs/docs/common/index.md
@@ -36,6 +36,20 @@ graph TB
 | **Human Commands** | Day-to-day operations with friendly output |
 | **Workflows** | Complex multi-step provisioning tasks |
 
+## Destructive Commands
+
+Commands that delete, flush, reset, or otherwise make irreversible changes ask for confirmation
+when run interactively. Use the long-only `--force` flag to bypass that prompt in automation:
+
+```bash
+redisctl cloud database delete 123456:789 --force
+```
+
+`--force` only skips the confirmation prompt; it does not change API validation, permissions, or
+error handling. The older `--yes` and `-y` spellings remain as hidden compatibility aliases on the
+commands that previously exposed them. They are deprecated, will be accepted throughout the 0.x
+release series, and are scheduled for removal in 1.0.
+
 ## Features at a Glance
 
 <div class="grid cards" markdown>

--- a/docs/docs/developer/contributing.md
+++ b/docs/docs/developer/contributing.md
@@ -54,6 +54,7 @@ Follow the existing code style. Key patterns:
 - Use `anyhow` for CLI errors, `thiserror` for library errors
 - All commands must support `-o json` output
 - Add tests for new functionality
+- Destructive commands must use long-only `--force` to skip confirmation; do not assign `-f`
 
 ### 3. Test Locally
 
@@ -111,6 +112,12 @@ crates/
 3. Add to command routing in `crates/redisctl/src/main.rs`
 4. Add tests in `crates/redisctl/tests/`
 5. Update documentation
+
+When adding a destructive command, add its command path to the `DESTRUCTIVE_COMMANDS` inventory in
+`crates/redisctl/src/main.rs`. The command-tree tests require every listed command to expose the
+canonical long-only `--force` bypass and reject a canonical `--yes` flag. Do not add new
+compatibility aliases; the hidden `--yes` and `-y` aliases exist only for commands that exposed them
+before this convention was adopted.
 
 ## Testing
 


### PR DESCRIPTION
## Summary
- make long-only `--force` the canonical confirmation bypass across Cloud and Enterprise commands
- keep legacy `--yes` and `-y` spellings as hidden aliases on the eight commands that previously exposed them, through the 0.x release series
- remove confirmation-related `-f` aliases and add a complete destructive-command inventory test
- document the user-facing contract and contributor convention

## Validation
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- documentation build deferred to CI because the local MkDocs Material dependency is unavailable

Closes #1042