### PR TITLE
refactor(core): centralize API client resolution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,8 @@ PRs must pass:
 - `secure-storage` enables keyring-based credential storage
 
 **redisctl-mcp** (MCP server):
-- `default = ["http", "cloud", "enterprise", "database"]`
+- `default = ["http", "cloud", "enterprise", "database", "secure-storage"]`
+- `secure-storage` enables keyring-backed profile credentials
 - Each toolset (`cloud`, `enterprise`, `database`) can be compiled independently
 
 ### Key Patterns

--- a/crates/redisctl-core/src/clients.rs
+++ b/crates/redisctl-core/src/clients.rs
@@ -1,0 +1,715 @@
+//! Shared profile resolution and API client construction.
+//!
+//! This module contains the product-level connection behavior shared by the
+//! redisctl CLI and MCP server. Frontends choose the profile and environment
+//! policy, while this layer resolves credentials and consistently configures
+//! the underlying API clients.
+
+use crate::{Config, ConfigError, CredentialStore, DeploymentType, EnvironmentOverrides, Profile};
+use thiserror::Error;
+
+const DEFAULT_CLOUD_API_URL: &str = "https://api.redislabs.com/v1";
+const DEFAULT_USER_AGENT: &str = concat!("redisctl-core/", env!("CARGO_PKG_VERSION"));
+
+/// Errors produced while resolving connection settings or building API clients.
+#[derive(Debug, Error)]
+pub enum ClientResolutionError {
+    /// The redisctl configuration could not be resolved.
+    #[error(transparent)]
+    Config(#[from] ConfigError),
+
+    /// A selected profile has the wrong deployment type.
+    #[error("Profile '{name}' is type '{actual_type}' but a {expected_type} profile is required")]
+    ProfileTypeMismatch {
+        /// Selected profile name.
+        name: String,
+        /// Deployment type stored on the selected profile.
+        actual_type: DeploymentType,
+        /// Deployment type required by the requested client.
+        expected_type: DeploymentType,
+        /// Other configured profiles with the required type.
+        available_profiles: Vec<String>,
+    },
+
+    /// Required credential fields were empty or absent.
+    #[error("Missing credentials for {deployment_type} profile '{profile_name}': {missing_fields}")]
+    MissingCredentials {
+        /// Profile name, or `environment` when a complete environment-only
+        /// configuration was selected.
+        profile_name: String,
+        /// Deployment type being resolved.
+        deployment_type: DeploymentType,
+        /// Comma-separated credential field names.
+        missing_fields: String,
+    },
+
+    /// Redis Cloud client construction failed.
+    #[error("Failed to build Redis Cloud client: {0}")]
+    CloudClient(#[source] redis_cloud::CloudError),
+
+    /// Redis Enterprise client construction failed.
+    #[error("Failed to build Redis Enterprise client: {0}")]
+    EnterpriseClient(#[source] redis_enterprise::RestError),
+}
+
+/// Fully resolved Redis Cloud connection settings.
+#[derive(Clone)]
+pub struct ResolvedCloudConnection {
+    /// Cloud API base URL.
+    pub base_url: String,
+    /// Cloud API key.
+    pub api_key: String,
+    /// Cloud API secret.
+    pub api_secret: String,
+    /// HTTP user-agent value.
+    pub user_agent: String,
+}
+
+impl ResolvedCloudConnection {
+    /// Build a Redis Cloud client from these resolved settings.
+    pub fn build_client(&self) -> Result<redis_cloud::CloudClient, ClientResolutionError> {
+        redis_cloud::CloudClient::builder()
+            .api_key(&self.api_key)
+            .api_secret(&self.api_secret)
+            .base_url(&self.base_url)
+            .user_agent(&self.user_agent)
+            .build()
+            .map_err(ClientResolutionError::CloudClient)
+    }
+}
+
+/// Fully resolved Redis Enterprise connection settings.
+#[derive(Clone)]
+pub struct ResolvedEnterpriseConnection {
+    /// Enterprise REST API base URL.
+    pub base_url: String,
+    /// Enterprise API username.
+    pub username: String,
+    /// Enterprise API password.
+    pub password: Option<String>,
+    /// Whether TLS certificate verification is disabled.
+    pub insecure: bool,
+    /// Optional custom CA certificate path.
+    pub ca_cert: Option<String>,
+    /// HTTP user-agent value.
+    pub user_agent: String,
+}
+
+impl ResolvedEnterpriseConnection {
+    /// Build a Redis Enterprise client from these resolved settings.
+    pub fn build_client(
+        &self,
+    ) -> Result<redis_enterprise::EnterpriseClient, ClientResolutionError> {
+        let mut builder = redis_enterprise::EnterpriseClient::builder()
+            .base_url(&self.base_url)
+            .username(&self.username)
+            .insecure(self.insecure)
+            .user_agent(&self.user_agent);
+
+        if let Some(password) = &self.password {
+            builder = builder.password(password);
+        }
+
+        if let Some(ca_cert) = &self.ca_cert {
+            builder = builder.ca_cert(ca_cert);
+        }
+
+        builder
+            .build()
+            .map_err(ClientResolutionError::EnterpriseClient)
+    }
+}
+
+/// Resolves configured profiles into typed connection settings and API clients.
+pub struct ClientResolver<'a> {
+    config: &'a Config,
+    environment_overrides: EnvironmentOverrides,
+    user_agent: String,
+}
+
+impl<'a> ClientResolver<'a> {
+    /// Create a resolver that allows supported environment variables to
+    /// override stored profile values.
+    pub fn new(config: &'a Config) -> Self {
+        Self {
+            config,
+            environment_overrides: EnvironmentOverrides::Enabled,
+            user_agent: DEFAULT_USER_AGENT.to_string(),
+        }
+    }
+
+    /// Set whether process environment variables may override profile values.
+    #[must_use]
+    pub fn environment_overrides(mut self, environment_overrides: EnvironmentOverrides) -> Self {
+        self.environment_overrides = environment_overrides;
+        self
+    }
+
+    /// Set the product-specific HTTP user agent applied to built clients.
+    #[must_use]
+    pub fn user_agent(mut self, user_agent: impl Into<String>) -> Self {
+        self.user_agent = user_agent.into();
+        self
+    }
+
+    /// Resolve Redis Cloud connection settings.
+    pub fn resolve_cloud(
+        &self,
+        explicit_profile: Option<&str>,
+    ) -> Result<ResolvedCloudConnection, ClientResolutionError> {
+        let env_api_key = self.environment_value("REDIS_CLOUD_API_KEY");
+        let env_api_secret = self
+            .environment_value("REDIS_CLOUD_SECRET_KEY")
+            .or_else(|| self.environment_value("REDIS_CLOUD_API_SECRET"));
+        let env_api_url = self.environment_value("REDIS_CLOUD_API_URL");
+
+        let (profile_name, api_key, api_secret, base_url) = if let (
+            None,
+            Some(api_key),
+            Some(api_secret),
+        ) =
+            (explicit_profile, &env_api_key, &env_api_secret)
+        {
+            (
+                "environment".to_string(),
+                api_key.clone(),
+                api_secret.clone(),
+                env_api_url.unwrap_or_else(|| DEFAULT_CLOUD_API_URL.to_string()),
+            )
+        } else {
+            let (profile_name, profile) =
+                self.resolve_profile(explicit_profile, DeploymentType::Cloud)?;
+            let (stored_api_key, stored_api_secret, stored_api_url) = profile
+                    .cloud_credentials()
+                    .ok_or_else(|| {
+                        ConfigError::CredentialError(format!(
+                            "Profile '{profile_name}' declares type cloud but contains different credentials"
+                        ))
+                    })?;
+            let store = CredentialStore::new();
+
+            let api_key = store.get_credential_with_environment(
+                stored_api_key,
+                &["REDIS_CLOUD_API_KEY"],
+                self.environment_overrides,
+            )?;
+            let api_secret = store.get_credential_with_environment(
+                stored_api_secret,
+                &["REDIS_CLOUD_SECRET_KEY", "REDIS_CLOUD_API_SECRET"],
+                self.environment_overrides,
+            )?;
+            let base_url = store.get_credential_with_environment(
+                stored_api_url,
+                &["REDIS_CLOUD_API_URL"],
+                self.environment_overrides,
+            )?;
+
+            (profile_name, api_key, api_secret, base_url)
+        };
+
+        self.ensure_credentials(
+            &profile_name,
+            DeploymentType::Cloud,
+            [
+                ("api_key", api_key.as_str()),
+                ("api_secret", api_secret.as_str()),
+                ("api_url", base_url.as_str()),
+            ],
+        )?;
+
+        Ok(ResolvedCloudConnection {
+            base_url,
+            api_key,
+            api_secret,
+            user_agent: self.user_agent.clone(),
+        })
+    }
+
+    /// Resolve Redis Enterprise connection settings.
+    pub fn resolve_enterprise(
+        &self,
+        explicit_profile: Option<&str>,
+    ) -> Result<ResolvedEnterpriseConnection, ClientResolutionError> {
+        let env_url = self.environment_value("REDIS_ENTERPRISE_URL");
+        let env_username = self.environment_value("REDIS_ENTERPRISE_USER");
+        let env_password = self.environment_value("REDIS_ENTERPRISE_PASSWORD");
+        let env_insecure = self.environment_value("REDIS_ENTERPRISE_INSECURE");
+        let env_ca_cert = self.environment_value("REDIS_ENTERPRISE_CA_CERT");
+
+        let (profile_name, base_url, username, password, insecure, ca_cert) = if let (
+            None,
+            Some(url),
+            Some(username),
+        ) =
+            (explicit_profile, &env_url, &env_username)
+        {
+            (
+                "environment".to_string(),
+                url.clone(),
+                username.clone(),
+                env_password,
+                env_insecure.as_deref().map(parse_bool).unwrap_or_default(),
+                env_ca_cert,
+            )
+        } else {
+            let (profile_name, profile) =
+                self.resolve_profile(explicit_profile, DeploymentType::Enterprise)?;
+            let (stored_url, stored_username, stored_password, stored_insecure, stored_ca_cert) =
+                    profile
+                        .enterprise_credentials()
+                        .ok_or_else(|| {
+                            ConfigError::CredentialError(format!(
+                                "Profile '{profile_name}' declares type enterprise but contains different credentials"
+                            ))
+                        })?;
+            let store = CredentialStore::new();
+
+            let base_url = store.get_credential_with_environment(
+                stored_url,
+                &["REDIS_ENTERPRISE_URL"],
+                self.environment_overrides,
+            )?;
+            let username = store.get_credential_with_environment(
+                stored_username,
+                &["REDIS_ENTERPRISE_USER"],
+                self.environment_overrides,
+            )?;
+            let password = match stored_password {
+                Some(stored_password) => Some(store.get_credential_with_environment(
+                    stored_password,
+                    &["REDIS_ENTERPRISE_PASSWORD"],
+                    self.environment_overrides,
+                )?),
+                None => env_password,
+            };
+            let insecure = env_insecure
+                .as_deref()
+                .map(parse_bool)
+                .unwrap_or(stored_insecure);
+            let ca_cert = env_ca_cert.or_else(|| stored_ca_cert.map(ToString::to_string));
+
+            (
+                profile_name,
+                base_url,
+                username,
+                password,
+                insecure,
+                ca_cert,
+            )
+        };
+
+        self.ensure_credentials(
+            &profile_name,
+            DeploymentType::Enterprise,
+            [
+                ("url", base_url.as_str()),
+                ("username", username.as_str()),
+                ("password", password.as_deref().unwrap_or_default()),
+            ],
+        )?;
+
+        Ok(ResolvedEnterpriseConnection {
+            base_url,
+            username,
+            password,
+            insecure,
+            ca_cert,
+            user_agent: self.user_agent.clone(),
+        })
+    }
+
+    /// Resolve settings and build a Redis Cloud client.
+    pub fn build_cloud_client(
+        &self,
+        explicit_profile: Option<&str>,
+    ) -> Result<redis_cloud::CloudClient, ClientResolutionError> {
+        self.resolve_cloud(explicit_profile)?.build_client()
+    }
+
+    /// Resolve settings and build a Redis Enterprise client.
+    pub fn build_enterprise_client(
+        &self,
+        explicit_profile: Option<&str>,
+    ) -> Result<redis_enterprise::EnterpriseClient, ClientResolutionError> {
+        self.resolve_enterprise(explicit_profile)?.build_client()
+    }
+
+    fn environment_value(&self, name: &str) -> Option<String> {
+        if self.environment_overrides == EnvironmentOverrides::Enabled {
+            std::env::var(name).ok()
+        } else {
+            None
+        }
+    }
+
+    fn resolve_profile(
+        &self,
+        explicit_profile: Option<&str>,
+        expected_type: DeploymentType,
+    ) -> Result<(String, &Profile), ClientResolutionError> {
+        let profile_name = match expected_type {
+            DeploymentType::Cloud => self.config.resolve_cloud_profile(explicit_profile)?,
+            DeploymentType::Enterprise => {
+                self.config.resolve_enterprise_profile(explicit_profile)?
+            }
+            DeploymentType::Database => unreachable!("database clients are resolved elsewhere"),
+        };
+        let profile = self.config.profiles.get(&profile_name).ok_or_else(|| {
+            ConfigError::ProfileNotFound {
+                name: profile_name.clone(),
+            }
+        })?;
+
+        if profile.deployment_type != expected_type {
+            return Err(ClientResolutionError::ProfileTypeMismatch {
+                name: profile_name,
+                actual_type: profile.deployment_type,
+                expected_type,
+                available_profiles: self
+                    .config
+                    .get_profiles_of_type(expected_type)
+                    .into_iter()
+                    .map(ToString::to_string)
+                    .collect(),
+            });
+        }
+
+        Ok((profile_name, profile))
+    }
+
+    fn ensure_credentials<const N: usize>(
+        &self,
+        profile_name: &str,
+        deployment_type: DeploymentType,
+        fields: [(&str, &str); N],
+    ) -> Result<(), ClientResolutionError> {
+        let missing_fields = fields
+            .into_iter()
+            .filter_map(|(name, value)| value.trim().is_empty().then_some(name))
+            .collect::<Vec<_>>();
+
+        if missing_fields.is_empty() {
+            Ok(())
+        } else {
+            Err(ClientResolutionError::MissingCredentials {
+                profile_name: profile_name.to_string(),
+                deployment_type,
+                missing_fields: missing_fields.join(", "),
+            })
+        }
+    }
+}
+
+fn parse_bool(value: &str) -> bool {
+    value.eq_ignore_ascii_case("true") || value == "1"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ProfileCredentials;
+    use std::collections::HashMap;
+
+    fn cloud_profile(api_key: &str, api_secret: &str, api_url: &str) -> Profile {
+        Profile {
+            deployment_type: DeploymentType::Cloud,
+            credentials: ProfileCredentials::Cloud {
+                api_key: api_key.to_string(),
+                api_secret: api_secret.to_string(),
+                api_url: api_url.to_string(),
+            },
+            files_api_key: None,
+            tags: Vec::new(),
+        }
+    }
+
+    fn enterprise_profile(
+        url: &str,
+        username: &str,
+        password: Option<&str>,
+        insecure: bool,
+        ca_cert: Option<&str>,
+    ) -> Profile {
+        Profile {
+            deployment_type: DeploymentType::Enterprise,
+            credentials: ProfileCredentials::Enterprise {
+                url: url.to_string(),
+                username: username.to_string(),
+                password: password.map(ToString::to_string),
+                insecure,
+                ca_cert: ca_cert.map(ToString::to_string),
+            },
+            files_api_key: None,
+            tags: Vec::new(),
+        }
+    }
+
+    fn isolated_resolver(config: &Config) -> ClientResolver<'_> {
+        ClientResolver::new(config).environment_overrides(EnvironmentOverrides::Disabled)
+    }
+
+    #[test]
+    fn resolves_default_cloud_profile() {
+        let mut profiles = HashMap::new();
+        profiles.insert(
+            "first".to_string(),
+            cloud_profile("first-key", "first-secret", "https://first.example/v1"),
+        );
+        profiles.insert(
+            "default".to_string(),
+            cloud_profile(
+                "default-key",
+                "default-secret",
+                "https://default.example/v1",
+            ),
+        );
+        let config = Config {
+            default_cloud: Some("default".to_string()),
+            profiles,
+            ..Config::default()
+        };
+
+        let resolved = isolated_resolver(&config).resolve_cloud(None).unwrap();
+
+        assert_eq!(resolved.api_key, "default-key");
+        assert_eq!(resolved.base_url, "https://default.example/v1");
+    }
+
+    #[test]
+    fn resolves_default_enterprise_profile() {
+        let mut profiles = HashMap::new();
+        profiles.insert(
+            "first".to_string(),
+            enterprise_profile(
+                "https://first.example:9443",
+                "first-user",
+                Some("first-password"),
+                false,
+                None,
+            ),
+        );
+        profiles.insert(
+            "default".to_string(),
+            enterprise_profile(
+                "https://default.example:9443",
+                "default-user",
+                Some("default-password"),
+                true,
+                None,
+            ),
+        );
+        let config = Config {
+            default_enterprise: Some("default".to_string()),
+            profiles,
+            ..Config::default()
+        };
+
+        let resolved = isolated_resolver(&config).resolve_enterprise(None).unwrap();
+
+        assert_eq!(resolved.username, "default-user");
+        assert_eq!(resolved.base_url, "https://default.example:9443");
+        assert!(resolved.insecure);
+    }
+
+    #[test]
+    fn resolves_explicit_profile_and_custom_endpoints() {
+        let mut profiles = HashMap::new();
+        profiles.insert(
+            "cloud-a".to_string(),
+            cloud_profile("key-a", "secret-a", "https://cloud-a.example/v1"),
+        );
+        profiles.insert(
+            "cloud-b".to_string(),
+            cloud_profile("key-b", "secret-b", "https://cloud-b.example/v1"),
+        );
+        profiles.insert(
+            "enterprise".to_string(),
+            enterprise_profile(
+                "https://enterprise.example:9443",
+                "admin",
+                Some("secret"),
+                false,
+                Some("/etc/redis/ca.pem"),
+            ),
+        );
+        let config = Config {
+            profiles,
+            ..Config::default()
+        };
+
+        let resolver = isolated_resolver(&config).user_agent("redisctl-test/1");
+        let cloud = resolver.resolve_cloud(Some("cloud-b")).unwrap();
+        let enterprise = resolver.resolve_enterprise(Some("enterprise")).unwrap();
+
+        assert_eq!(cloud.api_key, "key-b");
+        assert_eq!(cloud.base_url, "https://cloud-b.example/v1");
+        assert_eq!(cloud.user_agent, "redisctl-test/1");
+        assert_eq!(enterprise.base_url, "https://enterprise.example:9443");
+        assert_eq!(enterprise.ca_cert.as_deref(), Some("/etc/redis/ca.pem"));
+        assert_eq!(enterprise.user_agent, "redisctl-test/1");
+    }
+
+    #[test]
+    fn reports_missing_credentials() {
+        let mut profiles = HashMap::new();
+        profiles.insert(
+            "cloud".to_string(),
+            cloud_profile("key", "", "https://api.example/v1"),
+        );
+        profiles.insert(
+            "enterprise".to_string(),
+            enterprise_profile("https://cluster:9443", "admin", None, false, None),
+        );
+        let config = Config {
+            profiles,
+            ..Config::default()
+        };
+
+        let cloud_error = isolated_resolver(&config)
+            .resolve_cloud(Some("cloud"))
+            .err()
+            .expect("missing Cloud secret must fail");
+        let enterprise_error = isolated_resolver(&config)
+            .resolve_enterprise(Some("enterprise"))
+            .err()
+            .expect("missing Enterprise password must fail");
+
+        assert!(matches!(
+            cloud_error,
+            ClientResolutionError::MissingCredentials {
+                missing_fields,
+                ..
+            } if missing_fields == "api_secret"
+        ));
+        assert!(matches!(
+            enterprise_error,
+            ClientResolutionError::MissingCredentials {
+                missing_fields,
+                ..
+            } if missing_fields == "password"
+        ));
+    }
+
+    #[test]
+    fn rejects_an_explicit_profile_of_the_wrong_type() {
+        let mut profiles = HashMap::new();
+        profiles.insert(
+            "enterprise".to_string(),
+            enterprise_profile("https://cluster:9443", "admin", Some("secret"), false, None),
+        );
+        let config = Config {
+            profiles,
+            ..Config::default()
+        };
+
+        let error = isolated_resolver(&config)
+            .resolve_cloud(Some("enterprise"))
+            .err()
+            .expect("wrong profile type must fail");
+
+        assert!(matches!(
+            error,
+            ClientResolutionError::ProfileTypeMismatch {
+                actual_type: DeploymentType::Enterprise,
+                expected_type: DeploymentType::Cloud,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    #[serial_test::serial(client_resolution_env)]
+    fn environment_overrides_and_explicit_config_isolation_are_distinct() {
+        unsafe {
+            std::env::set_var("REDIS_CLOUD_API_KEY", "environment-key");
+            std::env::set_var("REDIS_CLOUD_SECRET_KEY", "environment-secret");
+            std::env::set_var("REDIS_CLOUD_API_URL", "https://environment.example/v1");
+        }
+        let mut profiles = HashMap::new();
+        profiles.insert(
+            "cloud".to_string(),
+            cloud_profile(
+                "profile-key",
+                "profile-secret",
+                "https://profile.example/v1",
+            ),
+        );
+        let config = Config {
+            profiles,
+            ..Config::default()
+        };
+
+        let overridden = ClientResolver::new(&config)
+            .resolve_cloud(Some("cloud"))
+            .unwrap();
+        let isolated = isolated_resolver(&config)
+            .resolve_cloud(Some("cloud"))
+            .unwrap();
+
+        unsafe {
+            std::env::remove_var("REDIS_CLOUD_API_KEY");
+            std::env::remove_var("REDIS_CLOUD_SECRET_KEY");
+            std::env::remove_var("REDIS_CLOUD_API_URL");
+        }
+
+        assert_eq!(overridden.api_key, "environment-key");
+        assert_eq!(overridden.base_url, "https://environment.example/v1");
+        assert_eq!(isolated.api_key, "profile-key");
+        assert_eq!(isolated.base_url, "https://profile.example/v1");
+    }
+
+    #[test]
+    #[serial_test::serial(client_resolution_env)]
+    fn environment_can_override_keyring_references() {
+        unsafe {
+            std::env::set_var("REDIS_CLOUD_API_KEY", "environment-key");
+            std::env::set_var("REDIS_CLOUD_SECRET_KEY", "environment-secret");
+        }
+        let mut profiles = HashMap::new();
+        profiles.insert(
+            "cloud".to_string(),
+            cloud_profile(
+                "keyring:cloud-key",
+                "keyring:cloud-secret",
+                "https://api.example/v1",
+            ),
+        );
+        let config = Config {
+            profiles,
+            ..Config::default()
+        };
+
+        let resolved = ClientResolver::new(&config)
+            .resolve_cloud(Some("cloud"))
+            .unwrap();
+
+        unsafe {
+            std::env::remove_var("REDIS_CLOUD_API_KEY");
+            std::env::remove_var("REDIS_CLOUD_SECRET_KEY");
+        }
+
+        assert_eq!(resolved.api_key, "environment-key");
+        assert_eq!(resolved.api_secret, "environment-secret");
+    }
+
+    #[test]
+    fn builds_clients_from_resolved_settings() {
+        let cloud = ResolvedCloudConnection {
+            base_url: "https://api.example/v1".to_string(),
+            api_key: "key".to_string(),
+            api_secret: "secret".to_string(),
+            user_agent: "redisctl-test/1".to_string(),
+        };
+        let enterprise = ResolvedEnterpriseConnection {
+            base_url: "https://cluster.example:9443".to_string(),
+            username: "admin".to_string(),
+            password: Some("secret".to_string()),
+            insecure: true,
+            ca_cert: None,
+            user_agent: "redisctl-test/1".to_string(),
+        };
+
+        cloud.build_client().unwrap();
+        enterprise.build_client().unwrap();
+    }
+}

--- a/crates/redisctl-core/src/config/credential.rs
+++ b/crates/redisctl-core/src/config/credential.rs
@@ -9,6 +9,15 @@
 use super::error::{ConfigError, Result};
 use std::env;
 
+/// Whether process environment variables may override stored profile values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EnvironmentOverrides {
+    /// Resolve supported environment variables before stored profile values.
+    Enabled,
+    /// Resolve only stored profile values and keyring references.
+    Disabled,
+}
+
 /// Prefix that indicates a value should be retrieved from the keyring
 const KEYRING_PREFIX: &str = "keyring:";
 
@@ -113,16 +122,39 @@ impl CredentialStore {
     /// 2. If value starts with "keyring:", retrieve from keyring
     /// 3. Otherwise, return the value as-is (plaintext)
     pub fn get_credential(&self, value: &str, env_var: Option<&str>) -> Result<String> {
-        self.get_credential_with_env_vars(value, env_var.into_iter().collect())
+        match env_var {
+            Some(env_var) => self.get_credential_with_environment(
+                value,
+                &[env_var],
+                EnvironmentOverrides::Enabled,
+            ),
+            None => self.get_credential_with_environment(value, &[], EnvironmentOverrides::Enabled),
+        }
     }
 
     /// Retrieve a credential value with support for multiple environment variable aliases.
     ///
     /// Environment variables are checked in order, and the first set value wins.
     pub fn get_credential_with_env_vars(&self, value: &str, env_vars: Vec<&str>) -> Result<String> {
-        for var in env_vars {
-            if let Ok(env_value) = env::var(var) {
-                return Ok(env_value);
+        self.get_credential_with_environment(value, &env_vars, EnvironmentOverrides::Enabled)
+    }
+
+    /// Retrieve a credential with an explicit environment override policy.
+    ///
+    /// This is used by callers that load an explicit configuration file and
+    /// require its credential values to be isolated from the process
+    /// environment.
+    pub fn get_credential_with_environment(
+        &self,
+        value: &str,
+        env_vars: &[&str],
+        environment_overrides: EnvironmentOverrides,
+    ) -> Result<String> {
+        if environment_overrides == EnvironmentOverrides::Enabled {
+            for var in env_vars {
+                if let Ok(env_value) = env::var(var) {
+                    return Ok(env_value);
+                }
             }
         }
 

--- a/crates/redisctl-core/src/config/mod.rs
+++ b/crates/redisctl-core/src/config/mod.rs
@@ -21,5 +21,5 @@ pub mod error;
 
 // Re-export main types for convenience
 pub use config::{Config, DeploymentType, Profile, ProfileCredentials};
-pub use credential::{CredentialStorage, CredentialStore};
+pub use credential::{CredentialStorage, CredentialStore, EnvironmentOverrides};
 pub use error::{ConfigError, Result};

--- a/crates/redisctl-core/src/lib.rs
+++ b/crates/redisctl-core/src/lib.rs
@@ -4,6 +4,7 @@
 //!
 //! This crate provides:
 //! - **Unified error handling** - CoreError wrapping both platform errors
+//! - **Client resolution** - Shared profile, credential, endpoint, and TLS handling
 //! - **Progress callbacks** - For Cloud's async task polling
 //! - **Module resolution** - Validate Enterprise modules before creation
 //! - **Workflows** - Multi-step operations (create + wait, etc.)
@@ -28,6 +29,7 @@
 //! ┌─────────────────────────────────────────────────────────────────┐
 //! │                 Layer 2: redisctl-core                          │
 //! │  - Unified errors (CoreError)                                   │
+//! │  - Client resolution (ClientResolver)                           │
 //! │  - Progress callbacks (poll_task)                               │
 //! │  - Module resolution (resolve_modules)                          │
 //! │  - Workflows (create_and_wait, etc.)                            │
@@ -66,6 +68,7 @@
 //! ).await?;
 //! ```
 
+pub mod clients;
 pub mod config;
 pub mod error;
 pub mod progress;
@@ -78,9 +81,12 @@ pub use error::{CoreError, Result};
 pub use progress::{ProgressCallback, ProgressEvent, poll_task};
 
 // Re-export config types for convenience
+pub use clients::{
+    ClientResolutionError, ClientResolver, ResolvedCloudConnection, ResolvedEnterpriseConnection,
+};
 pub use config::{
-    Config, ConfigError, CredentialStorage, CredentialStore, DeploymentType, Profile,
-    ProfileCredentials,
+    Config, ConfigError, CredentialStorage, CredentialStore, DeploymentType, EnvironmentOverrides,
+    Profile, ProfileCredentials,
 };
 
 // Re-export Layer 1 for convenience (but consumers can also import directly)

--- a/crates/redisctl-mcp/Cargo.toml
+++ b/crates/redisctl-mcp/Cargo.toml
@@ -55,11 +55,12 @@ clap = { workspace = true }
 tower = { workspace = true }
 
 [features]
-default = ["http", "cloud", "enterprise", "database"]
+default = ["http", "cloud", "enterprise", "database", "secure-storage"]
 http = []
 cloud = ["dep:redis-cloud"]
 enterprise = ["dep:redis-enterprise"]
 database = ["dep:redis", "dep:urlencoding"]
+secure-storage = ["redisctl-core/secure-storage"]
 test-support = []
 
 [dev-dependencies]

--- a/crates/redisctl-mcp/src/state.rs
+++ b/crates/redisctl-mcp/src/state.rs
@@ -1,5 +1,6 @@
 //! Application state and credential resolution
 
+#[cfg(any(feature = "cloud", feature = "enterprise", feature = "database"))]
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -10,10 +11,15 @@ use anyhow::Result;
 use redis_cloud::CloudClient;
 #[cfg(feature = "enterprise")]
 use redis_enterprise::EnterpriseClient;
+#[cfg(any(feature = "cloud", feature = "enterprise"))]
+use redisctl_core::ClientResolver;
 use redisctl_core::Config;
 use tokio::sync::RwLock;
 
 use crate::policy::{Policy, SafetyTier};
+
+#[cfg(any(feature = "cloud", feature = "enterprise"))]
+const REDISCTL_MCP_USER_AGENT: &str = concat!("redisctl-mcp/", env!("CARGO_PKG_VERSION"));
 
 /// How credentials are resolved
 #[derive(Debug, Clone)]
@@ -187,28 +193,10 @@ impl AppState {
                     .map(|s| s.to_string())
                     .or_else(|| profiles.first().cloned());
 
-                // Resolve the profile name
-                let resolved_profile_name = config
-                    .resolve_cloud_profile(profile_to_use.as_deref())
-                    .context("Failed to resolve cloud profile")?;
-
-                // Get the profile
-                let profile = config
-                    .profiles
-                    .get(&resolved_profile_name)
-                    .with_context(|| format!("Profile '{}' not found", resolved_profile_name))?;
-
-                // Get credentials
-                let (api_key, api_secret, _base_url) = profile
-                    .resolve_cloud_credentials()
-                    .context("Failed to resolve cloud credentials")?
-                    .context("No cloud credentials in profile")?;
-
-                CloudClient::builder()
-                    .api_key(api_key)
-                    .api_secret(api_secret)
-                    .build()
-                    .context("Failed to build Cloud client")
+                ClientResolver::new(config)
+                    .user_agent(REDISCTL_MCP_USER_AGENT)
+                    .build_cloud_client(profile_to_use.as_deref())
+                    .context("Failed to resolve Redis Cloud client")
             }
         }
     }
@@ -228,37 +216,10 @@ impl AppState {
                     .map(|s| s.to_string())
                     .or_else(|| profiles.first().cloned());
 
-                // Resolve the profile name
-                let resolved_profile_name = config
-                    .resolve_enterprise_profile(profile_to_use.as_deref())
-                    .context("Failed to resolve enterprise profile")?;
-
-                // Get the profile
-                let profile_config = config
-                    .profiles
-                    .get(&resolved_profile_name)
-                    .with_context(|| format!("Profile '{}' not found", resolved_profile_name))?;
-
-                // Get credentials
-                let (url, username, password, insecure, ca_cert) = profile_config
-                    .resolve_enterprise_credentials()
-                    .context("Failed to resolve enterprise credentials")?
-                    .context("No enterprise credentials in profile")?;
-
-                let mut builder = EnterpriseClient::builder()
-                    .base_url(&url)
-                    .username(&username)
-                    .insecure(insecure);
-
-                if let Some(pwd) = password {
-                    builder = builder.password(&pwd);
-                }
-
-                if let Some(cert_path) = ca_cert {
-                    builder = builder.ca_cert(&cert_path);
-                }
-
-                builder.build().context("Failed to build Enterprise client")
+                ClientResolver::new(config)
+                    .user_agent(REDISCTL_MCP_USER_AGENT)
+                    .build_enterprise_client(profile_to_use.as_deref())
+                    .context("Failed to resolve Redis Enterprise client")
             }
         }
     }

--- a/crates/redisctl/src/connection.rs
+++ b/crates/redisctl/src/connection.rs
@@ -1,39 +1,18 @@
-//! Connection management for Redis Cloud and Enterprise clients
+//! Connection management for Redis Cloud and Enterprise clients.
 
 use crate::error::Result as CliResult;
-use anyhow::Context;
-use redisctl_core::{Config, DeploymentType};
-use tracing::{debug, info, trace};
+use redisctl_core::{ClientResolver, Config, EnvironmentOverrides};
+use tracing::{debug, info};
 
-/// User agent string for redisctl HTTP requests
+pub use redisctl_core::{
+    ResolvedCloudConnection as CloudConnectionInfo,
+    ResolvedEnterpriseConnection as EnterpriseConnectionInfo,
+};
+
+/// User agent string for redisctl HTTP requests.
 const REDISCTL_USER_AGENT: &str = concat!("redisctl/", env!("CARGO_PKG_VERSION"));
 
-/// Resolved Cloud connection details (without creating an HTTP client)
-// The credential fields are populated but not yet read by the curl builder in
-// commands/curl.rs, so `api ... --curl` output omits its auth headers. Kept
-// pending that fix (see #1049); do not delete the fields without fixing curl.
-#[allow(dead_code)]
-pub struct CloudConnectionInfo {
-    pub base_url: String,
-    pub api_key: String,
-    pub api_secret: String,
-    pub user_agent: String,
-}
-
-/// Resolved Enterprise connection details (without creating an HTTP client)
-// See CloudConnectionInfo: credential fields populated but not read by the curl
-// builder, so `api ... --curl` output omits auth. Kept pending fix (see #1049).
-#[allow(dead_code)]
-pub struct EnterpriseConnectionInfo {
-    pub base_url: String,
-    pub username: String,
-    pub password: Option<String>,
-    pub insecure: bool,
-    pub ca_cert: Option<String>,
-    pub user_agent: String,
-}
-
-/// Connection manager for creating authenticated clients
+/// Connection manager for creating authenticated clients.
 #[derive(Clone)]
 pub struct ConnectionManager {
     pub config: Config,
@@ -41,7 +20,7 @@ pub struct ConnectionManager {
 }
 
 impl ConnectionManager {
-    /// Create a new connection manager with the given configuration
+    /// Create a new connection manager with the given configuration.
     pub fn new(config: Config) -> Self {
         Self {
             config,
@@ -49,7 +28,7 @@ impl ConnectionManager {
         }
     }
 
-    /// Create a new connection manager with a custom config path
+    /// Create a new connection manager with a custom config path.
     pub fn with_config_path(config: Config, config_path: Option<std::path::PathBuf>) -> Self {
         Self {
             config,
@@ -58,392 +37,60 @@ impl ConnectionManager {
     }
 
     /// Resolve Cloud connection info without creating an HTTP client.
-    ///
-    /// Follows the same credential resolution logic as `create_cloud_client`:
-    /// environment variables override profile config, and --config-file disables env vars.
     pub fn resolve_cloud_connection(
         &self,
         profile_name: Option<&str>,
     ) -> CliResult<CloudConnectionInfo> {
-        let (api_key, api_secret, base_url) = self.resolve_cloud_credentials(profile_name)?;
-        Ok(CloudConnectionInfo {
-            base_url,
-            api_key,
-            api_secret,
-            user_agent: REDISCTL_USER_AGENT.to_string(),
-        })
+        self.resolver()
+            .resolve_cloud(profile_name)
+            .map_err(Into::into)
     }
 
-    /// Create a Cloud client from profile credentials with environment variable override support
-    ///
-    /// When --config-file is explicitly specified, environment variables are ignored to provide
-    /// true configuration isolation. This allows testing with isolated configs and follows the
-    /// principle of "explicit wins" (CLI args > env vars > defaults).
+    /// Create a Cloud client from resolved profile credentials.
     pub async fn create_cloud_client(
         &self,
         profile_name: Option<&str>,
     ) -> CliResult<redis_cloud::CloudClient> {
         debug!("Creating Redis Cloud client");
-
-        let (final_api_key, final_api_secret, final_api_url) =
-            self.resolve_cloud_credentials(profile_name)?;
-
-        info!("Connecting to Redis Cloud API: {}", final_api_url);
-        trace!(
-            "API key: {}...",
-            &final_api_key[..final_api_key.len().min(8)]
-        );
-
-        // Create and configure the Cloud client
-        let client = redis_cloud::CloudClient::builder()
-            .api_key(&final_api_key)
-            .api_secret(&final_api_secret)
-            .base_url(&final_api_url)
-            .user_agent(REDISCTL_USER_AGENT)
-            .build()
-            .context("Failed to create Redis Cloud client")?;
-
+        let connection = self.resolve_cloud_connection(profile_name)?;
+        info!("Connecting to Redis Cloud API: {}", connection.base_url);
+        let client = connection.build_client()?;
         debug!("Redis Cloud client created successfully");
         Ok(client)
     }
 
-    /// Resolve Cloud credentials from profile and/or environment variables.
-    fn resolve_cloud_credentials(
-        &self,
-        profile_name: Option<&str>,
-    ) -> CliResult<(String, String, String)> {
-        trace!("Profile name: {:?}", profile_name);
-
-        // When --config-file is explicitly specified, ignore environment variables
-        let use_env_vars = self.config_path.is_none();
-
-        debug!(
-            "Config path: {:?}, use_env_vars: {}",
-            self.config_path, use_env_vars
-        );
-
-        if !use_env_vars {
-            info!("--config-file specified explicitly, ignoring environment variables");
-        }
-
-        // Check if all required environment variables are present (only if we're using them)
-        let env_api_key = if use_env_vars {
-            std::env::var("REDIS_CLOUD_API_KEY").ok()
-        } else {
-            None
-        };
-        let env_api_secret = if use_env_vars {
-            std::env::var("REDIS_CLOUD_SECRET_KEY")
-                .ok()
-                .or_else(|| std::env::var("REDIS_CLOUD_API_SECRET").ok())
-        } else {
-            None
-        };
-        let env_api_url = if use_env_vars {
-            std::env::var("REDIS_CLOUD_API_URL").ok()
-        } else {
-            None
-        };
-
-        if env_api_key.is_some() {
-            debug!("Found REDIS_CLOUD_API_KEY environment variable");
-        }
-        if env_api_secret.is_some() {
-            debug!(
-                "Found Redis Cloud secret environment variable (REDIS_CLOUD_SECRET_KEY or REDIS_CLOUD_API_SECRET)"
-            );
-        }
-        if env_api_url.is_some() {
-            debug!("Found REDIS_CLOUD_API_URL environment variable");
-        }
-
-        let result = if let (Some(key), Some(secret)) = (&env_api_key, &env_api_secret) {
-            // Environment variables provide complete credentials
-            info!("Using Redis Cloud credentials from environment variables");
-            let url = env_api_url.unwrap_or_else(|| "https://api.redislabs.com/v1".to_string());
-            (key.clone(), secret.clone(), url)
-        } else {
-            // Resolve the profile using type-specific logic
-            let resolved_profile_name = self.config.resolve_cloud_profile(profile_name)?;
-            info!("Using Redis Cloud profile: {}", resolved_profile_name);
-
-            let profile = self.config.profiles.get(&resolved_profile_name).ok_or(
-                crate::error::RedisCtlError::ProfileNotFound {
-                    name: resolved_profile_name.clone(),
-                },
-            )?;
-
-            // Verify it's a cloud profile
-            if profile.deployment_type != DeploymentType::Cloud {
-                return Err(crate::error::RedisCtlError::ProfileTypeMismatch {
-                    name: resolved_profile_name.to_string(),
-                    actual_type: match profile.deployment_type {
-                        DeploymentType::Cloud => "cloud",
-                        DeploymentType::Enterprise => "enterprise",
-                        DeploymentType::Database => "database",
-                    }
-                    .to_string(),
-                    expected_type: "cloud".to_string(),
-                    available_profiles: self
-                        .config
-                        .get_profiles_of_type(DeploymentType::Cloud)
-                        .into_iter()
-                        .map(String::from)
-                        .collect(),
-                });
-            }
-
-            // Use the new resolve method which handles keyring lookup
-            let (api_key, api_secret, api_url) = profile
-                .resolve_cloud_credentials()
-                .context("Failed to resolve Cloud credentials")?
-                .context("Profile is not configured for Redis Cloud")?;
-
-            // Check for partial overrides before consuming the Options
-            let has_overrides =
-                env_api_key.is_some() || env_api_secret.is_some() || env_api_url.is_some();
-
-            // Allow partial environment variable overrides
-            let key = env_api_key.unwrap_or(api_key);
-            let secret = env_api_secret.unwrap_or(api_secret);
-            let url = env_api_url.unwrap_or(api_url);
-
-            if has_overrides {
-                debug!("Applied partial environment variable overrides");
-            }
-
-            (key, secret, url)
-        };
-
-        Ok(result)
-    }
-
     /// Resolve Enterprise connection info without creating an HTTP client.
-    ///
-    /// Follows the same credential resolution logic as `create_enterprise_client`:
-    /// environment variables override profile config, and --config-file disables env vars.
     pub fn resolve_enterprise_connection(
         &self,
         profile_name: Option<&str>,
     ) -> CliResult<EnterpriseConnectionInfo> {
-        let (url, username, password, insecure, ca_cert) =
-            self.resolve_enterprise_credentials(profile_name)?;
-        Ok(EnterpriseConnectionInfo {
-            base_url: url,
-            username,
-            password,
-            insecure,
-            ca_cert,
-            user_agent: REDISCTL_USER_AGENT.to_string(),
-        })
+        self.resolver()
+            .resolve_enterprise(profile_name)
+            .map_err(Into::into)
     }
 
-    /// Create an Enterprise client from profile credentials with environment variable override support
-    ///
-    /// When --config-file is explicitly specified, environment variables are ignored to provide
-    /// true configuration isolation. This allows testing with isolated configs and follows the
-    /// principle of "explicit wins" (CLI args > env vars > defaults).
+    /// Create an Enterprise client from resolved profile credentials.
     pub async fn create_enterprise_client(
         &self,
         profile_name: Option<&str>,
     ) -> CliResult<redis_enterprise::EnterpriseClient> {
         debug!("Creating Redis Enterprise client");
-
-        let (final_url, final_username, final_password, final_insecure, final_ca_cert) =
-            self.resolve_enterprise_credentials(profile_name)?;
-
-        info!("Connecting to Redis Enterprise: {}", final_url);
-        debug!("Username: {}", final_username);
-        debug!(
-            "Password: {}",
-            if final_password.is_some() {
-                "configured"
-            } else {
-                "not set"
-            }
-        );
-        debug!("Insecure mode: {}", final_insecure);
-        debug!(
-            "CA cert: {}",
-            if final_ca_cert.is_some() {
-                "configured"
-            } else {
-                "not set"
-            }
-        );
-
-        // Build the Enterprise client
-        let mut builder = redis_enterprise::EnterpriseClient::builder()
-            .base_url(&final_url)
-            .username(&final_username)
-            .user_agent(REDISCTL_USER_AGENT);
-
-        // Add password if provided
-        if let Some(ref password) = final_password {
-            builder = builder.password(password);
-            trace!("Password added to client builder");
-        }
-
-        // Set insecure flag if needed
-        if final_insecure {
-            builder = builder.insecure(true);
-            debug!("SSL certificate verification disabled");
-        }
-
-        // Add CA certificate if provided
-        if let Some(ref ca_cert_path) = final_ca_cert {
-            builder = builder.ca_cert(ca_cert_path);
-            debug!("Using custom CA certificate: {}", ca_cert_path);
-        }
-
-        let client = builder
-            .build()
-            .context("Failed to create Redis Enterprise client")?;
-
+        let connection = self.resolve_enterprise_connection(profile_name)?;
+        info!("Connecting to Redis Enterprise: {}", connection.base_url);
+        let client = connection.build_client()?;
         debug!("Redis Enterprise client created successfully");
         Ok(client)
     }
 
-    /// Resolve Enterprise credentials from profile and/or environment variables.
-    #[allow(clippy::type_complexity)]
-    fn resolve_enterprise_credentials(
-        &self,
-        profile_name: Option<&str>,
-    ) -> CliResult<(String, String, Option<String>, bool, Option<String>)> {
-        trace!("Profile name: {:?}", profile_name);
-
-        // When --config-file is explicitly specified, ignore environment variables
-        let use_env_vars = self.config_path.is_none();
-
-        debug!(
-            "Config path: {:?}, use_env_vars: {}",
-            self.config_path, use_env_vars
-        );
-
-        if !use_env_vars {
-            info!("--config-file specified explicitly, ignoring environment variables");
-        }
-
-        // Check if all required environment variables are present (only if we're using them)
-        let env_url = if use_env_vars {
-            std::env::var("REDIS_ENTERPRISE_URL").ok()
+    fn resolver(&self) -> ClientResolver<'_> {
+        let environment_overrides = if self.config_path.is_some() {
+            EnvironmentOverrides::Disabled
         } else {
-            None
-        };
-        let env_user = if use_env_vars {
-            std::env::var("REDIS_ENTERPRISE_USER").ok()
-        } else {
-            None
-        };
-        let env_password = if use_env_vars {
-            std::env::var("REDIS_ENTERPRISE_PASSWORD").ok()
-        } else {
-            None
-        };
-        let env_insecure = if use_env_vars {
-            std::env::var("REDIS_ENTERPRISE_INSECURE").ok()
-        } else {
-            None
-        };
-        let env_ca_cert = if use_env_vars {
-            std::env::var("REDIS_ENTERPRISE_CA_CERT").ok()
-        } else {
-            None
+            EnvironmentOverrides::Enabled
         };
 
-        if env_url.is_some() {
-            debug!("Found REDIS_ENTERPRISE_URL environment variable");
-        }
-        if env_user.is_some() {
-            debug!("Found REDIS_ENTERPRISE_USER environment variable");
-        }
-        if env_password.is_some() {
-            debug!("Found REDIS_ENTERPRISE_PASSWORD environment variable");
-        }
-        if env_insecure.is_some() {
-            debug!("Found REDIS_ENTERPRISE_INSECURE environment variable");
-        }
-        if env_ca_cert.is_some() {
-            debug!("Found REDIS_ENTERPRISE_CA_CERT environment variable");
-        }
-
-        let result = if let (Some(url), Some(user)) = (&env_url, &env_user) {
-            // Environment variables provide complete credentials
-            info!("Using Redis Enterprise credentials from environment variables");
-            let password = env_password.clone();
-            let insecure = env_insecure
-                .as_ref()
-                .map(|s| s.to_lowercase() == "true" || s == "1")
-                .unwrap_or(false);
-            let ca_cert = env_ca_cert.clone();
-            (url.clone(), user.clone(), password, insecure, ca_cert)
-        } else {
-            // Resolve the profile using type-specific logic
-            let resolved_profile_name = self.config.resolve_enterprise_profile(profile_name)?;
-            info!("Using Redis Enterprise profile: {}", resolved_profile_name);
-
-            let profile = self.config.profiles.get(&resolved_profile_name).ok_or(
-                crate::error::RedisCtlError::ProfileNotFound {
-                    name: resolved_profile_name.clone(),
-                },
-            )?;
-
-            // Verify it's an enterprise profile
-            if profile.deployment_type != DeploymentType::Enterprise {
-                return Err(crate::error::RedisCtlError::ProfileTypeMismatch {
-                    name: resolved_profile_name.to_string(),
-                    actual_type: match profile.deployment_type {
-                        DeploymentType::Cloud => "cloud",
-                        DeploymentType::Enterprise => "enterprise",
-                        DeploymentType::Database => "database",
-                    }
-                    .to_string(),
-                    expected_type: "enterprise".to_string(),
-                    available_profiles: self
-                        .config
-                        .get_profiles_of_type(DeploymentType::Enterprise)
-                        .into_iter()
-                        .map(String::from)
-                        .collect(),
-                });
-            }
-
-            // Use the new resolve method which handles keyring lookup
-            let (url, username, password, insecure, profile_ca_cert) = profile
-                .resolve_enterprise_credentials()
-                .context("Failed to resolve Enterprise credentials")?
-                .context("Profile is not configured for Redis Enterprise")?;
-
-            // Check for partial overrides before consuming the Options
-            let has_overrides = env_url.is_some()
-                || env_user.is_some()
-                || env_password.is_some()
-                || env_insecure.is_some()
-                || env_ca_cert.is_some();
-
-            // Allow partial environment variable overrides
-            let final_url = env_url.unwrap_or(url);
-            let final_user = env_user.unwrap_or(username);
-            let final_password = env_password.or(password);
-            let final_insecure = env_insecure
-                .as_ref()
-                .map(|s| s.to_lowercase() == "true" || s == "1")
-                .unwrap_or(insecure);
-            let final_ca_cert = env_ca_cert.or(profile_ca_cert);
-
-            if has_overrides {
-                debug!("Applied partial environment variable overrides");
-            }
-
-            (
-                final_url,
-                final_user,
-                final_password,
-                final_insecure,
-                final_ca_cert,
-            )
-        };
-
-        Ok(result)
+        ClientResolver::new(&self.config)
+            .environment_overrides(environment_overrides)
+            .user_agent(REDISCTL_USER_AGENT)
     }
 }

--- a/crates/redisctl/src/error.rs
+++ b/crates/redisctl/src/error.rs
@@ -127,7 +127,6 @@ pub enum RedisCtlError {
     #[error("No profile configured. Use 'redisctl profile set' to configure a profile.")]
     NoProfileConfigured,
 
-    #[allow(dead_code)]
     #[error("Missing credentials for profile '{name}': {missing_fields}")]
     MissingCredentials {
         name: String,
@@ -487,7 +486,43 @@ impl From<anyhow::Error> for RedisCtlError {
 
 impl From<redisctl_core::ConfigError> for RedisCtlError {
     fn from(err: redisctl_core::ConfigError) -> Self {
-        RedisCtlError::Configuration(err.to_string())
+        match err {
+            redisctl_core::ConfigError::ProfileNotFound { name } => {
+                RedisCtlError::ProfileNotFound { name }
+            }
+            other => RedisCtlError::Configuration(other.to_string()),
+        }
+    }
+}
+
+impl From<redisctl_core::ClientResolutionError> for RedisCtlError {
+    fn from(err: redisctl_core::ClientResolutionError) -> Self {
+        match err {
+            redisctl_core::ClientResolutionError::Config(config_error) => config_error.into(),
+            redisctl_core::ClientResolutionError::ProfileTypeMismatch {
+                name,
+                actual_type,
+                expected_type,
+                available_profiles,
+            } => RedisCtlError::ProfileTypeMismatch {
+                name,
+                actual_type: actual_type.to_string(),
+                expected_type: expected_type.to_string(),
+                available_profiles,
+            },
+            redisctl_core::ClientResolutionError::MissingCredentials {
+                profile_name,
+                missing_fields,
+                ..
+            } => RedisCtlError::MissingCredentials {
+                name: profile_name,
+                missing_fields,
+            },
+            redisctl_core::ClientResolutionError::CloudClient(cloud_error) => cloud_error.into(),
+            redisctl_core::ClientResolutionError::EnterpriseClient(enterprise_error) => {
+                enterprise_error.into()
+            }
+        }
     }
 }
 

--- a/docs/docs/mcp/architecture.md
+++ b/docs/docs/mcp/architecture.md
@@ -35,6 +35,7 @@ The binary is compiled with feature flags that gate platform-specific dependenci
 | `enterprise` | yes | `redis-enterprise` crate + enterprise toolset |
 | `database` | yes | `redis` crate + database toolset |
 | `http` | yes | HTTP/SSE transport with optional OAuth |
+| `secure-storage` | yes | Keyring-backed profile credentials through `redisctl-core` |
 
 Profile/app tools and the two system tools are always compiled in (they only depend on `redisctl-core`).
 


### PR DESCRIPTION
## Summary
- add typed Cloud and Enterprise connection settings plus a shared `ClientResolver` in `redisctl-core`
- centralize profile selection, keyring/environment credential resolution, explicit-config isolation, custom endpoints, TLS/CA settings, user agents, and client builders
- reduce CLI `ConnectionManager` to frontend policy/logging and MCP `AppState` to profile selection/caching
- enable secure-storage by default for MCP profile credentials and preserve independent feature builds
- map shared resolution failures into the CLI error taxonomy

## Validation
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo check -p redisctl-core --no-default-features`
- `cargo check -p redisctl-mcp --no-default-features`
- `cargo doc --workspace --all-features --no-deps` (passes; existing unrelated rustdoc warnings remain)

Closes #1067