### PR TITLE
test(mcp): cover tolerant numeric tool inputs

### DIFF
--- a/crates/redisctl-mcp/src/serde_helpers.rs
+++ b/crates/redisctl-mcp/src/serde_helpers.rs
@@ -4,6 +4,28 @@
 //! of `0`). These helpers accept both native JSON numbers and string-encoded
 //! numbers for seamless interoperability.
 
+/// Deserialize an `i32` from either a JSON number or a string.
+pub mod string_or_i32 {
+    use serde::{Deserialize, Deserializer};
+    use serde_json::Value;
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<i32, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        match Value::deserialize(deserializer)? {
+            Value::Number(n) => {
+                let value = n
+                    .as_i64()
+                    .ok_or_else(|| serde::de::Error::custom("number out of i32 range"))?;
+                i32::try_from(value).map_err(serde::de::Error::custom)
+            }
+            Value::String(s) => s.parse::<i32>().map_err(serde::de::Error::custom),
+            _ => Err(serde::de::Error::custom("expected number or string")),
+        }
+    }
+}
+
 /// Deserialize an `i64` from either a JSON number or a string.
 pub mod string_or_i64 {
     use serde::{Deserialize, Deserializer};
@@ -159,6 +181,12 @@ mod tests {
     use serde_json::json;
 
     #[derive(Deserialize)]
+    struct TestI32 {
+        #[serde(deserialize_with = "super::string_or_i32::deserialize")]
+        val: i32,
+    }
+
+    #[derive(Deserialize)]
     struct TestI64 {
         #[serde(deserialize_with = "super::string_or_i64::deserialize")]
         val: i64,
@@ -198,6 +226,24 @@ mod tests {
     struct TestF64 {
         #[serde(deserialize_with = "super::string_or_f64::deserialize")]
         val: f64,
+    }
+
+    #[test]
+    fn i32_from_number() {
+        let t: TestI32 = serde_json::from_value(json!({"val": 42})).unwrap();
+        assert_eq!(t.val, 42);
+    }
+
+    #[test]
+    fn i32_from_string() {
+        let t: TestI32 = serde_json::from_value(json!({"val": "42"})).unwrap();
+        assert_eq!(t.val, 42);
+    }
+
+    #[test]
+    fn i32_rejects_out_of_range_number() {
+        let result = serde_json::from_value::<TestI32>(json!({"val": i64::from(i32::MAX) + 1}));
+        assert!(result.is_err());
     }
 
     #[test]

--- a/crates/redisctl-mcp/src/state.rs
+++ b/crates/redisctl-mcp/src/state.rs
@@ -448,6 +448,18 @@ impl AppState {
         ))
     }
 
+    /// Create a full policy for tests that exercise destructive tools
+    pub fn test_full_policy() -> Arc<Policy> {
+        Arc::new(Policy::new(
+            crate::policy::PolicyConfig {
+                tier: SafetyTier::Full,
+                ..Default::default()
+            },
+            std::collections::HashMap::new(),
+            "test".to_string(),
+        ))
+    }
+
     /// Create test state with a pre-configured Cloud client and write access
     /// enabled, for tests that exercise write tools.
     #[cfg(feature = "cloud")]

--- a/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs
+++ b/crates/redisctl-mcp/src/tools/cloud/subscriptions.rs
@@ -11,6 +11,7 @@ use redisctl_core::cloud::{
 };
 use tower_mcp::{CallToolResult, ResultExt};
 
+use crate::serde_helpers;
 use crate::tools::macros::{cloud_tool, mcp_module};
 
 // ============================================================================
@@ -140,6 +141,7 @@ cloud_tool!(read_only, get_subscription, "get_subscription",
     "Get Pro subscription details by ID. Use get_fixed_subscription for Essentials/Fixed subscriptions.",
     {
         /// Subscription ID
+        #[serde(deserialize_with = "serde_helpers::string_or_i32::deserialize")]
         pub subscription_id: i32,
     } => |client, input| {
         let handler = SubscriptionHandler::new(client);

--- a/crates/redisctl-mcp/src/tools/enterprise/databases.rs
+++ b/crates/redisctl-mcp/src/tools/enterprise/databases.rs
@@ -12,6 +12,7 @@ use redisctl_core::enterprise::{
 use serde_json::Value;
 use tower_mcp::{CallToolResult, ResultExt};
 
+use crate::serde_helpers;
 use crate::tools::macros::{enterprise_tool, mcp_module};
 
 mcp_module! {
@@ -253,6 +254,7 @@ enterprise_tool!(write, create_enterprise_database, "create_enterprise_database"
         pub name: String,
         /// Memory size in **bytes** (not GB — unlike Cloud tools). Example: 1073741824 = 1 GB.
         /// IMPORTANT: passing a value in GB (e.g., 1.0) will create a 1-byte database.
+        #[serde(default, deserialize_with = "serde_helpers::string_or_opt_u64::deserialize")]
         pub memory_size: Option<u64>,
         /// Port number (optional, cluster will assign if not specified)
         pub port: Option<u16>,

--- a/crates/redisctl-mcp/tests/cloud_tools.rs
+++ b/crates/redisctl-mcp/tests/cloud_tools.rs
@@ -1,6 +1,8 @@
 #![cfg(feature = "cloud")]
 //! Integration tests for Redis Cloud MCP tools using mock server
 
+mod support;
+
 use std::sync::Arc;
 
 use redis_cloud::testing::{
@@ -17,24 +19,13 @@ use wiremock::ResponseTemplate;
 // `body_partial_json`, which does a genuine partial (subset) match.
 use wiremock::matchers::body_partial_json;
 
-// Import the tools and state from the MCP crate
-use redisctl_mcp::policy::{Policy, PolicyConfig, SafetyTier};
 use redisctl_mcp::state::AppState;
 use redisctl_mcp::tools::cloud;
+use support::state_full;
 
 /// Create an AppState with full-tier policy for testing write/destructive tools.
-#[cfg(feature = "cloud")]
 fn full_policy_state(client: redis_cloud::CloudClient) -> Arc<AppState> {
-    let mut state = AppState::with_cloud_client(client);
-    state.policy = Arc::new(Policy::new(
-        PolicyConfig {
-            tier: SafetyTier::Full,
-            ..Default::default()
-        },
-        std::collections::HashMap::new(),
-        "test-full".to_string(),
-    ));
-    Arc::new(state)
+    state_full(AppState::with_cloud_client(client))
 }
 
 /// Helper to call a tool and get text result
@@ -122,7 +113,7 @@ async fn test_get_subscription() {
     let state = Arc::new(AppState::with_cloud_client(client));
     let tool = cloud::get_subscription(state);
 
-    let result = call_tool_json(&tool, json!({"subscription_id": 123})).await;
+    let result = call_tool_json(&tool, json!({"subscription_id": "123"})).await;
 
     assert_eq!(result["id"], 123);
     assert_eq!(result["name"], "Production");

--- a/crates/redisctl-mcp/tests/enterprise_tools.rs
+++ b/crates/redisctl-mcp/tests/enterprise_tools.rs
@@ -1,6 +1,8 @@
 #![cfg(feature = "enterprise")]
 //! Integration tests for Redis Enterprise MCP tools using mock server
 
+mod support;
+
 use std::sync::Arc;
 
 use redis_enterprise::testing::{
@@ -12,23 +14,13 @@ use tower_mcp::Tool;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, ResponseTemplate};
 
-// Import the tools and state from the MCP crate
-use redisctl_mcp::policy::{Policy, PolicyConfig, SafetyTier};
 use redisctl_mcp::state::AppState;
 use redisctl_mcp::tools::enterprise;
+use support::{state_full, state_write};
 
 /// Build an AppState with a full-tier policy so destructive tools are permitted.
 fn full_policy_state(client: redis_enterprise::EnterpriseClient) -> Arc<AppState> {
-    let mut state = AppState::with_enterprise_client(client);
-    state.policy = Arc::new(Policy::new(
-        PolicyConfig {
-            tier: SafetyTier::Full,
-            ..Default::default()
-        },
-        std::collections::HashMap::new(),
-        "test-full".to_string(),
-    ));
-    Arc::new(state)
+    state_full(AppState::with_enterprise_client(client))
 }
 
 /// Helper to call a tool and get text result
@@ -1219,14 +1211,12 @@ async fn test_create_enterprise_database() {
         .await;
 
     let client = server.client();
-    let mut state = AppState::with_enterprise_client(client);
-    state.policy = AppState::test_write_policy();
-    let state = Arc::new(state);
+    let state = state_write(AppState::with_enterprise_client(client));
     let tool = enterprise::create_enterprise_database(state);
 
     let result = call_tool_json(
         &tool,
-        json!({"name": "new-db", "memory_size": 1073741824u64}),
+        json!({"name": "new-db", "memory_size": "1073741824"}),
     )
     .await;
 

--- a/crates/redisctl-mcp/tests/redis_stack_tools.rs
+++ b/crates/redisctl-mcp/tests/redis_stack_tools.rs
@@ -13,7 +13,8 @@
 //! REUSE_CONTAINERS=1 cargo test -p redisctl-mcp --test redis_stack_tools --all-features -- --ignored --nocapture
 //! ```
 
-use std::collections::HashMap;
+mod support;
+
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -24,9 +25,9 @@ use serial_test::serial;
 use tokio::sync::OnceCell;
 use tower_mcp::Tool;
 
-use redisctl_mcp::policy::{Policy, PolicyConfig, SafetyTier};
 use redisctl_mcp::state::AppState;
 use redisctl_mcp::tools::redis;
+use support::{database_state_full, database_state_readonly, database_state_write};
 
 // ============================================================================
 // Test infrastructure
@@ -80,63 +81,15 @@ fn redis_url(port: u16) -> String {
 }
 
 fn make_state(port: u16) -> Arc<AppState> {
-    let policy = Arc::new(Policy::new(
-        PolicyConfig::default(),
-        HashMap::new(),
-        "test".to_string(),
-    ));
-    Arc::new(
-        AppState::new(
-            redisctl_mcp::state::CredentialSource::Profiles(vec![]),
-            policy,
-            Some(redis_url(port)),
-            false,
-            None,
-        )
-        .unwrap(),
-    )
+    database_state_readonly(redis_url(port))
 }
 
 fn make_rw_state(port: u16) -> Arc<AppState> {
-    let policy = Arc::new(Policy::new(
-        PolicyConfig {
-            tier: SafetyTier::ReadWrite,
-            ..Default::default()
-        },
-        HashMap::new(),
-        "test".to_string(),
-    ));
-    Arc::new(
-        AppState::new(
-            redisctl_mcp::state::CredentialSource::Profiles(vec![]),
-            policy,
-            Some(redis_url(port)),
-            false,
-            None,
-        )
-        .unwrap(),
-    )
+    database_state_write(redis_url(port))
 }
 
 fn make_full_state(port: u16) -> Arc<AppState> {
-    let policy = Arc::new(Policy::new(
-        PolicyConfig {
-            tier: SafetyTier::Full,
-            ..Default::default()
-        },
-        HashMap::new(),
-        "test".to_string(),
-    ));
-    Arc::new(
-        AppState::new(
-            redisctl_mcp::state::CredentialSource::Profiles(vec![]),
-            policy,
-            Some(redis_url(port)),
-            false,
-            None,
-        )
-        .unwrap(),
-    )
+    database_state_full(redis_url(port))
 }
 
 async fn call_tool_text(tool: &Tool, input: serde_json::Value) -> String {

--- a/crates/redisctl-mcp/tests/redis_tools.rs
+++ b/crates/redisctl-mcp/tests/redis_tools.rs
@@ -14,7 +14,8 @@
 //! REUSE_CONTAINERS=1 cargo test -p redisctl-mcp --test redis_tools --all-features -- --ignored --nocapture
 //! ```
 
-use std::collections::HashMap;
+mod support;
+
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -24,9 +25,9 @@ use serde_json::json;
 use tokio::sync::OnceCell;
 use tower_mcp::Tool;
 
-use redisctl_mcp::policy::{Policy, PolicyConfig, SafetyTier};
 use redisctl_mcp::state::AppState;
 use redisctl_mcp::tools::redis;
+use support::{database_state_full, database_state_readonly, database_state_write};
 
 // ============================================================================
 // Test infrastructure
@@ -78,63 +79,15 @@ fn redis_url(port: u16) -> String {
 }
 
 fn make_state(port: u16) -> Arc<AppState> {
-    let policy = Arc::new(Policy::new(
-        PolicyConfig::default(),
-        HashMap::new(),
-        "test".to_string(),
-    ));
-    Arc::new(
-        AppState::new(
-            redisctl_mcp::state::CredentialSource::Profiles(vec![]),
-            policy,
-            Some(redis_url(port)),
-            false,
-            None,
-        )
-        .unwrap(),
-    )
+    database_state_readonly(redis_url(port))
 }
 
 fn make_rw_state(port: u16) -> Arc<AppState> {
-    let policy = Arc::new(Policy::new(
-        PolicyConfig {
-            tier: SafetyTier::ReadWrite,
-            ..Default::default()
-        },
-        HashMap::new(),
-        "test".to_string(),
-    ));
-    Arc::new(
-        AppState::new(
-            redisctl_mcp::state::CredentialSource::Profiles(vec![]),
-            policy,
-            Some(redis_url(port)),
-            false,
-            None,
-        )
-        .unwrap(),
-    )
+    database_state_write(redis_url(port))
 }
 
 fn make_full_state(port: u16) -> Arc<AppState> {
-    let policy = Arc::new(Policy::new(
-        PolicyConfig {
-            tier: SafetyTier::Full,
-            ..Default::default()
-        },
-        HashMap::new(),
-        "test".to_string(),
-    ));
-    Arc::new(
-        AppState::new(
-            redisctl_mcp::state::CredentialSource::Profiles(vec![]),
-            policy,
-            Some(redis_url(port)),
-            false,
-            None,
-        )
-        .unwrap(),
-    )
+    database_state_full(redis_url(port))
 }
 
 async fn call_tool_text(tool: &Tool, input: serde_json::Value) -> String {
@@ -150,6 +103,18 @@ async fn call_tool_text(tool: &Tool, input: serde_json::Value) -> String {
 async fn get_conn(port: u16) -> ::redis::aio::MultiplexedConnection {
     let client = ::redis::Client::open(redis_url(port)).unwrap();
     client.get_multiplexed_async_connection().await.unwrap()
+}
+
+#[test]
+fn test_set_input_accepts_string_expiry() {
+    let input: redis::SetInput = serde_json::from_value(json!({
+        "key": "coercion-test",
+        "value": "value",
+        "ex": "3600"
+    }))
+    .expect("string expiry should deserialize");
+
+    assert_eq!(input.ex, Some(3600));
 }
 
 /// Clean up keys matching a prefix (for test isolation)
@@ -585,7 +550,7 @@ async fn test_key_write_tools() {
     // redis_set with EX
     let text = call_tool_text(
         &redis::set(state.clone()),
-        json!({"key": format!("{p}k_ex"), "value": "v", "ex": 3600}),
+        json!({"key": format!("{p}k_ex"), "value": "v", "ex": "3600"}),
     )
     .await;
     assert!(text.contains("OK"), "set ex: {}", text);
@@ -1600,24 +1565,7 @@ async fn test_flushdb_tool() {
     // Use a dedicated DB (SELECT 1) to avoid interfering with other tests on DB 0.
     // But since tool handlers use their own connections via URL, we pass db=1 in URL.
     let url_db1 = format!("redis://localhost:{}/1", ctx.port);
-    let policy = Arc::new(Policy::new(
-        PolicyConfig {
-            tier: SafetyTier::Full,
-            ..Default::default()
-        },
-        HashMap::new(),
-        "test".to_string(),
-    ));
-    let db1_state = Arc::new(
-        AppState::new(
-            redisctl_mcp::state::CredentialSource::Profiles(vec![]),
-            policy,
-            Some(url_db1.clone()),
-            false,
-            None,
-        )
-        .unwrap(),
-    );
+    let db1_state = database_state_full(url_db1.clone());
 
     // Switch our direct connection to DB 1 too
     let _: () = ::redis::cmd("SELECT")

--- a/crates/redisctl-mcp/tests/support/mod.rs
+++ b/crates/redisctl-mcp/tests/support/mod.rs
@@ -1,11 +1,63 @@
-#![cfg(feature = "enterprise")]
+#![allow(dead_code)]
 
 use std::sync::Arc;
 
+#[cfg(feature = "enterprise")]
 use redis_enterprise::EnterpriseClient;
 use redisctl_mcp::state::AppState;
+#[cfg(feature = "database")]
+use redisctl_mcp::state::CredentialSource;
+
+/// Wrap an AppState with an explicit read-only policy.
+pub fn state_readonly(mut state: AppState) -> Arc<AppState> {
+    state.policy = AppState::test_policy();
+    Arc::new(state)
+}
+
+/// Wrap an AppState with an explicit read-write policy.
+pub fn state_write(mut state: AppState) -> Arc<AppState> {
+    state.policy = AppState::test_write_policy();
+    Arc::new(state)
+}
+
+/// Wrap an AppState with an explicit full policy.
+pub fn state_full(mut state: AppState) -> Arc<AppState> {
+    state.policy = AppState::test_full_policy();
+    Arc::new(state)
+}
+
+#[cfg(feature = "database")]
+fn database_state(url: String) -> AppState {
+    AppState::new(
+        CredentialSource::Profiles(vec![]),
+        AppState::test_policy(),
+        Some(url),
+        false,
+        None,
+    )
+    .expect("database test state should be valid")
+}
+
+/// Build a direct-Redis test state with read-only access.
+#[cfg(feature = "database")]
+pub fn database_state_readonly(url: String) -> Arc<AppState> {
+    state_readonly(database_state(url))
+}
+
+/// Build a direct-Redis test state with read-write access.
+#[cfg(feature = "database")]
+pub fn database_state_write(url: String) -> Arc<AppState> {
+    state_write(database_state(url))
+}
+
+/// Build a direct-Redis test state with full access.
+#[cfg(feature = "database")]
+pub fn database_state_full(url: String) -> Arc<AppState> {
+    state_full(database_state(url))
+}
 
 /// Returns true when the local Enterprise demo cluster is reachable.
+#[cfg(feature = "enterprise")]
 pub fn docker_available() -> bool {
     std::process::Command::new("curl")
         .args([
@@ -25,6 +77,7 @@ pub fn docker_available() -> bool {
 }
 
 /// Build an EnterpriseClient from the standard Docker demo env vars.
+#[cfg(feature = "enterprise")]
 pub fn enterprise_client() -> EnterpriseClient {
     EnterpriseClient::builder()
         .base_url("https://localhost:9443")
@@ -36,6 +89,7 @@ pub fn enterprise_client() -> EnterpriseClient {
 }
 
 /// Build an AppState pre-wired with the Docker demo Enterprise client.
+#[cfg(feature = "enterprise")]
 pub fn enterprise_state() -> Arc<AppState> {
-    Arc::new(AppState::with_enterprise_client(enterprise_client()))
+    state_readonly(AppState::with_enterprise_client(enterprise_client()))
 }


### PR DESCRIPTION
## Summary

- add tolerant `i32` deserialization for Cloud identifiers
- exercise string-encoded numeric inputs through representative Redis, Cloud, and Enterprise tool requests
- centralize read-only, read-write, and full-tier test state construction across the MCP toolset suites

## Why

MCP clients commonly encode numeric arguments as JSON strings. The low-level coercion helpers had unit coverage, but the tool request wiring was not tested across all three toolsets. Policy-tier setup was also duplicated and inconsistent, especially for destructive-tool tests.

## Impact

Cloud subscription IDs and Enterprise database memory sizes now accept the same string-number form already supported by Redis numeric inputs. Test suites share explicit policy constructors, making future guard coverage smaller and more consistent.

## Validation

- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- independent Cloud, Enterprise, and database feature builds

Closes #1001
