### PR TITLE
test(mcp): cover enterprise write lifecycles

### DIFF
--- a/crates/redisctl-mcp/tests/enterprise_mcp_docker_integration_tests.rs
+++ b/crates/redisctl-mcp/tests/enterprise_mcp_docker_integration_tests.rs
@@ -17,13 +17,17 @@
 mod support;
 
 use serde_json::json;
+use serial_test::serial;
 use tower_mcp::Tool;
 
 use redisctl_mcp::tools::enterprise;
-use support::{docker_available, enterprise_state};
+use support::{docker_available, enterprise_state, enterprise_state_full};
 
-/// Call a tool and return its first text content as a parsed JSON Value.
-async fn call_json(tool: &Tool, input: serde_json::Value) -> serde_json::Value {
+/// Call a tool and return its first text content as parsed JSON.
+async fn call_json_result(
+    tool: &Tool,
+    input: serde_json::Value,
+) -> Result<serde_json::Value, String> {
     let result = tool.call(input).await;
     let text = result
         .content
@@ -31,7 +35,27 @@ async fn call_json(tool: &Tool, input: serde_json::Value) -> serde_json::Value {
         .and_then(|c| c.as_text())
         .unwrap_or_default()
         .to_string();
-    serde_json::from_str(&text).expect("tool returned valid JSON")
+
+    if result.is_error {
+        return Err(format!("tool returned an error: {text}"));
+    }
+
+    serde_json::from_str(&text).map_err(|error| format!("tool returned invalid JSON: {error}"))
+}
+
+/// Call a tool and return its first text content as a parsed JSON Value.
+async fn call_json(tool: &Tool, input: serde_json::Value) -> serde_json::Value {
+    call_json_result(tool, input)
+        .await
+        .unwrap_or_else(|error| panic!("{error}"))
+}
+
+fn unique_suffix() -> String {
+    let timestamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    format!("{}-{timestamp}", std::process::id())
 }
 
 // ============================================================================
@@ -98,6 +122,20 @@ async fn test_live_get_license() {
     let tool = enterprise::get_license(state);
     let result = call_json(&tool, json!({})).await;
     assert!(result["expired"].is_boolean());
+}
+
+#[tokio::test]
+#[ignore = "Requires Docker Redis Enterprise cluster"]
+async fn test_live_get_cluster_policy() {
+    if !docker_available() {
+        eprintln!("Skipping: Docker Redis Enterprise not available");
+        return;
+    }
+    let state = enterprise_state();
+
+    let tool = enterprise::get_cluster_policy(state);
+    let result = call_json(&tool, json!({})).await;
+    assert!(result.is_object());
 }
 
 // ============================================================================
@@ -220,6 +258,46 @@ async fn test_live_list_shards() {
 
 #[tokio::test]
 #[ignore = "Requires Docker Redis Enterprise cluster"]
+async fn test_live_get_shard_and_list_shards_by_database() {
+    if !docker_available() {
+        eprintln!("Skipping: Docker Redis Enterprise not available");
+        return;
+    }
+    let state = enterprise_state();
+
+    let database_tool = enterprise::list_databases(state.clone());
+    let databases = call_json(&database_tool, json!({})).await;
+    let Some(database_uid) = databases["databases"]
+        .as_array()
+        .and_then(|items| items.first())
+        .and_then(|database| database["uid"].as_u64())
+    else {
+        eprintln!("Skipping: no databases available to query shards");
+        return;
+    };
+
+    let list_tool = enterprise::list_shards_by_database(state.clone());
+    let shards = call_json(&list_tool, json!({ "bdb_uid": database_uid })).await;
+    let shard_items = shards["shards"]
+        .as_array()
+        .expect("database shard list should be an array");
+    let Some(shard_uid) = shard_items.first().and_then(|shard| {
+        shard["uid"]
+            .as_str()
+            .map(str::to_owned)
+            .or_else(|| shard["uid"].as_u64().map(|uid| uid.to_string()))
+    }) else {
+        eprintln!("Skipping: database has no shards to query");
+        return;
+    };
+
+    let get_tool = enterprise::get_shard(state);
+    let shard = call_json(&get_tool, json!({ "uid": shard_uid })).await;
+    assert!(shard.is_object());
+}
+
+#[tokio::test]
+#[ignore = "Requires Docker Redis Enterprise cluster"]
 async fn test_live_list_modules() {
     if !docker_available() {
         eprintln!("Skipping: Docker Redis Enterprise not available");
@@ -335,34 +413,114 @@ async fn test_live_list_services() {
 
 #[tokio::test]
 #[ignore = "Requires Docker Redis Enterprise cluster"]
-async fn test_live_create_and_delete_enterprise_database() {
+#[serial]
+async fn test_live_create_update_and_delete_enterprise_database() {
     if !docker_available() {
         eprintln!("Skipping: Docker Redis Enterprise not available");
         return;
     }
-    let state = enterprise_state();
-
-    let ts = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
-    let name = format!("test-mcp-{}", ts);
+    let state = enterprise_state_full();
+    let name = format!("test-mcp-db-{}", unique_suffix());
 
     // Create a minimal 100MB database.
     let create_tool = enterprise::create_enterprise_database(state.clone());
-    let created = call_json(
+    let created = call_json_result(
         &create_tool,
-        json!({ "name": name, "memory_size": 104857600u64 }),
+        json!({ "name": name, "memory_size": "104857600" }),
+    )
+    .await
+    .expect("database creation should succeed");
+    let uid = created["uid"]
+        .as_u64()
+        .expect("database creation should return a uid");
+
+    // Exercise a bounded update on the resource created by this test.
+    let update_tool = enterprise::update_enterprise_database(state.clone());
+    let updated = call_json_result(
+        &update_tool,
+        json!({ "uid": uid, "updates": { "memory_size": 125829120u64 } }),
     )
     .await;
 
-    let Some(uid) = created["uid"].as_u64() else {
-        eprintln!("Skipping cleanup: database creation did not return a uid: {created}");
-        return;
-    };
-
     // Always attempt cleanup.
     let delete_tool = enterprise::delete_enterprise_database(state);
-    let deleted = call_json(&delete_tool, json!({ "uid": uid })).await;
-    assert!(deleted.is_object());
+    let deleted = call_json_result(&delete_tool, json!({ "uid": uid })).await;
+
+    let updated = updated.expect("database update should succeed");
+    let deleted = deleted.expect("database cleanup should succeed");
+    assert_eq!(created["uid"], uid);
+    assert_eq!(created["name"], name);
+    assert_eq!(updated["uid"], uid);
+    assert_eq!(deleted["uid"], uid);
+}
+
+#[tokio::test]
+#[ignore = "Requires Docker Redis Enterprise cluster"]
+#[serial]
+async fn test_live_create_and_delete_enterprise_role() {
+    if !docker_available() {
+        eprintln!("Skipping: Docker Redis Enterprise not available");
+        return;
+    }
+    let state = enterprise_state_full();
+    let name = format!("test-mcp-role-{}", unique_suffix());
+
+    let create_tool = enterprise::create_enterprise_role(state.clone());
+    let created = call_json_result(
+        &create_tool,
+        json!({ "name": name, "management": "db_viewer" }),
+    )
+    .await
+    .expect("role creation should succeed");
+    let uid = created["uid"]
+        .as_u64()
+        .expect("role creation should return a uid");
+
+    // Delete before asserting the response body so cleanup is still attempted
+    // if a live API version changes a non-identity response field.
+    let delete_tool = enterprise::delete_enterprise_role(state);
+    let deleted = call_json_result(&delete_tool, json!({ "uid": uid })).await;
+
+    let deleted = deleted.expect("role cleanup should succeed");
+    assert_eq!(created["uid"], uid);
+    assert_eq!(created["name"], name);
+    assert_eq!(deleted["uid"], uid);
+}
+
+#[tokio::test]
+#[ignore = "Requires Docker Redis Enterprise cluster"]
+#[serial]
+async fn test_live_create_and_delete_enterprise_user() {
+    if !docker_available() {
+        eprintln!("Skipping: Docker Redis Enterprise not available");
+        return;
+    }
+    let state = enterprise_state_full();
+    let email = format!("test-mcp-{}@example.com", unique_suffix());
+
+    let create_tool = enterprise::create_enterprise_user(state.clone());
+    let created = call_json_result(
+        &create_tool,
+        json!({
+            "email": email,
+            "password": "McpTest123!",
+            "role": "db_viewer",
+            "name": "redisctl MCP integration test"
+        }),
+    )
+    .await
+    .expect("user creation should succeed");
+    let uid = created["uid"]
+        .as_u64()
+        .expect("user creation should return a uid");
+
+    // Delete before asserting the response body so cleanup is still attempted
+    // if a live API version changes a non-identity response field.
+    let delete_tool = enterprise::delete_enterprise_user(state);
+    let deleted = call_json_result(&delete_tool, json!({ "uid": uid })).await;
+
+    let deleted = deleted.expect("user cleanup should succeed");
+    assert_eq!(created["uid"], uid);
+    assert_eq!(created["email"], email);
+    assert_eq!(deleted["uid"], uid);
 }

--- a/crates/redisctl-mcp/tests/support/mod.rs
+++ b/crates/redisctl-mcp/tests/support/mod.rs
@@ -93,3 +93,9 @@ pub fn enterprise_client() -> EnterpriseClient {
 pub fn enterprise_state() -> Arc<AppState> {
     state_readonly(AppState::with_enterprise_client(enterprise_client()))
 }
+
+/// Build a full-tier AppState for bounded Enterprise Docker write tests.
+#[cfg(feature = "enterprise")]
+pub fn enterprise_state_full() -> Arc<AppState> {
+    state_full(AppState::with_enterprise_client(enterprise_client()))
+}


### PR DESCRIPTION
## Summary

- give Enterprise Docker mutation tests an explicit full-tier policy so destructive cleanup can run
- expand the database lifecycle from create/delete to create/update/delete
- add serial create/delete lifecycles for Enterprise roles and users with unique resource names
- add live cluster-policy, shard-by-database, and shard-detail reads
- surface tool errors clearly in the live-test helper and defer response assertions until cleanup has been attempted

## Why

The existing live database mutation test used the default read-only state, so it could not exercise the intended create/delete path. RBAC writes had only mock request coverage, and several safe live read paths identified in #998 were still absent.

## Impact

The ignored Enterprise Docker suite now covers bounded database and RBAC mutations without leaking successfully created resources. Mutation cases run serially to reduce pressure on the single-node demo cluster.

## Validation

- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo test -p redisctl-mcp --test enterprise_mcp_docker_integration_tests --features enterprise`

The local Enterprise demo cluster was not running, so the intentionally ignored live cases were compiled but not executed locally.

Closes #998
